### PR TITLE
Stop nested integration tests re-running in the non-integration worker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -451,8 +451,7 @@
     </repositories>
 
     <profiles>
-        <!-- Worker 1: everything outside the integration package.
-             The regex also excludes nested classes declared inside ITests. -->
+        <!-- Worker 1: every runnable test except the integration *ITests (and their nested classes). -->
         <profile>
             <id>test-non-integration</id>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -451,7 +451,9 @@
     </repositories>
 
     <profiles>
-        <!-- Worker 1: everything except integration ITests (service unit tests + all the rest). -->
+        <!-- Worker 1: everything outside the integration package.
+             The regex also excludes nested classes declared inside ITests; an Ant *ITest.java pattern
+             excludes only the outer class and causes its @Nested tests to run again on this worker. -->
         <profile>
             <id>test-non-integration</id>
             <build>
@@ -461,7 +463,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludes>
-                                <exclude>com/otilm/core/integration/**/*ITest.java</exclude>
+                                <exclude>%regex[.*/integration/.*ITest.*]</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -469,7 +471,7 @@
             </build>
         </profile>
 
-        <!-- Worker 2: integration ITests outside the service package. -->
+        <!-- Worker 2: integration ITests outside the service package, except transfers to worker 4. -->
         <profile>
             <id>test-integration-core</id>
             <build>
@@ -483,6 +485,8 @@
                             </includes>
                             <excludes>
                                 <exclude>com/otilm/core/integration/service/**/*ITest.java</exclude>
+                                <exclude>com/otilm/core/integration/cryptography/PQCITest.java</exclude>
+                                <exclude>com/otilm/core/integration/search/TimeQualityConfigurationSearchITest.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -491,8 +495,9 @@
         </profile>
 
         <!-- Workers 3 & 4 split integration.service by the shared %regex boundary below.
-             The split is currently unbalanced, and rebalancing is manual as the suite grows. -->
-        <!-- Worker 3: integration.service nested subpackages + flat classes A-C. -->
+             Four heavy A-C classes are transferred to worker 4 to balance wall-clock cost.
+             CertificateServiceITest and CryptographicKeyServiceITest stay together because they share a context. -->
+        <!-- Worker 3: integration.service nested subpackages + flat classes A-C, except transfers. -->
         <profile>
             <id>test-integration-service-1</id>
             <build>
@@ -506,6 +511,10 @@
                             </includes>
                             <excludes>
                                 <exclude>%regex[.*/integration/service/[D-Z][^/]*ITest.*]</exclude>
+                                <exclude>com/otilm/core/integration/service/AcmeProfileServiceITest.java</exclude>
+                                <exclude>com/otilm/core/integration/service/AcmeServiceITest.java</exclude>
+                                <exclude>com/otilm/core/integration/service/CertificateServiceITest.java</exclude>
+                                <exclude>com/otilm/core/integration/service/CryptographicKeyServiceITest.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -513,7 +522,7 @@
             </build>
         </profile>
 
-        <!-- Worker 4: integration.service flat classes D-Z. -->
+        <!-- Worker 4: integration.service flat classes D-Z plus transfers from workers 2 and 3. -->
         <profile>
             <id>test-integration-service-2</id>
             <build>
@@ -524,6 +533,12 @@
                         <configuration>
                             <includes>
                                 <include>%regex[.*/integration/service/[D-Z][^/]*ITest.*]</include>
+                                <include>com/otilm/core/integration/service/AcmeProfileServiceITest.java</include>
+                                <include>com/otilm/core/integration/service/AcmeServiceITest.java</include>
+                                <include>com/otilm/core/integration/service/CertificateServiceITest.java</include>
+                                <include>com/otilm/core/integration/service/CryptographicKeyServiceITest.java</include>
+                                <include>com/otilm/core/integration/cryptography/PQCITest.java</include>
+                                <include>com/otilm/core/integration/search/TimeQualityConfigurationSearchITest.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -461,7 +461,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludes>
-                                <exclude>%regex[.*/integration/.*ITest.*]</exclude>
+                                <exclude>%regex[com/otilm/core/integration/.*ITest.*]</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -507,7 +507,7 @@
                                 <include>com/otilm/core/integration/service/**/*ITest.java</include>
                             </includes>
                             <excludes>
