### PR TITLE
Fix TSA formatting failure integration test

### DIFF
--- a/src/test/java/com/otilm/core/integration/signing/tsa/TsaServiceImplITest.java
+++ b/src/test/java/com/otilm/core/integration/signing/tsa/TsaServiceImplITest.java
@@ -1,5 +1,6 @@
 package com.otilm.core.integration.signing.tsa;
 
+import com.otilm.api.exception.ConnectorServerException;
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.interfaces.core.tsp.error.TspException;
 import com.otilm.api.interfaces.core.tsp.error.TspFailureInfo;
@@ -352,17 +353,19 @@ class TsaServiceImplITest extends BaseSpringBootTest {
         }
 
         @Test
-        void rejectsWithSystemFailure_whenFormattingConnectorFails() throws Exception {
+        void throwsSystemFailure_whenFormattingConnectorFails() throws Exception {
             // given — the signature formatting is unavailable during token assembly
             SigningProfileDto profile = createTimestampingSigningProfile("sp-formatting-down");
             timestampingFormattingMock.stubTokenAssemblyFailure();
 
-            // when
-            TspResponse response = tsaService.processTspRequestForSigningProfile(profile.getName(), aTspRequest().build());
-
-            // then
-            assertThat(response).isInstanceOf(TspResponse.Rejected.class);
-            assertThat(((TspResponse.Rejected) response).failureInfo()).isEqualTo(TspFailureInfo.SYSTEM_FAILURE);
+            // when / then — the controller renders this service exception as a TSP rejection
+            assertThatThrownBy(() -> tsaService.processTspRequestForSigningProfile(
+                    profile.getName(), aTspRequest().build()))
+                    .isInstanceOf(TspException.class)
+                    .satisfies(ex -> assertThat(((TspException) ex).getFailureInfo())
+                            .isEqualTo(TspFailureInfo.SYSTEM_FAILURE))
+                    .hasMessageContaining("Signature formatting connector communication failed during DTBS phase")
+                    .hasCauseInstanceOf(ConnectorServerException.class);
         }
     }
 }

--- a/src/test/java/com/otilm/core/util/mocks/TimestampingFormattingConnectorMock.java
+++ b/src/test/java/com/otilm/core/util/mocks/TimestampingFormattingConnectorMock.java
@@ -114,7 +114,8 @@ public class TimestampingFormattingConnectorMock extends BaseConnectorMock {
     }
 
     /**
-     * Stubs the {@code formatDtbs} phase to fail, so the engine surfaces a {@code SYSTEM_FAILURE} rejection.
+     * Stubs the {@code formatDtbs} phase to fail, so the formatting client surfaces a
+     * {@code SYSTEM_FAILURE} TSP exception.
      */
     public TimestampingFormattingConnectorMock stubTokenAssemblyFailure() {
         server.stubFor(WireMock.post(WireMock.urlPathMatching(".*/v1/signatureProvider/formatting/formatDtbs"))


### PR DESCRIPTION
## Summary

- update `TsaServiceImplITest` to assert the service-level `TspException` produced for a formatting connector 500
- verify the failure remains classified as `SYSTEM_FAILURE` and retains `ConnectorServerException` as its cause
- correct the formatting mock documentation to describe exception propagation

## Root cause

OmniTrustILM/interfaces#827 fixed `BaseApiClient` handling of bodiless non-2xx responses. The mock’s empty 500 previously fell through as a `NullPointerException`, which `ManagedTimestampEngine` converted to a `TspResponse.Rejected`. It now correctly becomes `ConnectorServerException`; the formatting client wraps that in `TspException`, which the service deliberately propagates for the TSP controller to render as a rejection. The old assertion depended on the former client bug.

Unblocks #1993.

## Test

`mvn -B -U -ntp test -Ptest-integration-core -Dtest='TsaServiceImplITest$ProcessTspRequestForSigningProfile#throwsSystemFailure_whenFormattingConnectorFails'`