-                                <exclude>%regex[.*/integration/service/[D-Z][^/]*ITest.*]</exclude>
+                                <exclude>%regex[com/otilm/core/integration/service/[D-Z][^/]*ITest.*]</exclude>
                                 <exclude>com/otilm/core/integration/service/AcmeProfileServiceITest.java</exclude>
                                 <exclude>com/otilm/core/integration/service/AcmeServiceITest.java</exclude>
                                 <exclude>com/otilm/core/integration/service/CertificateServiceITest.java</exclude>
@@ -529,7 +529,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <includes>
-                                <include>%regex[.*/integration/service/[D-Z][^/]*ITest.*]</include>
+                                <include>%regex[com/otilm/core/integration/service/[D-Z][^/]*ITest.*]</include>
                                 <include>com/otilm/core/integration/service/AcmeProfileServiceITest.java</include>
                                 <include>com/otilm/core/integration/service/AcmeServiceITest.java</include>
                                 <include>com/otilm/core/integration/service/CertificateServiceITest.java</include>

--- a/pom.xml
+++ b/pom.xml
@@ -452,8 +452,7 @@
 
     <profiles>
         <!-- Worker 1: everything outside the integration package.
-             The regex also excludes nested classes declared inside ITests; an Ant *ITest.java pattern
-             excludes only the outer class and causes its @Nested tests to run again on this worker. -->
+             The regex also excludes nested classes declared inside ITests. -->
         <profile>
             <id>test-non-integration</id>
             <build>
@@ -495,8 +494,7 @@
         </profile>
 
         <!-- Workers 3 & 4 split integration.service by the shared %regex boundary below.
-             Four heavy A-C classes are transferred to worker 4 to balance wall-clock cost.
-             CertificateServiceITest and CryptographicKeyServiceITest stay together because they share a context. -->
+             Some heavy A-C classes are transferred to worker 4 to balance wall-clock cost. -->
         <!-- Worker 3: integration.service nested subpackages + flat classes A-C, except transfers. -->
         <profile>
             <id>test-integration-service-1</id>

--- a/src/test/java/com/otilm/core/architecture/CiTestSplitTest.java
+++ b/src/test/java/com/otilm/core/architecture/CiTestSplitTest.java
@@ -145,9 +145,22 @@ class CiTestSplitTest {
     @Test
     void nonIntegrationProfileExcludesNestedIntegrationTests() throws Exception {
         List<String> excludes = profilePatterns("test-non-integration", "exclude");
+        String outerClass = "com/otilm/core/integration/service/SampleITest.java";
+        String nestedClass = "com/otilm/core/integration/service/SampleITest$SomethingTest.java";
 
-        assertThat(matchesAny(excludes, "com/otilm/core/integration/service/SampleITest.java")).isTrue();
-        assertThat(matchesAny(excludes, "com/otilm/core/integration/service/SampleITest$Nested.java")).isTrue();
+        assertThat(matchesAny(SUREFIRE_DEFAULT_INCLUDES, nestedClass))
+                .describedAs("""
+                        The nested class this guard uses must be one surefire's default <includes> actually
+                        claim — otherwise the exclusion assertion below passes vacuously and the guard proves
+                        nothing about the duplicate-execution regression it exists to catch.""")
+                .isTrue();
+        assertThat(matchesAny(excludes, outerClass)).isTrue();
+        assertThat(matchesAny(excludes, nestedClass))
+                .describedAs("""
+                        A nested class inside an integration *ITest whose name matches surefire's default
+                        <includes> must still be excluded from test-non-integration, or it runs both there
+                        and on the integration worker that owns its enclosing class.""")
+                .isTrue();
     }
 
     @Test

--- a/src/test/java/com/otilm/core/architecture/CiTestSplitTest.java
+++ b/src/test/java/com/otilm/core/architecture/CiTestSplitTest.java
@@ -29,9 +29,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * any pattern.
  * <p>
  * The heavy {@code integration.service} package is split by leading class letter (A-C vs D-Z) via a shared
- * {@code %regex} boundary — excluded from {@code test-integration-service-1}, included by
- * {@code test-integration-service-2}. {@link #flatServiceSplitBoundaryMustBeConsistent} keeps the two sides identical
- * so the flat classes cannot silently gap or double-run.
+ * {@code %regex} boundary, with heavy classes transferred from the first shard to the second. The same patterns must be
+ * excluded from {@code test-integration-service-1} and included by {@code test-integration-service-2} so classes cannot
+ * silently gap or double-run. {@link #serviceSplitPatternsMustBeConsistent} keeps the two sides identical.
  * <p>
  * Additionally, every concrete test class in the service package must follow the naming convention surefire matches
  * (*Test, *Tests, *ITest); classes that don't are never picked up at all.
@@ -42,6 +42,22 @@ class CiTestSplitTest {
     private static final List<String> CI_PROFILES = List
             .of("test-non-integration", "test-integration-core", "test-integration-service-1",
                     "test-integration-service-2");
+
+    private static final String SERVICE_SPLIT_BOUNDARY =
+            "%regex[.*/integration/service/[D-Z][^/]*ITest.*]";
+
+    private static final String SERVICE_PACKAGE =
+            "com/otilm/core/integration/service/**/*ITest.java";
+
+    private static final List<String> SERVICE_SHARD_TRANSFERS = List.of(
+            "com/otilm/core/integration/service/AcmeProfileServiceITest.java",
+            "com/otilm/core/integration/service/AcmeServiceITest.java",
+            "com/otilm/core/integration/service/CertificateServiceITest.java",
+            "com/otilm/core/integration/service/CryptographicKeyServiceITest.java");
+
+    private static final List<String> CORE_SHARD_TRANSFERS = List.of(
+            "com/otilm/core/integration/cryptography/PQCITest.java",
+            "com/otilm/core/integration/search/TimeQualityConfigurationSearchITest.java");
 
     /**
      * Surefire's built-in default {@code <includes>}, applied to any profile that declares no {@code <includes>} of its
@@ -94,19 +110,44 @@ class CiTestSplitTest {
     }
 
     @Test
-    void flatServiceSplitBoundaryMustBeConsistent() throws Exception {
+    void serviceSplitPatternsMustBeConsistent() throws Exception {
         List<String> shard1Excludes = profilePatterns("test-integration-service-1", "exclude");
         List<String> shard2Includes = profilePatterns("test-integration-service-2", "include");
+        List<String> expectedServicePatterns = new ArrayList<>();
+        expectedServicePatterns.add(SERVICE_SPLIT_BOUNDARY);
+        expectedServicePatterns.addAll(SERVICE_SHARD_TRANSFERS);
+
+        List<String> expectedShard2Includes = new ArrayList<>(expectedServicePatterns);
+        expectedShard2Includes.addAll(CORE_SHARD_TRANSFERS);
 
         assertThat(shard2Includes)
-                .describedAs("test-integration-service-2 must include exactly the flat-class %regex boundary")
-                .hasSize(1);
+                .describedAs("test-integration-service-2 must include the boundary and all transfers")
+                .containsExactlyInAnyOrderElementsOf(expectedShard2Includes);
         assertThat(shard1Excludes)
                 .describedAs("""
-                        test-integration-service-1 must exclude exactly the same flat-class boundary that
-                        test-integration-service-2 includes. If the two drift apart, the integration.service
-                        flat classes on the boundary either run twice or run in neither shard.""")
-                .containsExactlyElementsOf(shard2Includes);
+                        test-integration-service-1 must exclude the service boundary and service transfers.
+                        If these patterns drift, affected integration.service classes run twice or in neither shard.""")
+                .containsExactlyInAnyOrderElementsOf(expectedServicePatterns);
+    }
+
+    @Test
+    void coreTransfersMustBeExcludedFromCoreAndIncludedByServiceShard2() throws Exception {
+        List<String> coreExcludes = profilePatterns("test-integration-core", "exclude");
+        List<String> shard2Includes = profilePatterns("test-integration-service-2", "include");
+        List<String> expectedCoreExcludes = new ArrayList<>();
+        expectedCoreExcludes.add(SERVICE_PACKAGE);
+        expectedCoreExcludes.addAll(CORE_SHARD_TRANSFERS);
+
+        assertThat(coreExcludes).containsExactlyInAnyOrderElementsOf(expectedCoreExcludes);
+        assertThat(shard2Includes).containsAll(CORE_SHARD_TRANSFERS);
+    }
+
+    @Test
+    void nonIntegrationProfileExcludesNestedIntegrationTests() throws Exception {
+        List<String> excludes = profilePatterns("test-non-integration", "exclude");
+
+        assertThat(matchesAny(excludes, "com/otilm/core/integration/service/SampleITest.java")).isTrue();
+        assertThat(matchesAny(excludes, "com/otilm/core/integration/service/SampleITest$Nested.java")).isTrue();
     }
 
     @Test

--- a/src/test/java/com/otilm/core/architecture/CiTestSplitTest.java
+++ b/src/test/java/com/otilm/core/architecture/CiTestSplitTest.java
@@ -43,21 +43,19 @@ class CiTestSplitTest {
             .of("test-non-integration", "test-integration-core", "test-integration-service-1",
                     "test-integration-service-2");
 
-    private static final String SERVICE_SPLIT_BOUNDARY =
-            "%regex[.*/integration/service/[D-Z][^/]*ITest.*]";
+    private static final String SERVICE_SPLIT_BOUNDARY = "%regex[.*/integration/service/[D-Z][^/]*ITest.*]";
 
-    private static final String SERVICE_PACKAGE =
-            "com/otilm/core/integration/service/**/*ITest.java";
+    private static final String SERVICE_PACKAGE = "com/otilm/core/integration/service/**/*ITest.java";
 
-    private static final List<String> SERVICE_SHARD_TRANSFERS = List.of(
-            "com/otilm/core/integration/service/AcmeProfileServiceITest.java",
-            "com/otilm/core/integration/service/AcmeServiceITest.java",
-            "com/otilm/core/integration/service/CertificateServiceITest.java",
-            "com/otilm/core/integration/service/CryptographicKeyServiceITest.java");
+    private static final List<String> SERVICE_SHARD_TRANSFERS = List
+            .of("com/otilm/core/integration/service/AcmeProfileServiceITest.java",
+                    "com/otilm/core/integration/service/AcmeServiceITest.java",
+                    "com/otilm/core/integration/service/CertificateServiceITest.java",
+                    "com/otilm/core/integration/service/CryptographicKeyServiceITest.java");
 
-    private static final List<String> CORE_SHARD_TRANSFERS = List.of(
-            "com/otilm/core/integration/cryptography/PQCITest.java",
-            "com/otilm/core/integration/search/TimeQualityConfigurationSearchITest.java");
+    private static final List<String> CORE_SHARD_TRANSFERS = List
+            .of("com/otilm/core/integration/cryptography/PQCITest.java",
+                    "com/otilm/core/integration/search/TimeQualityConfigurationSearchITest.java");
 
     /**
      * Surefire's built-in default {@code <includes>}, applied to any profile that declares no {@code <includes>} of its
@@ -148,19 +146,15 @@ class CiTestSplitTest {
         String outerClass = "com/otilm/core/integration/service/SampleITest.java";
         String nestedClass = "com/otilm/core/integration/service/SampleITest$SomethingTest.java";
 
-        assertThat(matchesAny(SUREFIRE_DEFAULT_INCLUDES, nestedClass))
-                .describedAs("""
-                        The nested class this guard uses must be one surefire's default <includes> actually
-                        claim — otherwise the exclusion assertion below passes vacuously and the guard proves
-                        nothing about the duplicate-execution regression it exists to catch.""")
-                .isTrue();
+        assertThat(matchesAny(SUREFIRE_DEFAULT_INCLUDES, nestedClass)).describedAs("""
+                The nested class this guard uses must be one surefire's default <includes> actually
+                claim — otherwise the exclusion assertion below passes vacuously and the guard proves
+                nothing about the duplicate-execution regression it exists to catch.""").isTrue();
         assertThat(matchesAny(excludes, outerClass)).isTrue();
-        assertThat(matchesAny(excludes, nestedClass))
-                .describedAs("""
-                        A nested class inside an integration *ITest whose name matches surefire's default
-                        <includes> must still be excluded from test-non-integration, or it runs both there
-                        and on the integration worker that owns its enclosing class.""")
-                .isTrue();
+        assertThat(matchesAny(excludes, nestedClass)).describedAs("""
+                A nested class inside an integration *ITest whose name matches surefire's default
+                <includes> must still be excluded from test-non-integration, or it runs both there
+                and on the integration worker that owns its enclosing class.""").isTrue();
     }
 
     @Test

--- a/src/test/java/com/otilm/core/architecture/CiTestSplitTest.java
+++ b/src/test/java/com/otilm/core/architecture/CiTestSplitTest.java
@@ -29,23 +29,24 @@ import static org.assertj.core.api.Assertions.assertThat;
  * any pattern.
  * <p>
  * The heavy {@code integration.service} package is split by leading class letter (A-C vs D-Z) via a shared
- * {@code %regex} boundary, with heavy classes transferred from the first shard to the second. The same patterns must be
- * excluded from {@code test-integration-service-1} and included by {@code test-integration-service-2} so classes cannot
- * silently gap or double-run. {@link #serviceSplitPatternsMustBeConsistent} keeps the two sides identical.
+ * {@code %regex} boundary, with heavy classes transferred from the first shard to the second.
  * <p>
  * Additionally, every concrete test class in the service package must follow the naming convention surefire matches
  * (*Test, *Tests, *ITest); classes that don't are never picked up at all.
  */
 class CiTestSplitTest {
 
+    private static final String NON_INTEGRATION_PROFILE = "test-non-integration";
+
     /** The profile ids the CI matrix runs, one per worker. Must partition the runnable test classes. */
     private static final List<String> CI_PROFILES = List
-            .of("test-non-integration", "test-integration-core", "test-integration-service-1",
+            .of(NON_INTEGRATION_PROFILE, "test-integration-core", "test-integration-service-1",
                     "test-integration-service-2");
 
-    private static final String SERVICE_SPLIT_BOUNDARY = "%regex[.*/integration/service/[D-Z][^/]*ITest.*]";
+    private static final String SERVICE_SPLIT_BOUNDARY = "%regex[com/otilm/core/integration/service/[D-Z][^/]*ITest.*]";
 
-    private static final String SERVICE_PACKAGE = "com/otilm/core/integration/service/**/*ITest.java";
+    /** {@code test-integration-core}'s exclude for the whole service package, which workers 3 and 4 own instead. */
+    private static final String CORE_SERVICE_EXCLUDE = "com/otilm/core/integration/service/**/*ITest.java";
 
     private static final List<String> SERVICE_SHARD_TRANSFERS = List
             .of("com/otilm/core/integration/service/AcmeProfileServiceITest.java",
@@ -66,13 +67,8 @@ class CiTestSplitTest {
 
     @Test
     void everyRunnableTestIsRunByExactlyOneCiProfile() throws Exception {
-        Map<String, List<String>> includes = new HashMap<>();
-        Map<String, List<String>> excludes = new HashMap<>();
-        for (String profile : CI_PROFILES) {
-            List<String> declared = profilePatterns(profile, "include");
-            includes.put(profile, declared.isEmpty() ? SUREFIRE_DEFAULT_INCLUDES : declared);
-            excludes.put(profile, profilePatterns(profile, "exclude"));
-        }
+        Map<String, List<String>> includes = profileIncludes();
+        Map<String, List<String>> excludes = profileExcludes();
 
         List<String> neverRun = new ArrayList<>();
         List<String> multiRun = new ArrayList<>();
@@ -82,12 +78,8 @@ class CiTestSplitTest {
                     .filter(TestClassTaxonomy::isRunnableTest)
                     .toList();
             for (Path p : runnable) {
-                String rel = TEST_ROOT.relativize(p).toString().replace('\\', '/');
-                List<String> claimedBy = CI_PROFILES
-                        .stream()
-                        .filter(profile -> matchesAny(includes.get(profile), rel)
-                                && !matchesAny(excludes.get(profile), rel))
-                        .toList();
+                String rel = relative(p);
+                List<String> claimedBy = claimingProfiles(rel, includes, excludes);
                 if (claimedBy.isEmpty()) {
                     neverRun.add(rel);
                 } else if (claimedBy.size() > 1) {
@@ -133,7 +125,7 @@ class CiTestSplitTest {
         List<String> coreExcludes = profilePatterns("test-integration-core", "exclude");
         List<String> shard2Includes = profilePatterns("test-integration-service-2", "include");
         List<String> expectedCoreExcludes = new ArrayList<>();
-        expectedCoreExcludes.add(SERVICE_PACKAGE);
+        expectedCoreExcludes.add(CORE_SERVICE_EXCLUDE);
         expectedCoreExcludes.addAll(CORE_SHARD_TRANSFERS);
 
         assertThat(coreExcludes).containsExactlyInAnyOrderElementsOf(expectedCoreExcludes);
@@ -141,20 +133,81 @@ class CiTestSplitTest {
     }
 
     @Test
-    void nonIntegrationProfileExcludesNestedIntegrationTests() throws Exception {
-        List<String> excludes = profilePatterns("test-non-integration", "exclude");
-        String outerClass = "com/otilm/core/integration/service/SampleITest.java";
-        String nestedClass = "com/otilm/core/integration/service/SampleITest$SomethingTest.java";
+    void transferredClassesMustExist() {
+        List<String> transfers = new ArrayList<>(SERVICE_SHARD_TRANSFERS);
+        transfers.addAll(CORE_SHARD_TRANSFERS);
 
-        assertThat(matchesAny(SUREFIRE_DEFAULT_INCLUDES, nestedClass)).describedAs("""
-                The nested class this guard uses must be one surefire's default <includes> actually
-                claim — otherwise the exclusion assertion below passes vacuously and the guard proves
-                nothing about the duplicate-execution regression it exists to catch.""").isTrue();
-        assertThat(matchesAny(excludes, outerClass)).isTrue();
-        assertThat(matchesAny(excludes, nestedClass)).describedAs("""
-                A nested class inside an integration *ITest whose name matches surefire's default
-                <includes> must still be excluded from test-non-integration, or it runs both there
-                and on the integration worker that owns its enclosing class.""").isTrue();
+        List<String> missing = transfers
+                .stream()
+                .filter(path -> !Files.isRegularFile(TEST_ROOT.resolve(path)))
+                .toList();
+
+        assertThat(missing).describedAs("""
+                Transferred test classes named in pom.xml that no longer exist under %s. Surefire ignores a
+                pattern that matches nothing, so the class silently reverts to the shard its name implies and
+                the worker balance these transfers bought degrades with no failing test. Update the pom
+                patterns and the transfer constants here to the class's new path.""", TEST_ROOT).isEmpty();
+    }
+
+    @Test
+    void nestedTestClassesInsideIntegrationTestsRunOnExactlyOneWorker() throws Exception {
+        Map<String, List<String>> includes = profileIncludes();
+        Map<String, List<String>> excludes = profileExcludes();
+
+        List<String> surefireNamed = new ArrayList<>();
+        List<String> violations = new ArrayList<>();
+        try (Stream<Path> stream = Files.walk(INTEGRATION_ROOT)) {
+            List<Path> outers = stream
+                    .filter(p -> p.toString().endsWith(".java"))
+                    .filter(TestClassTaxonomy::isRunnableTest)
+                    .sorted()
+                    .toList();
+            for (Path outer : outers) {
+                String outerRel = relative(outer);
+                List<String> outerClaims = claimingProfiles(outerRel, includes, excludes);
+                for (TestClassTaxonomy.NestedClass nested : TestClassTaxonomy.nestedClasses(outer)) {
+                    String nestedRel = nestedClassPath(outerRel, nested.name());
+                    boolean matchesSurefireDefaults = matchesAny(SUREFIRE_DEFAULT_INCLUDES, nestedRel);
+                    if (!matchesSurefireDefaults && !nested.junitNested()) {
+                        continue; // an ordinary helper class no profile could ever claim as a test
+                    }
+                    if (matchesSurefireDefaults) {
+                        surefireNamed.add(nestedRel);
+                    }
+                    List<String> claims = claimingProfiles(nestedRel, includes, excludes);
+                    if (claims.contains(NON_INTEGRATION_PROFILE)) {
+                        violations
+                                .add(nestedRel + " claimed by " + NON_INTEGRATION_PROFILE
+                                        + " while its enclosing class runs on " + outerClaims);
+                    } else if (nested.junitNested()) {
+                        if (!outerClaims.containsAll(claims)) {
+                            violations
+                                    .add(nestedRel + " claimed by " + claims + " but its enclosing class runs on "
+                                            + outerClaims);
+                        }
+                    } else if (claims.size() != 1) {
+                        violations
+                                .add(nestedRel + " is not a @Nested class, so it only runs if a profile claims it "
+                                        + "directly, but it is claimed by " + claims);
+                    }
+                }
+            }
+        }
+
+        assertThat(surefireNamed)
+                .describedAs(
+                        """
+                                No nested class under %s carries a name surefire's default <includes> would claim, so this guard
+                                proves nothing about the duplicate-execution regression it exists to catch. Either the nested-class
+                                parsing broke, or the tree changed shape — re-derive the guard against what it now contains.""",
+                        INTEGRATION_ROOT)
+                .isNotEmpty();
+        assertThat(violations).describedAs("""
+                Nested classes inside integration tests that do not run on exactly one CI worker. Surefire scans
+                Outer$Nested.class as its own entry, so a nested class claimed by a worker that does not run its
+                enclosing class runs twice across the matrix, and a non-@Nested one claimed by nobody never runs.
+                Fix the profile patterns in pom.xml — the integration excludes must keep their trailing .* so they
+                cover the $-suffixed entries.""").isEmpty();
     }
 
     @Test
@@ -206,6 +259,48 @@ class CiTestSplitTest {
     /** Whether a test class path (relative to {@link #TEST_ROOT}, {@code /}-separated) matches any pattern. */
     private static boolean matchesAny(List<String> patterns, String relPath) {
         return patterns.stream().anyMatch(pattern -> matches(pattern, relPath));
+    }
+
+    /**
+     * The declared {@code <includes>} per profile, falling back to surefire's defaults where a profile declares none.
+     */
+    private static Map<String, List<String>> profileIncludes() throws Exception {
+        Map<String, List<String>> includes = new HashMap<>();
+        for (String profile : CI_PROFILES) {
+            List<String> declared = profilePatterns(profile, "include");
+            includes.put(profile, declared.isEmpty() ? SUREFIRE_DEFAULT_INCLUDES : declared);
+        }
+        return includes;
+    }
+
+    private static Map<String, List<String>> profileExcludes() throws Exception {
+        Map<String, List<String>> excludes = new HashMap<>();
+        for (String profile : CI_PROFILES) {
+            excludes.put(profile, profilePatterns(profile, "exclude"));
+        }
+        return excludes;
+    }
+
+    /** The profiles whose surefire patterns claim the given class path — an include matches and no exclude does. */
+    private static List<String> claimingProfiles(String relPath, Map<String, List<String>> includes,
+            Map<String, List<String>> excludes) {
+        return CI_PROFILES
+                .stream()
+                .filter(profile -> matchesAny(includes.get(profile), relPath)
+                        && !matchesAny(excludes.get(profile), relPath))
+                .toList();
+    }
+
+    /** A test class path relative to {@link #TEST_ROOT}, {@code /}-separated on every platform. */
+    private static String relative(Path javaFile) {
+        return TEST_ROOT.relativize(javaFile).toString().replace('\\', '/');
+    }
+
+    /**
+     * The path surefire matches a nested class by: the enclosing class file with {@code $Nested} appended to its name.
+     */
+    private static String nestedClassPath(String outerRelPath, String nestedName) {
+        return outerRelPath.substring(0, outerRelPath.length() - ".java".length()) + "$" + nestedName + ".java";
     }
 
     /**

--- a/src/test/java/com/otilm/core/architecture/TestClassTaxonomy.java
+++ b/src/test/java/com/otilm/core/architecture/TestClassTaxonomy.java
@@ -49,6 +49,12 @@ final class TestClassTaxonomy {
     private static final Pattern CLASS_DECL = Pattern
             .compile("(abstract\\s+)?class\\s+(\\w+)(?:<[^>]*>)?(?:\\s+extends\\s+(\\w+))?");
 
+    // Nested class declaration: an indented `class` keyword (the primary type is at column 0), preceded by any run of
+    // annotations and modifiers, which may span lines — `@Nested` typically sits on its own line above the keyword.
+    private static final Pattern NESTED_CLASS_DECL = Pattern
+            .compile("(?m)^[ \\t]+((?:(?:@\\w+(?:\\([^)]*\\))?|public|protected|private|static|final|abstract|sealed"
+                    + "|non-sealed)\\s+)*)class\\s+(\\w+)");
+
     // Annotation checks are:
     // (a) line-anchored — a real annotation begins its line (after indentation)
     // (b) token-anchored with `\b` so `@Test` does not match `@TestConfiguration`/`@Testcontainers`/`@TestInstance`.
@@ -162,6 +168,27 @@ final class TestClassTaxonomy {
         Matcher m = CLASS_DECL.matcher(src);
         boolean primaryIsAbstract = m.find() && m.group(1) != null;
         return !primaryIsAbstract;
+    }
+
+    /**
+     * A class declared inside another class in the same file.
+     *
+     * @param name the nested class simple name
+     * @param junitNested whether the declaration carries {@code @Nested}
+     */
+    record NestedClass(String name, boolean junitNested) {
+    }
+
+    /**
+     * Every class declared inside the file's primary type, in declaration order.
+     */
+    static List<NestedClass> nestedClasses(Path javaFile) {
+        List<NestedClass> nested = new ArrayList<>();
+        Matcher m = NESTED_CLASS_DECL.matcher(code(javaFile));
+        while (m.find()) {
+            nested.add(new NestedClass(m.group(2), m.group(1).contains("@Nested")));
+        }
+        return nested;
     }
 
     /**


### PR DESCRIPTION
## Summary

- stop nested integration tests from running again in the non-integration worker
- preserve the integration shard assignment derived from the 20-run experiment in #1997
- guard all profile boundaries and explicit transfers against gaps or duplicate execution

## Established effects

- removes 125 duplicate nested integration-test executions from the non-integration worker
- post-change 20-run means were 9:42, 9:19, and 9:14 for the three integration workers, a 28-second (5.1%) spread; the non-integration worker is a separate ~3-minute leg (mean 2:56) and is not part of that spread
- leaves the existing four-worker workflow and coverage merge unchanged

Advances OmniTrustILM/ilm#308.

## Validation

- `mvn -B -ntp test -Dmaven.compiler.proc=full -Dtest=CiTestSplitTest,TestClassTaxonomyTest,ContextSignatureTest`
- `mvn -B -ntp test -Ptest-non-integration -Dmaven.compiler.skip=true` (2,111 tests; zero integration reports)
