### PR TITLE
Chop annotation member arrays and wrap annotation arguments

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -10,3 +10,6 @@
 
 # Break enum constants one per line
 169e29d8e2c961fd3ef36e49c44d060b4dd53c31
+
+# Chop annotation member arrays and wrap annotation arguments
+48d9ea738c5584b47ab7f75f25c3360b40cc08f0

--- a/src/main/java/com/otilm/core/api/acme/AcmeControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/acme/AcmeControllerImpl.java
@@ -38,33 +38,38 @@ public class AcmeControllerImpl implements AcmeController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_PROFILE, operation = Operation.ACME_DIRECTORY)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_PROFILE,
+            operation = Operation.ACME_DIRECTORY)
     public ResponseEntity<Directory> getDirectory(@LogResource(name = true) String acmeProfileName)
             throws NotFoundException, AcmeProblemDocumentException {
         return acmeService.getDirectory(acmeProfileName, getRequestUri(), false);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_PROFILE, operation = Operation.ACME_NONCE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_PROFILE,
+            operation = Operation.ACME_NONCE)
     public ResponseEntity<?> getNonce(@LogResource(name = true) String acmeProfileName) {
         return acmeService.getNonce(acmeProfileName, false, getRequestUri(), false);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_PROFILE, operation = Operation.ACME_NONCE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_PROFILE,
+            operation = Operation.ACME_NONCE)
     public ResponseEntity<?> headNonce(@LogResource(name = true) String acmeProfileName) {
         return acmeService.getNonce(acmeProfileName, true, getRequestUri(), false);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_PROFILE, operation = Operation.CREATE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_PROFILE, operation = Operation.CREATE)
     public ResponseEntity<Account> newAccount(@LogResource(name = true, affiliated = true) String acmeProfileName,
             String jwsBody) throws AcmeProblemDocumentException, NotFoundException {
         return acmeService.newAccount(acmeProfileName, jwsBody, getRequestUri(), false);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_PROFILE, operation = Operation.UPDATE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_PROFILE, operation = Operation.UPDATE)
     public ResponseEntity<Account> updateAccount(@LogResource(name = true, affiliated = true) String acmeProfileName,
             @LogResource(name = true) String accountId, String jwsBody)
             throws AcmeProblemDocumentException, NotFoundException {
@@ -72,21 +77,25 @@ public class AcmeControllerImpl implements AcmeController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_PROFILE, operation = Operation.ACME_KEY_ROLLOVER)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_PROFILE,
+            operation = Operation.ACME_KEY_ROLLOVER)
     public ResponseEntity<?> keyRollover(@LogResource(name = true, affiliated = true) String acmeProfileName,
             String jwsBody) throws NotFoundException, AcmeProblemDocumentException {
         return acmeService.keyRollover(acmeProfileName, jwsBody, getRequestUri(), false);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, operation = Operation.CREATE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ORDER,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, operation = Operation.CREATE)
     public ResponseEntity<Order> newOrder(String acmeProfileName, String jwsBody)
             throws AcmeProblemDocumentException, NotFoundException {
         return acmeService.newOrder(acmeProfileName, jwsBody, getRequestUri(), false);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, operation = Operation.LIST)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ORDER,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, operation = Operation.LIST)
     public ResponseEntity<List<Order>> listOrders(String acmeProfileName,
             @LogResource(name = true, affiliated = true) String accountId)
             throws NotFoundException, AcmeProblemDocumentException {
@@ -94,7 +103,8 @@ public class AcmeControllerImpl implements AcmeController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_AUTHORIZATION, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, operation = Operation.DETAIL)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_AUTHORIZATION,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, operation = Operation.DETAIL)
     public ResponseEntity<Authorization> getAuthorizations(String acmeProfileName,
             @LogResource(name = true) String authorizationId, String jwsBody)
             throws NotFoundException, AcmeProblemDocumentException {
@@ -102,7 +112,8 @@ public class AcmeControllerImpl implements AcmeController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_CHALLENGE, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, operation = Operation.ACME_VALIDATE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_CHALLENGE,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, operation = Operation.ACME_VALIDATE)
     public ResponseEntity<Challenge> validateChallenge(String acmeProfileName,
             @LogResource(name = true) String challengeId)
             throws NotFoundException, NoSuchAlgorithmException, InvalidKeySpecException, AcmeProblemDocumentException {
@@ -110,14 +121,17 @@ public class AcmeControllerImpl implements AcmeController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, operation = Operation.DETAIL)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ORDER,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, operation = Operation.DETAIL)
     public ResponseEntity<Order> getOrder(String acmeProfileName, @LogResource(name = true) String orderId)
             throws NotFoundException, AcmeProblemDocumentException {
         return acmeService.getOrder(acmeProfileName, orderId, getRequestUri(), false);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, operation = Operation.ACME_FINALIZE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ORDER,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT,
+            operation = Operation.ACME_FINALIZE)
     public ResponseEntity<Order> finalizeOrder(String acmeProfileName, @LogResource(name = true) String orderId,
             String jwsBody) throws AcmeProblemDocumentException, ConnectorException, JsonProcessingException,
             CertificateException, AlreadyExistException {
@@ -125,14 +139,16 @@ public class AcmeControllerImpl implements AcmeController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.CERTIFICATE, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, operation = Operation.DOWNLOAD)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.CERTIFICATE,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, operation = Operation.DOWNLOAD)
     public ResponseEntity<Resource> downloadCertificate(String acmeProfileName, String certificateId)
             throws NotFoundException, CertificateException {
         return acmeService.downloadCertificate(acmeProfileName, certificateId, getRequestUri(), false);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.CERTIFICATE, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_PROFILE, operation = Operation.REVOKE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.CERTIFICATE,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_PROFILE, operation = Operation.REVOKE)
     public ResponseEntity<?> revokeCertificate(@LogResource(name = true, affiliated = true) String acmeProfileName,
             String jwsBody) throws AcmeProblemDocumentException, ConnectorException, CertificateException {
         return acmeService.revokeCertificate(acmeProfileName, jwsBody, getRequestUri(), false);

--- a/src/main/java/com/otilm/core/api/acme/AcmeRaProfileControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/acme/AcmeRaProfileControllerImpl.java
@@ -39,34 +39,39 @@ public class AcmeRaProfileControllerImpl implements AcmeRaProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.RA_PROFILE, operation = Operation.ACME_DIRECTORY)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.RA_PROFILE,
+            operation = Operation.ACME_DIRECTORY)
     public ResponseEntity<Directory> getDirectory(@LogResource(name = true) @PathVariable String raProfileName)
             throws NotFoundException, AcmeProblemDocumentException {
         return acmeService.getDirectory(raProfileName, getRequestUri(), true);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.RA_PROFILE, operation = Operation.ACME_NONCE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.RA_PROFILE,
+            operation = Operation.ACME_NONCE)
     public ResponseEntity<?> getNonce(@LogResource(name = true) String raProfileName) {
         return acmeService.getNonce(raProfileName, false, getRequestUri(), true);
 
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.RA_PROFILE, operation = Operation.ACME_NONCE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.RA_PROFILE,
+            operation = Operation.ACME_NONCE)
     public ResponseEntity<?> headNonce(@LogResource(name = true) String raProfileName) {
         return acmeService.getNonce(raProfileName, true, getRequestUri(), true);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, affiliatedResource = com.otilm.api.model.core.auth.Resource.RA_PROFILE, operation = Operation.CREATE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.RA_PROFILE, operation = Operation.CREATE)
     public ResponseEntity<Account> newAccount(@LogResource(name = true, affiliated = true) String raProfileName,
             String jwsBody) throws AcmeProblemDocumentException, NotFoundException {
         return acmeService.newAccount(raProfileName, jwsBody, getRequestUri(), true);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, affiliatedResource = com.otilm.api.model.core.auth.Resource.RA_PROFILE, operation = Operation.UPDATE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.RA_PROFILE, operation = Operation.UPDATE)
     public ResponseEntity<Account> updateAccount(@LogResource(name = true, affiliated = true) String raProfileName,
             @LogResource(name = true) String accountId, String jwsBody)
             throws AcmeProblemDocumentException, NotFoundException {
@@ -74,21 +79,25 @@ public class AcmeRaProfileControllerImpl implements AcmeRaProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, affiliatedResource = com.otilm.api.model.core.auth.Resource.RA_PROFILE, operation = Operation.ACME_KEY_ROLLOVER)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.RA_PROFILE,
+            operation = Operation.ACME_KEY_ROLLOVER)
     public ResponseEntity<?> keyRollover(@LogResource(name = true, affiliated = true) String raProfileName,
             String jwsBody) throws NotFoundException, AcmeProblemDocumentException {
         return acmeService.keyRollover(raProfileName, jwsBody, getRequestUri(), true);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, operation = Operation.CREATE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ORDER,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, operation = Operation.CREATE)
     public ResponseEntity<Order> newOrder(String raProfileName, String jwsBody)
             throws AcmeProblemDocumentException, NotFoundException {
         return acmeService.newOrder(raProfileName, jwsBody, getRequestUri(), true);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, operation = Operation.LIST)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ORDER,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, operation = Operation.LIST)
     public ResponseEntity<List<Order>> listOrders(String raProfileName,
             @LogResource(name = true, affiliated = true) String accountId)
             throws NotFoundException, AcmeProblemDocumentException {
@@ -96,7 +105,8 @@ public class AcmeRaProfileControllerImpl implements AcmeRaProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_AUTHORIZATION, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, operation = Operation.DETAIL)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_AUTHORIZATION,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, operation = Operation.DETAIL)
     public ResponseEntity<Authorization> getAuthorizations(String raProfileName,
             @LogResource(name = true) String authorizationId, String jwsBody)
             throws NotFoundException, AcmeProblemDocumentException {
@@ -104,7 +114,8 @@ public class AcmeRaProfileControllerImpl implements AcmeRaProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_CHALLENGE, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, operation = Operation.ACME_VALIDATE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_CHALLENGE,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, operation = Operation.ACME_VALIDATE)
     public ResponseEntity<Challenge> validateChallenge(String raProfileName,
             @LogResource(name = true) String challengeId)
             throws NotFoundException, NoSuchAlgorithmException, InvalidKeySpecException, AcmeProblemDocumentException {
@@ -112,14 +123,17 @@ public class AcmeRaProfileControllerImpl implements AcmeRaProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, operation = Operation.DETAIL)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ORDER,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, operation = Operation.DETAIL)
     public ResponseEntity<Order> getOrder(String raProfileName, @LogResource(name = true) String orderId)
             throws NotFoundException, AcmeProblemDocumentException {
         return acmeService.getOrder(raProfileName, orderId, getRequestUri(), true);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, operation = Operation.ACME_FINALIZE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.ACME_ORDER,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT,
+            operation = Operation.ACME_FINALIZE)
     public ResponseEntity<Order> finalizeOrder(String raProfileName, @LogResource(name = true) String orderId,
             String jwsBody) throws AcmeProblemDocumentException, ConnectorException, JsonProcessingException,
             CertificateException, AlreadyExistException {
@@ -127,14 +141,16 @@ public class AcmeRaProfileControllerImpl implements AcmeRaProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.CERTIFICATE, affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, operation = Operation.DOWNLOAD)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.CERTIFICATE,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.ACME_ORDER, operation = Operation.DOWNLOAD)
     public ResponseEntity<Resource> downloadCertificate(String raProfileName, String certificateId)
             throws NotFoundException, CertificateException {
         return acmeService.downloadCertificate(raProfileName, certificateId, getRequestUri(), true);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.CERTIFICATE, affiliatedResource = com.otilm.api.model.core.auth.Resource.RA_PROFILE, operation = Operation.REVOKE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = com.otilm.api.model.core.auth.Resource.CERTIFICATE,
+            affiliatedResource = com.otilm.api.model.core.auth.Resource.RA_PROFILE, operation = Operation.REVOKE)
     public ResponseEntity<?> revokeCertificate(@LogResource(name = true, affiliated = true) String raProfileName,
             String jwsBody) throws AcmeProblemDocumentException, ConnectorException, CertificateException {
         return acmeService.revokeCertificate(raProfileName, jwsBody, getRequestUri(), true);

--- a/src/main/java/com/otilm/core/api/cmp/CmpControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/cmp/CmpControllerImpl.java
@@ -34,7 +34,8 @@ public class CmpControllerImpl implements CmpController {
      * @throws CmpBaseException - http get is not allowed
      */
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CERTIFICATE, affiliatedResource = Resource.CMP_PROFILE, operation = Operation.UNKNOWN)
+    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CERTIFICATE, affiliatedResource = Resource.CMP_PROFILE,
+            operation = Operation.UNKNOWN)
     public ResponseEntity<byte[]> doGet(@LogResource(name = true, affiliated = true) String cmpProfileName,
             byte[] request) throws CmpBaseException {
         throw new CmpProcessingException(PKIFailureInfo.badRequest, ImplFailureInfo.CMPCNTR001);
@@ -49,7 +50,8 @@ public class CmpControllerImpl implements CmpController {
      * @throws CmpBaseException if any error has been raised
      */
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CERTIFICATE, affiliatedResource = Resource.CMP_PROFILE, operation = Operation.UNKNOWN)
+    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CERTIFICATE, affiliatedResource = Resource.CMP_PROFILE,
+            operation = Operation.UNKNOWN)
     public ResponseEntity<byte[]> doPost(@LogResource(name = true, affiliated = true) String cmpProfileName,
             byte[] request) throws CmpBaseException {
         return cmpService.handlePost(cmpProfileName, request);

--- a/src/main/java/com/otilm/core/api/cmp/CmpRaProfileControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/cmp/CmpRaProfileControllerImpl.java
@@ -33,7 +33,8 @@ public class CmpRaProfileControllerImpl implements CmpRaProfileController {
      * @throws CmpBaseException - http get is not allowed
      */
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CERTIFICATE, affiliatedResource = Resource.CMP_PROFILE, operation = Operation.UNKNOWN)
+    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CERTIFICATE, affiliatedResource = Resource.CMP_PROFILE,
+            operation = Operation.UNKNOWN)
     public ResponseEntity<byte[]> doGet(String raProfileName, byte[] request) throws CmpBaseException {
         throw new CmpProcessingException(PKIFailureInfo.badRequest, ImplFailureInfo.CMPCNTR001);
     }
@@ -47,7 +48,8 @@ public class CmpRaProfileControllerImpl implements CmpRaProfileController {
      * @throws CmpBaseException if any error has been raised
      */
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CERTIFICATE, affiliatedResource = Resource.CMP_PROFILE, operation = Operation.UNKNOWN)
+    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CERTIFICATE, affiliatedResource = Resource.CMP_PROFILE,
+            operation = Operation.UNKNOWN)
     public ResponseEntity<byte[]> doPost(String raProfileName, byte[] request) throws CmpBaseException {
         return cmpService.handlePost(raProfileName, request);
     }

--- a/src/main/java/com/otilm/core/api/scep/ScepControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/scep/ScepControllerImpl.java
@@ -23,14 +23,16 @@ public class ScepControllerImpl implements ScepController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CERTIFICATE, affiliatedResource = Resource.SCEP_PROFILE, operation = Operation.UNKNOWN)
+    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CERTIFICATE, affiliatedResource = Resource.SCEP_PROFILE,
+            operation = Operation.UNKNOWN)
     public ResponseEntity<Object> doGet(@LogResource(name = true, affiliated = true) String scepProfileName,
             String operation, String message) throws ScepException {
         return scepService.handleGet(scepProfileName, operation, message);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CERTIFICATE, affiliatedResource = Resource.SCEP_PROFILE, operation = Operation.UNKNOWN)
+    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CERTIFICATE, affiliatedResource = Resource.SCEP_PROFILE,
+            operation = Operation.UNKNOWN)
     public ResponseEntity<Object> doPost(@LogResource(name = true, affiliated = true) String scepProfileName,
             String operation, byte[] request) throws ScepException {
         return scepService.handlePost(scepProfileName, operation, request);

--- a/src/main/java/com/otilm/core/api/scep/ScepRaProfileControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/scep/ScepRaProfileControllerImpl.java
@@ -22,13 +22,15 @@ public class ScepRaProfileControllerImpl implements ScepRaProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CERTIFICATE, affiliatedResource = Resource.SCEP_PROFILE, operation = Operation.UNKNOWN)
+    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CERTIFICATE, affiliatedResource = Resource.SCEP_PROFILE,
+            operation = Operation.UNKNOWN)
     public ResponseEntity<Object> doGet(String raProfileName, String operation, String message) throws ScepException {
         return scepService.handleGet(raProfileName, operation, message);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CERTIFICATE, affiliatedResource = Resource.SCEP_PROFILE, operation = Operation.UNKNOWN)
+    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CERTIFICATE, affiliatedResource = Resource.SCEP_PROFILE,
+            operation = Operation.UNKNOWN)
     public ResponseEntity<Object> doPost(String raProfileName, String operation, byte[] request) throws ScepException {
         return scepService.handlePost(raProfileName, operation, request);
     }

--- a/src/main/java/com/otilm/core/api/tsp/TspControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/tsp/TspControllerImpl.java
@@ -35,7 +35,8 @@ public class TspControllerImpl implements TspController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.SIGNING_RECORD, affiliatedResource = Resource.TSP_PROFILE, operation = Operation.SIGN)
+    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.SIGNING_RECORD,
+            affiliatedResource = Resource.TSP_PROFILE, operation = Operation.SIGN)
     public ResponseEntity<byte[]> timestamp(@LogResource(name = true, affiliated = true) String tspProfileName,
             byte[] request) {
         byte[] responseBytes;

--- a/src/main/java/com/otilm/core/api/tsp/TspSigningProfileControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/tsp/TspSigningProfileControllerImpl.java
@@ -35,7 +35,8 @@ public class TspSigningProfileControllerImpl implements TspSigningProfileControl
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.SIGNING_RECORD, affiliatedResource = Resource.SIGNING_PROFILE, operation = Operation.SIGN)
+    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.SIGNING_RECORD,
+            affiliatedResource = Resource.SIGNING_PROFILE, operation = Operation.SIGN)
     public ResponseEntity<byte[]> timestamp(@LogResource(name = true, affiliated = true) String signingProfileName,
             byte[] request) {
         byte[] responseBytes;

--- a/src/main/java/com/otilm/core/api/v2/client/ClientOperationControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/v2/client/ClientOperationControllerImpl.java
@@ -44,7 +44,8 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE, affiliatedResource = Resource.RA_PROFILE, operation = Operation.ISSUE)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE,
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.ISSUE)
     public ClientCertificateDataResponseDto issueExistingCertificate(String authorityUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid,
             @LogResource(uuid = true) String certificateUuid, ClientCertificateIssueRequestDto request)
@@ -56,7 +57,8 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE, affiliatedResource = Resource.RA_PROFILE, operation = Operation.REQUEST)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE,
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.REQUEST)
     public ClientCertificateDataResponseDto issueCertificate(String authorityUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid, ClientCertificateIssueRequestDto request)
             throws NotFoundException, CertificateException, IOException, NoSuchAlgorithmException, InvalidKeyException,
@@ -67,7 +69,8 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE, affiliatedResource = Resource.RA_PROFILE, operation = Operation.RENEW)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE,
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.RENEW)
     public ClientCertificateDataResponseDto renewCertificate(String authorityUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid,
             @LogResource(uuid = true) String certificateUuid, ClientCertificateRenewRequestDto request)
@@ -79,7 +82,8 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE, affiliatedResource = Resource.RA_PROFILE, operation = Operation.REKEY)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE,
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.REKEY)
     public ClientCertificateDataResponseDto rekeyCertificate(String authorityUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid,
             @LogResource(uuid = true) String certificateUuid, ClientCertificateRekeyRequestDto request)
@@ -91,7 +95,8 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE, affiliatedResource = Resource.RA_PROFILE, operation = Operation.REVOKE)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE,
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.REVOKE)
     public void revokeCertificate(String authorityUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid,
             @LogResource(uuid = true) String certificateUuid, ClientCertificateRevocationDto request)
@@ -102,7 +107,8 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "issue", affiliatedResource = Resource.RA_PROFILE, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "issue",
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listIssueCertificateAttributes(String authorityUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid)
             throws ConnectorException, NotFoundException {
@@ -112,7 +118,8 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "issue", affiliatedResource = Resource.RA_PROFILE, operation = Operation.VALIDATE_ATTRIBUTES)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "issue",
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.VALIDATE_ATTRIBUTES)
     public void validateIssueCertificateAttributes(String authorityUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid, List<RequestAttribute> attributes)
             throws ConnectorException, ValidationException, NotFoundException {
@@ -122,7 +129,8 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "revoke", affiliatedResource = Resource.RA_PROFILE, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "revoke",
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listRevokeCertificateAttributes(String authorityUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid)
             throws ConnectorException, NotFoundException {
@@ -132,7 +140,8 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "register", affiliatedResource = Resource.RA_PROFILE, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "register",
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listRegisterCertificateAttributes(String authorityUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid)
             throws ConnectorException, NotFoundException {
@@ -142,7 +151,8 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "revoke", affiliatedResource = Resource.RA_PROFILE, operation = Operation.VALIDATE_ATTRIBUTES)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "revoke",
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.VALIDATE_ATTRIBUTES)
     public void validateRevokeCertificateAttributes(String authorityUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid, List<RequestAttribute> attributes)
             throws ConnectorException, ValidationException, NotFoundException {
@@ -152,7 +162,8 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE, affiliatedResource = Resource.RA_PROFILE, operation = Operation.FINALIZE_ISSUE)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE,
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.FINALIZE_ISSUE)
     public com.otilm.api.model.core.certificate.CertificateDetailDto manuallyIssueCertificate(String authorityUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid,
             @LogResource(uuid = true) String certificateUuid,
@@ -164,7 +175,8 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE, affiliatedResource = Resource.RA_PROFILE, operation = Operation.CONFIRM_REVOKE)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE,
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.CONFIRM_REVOKE)
     public void manuallyConfirmRevoke(String authorityUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid,
             @LogResource(uuid = true) String certificateUuid) throws NotFoundException {
@@ -174,7 +186,8 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE, affiliatedResource = Resource.RA_PROFILE, operation = Operation.CANCEL)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE,
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.CANCEL)
     public com.otilm.api.model.core.certificate.CertificateDetailDto cancelPendingCertificateOperation(
             String authorityUuid, @LogResource(uuid = true, affiliated = true) String raProfileUuid,
             @LogResource(uuid = true) String certificateUuid,
@@ -186,7 +199,8 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE, affiliatedResource = Resource.RA_PROFILE, operation = Operation.REGISTER)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE,
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.REGISTER)
     public ClientCertificateDataResponseDto registerCertificate(String authorityUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid, ClientCertificateRegistrationDto request)
             throws NotFoundException, ValidationException, ConnectorException, AttributeException {
@@ -196,7 +210,8 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY, operation = Operation.LIST)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY,
+            operation = Operation.LIST)
     public AvailableOperationsDto listAvailableOperations(
             @LogResource(uuid = true, affiliated = true) String authorityUuid,
             @LogResource(uuid = true) String raProfileUuid) throws NotFoundException {

--- a/src/main/java/com/otilm/core/api/web/AcmeProfileControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/AcmeProfileControllerImpl.java
@@ -118,7 +118,8 @@ public class AcmeProfileControllerImpl implements AcmeProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.ACME_PROFILE, affiliatedResource = Resource.RA_PROFILE, operation = Operation.UPDATE_PROTOCOL_ISSUE_PROFILE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.ACME_PROFILE, affiliatedResource = Resource.RA_PROFILE,
+            operation = Operation.UPDATE_PROTOCOL_ISSUE_PROFILE)
     public void updateRaProfile(@LogResource(uuid = true) String uuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid) throws NotFoundException {
         acmeProfileService.updateRaProfile(SecuredUUID.fromString(uuid), raProfileUuid);

--- a/src/main/java/com/otilm/core/api/web/ApprovalProfileControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/ApprovalProfileControllerImpl.java
@@ -96,7 +96,8 @@ public class ApprovalProfileControllerImpl implements ApprovalProfileController 
     }
 
     @Override
-    @AuditLogged(module = Module.APPROVALS, resource = Resource.APPROVAL_PROFILE, operation = Operation.LIST_ASSOCIATIONS)
+    @AuditLogged(module = Module.APPROVALS, resource = Resource.APPROVAL_PROFILE,
+            operation = Operation.LIST_ASSOCIATIONS)
     public List<ResourceObjectDto> getAssociations(@LogResource(uuid = true) UUID uuid) throws NotFoundException {
         return approvalProfileService.getAssociations(SecuredUUID.fromUUID(uuid));
     }
@@ -119,7 +120,8 @@ public class ApprovalProfileControllerImpl implements ApprovalProfileController 
     }
 
     @Override
-    @AuditLogged(module = Module.APPROVALS, resource = Resource.APPROVAL_PROFILE, operation = Operation.LIST_ASSOCIATIONS)
+    @AuditLogged(module = Module.APPROVALS, resource = Resource.APPROVAL_PROFILE,
+            operation = Operation.LIST_ASSOCIATIONS)
     public List<ApprovalProfileDto> getAssociatedApprovalProfiles(
             @LogResource(resource = true, affiliated = true) Resource resource,
             @LogResource(uuid = true, affiliated = true) UUID associationObjectUuid) throws NotFoundException {

--- a/src/main/java/com/otilm/core/api/web/AuditLogControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/AuditLogControllerImpl.java
@@ -56,7 +56,8 @@ public class AuditLogControllerImpl implements AuditLogController {
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.AUDIT_LOG, operation = Operation.LIST)
+    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.AUDIT_LOG,
+            operation = Operation.LIST)
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformation() {
         return auditLogService.getSearchableFieldInformationByGroup();
     }

--- a/src/main/java/com/otilm/core/api/web/AuthorityInstanceControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/AuthorityInstanceControllerImpl.java
@@ -84,14 +84,16 @@ public class AuthorityInstanceControllerImpl implements AuthorityInstanceControl
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.END_ENTITY_PROFILE, affiliatedResource = Resource.AUTHORITY, operation = Operation.LIST)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.END_ENTITY_PROFILE,
+            affiliatedResource = Resource.AUTHORITY, operation = Operation.LIST)
     public List<NameAndIdDto> listEntityProfiles(@LogResource(uuid = true, affiliated = true) @PathVariable String uuid)
             throws ConnectorException, NotFoundException {
         return authorityInstanceService.listEndEntityProfiles(SecuredUUID.fromString(uuid));
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.END_ENTITY_PROFILE, affiliatedResource = Resource.AUTHORITY, operation = Operation.LIST_CERTIFICATE_PROFILES)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.END_ENTITY_PROFILE,
+            affiliatedResource = Resource.AUTHORITY, operation = Operation.LIST_CERTIFICATE_PROFILES)
     public List<NameAndIdDto> listCertificateProfiles(
             @LogResource(uuid = true, affiliated = true) @PathVariable String uuid,
             @PathVariable Integer endEntityProfileId) throws ConnectorException, NotFoundException {
@@ -99,14 +101,16 @@ public class AuthorityInstanceControllerImpl implements AuthorityInstanceControl
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.END_ENTITY_PROFILE, affiliatedResource = Resource.AUTHORITY, operation = Operation.LIST_CAS)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.END_ENTITY_PROFILE,
+            affiliatedResource = Resource.AUTHORITY, operation = Operation.LIST_CAS)
     public List<NameAndIdDto> listCAsInProfile(@LogResource(uuid = true, affiliated = true) @PathVariable String uuid,
             @PathVariable Integer endEntityProfileId) throws ConnectorException, NotFoundException {
         return authorityInstanceService.listCAsInProfile(SecuredUUID.fromString(uuid), endEntityProfileId);
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "authority", affiliatedResource = Resource.AUTHORITY, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "authority",
+            affiliatedResource = Resource.AUTHORITY, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listAuthorityInstanceAttributes(@PathVariable("connectorUuid") String connectorUuid,
             @RequestParam(name = "interfaceUuid", required = false) String interfaceUuid)
             throws ConnectorException, NotFoundException, AttributeException {
@@ -116,7 +120,8 @@ public class AuthorityInstanceControllerImpl implements AuthorityInstanceControl
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "raProfile", affiliatedResource = Resource.AUTHORITY, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "raProfile",
+            affiliatedResource = Resource.AUTHORITY, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listRAProfileAttributes(
             @LogResource(uuid = true, affiliated = true) @PathVariable String uuid)
             throws ConnectorException, NotFoundException, AttributeException {
@@ -124,7 +129,8 @@ public class AuthorityInstanceControllerImpl implements AuthorityInstanceControl
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "raProfile", affiliatedResource = Resource.AUTHORITY, operation = Operation.VALIDATE_ATTRIBUTES)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "raProfile",
+            affiliatedResource = Resource.AUTHORITY, operation = Operation.VALIDATE_ATTRIBUTES)
     public void validateRAProfileAttributes(@PathVariable String uuid, @RequestBody List<RequestAttribute> attributes)
             throws ConnectorException, AttributeException, NotFoundException {
         authorityInstanceService.validateRAProfileAttributes(SecuredUUID.fromString(uuid), attributes);

--- a/src/main/java/com/otilm/core/api/web/CallbackControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/CallbackControllerImpl.java
@@ -36,7 +36,8 @@ public class CallbackControllerImpl implements CallbackController {
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, affiliatedResource = Resource.CONNECTOR, operation = Operation.ATTRIBUTE_CALLBACK)
+    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, affiliatedResource = Resource.CONNECTOR,
+            operation = Operation.ATTRIBUTE_CALLBACK)
     public Object callback(@LogResource(uuid = true, affiliated = true) String uuid, String functionGroup,
             @LogResource(name = true) String kind, RequestAttributeCallback callback)
             throws NotFoundException, ConnectorException, ValidationException, AttributeException {
@@ -44,14 +45,16 @@ public class CallbackControllerImpl implements CallbackController {
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, affiliatedResource = Resource.CONNECTOR, operation = Operation.ATTRIBUTE_CALLBACK)
+    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, affiliatedResource = Resource.CONNECTOR,
+            operation = Operation.ATTRIBUTE_CALLBACK)
     public Object callback(UUID uuid, RequestAttributeCallback callback)
             throws ConnectorException, NotFoundException, AttributeException {
         return callbackService.callback(uuid, callback);
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, affiliatedResource = Resource.CONNECTOR, operation = Operation.ATTRIBUTE_CALLBACK)
+    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, affiliatedResource = Resource.CONNECTOR,
+            operation = Operation.ATTRIBUTE_CALLBACK)
     public Object resourceCallback(Resource resource, String parentObjectUuid, RequestAttributeCallback callback)
             throws NotFoundException, ConnectorException, ValidationException, AttributeException {
         return callbackService.resourceCallback(resource, parentObjectUuid, callback);

--- a/src/main/java/com/otilm/core/api/web/CbomControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/CbomControllerImpl.java
@@ -79,7 +79,8 @@ public class CbomControllerImpl implements CbomController {
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.CBOM, operation = Operation.LIST)
+    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.CBOM,
+            operation = Operation.LIST)
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformation() {
         return cbomService.getSearchableFieldInformationByGroup();
     }

--- a/src/main/java/com/otilm/core/api/web/CertificateControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/CertificateControllerImpl.java
@@ -165,7 +165,8 @@ public class CertificateControllerImpl implements CertificateController {
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.CERTIFICATE, operation = Operation.LIST)
+    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.CERTIFICATE,
+            operation = Operation.LIST)
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformation() {
         return certificateService.getSearchableFieldInformationByGroup();
     }
@@ -178,7 +179,8 @@ public class CertificateControllerImpl implements CertificateController {
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE, affiliatedResource = Resource.LOCATION, operation = Operation.LIST)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE, affiliatedResource = Resource.LOCATION,
+            operation = Operation.LIST)
     public List<LocationDto> listLocations(@LogResource(uuid = true) UUID certificateUuid) throws NotFoundException {
         return certificateService.listLocations(SecuredUUID.fromUUID(certificateUuid));
     }
@@ -197,7 +199,8 @@ public class CertificateControllerImpl implements CertificateController {
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "csr", affiliatedResource = Resource.RA_PROFILE, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "csr",
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> getCsrGenerationAttributes(
             @LogResource(uuid = true, affiliated = true) UUID raProfileUuid)
             throws NotFoundException, ConnectorException {
@@ -238,7 +241,8 @@ public class CertificateControllerImpl implements CertificateController {
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE, affiliatedResource = Resource.APPROVAL, operation = Operation.LIST)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE, affiliatedResource = Resource.APPROVAL,
+            operation = Operation.LIST)
     public ApprovalResponseDto listCertificateApprovals(@LogResource(uuid = true) final UUID uuid,
             final PaginationRequestDto paginationRequestDto) {
         return approvalService
@@ -277,14 +281,16 @@ public class CertificateControllerImpl implements CertificateController {
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE, operation = Operation.ASSOCIATE, affiliatedResource = Resource.CERTIFICATE)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE, operation = Operation.ASSOCIATE,
+            affiliatedResource = Resource.CERTIFICATE)
     public void associateCertificates(@LogResource(uuid = true) UUID uuid,
             @LogResource(uuid = true, affiliated = true) UUID certificateUuid) throws NotFoundException {
         certificateService.associateCertificates(uuid, certificateUuid);
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE, operation = Operation.DISASSOCIATE, affiliatedResource = Resource.CERTIFICATE)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.CERTIFICATE, operation = Operation.DISASSOCIATE,
+            affiliatedResource = Resource.CERTIFICATE)
     public void removeCertificateAssociation(@LogResource(uuid = true) UUID uuid,
             @LogResource(uuid = true, affiliated = true) UUID certificateUuid) throws NotFoundException {
         certificateService.removeCertificateAssociation(uuid, certificateUuid);

--- a/src/main/java/com/otilm/core/api/web/CmpProfileControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/CmpProfileControllerImpl.java
@@ -121,14 +121,16 @@ public class CmpProfileControllerImpl implements CmpProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CMP_PROFILE, affiliatedResource = Resource.RA_PROFILE, operation = Operation.UPDATE_PROTOCOL_ISSUE_PROFILE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CMP_PROFILE, affiliatedResource = Resource.RA_PROFILE,
+            operation = Operation.UPDATE_PROTOCOL_ISSUE_PROFILE)
     public void updateRaProfile(@LogResource(uuid = true) String cmpProfileUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid) throws NotFoundException {
         cmpProfileService.updateRaProfile(SecuredUUID.fromString(cmpProfileUuid), raProfileUuid);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CMP_PROFILE, affiliatedResource = Resource.CERTIFICATE, operation = Operation.LIST_PROTOCOL_CERTIFICATES)
+    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.CMP_PROFILE, affiliatedResource = Resource.CERTIFICATE,
+            operation = Operation.LIST_PROTOCOL_CERTIFICATES)
     public List<CertificateDto> listCmpSigningCertificates() {
         return cmpProfileService.listCmpSigningCertificates();
     }

--- a/src/main/java/com/otilm/core/api/web/ComplianceProfileControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/ComplianceProfileControllerImpl.java
@@ -82,7 +82,8 @@ public class ComplianceProfileControllerImpl implements ComplianceProfileControl
     }
 
     @Override
-    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE, affiliatedResource = Resource.COMPLIANCE_RULE, operation = Operation.ADD)
+    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE,
+            affiliatedResource = Resource.COMPLIANCE_RULE, operation = Operation.ADD)
     public ComplianceProfileRuleDto addRule(@LogResource(uuid = true) String uuid,
             ComplianceRuleAdditionRequestDto request)
             throws AlreadyExistException, NotFoundException, ValidationException, ConnectorException {
@@ -90,7 +91,8 @@ public class ComplianceProfileControllerImpl implements ComplianceProfileControl
     }
 
     @Override
-    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE, affiliatedResource = Resource.COMPLIANCE_RULE, operation = Operation.REMOVE)
+    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE,
+            affiliatedResource = Resource.COMPLIANCE_RULE, operation = Operation.REMOVE)
     public void removeRule(@LogResource(uuid = true) String uuid, ComplianceRuleDeletionRequestDto request)
             throws NotFoundException, ConnectorException {
         complianceProfileService.removeRule(SecuredUUID.fromString(uuid), request);
@@ -104,14 +106,16 @@ public class ComplianceProfileControllerImpl implements ComplianceProfileControl
     }
 
     @Override
-    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE, affiliatedResource = Resource.COMPLIANCE_GROUP, operation = Operation.ADD)
+    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE,
+            affiliatedResource = Resource.COMPLIANCE_GROUP, operation = Operation.ADD)
     public void addGroup(@LogResource(uuid = true) String uuid, ComplianceGroupRequestDto request)
             throws AlreadyExistException, NotFoundException, ConnectorException {
         complianceProfileService.addGroup(SecuredUUID.fromString(uuid), request);
     }
 
     @Override
-    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE, affiliatedResource = Resource.COMPLIANCE_GROUP, operation = Operation.REMOVE)
+    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE,
+            affiliatedResource = Resource.COMPLIANCE_GROUP, operation = Operation.REMOVE)
     public void removeGroup(@LogResource(uuid = true) String uuid, ComplianceGroupRequestDto request)
             throws NotFoundException, ConnectorException {
         complianceProfileService.removeGroup(SecuredUUID.fromString(uuid), request);
@@ -124,7 +128,8 @@ public class ComplianceProfileControllerImpl implements ComplianceProfileControl
     }
 
     @Override
-    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE, affiliatedResource = Resource.RA_PROFILE, operation = Operation.LIST_ASSOCIATIONS)
+    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE,
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.LIST_ASSOCIATIONS)
     public List<SimplifiedRaProfileDto> getAssociatedRAProfiles(@LogResource(uuid = true) String uuid)
             throws NotFoundException {
         return complianceProfileService.getAssociatedRAProfiles(SecuredUUID.fromString(uuid));
@@ -145,21 +150,24 @@ public class ComplianceProfileControllerImpl implements ComplianceProfileControl
     }
 
     @Override
-    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE, affiliatedResource = Resource.RA_PROFILE, operation = Operation.ASSOCIATE)
+    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE,
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.ASSOCIATE)
     public void associateProfiles(@LogResource(uuid = true) String uuid, RaProfileAssociationRequestDto raProfiles)
             throws NotFoundException, AlreadyExistException {
         complianceProfileService.associateProfile(SecuredUUID.fromString(uuid), raProfiles);
     }
 
     @Override
-    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE, affiliatedResource = Resource.RA_PROFILE, operation = Operation.DISASSOCIATE)
+    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE,
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.DISASSOCIATE)
     public void disassociateProfiles(@LogResource(uuid = true) String uuid, RaProfileAssociationRequestDto raProfiles)
             throws NotFoundException {
         complianceProfileService.disassociateProfile(SecuredUUID.fromString(uuid), raProfiles);
     }
 
     @Override
-    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE, operation = Operation.CHECK_COMPLIANCE)
+    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE,
+            operation = Operation.CHECK_COMPLIANCE)
     public void checkCompliance(@LogResource(uuid = true) List<String> uuids) throws NotFoundException {
         complianceProfileService.checkCompliance(SecuredUUID.fromList(uuids));
     }

--- a/src/main/java/com/otilm/core/api/web/ConnectorAuthControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/ConnectorAuthControllerImpl.java
@@ -31,49 +31,57 @@ public class ConnectorAuthControllerImpl implements ConnectorAuthController {
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, name = "authBasic", affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, name = "authBasic",
+            affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST_ATTRIBUTES)
     public List<DataAttribute> getBasicAuthAttributes() {
         return connectorAuthService.getBasicAuthAttributes();
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, name = "authBasic", affiliatedResource = Resource.CONNECTOR, operation = Operation.VALIDATE_ATTRIBUTES)
+    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, name = "authBasic",
+            affiliatedResource = Resource.CONNECTOR, operation = Operation.VALIDATE_ATTRIBUTES)
     public void validateBasicAuthAttributes(@RequestBody List<RequestAttribute> attributes) {
         connectorAuthService.validateBasicAuthAttributes(attributes);
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, name = "authCertificate", affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, name = "authCertificate",
+            affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST_ATTRIBUTES)
     public List<DataAttribute> getCertificateAttributes() {
         return connectorAuthService.getCertificateAttributes();
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, name = "authCertificate", affiliatedResource = Resource.CONNECTOR, operation = Operation.VALIDATE_ATTRIBUTES)
+    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, name = "authCertificate",
+            affiliatedResource = Resource.CONNECTOR, operation = Operation.VALIDATE_ATTRIBUTES)
     public void validateCertificateAttributes(@RequestBody List<RequestAttribute> attributes) {
         connectorAuthService.validateCertificateAttributes(attributes);
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, name = "authApiKey", affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, name = "authApiKey",
+            affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST_ATTRIBUTES)
     public List<DataAttribute> getApiKeyAuthAttributes() {
         return connectorAuthService.getApiKeyAuthAttributes();
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, name = "authApiKey", affiliatedResource = Resource.CONNECTOR, operation = Operation.VALIDATE_ATTRIBUTES)
+    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, name = "authApiKey",
+            affiliatedResource = Resource.CONNECTOR, operation = Operation.VALIDATE_ATTRIBUTES)
     public void validateApiKeyAuthAttributes(@RequestBody List<RequestAttribute> attributes) {
         connectorAuthService.validateApiKeyAuthAttributes(attributes);
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, name = "authJwt", affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, name = "authJwt",
+            affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST_ATTRIBUTES)
     public List<DataAttribute> getJWTAuthAttributes() {
         return connectorAuthService.getJWTAuthAttributes();
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, name = "authJwt", affiliatedResource = Resource.CONNECTOR, operation = Operation.VALIDATE_ATTRIBUTES)
+    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, name = "authJwt",
+            affiliatedResource = Resource.CONNECTOR, operation = Operation.VALIDATE_ATTRIBUTES)
     public void validateJWTAuthAttributes(@RequestBody List<RequestAttribute> attributes) {
         connectorAuthService.validateJWTAuthAttributes(attributes);
     }

--- a/src/main/java/com/otilm/core/api/web/ConnectorControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/ConnectorControllerImpl.java
@@ -148,7 +148,8 @@ public class ConnectorControllerImpl implements ConnectorController {
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, affiliatedResource = Resource.CONNECTOR,
+            operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> getAttributes(@LogResource(uuid = true, affiliated = true) @PathVariable String uuid,
             @PathVariable FunctionGroupCode functionGroup, @LogResource(name = true) @PathVariable String kind)
             throws NotFoundException, ConnectorException {
@@ -156,7 +157,8 @@ public class ConnectorControllerImpl implements ConnectorController {
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, affiliatedResource = Resource.CONNECTOR, operation = Operation.VALIDATE_ATTRIBUTES)
+    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, affiliatedResource = Resource.CONNECTOR,
+            operation = Operation.VALIDATE_ATTRIBUTES)
     public void validateAttributes(@LogResource(uuid = true, affiliated = true) @PathVariable String uuid,
             @PathVariable String functionGroup, @LogResource(name = true) @PathVariable String kind,
             @RequestBody List<RequestAttribute> attributes) throws NotFoundException, ConnectorException {
@@ -166,7 +168,8 @@ public class ConnectorControllerImpl implements ConnectorController {
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CORE, resource = Resource.ATTRIBUTE, affiliatedResource = Resource.CONNECTOR,
+            operation = Operation.LIST_ATTRIBUTES)
     public Map<FunctionGroupCode, Map<String, List<BaseAttribute>>> getAttributesAll(
             @LogResource(uuid = true, affiliated = true) String uuid) throws NotFoundException, ConnectorException {
         return connectorService.getAllAttributesOfConnector(SecuredUUID.fromString(uuid));

--- a/src/main/java/com/otilm/core/api/web/CryptographicKeyControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/CryptographicKeyControllerImpl.java
@@ -64,26 +64,30 @@ public class CryptographicKeyControllerImpl implements CryptographicKeyControlle
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.CRYPTOGRAPHIC_KEY, operation = Operation.LIST)
+    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER,
+            affiliatedResource = Resource.CRYPTOGRAPHIC_KEY, operation = Operation.LIST)
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformation() {
         return cryptographicKeyService.getSearchableFieldInformation();
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, affiliatedResource = Resource.TOKEN_PROFILE, operation = Operation.LIST)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            affiliatedResource = Resource.TOKEN_PROFILE, operation = Operation.LIST)
     public List<KeyDto> listKeyPairs(@LogResource(uuid = true, affiliated = true) Optional<String> tokenProfileUuid) {
         return cryptographicKeyService.listKeyPairs(tokenProfileUuid, SecurityFilter.create());
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, affiliatedResource = Resource.TOKEN, operation = Operation.DETAIL)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            affiliatedResource = Resource.TOKEN, operation = Operation.DETAIL)
     public KeyDetailDto getKey(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             @LogResource(uuid = true) String uuid) throws NotFoundException {
         return cryptographicKeyService.getKey(SecuredUUID.fromString(uuid));
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, operation = Operation.DETAIL)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            operation = Operation.DETAIL)
     public KeyDetailDto getKey(@LogResource(uuid = true) String uuid) throws NotFoundException {
         return cryptographicKeyService.getKey(SecuredUUID.fromString(uuid));
     }
@@ -95,21 +99,24 @@ public class CryptographicKeyControllerImpl implements CryptographicKeyControlle
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM, operation = Operation.DETAIL)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM,
+            operation = Operation.DETAIL)
     public KeyItemDetailDto getKeyItem(String uuid, @LogResource(uuid = true) String keyItemUuid)
             throws NotFoundException {
         return cryptographicKeyService.getKeyItem(SecuredUUID.fromString(uuid), keyItemUuid);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM, affiliatedResource = Resource.TOKEN, operation = Operation.DETAIL)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM,
+            affiliatedResource = Resource.TOKEN, operation = Operation.DETAIL)
     public KeyItemDetailDto getKeyItem(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             String uuid, @LogResource(uuid = true) String keyItemUuid) throws NotFoundException {
         return cryptographicKeyService.getKeyItem(SecuredUUID.fromString(uuid), keyItemUuid);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, affiliatedResource = Resource.TOKEN, operation = Operation.CREATE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            affiliatedResource = Resource.TOKEN, operation = Operation.CREATE)
     public KeyDetailDto createKey(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             String tokenProfileUuid, KeyRequestType type, KeyRequestDto request) throws AlreadyExistException,
             ValidationException, ConnectorException, AttributeException, NotFoundException {
@@ -119,53 +126,61 @@ public class CryptographicKeyControllerImpl implements CryptographicKeyControlle
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, operation = Operation.UPDATE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            operation = Operation.UPDATE)
     public KeyDetailDto editKey(@LogResource(uuid = true) String uuid, EditKeyRequestDto request)
             throws ConnectorException, AttributeException, NotFoundException {
         return cryptographicKeyService.editKey(SecuredUUID.fromString(uuid), request);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, affiliatedResource = Resource.TOKEN, operation = Operation.SYNC)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            affiliatedResource = Resource.TOKEN, operation = Operation.SYNC)
     public void syncKeys(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid)
             throws ConnectorException, AttributeException, NotFoundException {
         cryptographicKeyService.syncKeys(SecuredParentUUID.fromString(tokenInstanceUuid));
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, operation = Operation.COMPROMISE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            operation = Operation.COMPROMISE)
     public void compromiseKey(@LogResource(uuid = true) String uuid, CompromiseKeyRequestDto request)
             throws NotFoundException {
         cryptographicKeyService.compromiseKey(UUID.fromString(uuid), request);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, affiliatedResource = Resource.TOKEN, operation = Operation.COMPROMISE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            affiliatedResource = Resource.TOKEN, operation = Operation.COMPROMISE)
     public void compromiseKey(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             @LogResource(uuid = true) String uuid, CompromiseKeyRequestDto request) throws NotFoundException {
         cryptographicKeyService.compromiseKey(UUID.fromString(uuid), request);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, operation = Operation.COMPROMISE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            operation = Operation.COMPROMISE)
     public void compromiseKeys(BulkCompromiseKeyRequestDto request) {
         cryptographicKeyService.compromiseKey(request);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM, operation = Operation.COMPROMISE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM,
+            operation = Operation.COMPROMISE)
     public void compromiseKeyItems(BulkCompromiseKeyItemRequestDto request) {
         cryptographicKeyService.compromiseKeyItems(request);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, operation = Operation.DESTROY)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            operation = Operation.DESTROY)
     public void destroyKey(String uuid, List<String> keyItemUuids) throws ConnectorException, NotFoundException {
         cryptographicKeyService.destroyKey(UUID.fromString(uuid), keyItemUuids);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, affiliatedResource = Resource.TOKEN, operation = Operation.DESTROY)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            affiliatedResource = Resource.TOKEN, operation = Operation.DESTROY)
     public void destroyKey(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             @LogResource(uuid = true) String uuid, List<String> keyItemUuids)
             throws ConnectorException, NotFoundException {
@@ -173,27 +188,31 @@ public class CryptographicKeyControllerImpl implements CryptographicKeyControlle
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, operation = Operation.DESTROY)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            operation = Operation.DESTROY)
     public void destroyKeys(@LogResource(uuid = true) List<String> keyUuids)
             throws ConnectorException, NotFoundException {
         cryptographicKeyService.destroyKey(keyUuids);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM, operation = Operation.DESTROY)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM,
+            operation = Operation.DESTROY)
     public void destroyKeyItems(@LogResource(uuid = true) List<String> keyItemUuids) throws ConnectorException {
         cryptographicKeyService.destroyKeyItems(keyItemUuids);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, operation = Operation.DELETE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            operation = Operation.DELETE)
     public void deleteKey(@LogResource(uuid = true) String uuid, List<String> keyItemUuids)
             throws ConnectorException, NotFoundException {
         cryptographicKeyService.deleteKey(UUID.fromString(uuid), keyItemUuids);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, affiliatedResource = Resource.TOKEN, operation = Operation.DELETE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            affiliatedResource = Resource.TOKEN, operation = Operation.DELETE)
     public void deleteKey(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             @LogResource(uuid = true) String uuid, List<String> keyItemUuids)
             throws ConnectorException, NotFoundException {
@@ -201,76 +220,88 @@ public class CryptographicKeyControllerImpl implements CryptographicKeyControlle
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, operation = Operation.DELETE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            operation = Operation.DELETE)
     public void deleteKeys(@LogResource(uuid = true) List<String> keyUuids) throws ConnectorException {
         cryptographicKeyService.deleteKey(keyUuids);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM, operation = Operation.DELETE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM,
+            operation = Operation.DELETE)
     public void deleteKeyItems(@LogResource(uuid = true) List<String> keyItemUuids) throws ConnectorException {
         cryptographicKeyService.deleteKeyItems(SecurityFilter.create(), keyItemUuids);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, operation = Operation.ENABLE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            operation = Operation.ENABLE)
     public void enableKey(@LogResource(uuid = true) String uuid, List<String> keyItemUuids) throws NotFoundException {
         cryptographicKeyService.enableKey(UUID.fromString(uuid), keyItemUuids);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, affiliatedResource = Resource.TOKEN, operation = Operation.ENABLE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            affiliatedResource = Resource.TOKEN, operation = Operation.ENABLE)
     public void enableKey(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             @LogResource(uuid = true) String uuid, List<String> keyItemUuids) throws NotFoundException {
         cryptographicKeyService.enableKey(UUID.fromString(uuid), keyItemUuids);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, operation = Operation.ENABLE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            operation = Operation.ENABLE)
     public void enableKeys(@LogResource(uuid = true) List<String> uuids) {
         cryptographicKeyService.enableKey(uuids);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM, operation = Operation.ENABLE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM,
+            operation = Operation.ENABLE)
     public void enableKeyItems(@LogResource(uuid = true) List<String> uuids) {
         cryptographicKeyService.enableKeyItems(uuids);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, operation = Operation.DISABLE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            operation = Operation.DISABLE)
     public void disableKey(@LogResource(uuid = true) String uuid, List<String> keyItemUuids) throws NotFoundException {
         cryptographicKeyService.disableKey(UUID.fromString(uuid), keyItemUuids);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, affiliatedResource = Resource.TOKEN, operation = Operation.DISABLE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            affiliatedResource = Resource.TOKEN, operation = Operation.DISABLE)
     public void disableKey(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             @LogResource(uuid = true) String uuid, List<String> keyItemUuids) throws NotFoundException {
         cryptographicKeyService.disableKey(UUID.fromString(uuid), keyItemUuids);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, operation = Operation.DISABLE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            operation = Operation.DISABLE)
     public void disableKeys(@LogResource(uuid = true) List<String> uuids) {
         cryptographicKeyService.disableKey(uuids);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM, operation = Operation.DISABLE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM,
+            operation = Operation.DISABLE)
     public void disableKeyItems(@LogResource(uuid = true) List<String> uuids) {
         cryptographicKeyService.disableKeyItems(uuids);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, operation = Operation.UPDATE_KEY_USAGE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            operation = Operation.UPDATE_KEY_USAGE)
     public void updateKeyUsages(@LogResource(uuid = true) String uuid, UpdateKeyUsageRequestDto request)
             throws NotFoundException, ValidationException {
         cryptographicKeyService.updateKeyUsages(UUID.fromString(uuid), request);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, affiliatedResource = Resource.TOKEN, operation = Operation.UPDATE_KEY_USAGE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            affiliatedResource = Resource.TOKEN, operation = Operation.UPDATE_KEY_USAGE)
     public void updateKeyUsages(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             @LogResource(uuid = true) String uuid, UpdateKeyUsageRequestDto request)
             throws NotFoundException, ValidationException {
@@ -278,19 +309,22 @@ public class CryptographicKeyControllerImpl implements CryptographicKeyControlle
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, operation = Operation.UPDATE_KEY_USAGE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            operation = Operation.UPDATE_KEY_USAGE)
     public void updateKeysUsages(BulkKeyUsageRequestDto request) {
         cryptographicKeyService.updateKeyUsages(request);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM, operation = Operation.UPDATE_KEY_USAGE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM,
+            operation = Operation.UPDATE_KEY_USAGE)
     public void updateKeyItemUsages(BulkKeyItemUsageRequestDto request) {
         cryptographicKeyService.updateKeyItemUsages(request);
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.ATTRIBUTE, affiliatedResource = Resource.TOKEN, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.ATTRIBUTE, affiliatedResource = Resource.TOKEN,
+            operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listCreateKeyAttributes(
             @LogResource(uuid = true, affiliated = true) String tokenInstanceUuid, String tokenProfileUuid,
             @LogResource(name = true) KeyRequestType type) throws ConnectorException, NotFoundException {
@@ -300,14 +334,16 @@ public class CryptographicKeyControllerImpl implements CryptographicKeyControlle
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM, operation = Operation.HISTORY)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM,
+            operation = Operation.HISTORY)
     public List<KeyEventHistoryDto> getEventHistory(@LogResource(uuid = true) String uuid, String keyItemUuid)
             throws NotFoundException {
         return cryptographicKeyService.getEventHistory(UUID.fromString(uuid), UUID.fromString(keyItemUuid));
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM, affiliatedResource = Resource.TOKEN, operation = Operation.HISTORY)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM,
+            affiliatedResource = Resource.TOKEN, operation = Operation.HISTORY)
     public List<KeyEventHistoryDto> getEventHistory(
             @LogResource(uuid = true, affiliated = true) String tokenInstanceUuid, String uuid,
             @LogResource(uuid = true) String keyItemUuid) throws NotFoundException {

--- a/src/main/java/com/otilm/core/api/web/CryptographicOperationControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/CryptographicOperationControllerImpl.java
@@ -38,7 +38,8 @@ public class CryptographicOperationControllerImpl implements CryptographicOperat
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM, affiliatedResource = Resource.TOKEN, operation = Operation.ENCRYPT)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM,
+            affiliatedResource = Resource.TOKEN, operation = Operation.ENCRYPT)
     public EncryptDataResponseDto encryptData(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             String tokenProfileUuid, String uuid, @LogResource(uuid = true) String keyItemUuid,
             CipherDataRequestDto request) throws ConnectorException, NotFoundException {
@@ -48,7 +49,8 @@ public class CryptographicOperationControllerImpl implements CryptographicOperat
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM, affiliatedResource = Resource.TOKEN, operation = Operation.DECRYPT)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY_ITEM,
+            affiliatedResource = Resource.TOKEN, operation = Operation.DECRYPT)
     public DecryptDataResponseDto decryptData(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             String tokenProfileUuid, String uuid, @LogResource(uuid = true) String keyItemUuid,
             CipherDataRequestDto request) throws ConnectorException, NotFoundException {
@@ -58,7 +60,8 @@ public class CryptographicOperationControllerImpl implements CryptographicOperat
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, affiliatedResource = Resource.TOKEN, operation = Operation.SIGN)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            affiliatedResource = Resource.TOKEN, operation = Operation.SIGN)
     public SignDataResponseDto signData(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             String tokenProfileUuid, String uuid, @LogResource(uuid = true) String keyItemUuid,
             SignDataRequestDto request) throws ConnectorException, NotFoundException {
@@ -68,7 +71,8 @@ public class CryptographicOperationControllerImpl implements CryptographicOperat
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY, affiliatedResource = Resource.TOKEN, operation = Operation.VERIFY)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.CRYPTOGRAPHIC_KEY,
+            affiliatedResource = Resource.TOKEN, operation = Operation.VERIFY)
     public VerifyDataResponseDto verifyData(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             String tokenProfileUuid, String uuid, @LogResource(uuid = true) String keyItemUuid,
             VerifyDataRequestDto request) throws ConnectorException, NotFoundException {
@@ -85,7 +89,8 @@ public class CryptographicOperationControllerImpl implements CryptographicOperat
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.ATTRIBUTE, name = "signature", affiliatedResource = Resource.CRYPTOGRAPHIC_KEY_ITEM, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.ATTRIBUTE, name = "signature",
+            affiliatedResource = Resource.CRYPTOGRAPHIC_KEY_ITEM, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listSignatureAttributes(String tokenInstanceUuid, String tokenProfileUuid, String uuid,
             @LogResource(uuid = true, affiliated = true) String keyItemUuid, KeyAlgorithm algorithm)
             throws ConnectorException, NotFoundException {
@@ -96,7 +101,8 @@ public class CryptographicOperationControllerImpl implements CryptographicOperat
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.ATTRIBUTE, name = "cipher", affiliatedResource = Resource.CRYPTOGRAPHIC_KEY_ITEM, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.ATTRIBUTE, name = "cipher",
+            affiliatedResource = Resource.CRYPTOGRAPHIC_KEY_ITEM, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listCipherAttributes(String tokenInstanceUuid, String tokenProfileUuid, String uuid,
             @LogResource(uuid = true, affiliated = true) String keyItemUuid, KeyAlgorithm algorithm)
             throws ConnectorException, NotFoundException {
@@ -107,7 +113,8 @@ public class CryptographicOperationControllerImpl implements CryptographicOperat
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.ATTRIBUTE, name = "random", affiliatedResource = Resource.TOKEN, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.ATTRIBUTE, name = "random",
+            affiliatedResource = Resource.TOKEN, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listRandomAttributes(
             @LogResource(uuid = true, affiliated = true) String tokenInstanceUuid)
             throws ConnectorException, NotFoundException {

--- a/src/main/java/com/otilm/core/api/web/CustomAttributeControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/CustomAttributeControllerImpl.java
@@ -129,7 +129,8 @@ public class CustomAttributeControllerImpl implements CustomAttributeController 
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.CUSTOM_ATTRIBUTE, operation = Operation.UPDATE_ATTRIBUTE_RESOURCES)
+    @AuditLogged(module = Module.CORE, resource = Resource.CUSTOM_ATTRIBUTE,
+            operation = Operation.UPDATE_ATTRIBUTE_RESOURCES)
     public void updateResources(@LogResource(uuid = true) String uuid, List<Resource> resources)
             throws NotFoundException {
         attributeService.updateResources(UUID.fromString(uuid), resources);
@@ -143,13 +144,15 @@ public class CustomAttributeControllerImpl implements CustomAttributeController 
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.RESOURCE, affiliatedResource = Resource.CUSTOM_ATTRIBUTE, operation = Operation.LIST)
+    @AuditLogged(module = Module.CORE, resource = Resource.RESOURCE, affiliatedResource = Resource.CUSTOM_ATTRIBUTE,
+            operation = Operation.LIST)
     public List<Resource> getResources() {
         return attributeService.getResources();
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.CUSTOM_ATTRIBUTE, operation = Operation.UPDATE_ATTRIBUTE_CONTENT)
+    @AuditLogged(module = Module.CORE, resource = Resource.CUSTOM_ATTRIBUTE,
+            operation = Operation.UPDATE_ATTRIBUTE_CONTENT)
     public List<ResponseAttribute> updateAttributeContentForResource(
             @LogResource(resource = true, affiliated = true) Resource resourceName,
             @LogResource(uuid = true, affiliated = true) String objectUuid,
@@ -161,7 +164,8 @@ public class CustomAttributeControllerImpl implements CustomAttributeController 
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.CUSTOM_ATTRIBUTE, operation = Operation.DELETE_ATTRIBUTE_CONTENT)
+    @AuditLogged(module = Module.CORE, resource = Resource.CUSTOM_ATTRIBUTE,
+            operation = Operation.DELETE_ATTRIBUTE_CONTENT)
     public List<ResponseAttribute> deleteAttributeContentForResource(
             @LogResource(resource = true, affiliated = true) Resource resourceName,
             @LogResource(uuid = true, affiliated = true) String objectUuid,

--- a/src/main/java/com/otilm/core/api/web/CustomOidEntryControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/CustomOidEntryControllerImpl.java
@@ -72,7 +72,8 @@ public class CustomOidEntryControllerImpl implements CustomOidEntryController {
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.OID, operation = Operation.LIST)
+    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.OID,
+            operation = Operation.LIST)
     public List<SearchFieldDataByGroupDto> getSearchableInformation() {
         return customOidEntryService.getSearchableFieldInformation();
     }

--- a/src/main/java/com/otilm/core/api/web/DiscoveryControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/DiscoveryControllerImpl.java
@@ -70,7 +70,8 @@ public class DiscoveryControllerImpl implements DiscoveryController {
     }
 
     @Override
-    @AuditLogged(module = Module.DISCOVERY, resource = Resource.DISCOVERY, affiliatedResource = Resource.CERTIFICATE, operation = Operation.LIST)
+    @AuditLogged(module = Module.DISCOVERY, resource = Resource.DISCOVERY, affiliatedResource = Resource.CERTIFICATE,
+            operation = Operation.LIST)
     public DiscoveryCertificateResponseDto getDiscoveryCertificates(@LogResource(uuid = true) String uuid,
             Boolean newlyDiscovered, int itemsPerPage, int pageNumber) throws NotFoundException {
         return discoveryService
@@ -94,7 +95,8 @@ public class DiscoveryControllerImpl implements DiscoveryController {
     }
 
     @Override
-    @AuditLogged(module = Module.SCHEDULER, resource = Resource.SCHEDULED_JOB, affiliatedResource = Resource.DISCOVERY, operation = Operation.SCHEDULE)
+    @AuditLogged(module = Module.SCHEDULER, resource = Resource.SCHEDULED_JOB, affiliatedResource = Resource.DISCOVERY,
+            operation = Operation.SCHEDULE)
     public ResponseEntity<?> scheduleDiscovery(final ScheduleDiscoveryDto scheduleDiscoveryDto)
             throws SchedulerException, ConnectorException, AlreadyExistException, AttributeException,
             NotFoundException {
@@ -137,7 +139,8 @@ public class DiscoveryControllerImpl implements DiscoveryController {
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.DISCOVERY, operation = Operation.LIST)
+    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.DISCOVERY,
+            operation = Operation.LIST)
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformation() {
         return discoveryService.getSearchableFieldInformationByGroup();
     }

--- a/src/main/java/com/otilm/core/api/web/EntityInstanceControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/EntityInstanceControllerImpl.java
@@ -48,7 +48,8 @@ public class EntityInstanceControllerImpl implements EntityInstanceController {
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.ENTITY, operation = Operation.LIST)
+    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.ENTITY,
+            operation = Operation.LIST)
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformation() {
         return entityInstanceService.getSearchableFieldInformationByGroup();
     }
@@ -91,14 +92,16 @@ public class EntityInstanceControllerImpl implements EntityInstanceController {
     }
 
     @Override
-    @AuditLogged(module = Module.ENTITIES, resource = Resource.ATTRIBUTE, name = "location", affiliatedResource = Resource.ENTITY, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.ENTITIES, resource = Resource.ATTRIBUTE, name = "location",
+            affiliatedResource = Resource.ENTITY, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listLocationAttributes(@LogResource(uuid = true, affiliated = true) String entityUuid)
             throws ConnectorException, NotFoundException {
         return entityInstanceService.listLocationAttributes(SecuredUUID.fromString(entityUuid));
     }
 
     @Override
-    @AuditLogged(module = Module.ENTITIES, resource = Resource.ATTRIBUTE, name = "location", affiliatedResource = Resource.ENTITY, operation = Operation.VALIDATE_ATTRIBUTES)
+    @AuditLogged(module = Module.ENTITIES, resource = Resource.ATTRIBUTE, name = "location",
+            affiliatedResource = Resource.ENTITY, operation = Operation.VALIDATE_ATTRIBUTES)
     public void validateLocationAttributes(@LogResource(uuid = true, affiliated = true) String entityUuid,
             List<RequestAttribute> attributes) throws ConnectorException, NotFoundException {
         entityInstanceService.validateLocationAttributes(SecuredUUID.fromString(entityUuid), attributes);

--- a/src/main/java/com/otilm/core/api/web/LocationManagementControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/LocationManagementControllerImpl.java
@@ -51,7 +51,8 @@ public class LocationManagementControllerImpl implements LocationManagementContr
     }
 
     @Override
-    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.ENTITY, operation = Operation.CREATE)
+    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.ENTITY,
+            operation = Operation.CREATE)
     public ResponseEntity<?> addLocation(@LogResource(uuid = true, affiliated = true) String entityUuid,
             AddLocationRequestDto request)
             throws ConnectorException, AlreadyExistException, LocationException, AttributeException, NotFoundException {
@@ -67,7 +68,8 @@ public class LocationManagementControllerImpl implements LocationManagementContr
     }
 
     @Override
-    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.ENTITY, operation = Operation.DETAIL)
+    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.ENTITY,
+            operation = Operation.DETAIL)
     public LocationDto getLocation(@LogResource(uuid = true, affiliated = true) String entityUuid,
             @LogResource(uuid = true) String locationUuid) throws NotFoundException {
         return locationService
@@ -75,7 +77,8 @@ public class LocationManagementControllerImpl implements LocationManagementContr
     }
 
     @Override
-    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.ENTITY, operation = Operation.UPDATE)
+    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.ENTITY,
+            operation = Operation.UPDATE)
     public LocationDto editLocation(@LogResource(uuid = true, affiliated = true) String entityUuid,
             @LogResource(uuid = true) String locationUuid, EditLocationRequestDto request)
             throws ConnectorException, LocationException, AttributeException, NotFoundException {
@@ -84,28 +87,32 @@ public class LocationManagementControllerImpl implements LocationManagementContr
     }
 
     @Override
-    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.ENTITY, operation = Operation.DELETE)
+    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.ENTITY,
+            operation = Operation.DELETE)
     public void deleteLocation(@LogResource(uuid = true, affiliated = true) String entityUuid,
             @LogResource(uuid = true) String locationUuid) throws NotFoundException {
         locationService.deleteLocation(SecuredParentUUID.fromString(entityUuid), SecuredUUID.fromString(locationUuid));
     }
 
     @Override
-    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.ENTITY, operation = Operation.DISABLE)
+    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.ENTITY,
+            operation = Operation.DISABLE)
     public void disableLocation(@LogResource(uuid = true, affiliated = true) String entityUuid,
             @LogResource(uuid = true) String locationUuid) throws NotFoundException {
         locationService.disableLocation(SecuredParentUUID.fromString(entityUuid), SecuredUUID.fromString(locationUuid));
     }
 
     @Override
-    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.ENTITY, operation = Operation.ENABLE)
+    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.ENTITY,
+            operation = Operation.ENABLE)
     public void enableLocation(@LogResource(uuid = true, affiliated = true) String entityUuid,
             @LogResource(uuid = true) String locationUuid) throws NotFoundException {
         locationService.enableLocation(SecuredParentUUID.fromString(entityUuid), SecuredUUID.fromString(locationUuid));
     }
 
     @Override
-    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.CERTIFICATE, operation = Operation.SYNC)
+    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.CERTIFICATE,
+            operation = Operation.SYNC)
     public LocationDto updateLocationContent(@LogResource(uuid = true, affiliated = true) String entityUuid,
             @LogResource(uuid = true) String locationUuid) throws NotFoundException, LocationException {
         return locationService
@@ -113,7 +120,8 @@ public class LocationManagementControllerImpl implements LocationManagementContr
     }
 
     @Override
-    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.CERTIFICATE, operation = Operation.PUSH_TO_LOCATION)
+    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.CERTIFICATE,
+            operation = Operation.PUSH_TO_LOCATION)
     public LocationDto pushCertificate(String entityUuid, @LogResource(uuid = true) String locationUuid,
             @LogResource(uuid = true, affiliated = true) String certificateUuid, PushToLocationRequestDto request)
             throws NotFoundException, LocationException, AttributeException {
@@ -123,7 +131,8 @@ public class LocationManagementControllerImpl implements LocationManagementContr
     }
 
     @Override
-    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.CERTIFICATE, operation = Operation.REMOVE_FROM_LOCATION)
+    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.CERTIFICATE,
+            operation = Operation.REMOVE_FROM_LOCATION)
     public LocationDto removeCertificate(String entityUuid, @LogResource(uuid = true) String locationUuid,
             @LogResource(uuid = true, affiliated = true) String certificateUuid)
             throws NotFoundException, LocationException {
@@ -133,7 +142,8 @@ public class LocationManagementControllerImpl implements LocationManagementContr
     }
 
     @Override
-    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.CERTIFICATE, operation = Operation.ISSUE_IN_LOCATION)
+    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.CERTIFICATE,
+            operation = Operation.ISSUE_IN_LOCATION)
     public LocationDto issueCertificate(String entityUuid, @LogResource(uuid = true) String locationUuid,
             IssueToLocationRequestDto request) throws ConnectorException, LocationException, NotFoundException {
         return locationService
@@ -142,7 +152,8 @@ public class LocationManagementControllerImpl implements LocationManagementContr
     }
 
     @Override
-    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.CERTIFICATE, operation = Operation.RENEW_IN_LOCATION)
+    @AuditLogged(module = Module.ENTITIES, resource = Resource.LOCATION, affiliatedResource = Resource.CERTIFICATE,
+            operation = Operation.RENEW_IN_LOCATION)
     public LocationDto renewCertificateInLocation(String entityUuid, @LogResource(uuid = true) String locationUuid,
             @LogResource(uuid = true, affiliated = true) String certificateUuid)
             throws ConnectorException, LocationException, NotFoundException {
@@ -152,7 +163,8 @@ public class LocationManagementControllerImpl implements LocationManagementContr
     }
 
     @Override
-    @AuditLogged(module = Module.ENTITIES, resource = Resource.ATTRIBUTE, name = "push", affiliatedResource = Resource.ENTITY, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.ENTITIES, resource = Resource.ATTRIBUTE, name = "push",
+            affiliatedResource = Resource.ENTITY, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listPushAttributes(@LogResource(uuid = true, affiliated = true) String entityUuid,
             String locationUuid) throws NotFoundException, LocationException {
         return locationService
@@ -160,7 +172,8 @@ public class LocationManagementControllerImpl implements LocationManagementContr
     }
 
     @Override
-    @AuditLogged(module = Module.ENTITIES, resource = Resource.ATTRIBUTE, name = "csr", affiliatedResource = Resource.ENTITY, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.ENTITIES, resource = Resource.ATTRIBUTE, name = "csr",
+            affiliatedResource = Resource.ENTITY, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listCsrAttributes(@LogResource(uuid = true, affiliated = true) String entityUuid,
             String locationUuid) throws NotFoundException, LocationException {
         return locationService
@@ -168,7 +181,8 @@ public class LocationManagementControllerImpl implements LocationManagementContr
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.LOCATION, operation = Operation.LIST)
+    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.LOCATION,
+            operation = Operation.LIST)
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformation() {
         return locationService.getSearchableFieldInformationByGroup();
     }

--- a/src/main/java/com/otilm/core/api/web/RAProfileManagementControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/RAProfileManagementControllerImpl.java
@@ -58,7 +58,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY, operation = Operation.CREATE)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY,
+            operation = Operation.CREATE)
     public ResponseEntity<?> createRaProfile(@LogResource(uuid = true, affiliated = true) String authorityUuid,
             AddRaProfileRequestDto request) throws AlreadyExistException, ValidationException, ConnectorException,
             AttributeException, NotFoundException {
@@ -74,7 +75,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY, operation = Operation.DETAIL)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY,
+            operation = Operation.DETAIL)
     public RaProfileDto getRaProfile(@LogResource(uuid = true, affiliated = true) String authorityUuid,
             @LogResource(uuid = true) String raProfileUuid) throws NotFoundException {
         return raProfileService
@@ -88,7 +90,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY, operation = Operation.UPDATE)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY,
+            operation = Operation.UPDATE)
     public RaProfileDto editRaProfile(@LogResource(uuid = true, affiliated = true) String authorityUuid,
             @LogResource(uuid = true) String raProfileUuid, EditRaProfileRequestDto request)
             throws ConnectorException, AttributeException, NotFoundException {
@@ -98,7 +101,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY, operation = Operation.UPDATE)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY,
+            operation = Operation.UPDATE)
     public RaProfileDto updateRaProfileValidationConfiguration(String authorityUuid, String raProfileUuid,
             RaProfileCertificateValidationSettingsUpdateDto request) throws NotFoundException {
         return raProfileService
@@ -107,7 +111,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY, operation = Operation.UPDATE)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY,
+            operation = Operation.UPDATE)
     public RaProfileDto updateRaProfileRequestAttributesConfiguration(String authorityUuid, String raProfileUuid,
             RaProfileCertificateRequestAttributesUpdateDto request) throws NotFoundException {
         return raProfileService
@@ -116,7 +121,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY, operation = Operation.DELETE)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY,
+            operation = Operation.DELETE)
     public void deleteRaProfile(@LogResource(uuid = true, affiliated = true) String authorityUuid,
             @LogResource(uuid = true) String raProfileUuid) throws NotFoundException {
         raProfileService
@@ -130,7 +136,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY, operation = Operation.DISABLE)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY,
+            operation = Operation.DISABLE)
     public void disableRaProfile(@LogResource(uuid = true, affiliated = true) String authorityUuid,
             @LogResource(uuid = true) String raProfileUuid) throws NotFoundException {
         raProfileService
@@ -138,7 +145,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY, operation = Operation.ENABLE)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY,
+            operation = Operation.ENABLE)
     public void enableRaProfile(@LogResource(uuid = true, affiliated = true) String authorityUuid,
             @LogResource(uuid = true) String raProfileUuid) throws NotFoundException {
         raProfileService
@@ -165,7 +173,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.ACME_PROFILE, operation = Operation.GET_PROTOCOL_INFO)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE,
+            affiliatedResource = Resource.ACME_PROFILE, operation = Operation.GET_PROTOCOL_INFO)
     public RaProfileAcmeDetailResponseDto getAcmeForRaProfile(String authorityUuid,
             @LogResource(uuid = true) String raProfileUuid) throws NotFoundException {
         return raProfileService
@@ -174,7 +183,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.ACME_PROFILE, operation = Operation.ACTIVATE_PROTOCOL)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE,
+            affiliatedResource = Resource.ACME_PROFILE, operation = Operation.ACTIVATE_PROTOCOL)
     public RaProfileAcmeDetailResponseDto activateAcmeForRaProfile(String authorityUuid,
             @LogResource(uuid = true) String raProfileUuid,
             @LogResource(uuid = true, affiliated = true) String acmeProfileUuid,
@@ -186,7 +196,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.ACME_PROFILE, operation = Operation.DEACTIVATE_PROTOCOL)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE,
+            affiliatedResource = Resource.ACME_PROFILE, operation = Operation.DEACTIVATE_PROTOCOL)
     public void deactivateAcmeForRaProfile(String authorityUuid, @LogResource(uuid = true) String raProfileUuid)
             throws NotFoundException {
         raProfileService
@@ -195,7 +206,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.SCEP_PROFILE, operation = Operation.GET_PROTOCOL_INFO)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE,
+            affiliatedResource = Resource.SCEP_PROFILE, operation = Operation.GET_PROTOCOL_INFO)
     public RaProfileScepDetailResponseDto getScepForRaProfile(String authorityUuid,
             @LogResource(uuid = true) String raProfileUuid) throws NotFoundException {
         return raProfileService
@@ -204,7 +216,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.SCEP_PROFILE, operation = Operation.ACTIVATE_PROTOCOL)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE,
+            affiliatedResource = Resource.SCEP_PROFILE, operation = Operation.ACTIVATE_PROTOCOL)
     public RaProfileScepDetailResponseDto activateScepForRaProfile(String authorityUuid,
             @LogResource(uuid = true) String raProfileUuid,
             @LogResource(uuid = true, affiliated = true) String scepProfileUuid,
@@ -216,7 +229,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.SCEP_PROFILE, operation = Operation.DEACTIVATE_PROTOCOL)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE,
+            affiliatedResource = Resource.SCEP_PROFILE, operation = Operation.DEACTIVATE_PROTOCOL)
     public void deactivateScepForRaProfile(String authorityUuid, @LogResource(uuid = true) String raProfileUuid)
             throws NotFoundException {
         raProfileService
@@ -225,7 +239,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.CMP_PROFILE, operation = Operation.GET_PROTOCOL_INFO)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE,
+            affiliatedResource = Resource.CMP_PROFILE, operation = Operation.GET_PROTOCOL_INFO)
     public RaProfileCmpDetailResponseDto getCmpForRaProfile(String authorityUuid,
             @LogResource(uuid = true) String raProfileUuid) throws NotFoundException {
         return raProfileService
@@ -233,7 +248,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.CMP_PROFILE, operation = Operation.ACTIVATE_PROTOCOL)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE,
+            affiliatedResource = Resource.CMP_PROFILE, operation = Operation.ACTIVATE_PROTOCOL)
     public RaProfileCmpDetailResponseDto activateCmpForRaProfile(String authorityUuid,
             @LogResource(uuid = true) String raProfileUuid,
             @LogResource(uuid = true, affiliated = true) String cmpProfileUuid,
@@ -245,7 +261,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.CMP_PROFILE, operation = Operation.DEACTIVATE_PROTOCOL)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE,
+            affiliatedResource = Resource.CMP_PROFILE, operation = Operation.DEACTIVATE_PROTOCOL)
     public void deactivateCmpForRaProfile(String authorityUuid, @LogResource(uuid = true) String raProfileUuid)
             throws NotFoundException {
         raProfileService
@@ -260,21 +277,24 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.COMPLIANCE_PROFILE, operation = Operation.LIST_ASSOCIATIONS)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE,
+            affiliatedResource = Resource.COMPLIANCE_PROFILE, operation = Operation.LIST_ASSOCIATIONS)
     public List<SimplifiedComplianceProfileDto> getAssociatedComplianceProfiles(String authorityUuid,
             @LogResource(uuid = true) String raProfileUuid) throws NotFoundException {
         return raProfileService.getComplianceProfiles(authorityUuid, raProfileUuid, SecurityFilter.create());
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.APPROVAL_PROFILE, operation = Operation.LIST_ASSOCIATIONS)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE,
+            affiliatedResource = Resource.APPROVAL_PROFILE, operation = Operation.LIST_ASSOCIATIONS)
     public List<ApprovalProfileDto> getAssociatedApprovalProfiles(String authorityUuid,
             @LogResource(uuid = true) String raProfileUuid) throws NotFoundException {
         return raProfileService.getAssociatedApprovalProfiles(authorityUuid, raProfileUuid, SecurityFilter.create());
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.APPROVAL_PROFILE, operation = Operation.ASSOCIATE)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE,
+            affiliatedResource = Resource.APPROVAL_PROFILE, operation = Operation.ASSOCIATE)
     public void associateRAProfileWithApprovalProfile(String authorityUuid,
             @LogResource(uuid = true) String raProfileUuid,
             @LogResource(uuid = true, affiliated = true) String approvalProfileUuid) throws NotFoundException {
@@ -283,7 +303,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.APPROVAL_PROFILE, operation = Operation.DISASSOCIATE)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE,
+            affiliatedResource = Resource.APPROVAL_PROFILE, operation = Operation.DISASSOCIATE)
     public void disassociateRAProfileFromApprovalProfile(String authorityUuid,
             @LogResource(uuid = true) String raProfileUuid,
             @LogResource(uuid = true, affiliated = true) String approvalProfileUuid) throws NotFoundException {
@@ -292,7 +313,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY, operation = Operation.GET_CHAIN)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.RA_PROFILE, affiliatedResource = Resource.AUTHORITY,
+            operation = Operation.GET_CHAIN)
     public List<CertificateDetailDto> getAuthorityCertificateChain(
             @LogResource(uuid = true, affiliated = true) String authorityUuid,
             @LogResource(uuid = true) String raProfileUuid) throws ConnectorException, NotFoundException {
@@ -302,7 +324,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "revoke", affiliatedResource = Resource.RA_PROFILE, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "revoke",
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listRevokeCertificateAttributes(String authorityUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid)
             throws ConnectorException, NotFoundException {
@@ -312,7 +335,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "issue", affiliatedResource = Resource.RA_PROFILE, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "issue",
+            affiliatedResource = Resource.RA_PROFILE, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listIssueCertificateAttributes(String authorityUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid)
             throws ConnectorException, NotFoundException {

--- a/src/main/java/com/otilm/core/api/web/RoleManagementControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/RoleManagementControllerImpl.java
@@ -74,13 +74,15 @@ public class RoleManagementControllerImpl implements RoleManagementController {
     }
 
     @Override
-    @AuditLogged(module = Module.AUTH, resource = Resource.ROLE, affiliatedResource = Resource.USER, operation = Operation.LIST)
+    @AuditLogged(module = Module.AUTH, resource = Resource.ROLE, affiliatedResource = Resource.USER,
+            operation = Operation.LIST)
     public List<UserDto> getRoleUsers(@LogResource(uuid = true) String roleUuid) throws NotFoundException {
         return roleManagementService.getRoleUsers(roleUuid);
     }
 
     @Override
-    @AuditLogged(module = Module.AUTH, resource = Resource.ROLE, affiliatedResource = Resource.USER, operation = Operation.UPDATE)
+    @AuditLogged(module = Module.AUTH, resource = Resource.ROLE, affiliatedResource = Resource.USER,
+            operation = Operation.UPDATE)
     public RoleDetailDto updateUsers(@LogResource(uuid = true) String roleUuid,
             @LogResource(uuid = true, affiliated = true) List<String> userUuids) throws NotFoundException {
         return roleManagementService.updateUsers(roleUuid, userUuids);

--- a/src/main/java/com/otilm/core/api/web/ScepProfileControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/ScepProfileControllerImpl.java
@@ -115,14 +115,16 @@ public class ScepProfileControllerImpl implements ScepProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.SCEP_PROFILE, affiliatedResource = Resource.RA_PROFILE, operation = Operation.UPDATE_PROTOCOL_ISSUE_PROFILE)
+    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.SCEP_PROFILE, affiliatedResource = Resource.RA_PROFILE,
+            operation = Operation.UPDATE_PROTOCOL_ISSUE_PROFILE)
     public void updateRaProfile(@LogResource(uuid = true) String uuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid) throws NotFoundException {
         scepProfileService.updateRaProfile(SecuredUUID.fromString(uuid), raProfileUuid);
     }
 
     @Override
-    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.SCEP_PROFILE, affiliatedResource = Resource.CERTIFICATE, operation = Operation.LIST_PROTOCOL_CERTIFICATES)
+    @AuditLogged(module = Module.PROTOCOLS, resource = Resource.SCEP_PROFILE, affiliatedResource = Resource.CERTIFICATE,
+            operation = Operation.LIST_PROTOCOL_CERTIFICATES)
     public List<CertificateDto> listScepCaCertificates(boolean intuneEnabled) {
         return scepProfileService.listScepCaCertificates(intuneEnabled);
     }

--- a/src/main/java/com/otilm/core/api/web/SecretManagementControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/SecretManagementControllerImpl.java
@@ -41,7 +41,8 @@ public class SecretManagementControllerImpl implements SecretManagementControlle
     }
 
     @Override
-    @AuditLogged(module = Module.SECRETS, resource = Resource.SEARCH_FILTER, operation = Operation.LIST, affiliatedResource = Resource.SECRET)
+    @AuditLogged(module = Module.SECRETS, resource = Resource.SEARCH_FILTER, operation = Operation.LIST,
+            affiliatedResource = Resource.SECRET)
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformation() {
         return secretService.getSearchableFieldInformation();
     }
@@ -72,7 +73,8 @@ public class SecretManagementControllerImpl implements SecretManagementControlle
     }
 
     @Override
-    @AuditLogged(module = Module.SECRETS, resource = Resource.SECRET, operation = Operation.CREATE, affiliatedResource = Resource.VAULT)
+    @AuditLogged(module = Module.SECRETS, resource = Resource.SECRET, operation = Operation.CREATE,
+            affiliatedResource = Resource.VAULT)
     public SecretDetailDto createSecret(SecretRequestDto secretRequest,
             @LogResource(uuid = true, affiliated = true) UUID vaultProfileUuid, UUID vaultUuid)
             throws NotFoundException, AttributeException, AlreadyExistException, ConnectorException {
@@ -108,7 +110,8 @@ public class SecretManagementControllerImpl implements SecretManagementControlle
     }
 
     @Override
-    @AuditLogged(module = Module.SECRETS, resource = Resource.SECRET, affiliatedResource = Resource.VAULT_PROFILE, operation = Operation.ASSOCIATE)
+    @AuditLogged(module = Module.SECRETS, resource = Resource.SECRET, affiliatedResource = Resource.VAULT_PROFILE,
+            operation = Operation.ASSOCIATE)
     public void addVaultProfileToSecret(@LogResource(uuid = true) UUID uuid,
             @LogResource(uuid = true, affiliated = true) UUID vaultProfileUuid,
             List<RequestAttribute> createSecretAttributes)
@@ -117,7 +120,8 @@ public class SecretManagementControllerImpl implements SecretManagementControlle
     }
 
     @Override
-    @AuditLogged(module = Module.SECRETS, resource = Resource.SECRET, affiliatedResource = Resource.VAULT_PROFILE, operation = Operation.DISASSOCIATE)
+    @AuditLogged(module = Module.SECRETS, resource = Resource.SECRET, affiliatedResource = Resource.VAULT_PROFILE,
+            operation = Operation.DISASSOCIATE)
     public void removeVaultProfileFromSecret(@LogResource(uuid = true) UUID uuid,
             @LogResource(uuid = true, affiliated = true) UUID vaultProfileUuid, boolean deleteInVault)
             throws NotFoundException, ConnectorException, AttributeException {

--- a/src/main/java/com/otilm/core/api/web/SettingControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/SettingControllerImpl.java
@@ -70,33 +70,41 @@ public class SettingControllerImpl implements SettingController {
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.SETTINGS, operation = Operation.DETAIL, name = "authentication")
+    @AuditLogged(module = Module.CORE, resource = Resource.SETTINGS, operation = Operation.DETAIL,
+            name = "authentication")
     public AuthenticationSettingsDto getAuthenticationSettings() {
         return settingService.getAuthenticationSettings(false);
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.SETTINGS, operation = Operation.UPDATE, name = "authentication")
+    @AuditLogged(module = Module.CORE, resource = Resource.SETTINGS, operation = Operation.UPDATE,
+            name = "authentication")
     public void updateAuthenticationSettings(AuthenticationSettingsUpdateDto authenticationSettingsDto) {
         settingService.updateAuthenticationSettings(authenticationSettingsDto);
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.SETTINGS, affiliatedResource = Resource.AUTHENTICATION_PROVIDER, operation = Operation.DETAIL, name = "authentication")
+    @AuditLogged(module = Module.CORE, resource = Resource.SETTINGS,
+            affiliatedResource = Resource.AUTHENTICATION_PROVIDER, operation = Operation.DETAIL,
+            name = "authentication")
     public OAuth2ProviderSettingsResponseDto getOAuth2ProviderSettings(
             @LogResource(name = true, affiliated = true) String providerName) {
         return settingService.getOAuth2ProviderSettings(providerName, false);
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.SETTINGS, affiliatedResource = Resource.AUTHENTICATION_PROVIDER, operation = Operation.UPDATE, name = "authentication")
+    @AuditLogged(module = Module.CORE, resource = Resource.SETTINGS,
+            affiliatedResource = Resource.AUTHENTICATION_PROVIDER, operation = Operation.UPDATE,
+            name = "authentication")
     public void updateOAuth2ProviderSettings(@LogResource(name = true, affiliated = true) String providerName,
             OAuth2ProviderSettingsUpdateDto oauth2SettingsDto) {
         settingService.updateOAuth2ProviderSettings(providerName, oauth2SettingsDto);
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.SETTINGS, affiliatedResource = Resource.AUTHENTICATION_PROVIDER, operation = Operation.DELETE, name = "authentication")
+    @AuditLogged(module = Module.CORE, resource = Resource.SETTINGS,
+            affiliatedResource = Resource.AUTHENTICATION_PROVIDER, operation = Operation.DELETE,
+            name = "authentication")
     public void removeOAuth2Provider(@LogResource(name = true, affiliated = true) String providerName) {
         settingService.removeOAuth2Provider(providerName);
     }

--- a/src/main/java/com/otilm/core/api/web/SigningProfileControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/SigningProfileControllerImpl.java
@@ -176,7 +176,8 @@ public class SigningProfileControllerImpl implements SigningProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.SIGNING, resource = Resource.SIGNING_PROFILE, operation = Operation.DEACTIVATE_PROTOCOL)
+    @AuditLogged(module = Module.SIGNING, resource = Resource.SIGNING_PROFILE,
+            operation = Operation.DEACTIVATE_PROTOCOL)
     public void deactivateTsp(@LogResource(uuid = true) UUID uuid) throws NotFoundException {
         signingProfileService.deactivateTsp(SecuredUUID.fromUUID(uuid));
     }

--- a/src/main/java/com/otilm/core/api/web/TimeQualityConfigurationControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/TimeQualityConfigurationControllerImpl.java
@@ -42,7 +42,8 @@ public class TimeQualityConfigurationControllerImpl implements TimeQualityConfig
     }
 
     @Override
-    @AuditLogged(module = Module.SIGNING, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.TIME_QUALITY_CONFIGURATION, operation = Operation.LIST)
+    @AuditLogged(module = Module.SIGNING, resource = Resource.SEARCH_FILTER,
+            affiliatedResource = Resource.TIME_QUALITY_CONFIGURATION, operation = Operation.LIST)
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformation() {
         return timeQualityConfigurationService.getSearchableFieldInformation();
     }
@@ -84,7 +85,8 @@ public class TimeQualityConfigurationControllerImpl implements TimeQualityConfig
     }
 
     @Override
-    @AuditLogged(module = Module.SIGNING, resource = Resource.TIME_QUALITY_CONFIGURATION, affiliatedResource = Resource.SIGNING_PROFILE, operation = Operation.LIST)
+    @AuditLogged(module = Module.SIGNING, resource = Resource.TIME_QUALITY_CONFIGURATION,
+            affiliatedResource = Resource.SIGNING_PROFILE, operation = Operation.LIST)
     public List<SimplifiedSigningProfileDto> listSigningProfilesForTimeQualityConfiguration(
             @LogResource(uuid = true) UUID uuid) {
         return signingProfileService

--- a/src/main/java/com/otilm/core/api/web/TokenInstanceControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/TokenInstanceControllerImpl.java
@@ -97,14 +97,16 @@ public class TokenInstanceControllerImpl implements TokenInstanceController {
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.ATTRIBUTE, name = "tokenProfile", affiliatedResource = Resource.TOKEN, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.ATTRIBUTE, name = "tokenProfile",
+            affiliatedResource = Resource.TOKEN, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listTokenProfileAttributes(@LogResource(uuid = true, affiliated = true) String uuid)
             throws ConnectorException, NotFoundException {
         return tokenInstanceService.listTokenProfileAttributes(SecuredUUID.fromString(uuid));
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.ATTRIBUTE, name = "activate", affiliatedResource = Resource.TOKEN, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.ATTRIBUTE, name = "activate",
+            affiliatedResource = Resource.TOKEN, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listTokenInstanceActivationAttributes(
             @LogResource(uuid = true, affiliated = true) String uuid) throws ConnectorException, NotFoundException {
         return tokenInstanceService.listTokenInstanceActivationAttributes(SecuredUUID.fromString(uuid));

--- a/src/main/java/com/otilm/core/api/web/TokenProfileControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/TokenProfileControllerImpl.java
@@ -48,7 +48,8 @@ public class TokenProfileControllerImpl implements TokenProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.TOKEN_PROFILE, affiliatedResource = Resource.TOKEN, operation = Operation.DETAIL)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.TOKEN_PROFILE,
+            affiliatedResource = Resource.TOKEN, operation = Operation.DETAIL)
     public TokenProfileDetailDto getTokenProfile(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             @LogResource(uuid = true) String uuid) throws NotFoundException {
         return tokenProfileService
@@ -56,7 +57,8 @@ public class TokenProfileControllerImpl implements TokenProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.TOKEN_PROFILE, affiliatedResource = Resource.TOKEN, operation = Operation.CREATE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.TOKEN_PROFILE,
+            affiliatedResource = Resource.TOKEN, operation = Operation.CREATE)
     public ResponseEntity<TokenProfileDetailDto> createTokenProfile(
             @LogResource(uuid = true, affiliated = true) String tokenInstanceUuid, AddTokenProfileRequestDto request)
             throws AlreadyExistException, ValidationException, ConnectorException, AttributeException,
@@ -72,7 +74,8 @@ public class TokenProfileControllerImpl implements TokenProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.TOKEN_PROFILE, affiliatedResource = Resource.TOKEN, operation = Operation.UPDATE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.TOKEN_PROFILE,
+            affiliatedResource = Resource.TOKEN, operation = Operation.UPDATE)
     public TokenProfileDetailDto editTokenProfile(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             @LogResource(uuid = true) String uuid, EditTokenProfileRequestDto request)
             throws ConnectorException, AttributeException, NotFoundException {
@@ -82,7 +85,8 @@ public class TokenProfileControllerImpl implements TokenProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.TOKEN_PROFILE, affiliatedResource = Resource.TOKEN, operation = Operation.DELETE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.TOKEN_PROFILE,
+            affiliatedResource = Resource.TOKEN, operation = Operation.DELETE)
     public void deleteTokenProfile(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             @LogResource(uuid = true) String uuid) throws NotFoundException {
         tokenProfileService
@@ -96,7 +100,8 @@ public class TokenProfileControllerImpl implements TokenProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.TOKEN_PROFILE, affiliatedResource = Resource.TOKEN, operation = Operation.DISABLE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.TOKEN_PROFILE,
+            affiliatedResource = Resource.TOKEN, operation = Operation.DISABLE)
     public void disableTokenProfile(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             @LogResource(uuid = true) String uuid) throws NotFoundException {
         tokenProfileService
@@ -104,7 +109,8 @@ public class TokenProfileControllerImpl implements TokenProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.TOKEN_PROFILE, affiliatedResource = Resource.TOKEN, operation = Operation.ENABLE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.TOKEN_PROFILE,
+            affiliatedResource = Resource.TOKEN, operation = Operation.ENABLE)
     public void enableTokenProfile(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             @LogResource(uuid = true) String uuid) throws NotFoundException {
         tokenProfileService
@@ -130,7 +136,8 @@ public class TokenProfileControllerImpl implements TokenProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.TOKEN_PROFILE, affiliatedResource = Resource.TOKEN, operation = Operation.UPDATE_KEY_USAGE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.TOKEN_PROFILE,
+            affiliatedResource = Resource.TOKEN, operation = Operation.UPDATE_KEY_USAGE)
     public void updateKeyUsages(@LogResource(uuid = true, affiliated = true) String tokenInstanceUuid,
             @LogResource(uuid = true) String tokenProfileUuid, TokenProfileKeyUsageRequestDto request)
             throws NotFoundException, ValidationException {
@@ -140,7 +147,8 @@ public class TokenProfileControllerImpl implements TokenProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.TOKEN_PROFILE, operation = Operation.UPDATE_KEY_USAGE)
+    @AuditLogged(module = Module.CRYPTOGRAPHIC_KEYS, resource = Resource.TOKEN_PROFILE,
+            operation = Operation.UPDATE_KEY_USAGE)
     public void updateKeysUsages(BulkTokenProfileKeyUsageRequestDto request) {
         tokenProfileService.updateKeyUsages(SecuredUUID.fromUuidList(request.getUuids()), request.getUsage());
     }

--- a/src/main/java/com/otilm/core/api/web/TspProfileBasicCredentialControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/TspProfileBasicCredentialControllerImpl.java
@@ -33,21 +33,24 @@ public class TspProfileBasicCredentialControllerImpl implements TspProfileBasicC
     }
 
     @Override
-    @AuditLogged(module = Module.SIGNING, resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL, affiliatedResource = Resource.TSP_PROFILE, operation = Operation.LIST)
+    @AuditLogged(module = Module.SIGNING, resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL,
+            affiliatedResource = Resource.TSP_PROFILE, operation = Operation.LIST)
     public List<TspBasicCredentialDto> list(@LogResource(uuid = true, affiliated = true) UUID tspProfileUuid)
             throws NotFoundException {
         return service.list(SecuredParentUUID.fromUUID(tspProfileUuid));
     }
 
     @Override
-    @AuditLogged(module = Module.SIGNING, resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL, affiliatedResource = Resource.TSP_PROFILE, operation = Operation.DETAIL)
+    @AuditLogged(module = Module.SIGNING, resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL,
+            affiliatedResource = Resource.TSP_PROFILE, operation = Operation.DETAIL)
     public TspBasicCredentialDto get(@LogResource(uuid = true, affiliated = true) UUID tspProfileUuid,
             @LogResource(uuid = true) UUID uuid) throws NotFoundException {
         return service.get(SecuredParentUUID.fromUUID(tspProfileUuid), SecuredUUID.fromUUID(uuid));
     }
 
     @Override
-    @AuditLogged(module = Module.SIGNING, resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL, affiliatedResource = Resource.TSP_PROFILE, operation = Operation.CREATE)
+    @AuditLogged(module = Module.SIGNING, resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL,
+            affiliatedResource = Resource.TSP_PROFILE, operation = Operation.CREATE)
     public TspBasicCredentialDto create(@LogResource(uuid = true, affiliated = true) UUID tspProfileUuid,
             @Valid TspBasicCredentialCreateRequestDto request)
             throws AlreadyExistException, AttributeException, ConnectorCommunicationException, NotFoundException {
@@ -55,7 +58,8 @@ public class TspProfileBasicCredentialControllerImpl implements TspProfileBasicC
     }
 
     @Override
-    @AuditLogged(module = Module.SIGNING, resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL, affiliatedResource = Resource.TSP_PROFILE, operation = Operation.UPDATE)
+    @AuditLogged(module = Module.SIGNING, resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL,
+            affiliatedResource = Resource.TSP_PROFILE, operation = Operation.UPDATE)
     public TspBasicCredentialDto update(@LogResource(uuid = true, affiliated = true) UUID tspProfileUuid,
             @LogResource(uuid = true) UUID uuid, @Valid TspBasicCredentialUpdateRequestDto request)
             throws AlreadyExistException, AttributeException, ConnectorCommunicationException, NotFoundException {
@@ -63,7 +67,8 @@ public class TspProfileBasicCredentialControllerImpl implements TspProfileBasicC
     }
 
     @Override
-    @AuditLogged(module = Module.SIGNING, resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL, affiliatedResource = Resource.TSP_PROFILE, operation = Operation.DELETE)
+    @AuditLogged(module = Module.SIGNING, resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL,
+            affiliatedResource = Resource.TSP_PROFILE, operation = Operation.DELETE)
     public void delete(@LogResource(uuid = true, affiliated = true) UUID tspProfileUuid,
             @LogResource(uuid = true) UUID uuid)
             throws AttributeException, ConnectorCommunicationException, NotFoundException {

--- a/src/main/java/com/otilm/core/api/web/TspProfileControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/TspProfileControllerImpl.java
@@ -38,7 +38,8 @@ public class TspProfileControllerImpl implements TspProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.SIGNING, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.TSP_PROFILE, operation = Operation.LIST)
+    @AuditLogged(module = Module.SIGNING, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.TSP_PROFILE,
+            operation = Operation.LIST)
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformation() {
         return tspProfileService.getSearchableFieldInformation();
     }

--- a/src/main/java/com/otilm/core/api/web/UserManagementControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/UserManagementControllerImpl.java
@@ -86,27 +86,31 @@ public class UserManagementControllerImpl implements UserManagementController {
     }
 
     @Override
-    @AuditLogged(module = Module.AUTH, resource = Resource.USER, affiliatedResource = Resource.ROLE, operation = Operation.LIST)
+    @AuditLogged(module = Module.AUTH, resource = Resource.USER, affiliatedResource = Resource.ROLE,
+            operation = Operation.LIST)
     public List<RoleDto> getUserRoles(@LogResource(uuid = true) String userUuid) throws NotFoundException {
         return userManagementService.getUserRoles(userUuid);
     }
 
     @Override
-    @AuditLogged(module = Module.AUTH, resource = Resource.USER, affiliatedResource = Resource.ROLE, operation = Operation.UPDATE)
+    @AuditLogged(module = Module.AUTH, resource = Resource.USER, affiliatedResource = Resource.ROLE,
+            operation = Operation.UPDATE)
     public UserDetailDto updateRoles(@LogResource(uuid = true) String userUuid,
             @LogResource(uuid = true, affiliated = true) List<String> roleUuids) throws NotFoundException {
         return userManagementService.updateRoles(userUuid, roleUuids);
     }
 
     @Override
-    @AuditLogged(module = Module.AUTH, resource = Resource.USER, affiliatedResource = Resource.ROLE, operation = Operation.ADD)
+    @AuditLogged(module = Module.AUTH, resource = Resource.USER, affiliatedResource = Resource.ROLE,
+            operation = Operation.ADD)
     public UserDetailDto addRole(@LogResource(uuid = true) String userUuid,
             @LogResource(uuid = true, affiliated = true) String roleUuid) throws NotFoundException {
         return userManagementService.updateRole(userUuid, roleUuid);
     }
 
     @Override
-    @AuditLogged(module = Module.AUTH, resource = Resource.USER, affiliatedResource = Resource.ROLE, operation = Operation.REMOVE)
+    @AuditLogged(module = Module.AUTH, resource = Resource.USER, affiliatedResource = Resource.ROLE,
+            operation = Operation.REMOVE)
     public UserDetailDto removeRole(@LogResource(uuid = true) String userUuid,
             @LogResource(uuid = true, affiliated = true) String roleUuid) throws NotFoundException {
         return userManagementService.removeRole(userUuid, roleUuid);

--- a/src/main/java/com/otilm/core/api/web/VaultInstanceControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/VaultInstanceControllerImpl.java
@@ -37,14 +37,16 @@ public class VaultInstanceControllerImpl implements VaultInstanceController {
     }
 
     @Override
-    @AuditLogged(module = Module.SECRETS, resource = Resource.ATTRIBUTE, affiliatedResource = Resource.VAULT, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.SECRETS, resource = Resource.ATTRIBUTE, affiliatedResource = Resource.VAULT,
+            operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listVaultInstanceAttributes(UUID connectorUuid)
             throws ConnectorException, NotFoundException, AttributeException {
         return vaultInstanceService.listVaultInstanceAttributes(connectorUuid);
     }
 
     @Override
-    @AuditLogged(module = Module.SECRETS, resource = Resource.ATTRIBUTE, name = "vaultProfile", affiliatedResource = Resource.VAULT, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.SECRETS, resource = Resource.ATTRIBUTE, name = "vaultProfile",
+            affiliatedResource = Resource.VAULT, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listVaultProfileAttributes(@LogResource(uuid = true, affiliated = true) UUID uuid)
             throws ConnectorException, NotFoundException, AttributeException {
         return vaultInstanceService.listVaultProfileAttributes(SecuredUUID.fromUUID(uuid));
@@ -85,7 +87,8 @@ public class VaultInstanceControllerImpl implements VaultInstanceController {
     }
 
     @Override
-    @AuditLogged(module = Module.SECRETS, resource = Resource.SEARCH_FILTER, operation = Operation.LIST, affiliatedResource = Resource.VAULT)
+    @AuditLogged(module = Module.SECRETS, resource = Resource.SEARCH_FILTER, operation = Operation.LIST,
+            affiliatedResource = Resource.VAULT)
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformation() {
         return vaultInstanceService.getSearchableFieldInformation();
     }

--- a/src/main/java/com/otilm/core/api/web/VaultProfileControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/VaultProfileControllerImpl.java
@@ -53,7 +53,8 @@ public class VaultProfileControllerImpl implements VaultProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.SECRETS, resource = Resource.VAULT_PROFILE, affiliatedResource = Resource.VAULT, operation = Operation.DETAIL)
+    @AuditLogged(module = Module.SECRETS, resource = Resource.VAULT_PROFILE, affiliatedResource = Resource.VAULT,
+            operation = Operation.DETAIL)
     public VaultProfileDetailDto getVaultProfileDetails(@LogResource(uuid = true, affiliated = true) UUID vaultUuid,
             @LogResource(uuid = true) UUID vaultProfileUuid) throws NotFoundException {
         return vaultProfileService
@@ -61,7 +62,8 @@ public class VaultProfileControllerImpl implements VaultProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.SECRETS, resource = Resource.VAULT_PROFILE, affiliatedResource = Resource.VAULT, operation = Operation.UPDATE)
+    @AuditLogged(module = Module.SECRETS, resource = Resource.VAULT_PROFILE, affiliatedResource = Resource.VAULT,
+            operation = Operation.UPDATE)
     public VaultProfileDetailDto updateVaultProfile(@LogResource(uuid = true, affiliated = true) UUID vaultUuid,
             @LogResource(uuid = true) UUID vaultProfileUuid, VaultProfileUpdateRequestDto vaultProfileUpdateRequest)
             throws NotFoundException, AttributeException {
@@ -71,7 +73,8 @@ public class VaultProfileControllerImpl implements VaultProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.SECRETS, resource = Resource.VAULT_PROFILE, affiliatedResource = Resource.VAULT, operation = Operation.DELETE)
+    @AuditLogged(module = Module.SECRETS, resource = Resource.VAULT_PROFILE, affiliatedResource = Resource.VAULT,
+            operation = Operation.DELETE)
     public void deleteVaultProfile(@LogResource(uuid = true, affiliated = true) UUID vaultUuid,
             @LogResource(uuid = true) UUID vaultProfileUuid) throws NotFoundException {
         vaultProfileService
@@ -79,7 +82,8 @@ public class VaultProfileControllerImpl implements VaultProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.SECRETS, resource = Resource.VAULT_PROFILE, affiliatedResource = Resource.VAULT, operation = Operation.CREATE)
+    @AuditLogged(module = Module.SECRETS, resource = Resource.VAULT_PROFILE, affiliatedResource = Resource.VAULT,
+            operation = Operation.CREATE)
     public VaultProfileDetailDto createVaultProfile(@LogResource(uuid = true, affiliated = true) UUID vaultUuid,
             VaultProfileRequestDto vaultProfileRequest)
             throws NotFoundException, AttributeException, AlreadyExistException {
@@ -87,7 +91,8 @@ public class VaultProfileControllerImpl implements VaultProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.SECRETS, resource = Resource.VAULT_PROFILE, affiliatedResource = Resource.VAULT, operation = Operation.ENABLE)
+    @AuditLogged(module = Module.SECRETS, resource = Resource.VAULT_PROFILE, affiliatedResource = Resource.VAULT,
+            operation = Operation.ENABLE)
     public void enableVaultProfile(@LogResource(uuid = true, affiliated = true) UUID vaultUuid,
             @LogResource(uuid = true) UUID vaultProfileUuid) throws NotFoundException {
         vaultProfileService
@@ -95,7 +100,8 @@ public class VaultProfileControllerImpl implements VaultProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.SECRETS, resource = Resource.VAULT_PROFILE, affiliatedResource = Resource.VAULT, operation = Operation.DISABLE)
+    @AuditLogged(module = Module.SECRETS, resource = Resource.VAULT_PROFILE, affiliatedResource = Resource.VAULT,
+            operation = Operation.DISABLE)
     public void disableVaultProfile(@LogResource(uuid = true, affiliated = true) UUID vaultUuid,
             @LogResource(uuid = true) UUID vaultProfileUuid) throws NotFoundException {
         vaultProfileService
@@ -103,7 +109,8 @@ public class VaultProfileControllerImpl implements VaultProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.SECRETS, resource = Resource.VAULT_PROFILE, affiliatedResource = Resource.VAULT, operation = Operation.LIST_ATTRIBUTES)
+    @AuditLogged(module = Module.SECRETS, resource = Resource.VAULT_PROFILE, affiliatedResource = Resource.VAULT,
+            operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listSecretAttributes(@LogResource(uuid = true, affiliated = true) UUID vaultUuid,
             @LogResource(uuid = true) UUID vaultProfileUuid, SecretType secretType)
             throws ConnectorException, NotFoundException, AttributeException {
@@ -113,7 +120,8 @@ public class VaultProfileControllerImpl implements VaultProfileController {
     }
 
     @Override
-    @AuditLogged(module = Module.SECRETS, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.VAULT_PROFILE, operation = Operation.LIST)
+    @AuditLogged(module = Module.SECRETS, resource = Resource.SEARCH_FILTER,
+            affiliatedResource = Resource.VAULT_PROFILE, operation = Operation.LIST)
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformation() {
         return vaultProfileService.getSearchableFieldInformation();
     }

--- a/src/main/java/com/otilm/core/api/web/v2/ComplianceControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/v2/ComplianceControllerImpl.java
@@ -36,7 +36,8 @@ public class ComplianceControllerImpl implements ComplianceController {
     }
 
     @Override
-    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE, operation = Operation.CHECK_COMPLIANCE)
+    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE,
+            operation = Operation.CHECK_COMPLIANCE)
     public void checkCompliance(@LogResource(uuid = true) List<UUID> uuids,
             @LogResource(resource = true, affiliated = true) Resource resource, String type)
             throws ConnectorException, NotFoundException {

--- a/src/main/java/com/otilm/core/api/web/v2/ComplianceProfileControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/v2/ComplianceProfileControllerImpl.java
@@ -96,7 +96,8 @@ public class ComplianceProfileControllerImpl implements ComplianceProfileControl
     }
 
     @Override
-    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_RULE, affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST)
+    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_RULE,
+            affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST)
     public List<ComplianceRuleListDto> getComplianceRules(
             @LogResource(uuid = true, affiliated = true) UUID connectorUuid, String kind,
             @LogResource(resource = true, affiliated = true) Resource resource, String type, String format)
@@ -105,7 +106,8 @@ public class ComplianceProfileControllerImpl implements ComplianceProfileControl
     }
 
     @Override
-    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_GROUP, affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST)
+    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_GROUP,
+            affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST)
     public List<ComplianceGroupListDto> getComplianceGroups(
             @LogResource(uuid = true, affiliated = true) UUID connectorUuid, String kind,
             @LogResource(resource = true, affiliated = true) Resource resource)
@@ -114,7 +116,8 @@ public class ComplianceProfileControllerImpl implements ComplianceProfileControl
     }
 
     @Override
-    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_GROUP, affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST_RULES)
+    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_GROUP,
+            affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST_RULES)
     public List<ComplianceRuleListDto> getComplianceGroupRules(@LogResource(uuid = true) UUID groupUuid,
             @LogResource(uuid = true, affiliated = true) UUID connectorUuid, String kind)
             throws ConnectorException, NotFoundException {
@@ -142,27 +145,31 @@ public class ComplianceProfileControllerImpl implements ComplianceProfileControl
     }
 
     @Override
-    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE, affiliatedResource = Resource.COMPLIANCE_RULE, operation = Operation.UPDATE)
+    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE,
+            affiliatedResource = Resource.COMPLIANCE_RULE, operation = Operation.UPDATE)
     public void patchComplianceProfileRule(@LogResource(uuid = true) UUID uuid,
             ComplianceProfileRulesPatchRequestDto request) throws ConnectorException, NotFoundException {
         complianceProfileService.patchComplianceProfileRules(SecuredUUID.fromUUID(uuid), request);
     }
 
     @Override
-    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE, affiliatedResource = Resource.COMPLIANCE_GROUP, operation = Operation.UPDATE)
+    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE,
+            affiliatedResource = Resource.COMPLIANCE_GROUP, operation = Operation.UPDATE)
     public void patchComplianceProfileGroup(@LogResource(uuid = true) UUID uuid,
             ComplianceProfileGroupsPatchRequestDto request) throws ConnectorException, NotFoundException {
         complianceProfileService.patchComplianceProfileGroups(SecuredUUID.fromUUID(uuid), request);
     }
 
     @Override
-    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE, operation = Operation.LIST_ASSOCIATIONS)
+    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE,
+            operation = Operation.LIST_ASSOCIATIONS)
     public List<ResourceObjectDto> getAssociations(@LogResource(uuid = true) UUID uuid) throws NotFoundException {
         return complianceProfileService.getAssociations(SecuredUUID.fromUUID(uuid));
     }
 
     @Override
-    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE, operation = Operation.LIST_ASSOCIATIONS)
+    @AuditLogged(module = Module.COMPLIANCE, resource = Resource.COMPLIANCE_PROFILE,
+            operation = Operation.LIST_ASSOCIATIONS)
     public List<ComplianceProfileListDto> getAssociatedComplianceProfiles(
             @LogResource(resource = true, affiliated = true) Resource resource,
             @LogResource(uuid = true, affiliated = true) UUID associationObjectUuid) {

--- a/src/main/java/com/otilm/core/api/web/v2/ConnectorControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/v2/ConnectorControllerImpl.java
@@ -50,7 +50,8 @@ public class ConnectorControllerImpl implements ConnectorController {
     }
 
     @Override
-    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST)
+    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.CONNECTOR,
+            operation = Operation.LIST)
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformation() {
         return connectorService.getSearchableFieldInformationByGroup();
     }

--- a/src/main/java/com/otilm/core/config/ApplicationConfig.java
+++ b/src/main/java/com/otilm/core/config/ApplicationConfig.java
@@ -42,7 +42,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration
 @EnableJpaAuditing(auditorAwareRef = "auditorAware")
 @EnableConfigurationProperties({DiscoveryProperties.class, ConnectorApiClientProperties.class})
-@ComponentScan(basePackages = "com.otilm.core", excludeFilters = @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class))
+@ComponentScan(basePackages = "com.otilm.core",
+        excludeFilters = @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class))
 public class ApplicationConfig {
 
     @Autowired

--- a/src/main/java/com/otilm/core/config/cache/CacheConfig.java
+++ b/src/main/java/com/otilm/core/config/cache/CacheConfig.java
@@ -15,10 +15,15 @@ import org.springframework.core.Ordered;
 
 @Configuration
 @EnableCaching(order = Ordered.HIGHEST_PRECEDENCE)
-@EnableConfigurationProperties({AuthCacheProperties.class, ConnectorApiClientCacheProperties.class,
-        CertificateChainCacheProperties.class, CryptographicKeyItemCacheProperties.class,
-        SigningCertificateCacheProperties.class, SigningProfileCacheProperties.class,
-        TimeQualityConfigurationCacheProperties.class, TspProfileCacheProperties.class,})
+@EnableConfigurationProperties({
+        AuthCacheProperties.class,
+        ConnectorApiClientCacheProperties.class,
+        CertificateChainCacheProperties.class,
+        CryptographicKeyItemCacheProperties.class,
+        SigningCertificateCacheProperties.class,
+        SigningProfileCacheProperties.class,
+        TimeQualityConfigurationCacheProperties.class,
+        TspProfileCacheProperties.class,})
 public class CacheConfig {
 
     public static final String CERTIFICATE_AUTH_CACHE = "certificateAuth";

--- a/src/main/java/com/otilm/core/dao/entity/Certificate.java
+++ b/src/main/java/com/otilm/core/dao/entity/Certificate.java
@@ -206,9 +206,8 @@ public class Certificate extends UniquelyIdentifiedAndAudited
     @Column(name = "status_validation_timestamp")
     private OffsetDateTime statusValidationTimestamp;
 
-    @OneToMany(mappedBy = "certificate", fetch = FetchType.LAZY
     // orphanRemoval = true
-    )
+    @OneToMany(mappedBy = "certificate", fetch = FetchType.LAZY)
     @JsonBackReference
     @ToString.Exclude
     private Set<CertificateLocation> locations = new HashSet<>();

--- a/src/main/java/com/otilm/core/dao/entity/Certificate.java
+++ b/src/main/java/com/otilm/core/dao/entity/Certificate.java
@@ -61,19 +61,34 @@ import org.hibernate.type.SqlTypes;
 @ToString
 @RequiredArgsConstructor
 // Entity graph that eagerly loads associations needed by mapToChainDto().
-@NamedEntityGraph(name = "Certificate.chainAssociations", attributeNodes = {@NamedAttributeNode("certificateContent"),
-        @NamedAttributeNode(value = "key", subgraph = "key-items"),
-        @NamedAttributeNode(value = "altKey", subgraph = "alt-key-items"), @NamedAttributeNode("groups"),
-        @NamedAttributeNode("owner"), @NamedAttributeNode(value = "raProfile", subgraph = "ra-profile-authority"),
-        @NamedAttributeNode("certificateRequestEntity"), @NamedAttributeNode("predecessorRelations"),
-        @NamedAttributeNode("protocolAssociation")}, subgraphs = {
-                @NamedSubgraph(name = "key-items", attributeNodes = {@NamedAttributeNode("items"),
-                        @NamedAttributeNode("groups"), @NamedAttributeNode("owner"),
-                        @NamedAttributeNode("tokenProfile"), @NamedAttributeNode("tokenInstanceReference")}),
-                @NamedSubgraph(name = "alt-key-items", attributeNodes = {@NamedAttributeNode("items"),
-                        @NamedAttributeNode("groups"), @NamedAttributeNode("owner"),
-                        @NamedAttributeNode("tokenProfile"), @NamedAttributeNode("tokenInstanceReference")}),
-                @NamedSubgraph(name = "ra-profile-authority", attributeNodes = @NamedAttributeNode("authorityInstanceReference"))})
+@NamedEntityGraph(name = "Certificate.chainAssociations",
+        attributeNodes = {
+                @NamedAttributeNode("certificateContent"),
+                @NamedAttributeNode(value = "key", subgraph = "key-items"),
+                @NamedAttributeNode(value = "altKey", subgraph = "alt-key-items"),
+                @NamedAttributeNode("groups"),
+                @NamedAttributeNode("owner"),
+                @NamedAttributeNode(value = "raProfile", subgraph = "ra-profile-authority"),
+                @NamedAttributeNode("certificateRequestEntity"),
+                @NamedAttributeNode("predecessorRelations"),
+                @NamedAttributeNode("protocolAssociation")},
+        subgraphs = {
+                @NamedSubgraph(name = "key-items",
+                        attributeNodes = {
+                                @NamedAttributeNode("items"),
+                                @NamedAttributeNode("groups"),
+                                @NamedAttributeNode("owner"),
+                                @NamedAttributeNode("tokenProfile"),
+                                @NamedAttributeNode("tokenInstanceReference")}),
+                @NamedSubgraph(name = "alt-key-items",
+                        attributeNodes = {
+                                @NamedAttributeNode("items"),
+                                @NamedAttributeNode("groups"),
+                                @NamedAttributeNode("owner"),
+                                @NamedAttributeNode("tokenProfile"),
+                                @NamedAttributeNode("tokenInstanceReference")}),
+                @NamedSubgraph(name = "ra-profile-authority",
+                        attributeNodes = @NamedAttributeNode("authorityInstanceReference"))})
 @Entity
 @Table(name = "certificate")
 public class Certificate extends UniquelyIdentifiedAndAudited
@@ -176,7 +191,10 @@ public class Certificate extends UniquelyIdentifiedAndAudited
     private UUID raProfileUuid;
 
     @ManyToMany(fetch = FetchType.LAZY)
-    @JoinTable(name = "group_association", joinColumns = @JoinColumn(name = "object_uuid", referencedColumnName = "uuid", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)), inverseJoinColumns = @JoinColumn(name = "group_uuid", insertable = false, updatable = false))
+    @JoinTable(name = "group_association",
+            joinColumns = @JoinColumn(name = "object_uuid", referencedColumnName = "uuid", insertable = false,
+                    updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)),
+            inverseJoinColumns = @JoinColumn(name = "group_uuid", insertable = false, updatable = false))
     @SQLJoinTableRestriction("resource = 'CERTIFICATE'")
     @ToString.Exclude
     private Set<Group> groups = new HashSet<>();

--- a/src/main/java/com/otilm/core/dao/entity/CertificateContent.java
+++ b/src/main/java/com/otilm/core/dao/entity/CertificateContent.java
@@ -34,7 +34,8 @@ public class CertificateContent implements Serializable {
     @Column(name = "id")
     @ColumnDefault("nextval('certificate_content_id_seq'::regclass)")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "certificate_content_seq")
-    @SequenceGenerator(name = "certificate_content_seq", sequenceName = "certificate_content_id_seq", allocationSize = 1)
+    @SequenceGenerator(name = "certificate_content_seq", sequenceName = "certificate_content_id_seq",
+            allocationSize = 1)
     private Long id;
 
     @Column(name = "fingerprint", unique = true)

--- a/src/main/java/com/otilm/core/dao/entity/CertificateProtocolAssociation.java
+++ b/src/main/java/com/otilm/core/dao/entity/CertificateProtocolAssociation.java
@@ -50,25 +50,29 @@ public class CertificateProtocolAssociation extends UniquelyIdentified implement
 
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "protocol_profile_uuid", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @JoinColumn(name = "protocol_profile_uuid", insertable = false, updatable = false,
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     @SQLRestriction("protocol = 'ACME'")
     private AcmeProfile acmeProfile;
 
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "protocol_profile_uuid", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @JoinColumn(name = "protocol_profile_uuid", insertable = false, updatable = false,
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     @SQLRestriction("protocol = 'SCEP'")
     private ScepProfile scepProfile;
 
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "protocol_profile_uuid", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @JoinColumn(name = "protocol_profile_uuid", insertable = false, updatable = false,
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     @SQLRestriction("protocol = 'CMP'")
     private CmpProfile cmpProfile;
 
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "additional_protocol_uuid", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @JoinColumn(name = "additional_protocol_uuid", insertable = false, updatable = false,
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     @SQLRestriction("protocol = 'ACME'")
     private AcmeAccount acmeAccount;
 

--- a/src/main/java/com/otilm/core/dao/entity/CertificateRegistration.java
+++ b/src/main/java/com/otilm/core/dao/entity/CertificateRegistration.java
@@ -18,7 +18,9 @@ import lombok.Setter;
 @Setter
 @Entity
 // A certificate has at most one registration binding at a time.
-@Table(name = "certificate_registration", uniqueConstraints = @UniqueConstraint(name = "uq_certificate_registration_certificate", columnNames = "certificate_uuid"))
+@Table(name = "certificate_registration",
+        uniqueConstraints = @UniqueConstraint(name = "uq_certificate_registration_certificate",
+                columnNames = "certificate_uuid"))
 public class CertificateRegistration extends UniquelyIdentified {
 
     @Column(name = "certificate_uuid", nullable = false)
@@ -29,11 +31,13 @@ public class CertificateRegistration extends UniquelyIdentified {
     private String meta;
 
     // Set by the database on insert, never by the application.
-    @Column(name = "i_cre", nullable = false, insertable = false, updatable = false, columnDefinition = "timestamptz not null default now()")
+    @Column(name = "i_cre", nullable = false, insertable = false, updatable = false,
+            columnDefinition = "timestamptz not null default now()")
     private OffsetDateTime created;
 
     // Maintained by the upsert SQL (audit-columns-in-SQL rule); read-only on the entity.
-    @Column(name = "i_upd", nullable = false, insertable = false, updatable = false, columnDefinition = "timestamptz not null default now()")
+    @Column(name = "i_upd", nullable = false, insertable = false, updatable = false,
+            columnDefinition = "timestamptz not null default now()")
     private OffsetDateTime updated;
 
     @Override

--- a/src/main/java/com/otilm/core/dao/entity/CertificateRegistrationAuthorization.java
+++ b/src/main/java/com/otilm/core/dao/entity/CertificateRegistrationAuthorization.java
@@ -25,7 +25,9 @@ import lombok.ToString;
 @ToString
 @Entity
 // A certificate has at most one durable authorization record.
-@Table(name = "certificate_registration_authorization", uniqueConstraints = @UniqueConstraint(name = "uq_certificate_registration_authorization_certificate", columnNames = "certificate_uuid"))
+@Table(name = "certificate_registration_authorization",
+        uniqueConstraints = @UniqueConstraint(name = "uq_certificate_registration_authorization_certificate",
+                columnNames = "certificate_uuid"))
 public class CertificateRegistrationAuthorization extends UniquelyIdentifiedAndAudited {
 
     @Column(name = "certificate_uuid", nullable = false)

--- a/src/main/java/com/otilm/core/dao/entity/CertificateStatusPoll.java
+++ b/src/main/java/com/otilm/core/dao/entity/CertificateStatusPoll.java
@@ -21,7 +21,9 @@ import lombok.Setter;
 @Setter
 @Entity
 // A certificate has at most one async operation in flight at a time.
-@Table(name = "certificate_status_poll", uniqueConstraints = @UniqueConstraint(name = "uq_certificate_status_poll_certificate", columnNames = "certificate_uuid"))
+@Table(name = "certificate_status_poll",
+        uniqueConstraints = @UniqueConstraint(name = "uq_certificate_status_poll_certificate",
+                columnNames = "certificate_uuid"))
 public class CertificateStatusPoll extends UniquelyIdentified {
 
     @Column(name = "certificate_uuid", nullable = false)
@@ -38,7 +40,8 @@ public class CertificateStatusPoll extends UniquelyIdentified {
     private OffsetDateTime nextPollAt;
 
     // Set by the database on insert, never written by the application — hence a read-only mapping.
-    @Column(name = "i_cre", nullable = false, insertable = false, updatable = false, columnDefinition = "timestamptz not null default now()")
+    @Column(name = "i_cre", nullable = false, insertable = false, updatable = false,
+            columnDefinition = "timestamptz not null default now()")
     private OffsetDateTime created;
 
     // No-op override required by Sonar S2160 (a field-adding subclass of UniquelyIdentified must override

--- a/src/main/java/com/otilm/core/dao/entity/Connector.java
+++ b/src/main/java/com/otilm/core/dao/entity/Connector.java
@@ -45,8 +45,8 @@ import org.hibernate.proxy.HibernateProxy;
 @ToString
 @RequiredArgsConstructor
 @Entity
-@Table(name = "connector", uniqueConstraints = {
-        @UniqueConstraint(name = "uq_connector_url_version", columnNames = {"url", "version"})})
+@Table(name = "connector",
+        uniqueConstraints = {@UniqueConstraint(name = "uq_connector_url_version", columnNames = {"url", "version"})})
 public class Connector extends UniquelyIdentifiedAndAudited
         implements
             Serializable,

--- a/src/main/java/com/otilm/core/dao/entity/Connector2FunctionGroup.java
+++ b/src/main/java/com/otilm/core/dao/entity/Connector2FunctionGroup.java
@@ -32,7 +32,8 @@ public class Connector2FunctionGroup implements Serializable {
     @Id
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "connector_2_function_group_seq")
-    @SequenceGenerator(name = "connector_2_function_group_seq", sequenceName = "connector_2_function_group_id_seq", allocationSize = 1)
+    @SequenceGenerator(name = "connector_2_function_group_seq", sequenceName = "connector_2_function_group_id_seq",
+            allocationSize = 1)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/otilm/core/dao/entity/CryptographicKey.java
+++ b/src/main/java/com/otilm/core/dao/entity/CryptographicKey.java
@@ -67,7 +67,10 @@ public class CryptographicKey extends UniquelyIdentifiedAndAudited implements Se
     private UUID tokenInstanceReferenceUuid;
 
     @ManyToMany(fetch = FetchType.LAZY)
-    @JoinTable(name = "group_association", joinColumns = @JoinColumn(name = "object_uuid", referencedColumnName = "uuid", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)), inverseJoinColumns = @JoinColumn(name = "group_uuid", insertable = false, updatable = false))
+    @JoinTable(name = "group_association",
+            joinColumns = @JoinColumn(name = "object_uuid", referencedColumnName = "uuid", insertable = false,
+                    updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)),
+            inverseJoinColumns = @JoinColumn(name = "group_uuid", insertable = false, updatable = false))
     @SQLJoinTableRestriction("resource = 'CRYPTOGRAPHIC_KEY'")
     @ToString.Exclude
     private Set<Group> groups = new HashSet<>();

--- a/src/main/java/com/otilm/core/dao/entity/DiscoveryHistory.java
+++ b/src/main/java/com/otilm/core/dao/entity/DiscoveryHistory.java
@@ -92,7 +92,12 @@ public class DiscoveryHistory extends UniquelyIdentifiedAndAudited
     private Set<DiscoveryCertificate> certificate = new HashSet<>();
 
     @ManyToMany(fetch = FetchType.LAZY)
-    @JoinTable(name = "trigger_association", joinColumns = @JoinColumn(name = "object_uuid", referencedColumnName = "uuid", insertable = false, updatable = false), inverseJoinColumns = @JoinColumn(name = "trigger_uuid", insertable = false, updatable = false), foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT), inverseForeignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @JoinTable(name = "trigger_association",
+            joinColumns = @JoinColumn(name = "object_uuid", referencedColumnName = "uuid", insertable = false,
+                    updatable = false),
+            inverseJoinColumns = @JoinColumn(name = "trigger_uuid", insertable = false, updatable = false),
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT),
+            inverseForeignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     @SQLJoinTableRestriction("resource = 'DISCOVERY'")
     @ToString.Exclude
     private List<Trigger> triggers = new ArrayList<>();

--- a/src/main/java/com/otilm/core/dao/entity/Location.java
+++ b/src/main/java/com/otilm/core/dao/entity/Location.java
@@ -68,9 +68,8 @@ public class Location extends UniquelyIdentifiedAndAudited
     @Column(name = "enabled")
     private Boolean enabled;
 
-    @OneToMany(mappedBy = "location", cascade = CascadeType.ALL, fetch = FetchType.LAZY
     // orphanRemoval = true
-    )
+    @OneToMany(mappedBy = "location", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JsonManagedReference
     @ToString.Exclude
     private Set<CertificateLocation> certificates = new HashSet<>();

--- a/src/main/java/com/otilm/core/dao/entity/OwnerAssociation.java
+++ b/src/main/java/com/otilm/core/dao/entity/OwnerAssociation.java
@@ -34,19 +34,22 @@ public class OwnerAssociation extends ResourceObjectAssociation {
 
     @JsonIgnore
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "object_uuid", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @JoinColumn(name = "object_uuid", insertable = false, updatable = false,
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     @SQLRestriction("resource = 'CERTIFICATE'")
     private Certificate certificate;
 
     @JsonIgnore
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "object_uuid", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @JoinColumn(name = "object_uuid", insertable = false, updatable = false,
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     @SQLRestriction("resource = 'CRYPTOGRAPHIC_KEY'")
     private CryptographicKey key;
 
     @JsonIgnore
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "object_uuid", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @JoinColumn(name = "object_uuid", insertable = false, updatable = false,
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     @SQLRestriction("resource = 'SECRET'")
     private Secret secret;
 

--- a/src/main/java/com/otilm/core/dao/entity/Secret.java
+++ b/src/main/java/com/otilm/core/dao/entity/Secret.java
@@ -87,7 +87,10 @@ public class Secret extends UniquelyIdentifiedAndAudited implements ComplianceSu
     private boolean enabled;
 
     @ManyToMany(fetch = FetchType.LAZY)
-    @JoinTable(name = "group_association", joinColumns = @JoinColumn(name = "object_uuid", referencedColumnName = "uuid", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)), inverseJoinColumns = @JoinColumn(name = "group_uuid", insertable = false, updatable = false))
+    @JoinTable(name = "group_association",
+            joinColumns = @JoinColumn(name = "object_uuid", referencedColumnName = "uuid", insertable = false,
+                    updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)),
+            inverseJoinColumns = @JoinColumn(name = "group_uuid", insertable = false, updatable = false))
     @SQLJoinTableRestriction("resource = 'SECRET'")
     @ToString.Exclude
     private Set<Group> groups = new HashSet<>();

--- a/src/main/java/com/otilm/core/dao/entity/notifications/NotificationInstanceMappedAttributes.java
+++ b/src/main/java/com/otilm/core/dao/entity/notifications/NotificationInstanceMappedAttributes.java
@@ -41,12 +41,14 @@ public class NotificationInstanceMappedAttributes extends UniquelyIdentified
     private String mappingAttributeName;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "notification_instance_ref_uuid", referencedColumnName = "uuid", insertable = false, updatable = false)
+    @JoinColumn(name = "notification_instance_ref_uuid", referencedColumnName = "uuid", insertable = false,
+            updatable = false)
     @ToString.Exclude
     private NotificationInstanceReference notificationInstanceReference;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "attribute_definition_uuid", referencedColumnName = "uuid", insertable = false, updatable = false)
+    @JoinColumn(name = "attribute_definition_uuid", referencedColumnName = "uuid", insertable = false,
+            updatable = false)
     @ToString.Exclude
     private AttributeDefinition attributeDefinition;
 

--- a/src/main/java/com/otilm/core/dao/entity/notifications/NotificationProfileVersion.java
+++ b/src/main/java/com/otilm/core/dao/entity/notifications/NotificationProfileVersion.java
@@ -31,8 +31,9 @@ import org.hibernate.type.SqlTypes;
 @ToString
 @RequiredArgsConstructor
 @Entity
-@Table(name = "notification_profile_version", uniqueConstraints = @UniqueConstraint(name = NotificationProfileVersion.UNIQUE_VERSION_CONSTRAINT, columnNames = {
-        "notification_profile_uuid", "version"}))
+@Table(name = "notification_profile_version",
+        uniqueConstraints = @UniqueConstraint(name = NotificationProfileVersion.UNIQUE_VERSION_CONSTRAINT,
+                columnNames = {"notification_profile_uuid", "version"}))
 public class NotificationProfileVersion extends UniquelyIdentified {
 
     public static final String UNIQUE_VERSION_CONSTRAINT = "uq_notification_profile_version";
@@ -60,7 +61,8 @@ public class NotificationProfileVersion extends UniquelyIdentified {
     private UUID notificationInstanceRefUuid;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "notification_instance_ref_uuid", referencedColumnName = "uuid", insertable = false, updatable = false)
+    @JoinColumn(name = "notification_instance_ref_uuid", referencedColumnName = "uuid", insertable = false,
+            updatable = false)
     @ToString.Exclude
     private NotificationInstanceReference notificationInstance;
 

--- a/src/main/java/com/otilm/core/dao/entity/notifications/NotificationRecipient.java
+++ b/src/main/java/com/otilm/core/dao/entity/notifications/NotificationRecipient.java
@@ -20,8 +20,8 @@ import lombok.ToString;
 @ToString
 @RequiredArgsConstructor
 @Entity
-@Table(name = "notification_recipient", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"notification_uuid", "user_uuid"})})
+@Table(name = "notification_recipient",
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"notification_uuid", "user_uuid"})})
 public class NotificationRecipient extends UniquelyIdentified {
 
     @Column(name = "notification_uuid", nullable = false)

--- a/src/main/java/com/otilm/core/dao/entity/notifications/PendingNotification.java
+++ b/src/main/java/com/otilm/core/dao/entity/notifications/PendingNotification.java
@@ -24,8 +24,9 @@ import org.hibernate.annotations.UpdateTimestamp;
 @ToString
 @RequiredArgsConstructor
 @Entity
-@Table(name = "pending_notification", uniqueConstraints = @UniqueConstraint(name = PendingNotification.UNIQUE_SUPPRESSION_ROW_CONSTRAINT, columnNames = {
-        "notification_profile_uuid", "resource", "object_uuid", "event"}))
+@Table(name = "pending_notification",
+        uniqueConstraints = @UniqueConstraint(name = PendingNotification.UNIQUE_SUPPRESSION_ROW_CONSTRAINT,
+                columnNames = {"notification_profile_uuid", "resource", "object_uuid", "event"}))
 public class PendingNotification extends ResourceObjectAssociation {
 
     public static final String UNIQUE_SUPPRESSION_ROW_CONSTRAINT = "uq_pending_notification_suppression_row";

--- a/src/main/java/com/otilm/core/dao/entity/signing/SigningProfileVersion.java
+++ b/src/main/java/com/otilm/core/dao/entity/signing/SigningProfileVersion.java
@@ -30,8 +30,8 @@ import org.hibernate.type.SqlTypes;
 @Getter
 @Setter
 @Entity
-@Table(name = "signing_profile_version", uniqueConstraints = @UniqueConstraint(name = "uq_signing_profile_version", columnNames = {
-        "signing_profile_uuid", "version"}))
+@Table(name = "signing_profile_version", uniqueConstraints = @UniqueConstraint(name = "uq_signing_profile_version",
+        columnNames = {"signing_profile_uuid", "version"}))
 public class SigningProfileVersion extends UniquelyIdentifiedAndAudited {
 
     @Column(name = "signing_profile_uuid", nullable = false)

--- a/src/main/java/com/otilm/core/dao/entity/signing/SigningRecord.java
+++ b/src/main/java/com/otilm/core/dao/entity/signing/SigningRecord.java
@@ -58,8 +58,11 @@ public class SigningRecord extends UniquelyIdentifiedAndAudited implements Secur
      */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumns(value = {
-            @JoinColumn(name = "signing_profile_uuid", referencedColumnName = "signing_profile_uuid", insertable = false, updatable = false),
-            @JoinColumn(name = "signing_profile_version", referencedColumnName = "version", insertable = false, updatable = false)}, foreignKey = @ForeignKey(name = "fk_signing_record_profile_version"))
+            @JoinColumn(name = "signing_profile_uuid", referencedColumnName = "signing_profile_uuid",
+                    insertable = false, updatable = false),
+            @JoinColumn(name = "signing_profile_version", referencedColumnName = "version", insertable = false,
+                    updatable = false)},
+            foreignKey = @ForeignKey(name = "fk_signing_record_profile_version"))
     @ToString.Exclude
     private SigningProfileVersion signingProfileVersionEntity;
 

--- a/src/main/java/com/otilm/core/dao/entity/signing/TspProfileBasicCredential.java
+++ b/src/main/java/com/otilm/core/dao/entity/signing/TspProfileBasicCredential.java
@@ -18,10 +18,11 @@ import lombok.ToString;
 @Setter
 @ToString
 @Entity
-@Table(name = "tsp_profile_basic_credential", uniqueConstraints = {
-        @UniqueConstraint(name = "tsp_profile_basic_credential_username", columnNames = {"tsp_profile_uuid",
-                "username"}),
-        @UniqueConstraint(name = "tsp_profile_basic_credential_secret_uuid", columnNames = {"secret_uuid"})})
+@Table(name = "tsp_profile_basic_credential",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "tsp_profile_basic_credential_username",
+                        columnNames = {"tsp_profile_uuid", "username"}),
+                @UniqueConstraint(name = "tsp_profile_basic_credential_secret_uuid", columnNames = {"secret_uuid"})})
 public class TspProfileBasicCredential extends UniquelyIdentified {
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/otilm/core/dao/entity/workflows/Action.java
+++ b/src/main/java/com/otilm/core/dao/entity/workflows/Action.java
@@ -43,7 +43,8 @@ public class Action extends UniquelyIdentified {
     private Resource resource;
 
     @ManyToMany(fetch = FetchType.LAZY)
-    @JoinTable(name = "action_2_execution", joinColumns = @JoinColumn(name = "action_uuid"), inverseJoinColumns = @JoinColumn(name = "execution_uuid"))
+    @JoinTable(name = "action_2_execution", joinColumns = @JoinColumn(name = "action_uuid"),
+            inverseJoinColumns = @JoinColumn(name = "execution_uuid"))
     @ToString.Exclude
     private Set<Execution> executions;
 

--- a/src/main/java/com/otilm/core/dao/entity/workflows/Rule.java
+++ b/src/main/java/com/otilm/core/dao/entity/workflows/Rule.java
@@ -42,7 +42,8 @@ public class Rule extends UniquelyIdentified {
     private Resource resource;
 
     @ManyToMany(fetch = FetchType.LAZY)
-    @JoinTable(name = "rule_2_condition", joinColumns = @JoinColumn(name = "rule_uuid"), inverseJoinColumns = @JoinColumn(name = "condition_uuid"))
+    @JoinTable(name = "rule_2_condition", joinColumns = @JoinColumn(name = "rule_uuid"),
+            inverseJoinColumns = @JoinColumn(name = "condition_uuid"))
     @ToString.Exclude
     private Set<Condition> conditions;
 

--- a/src/main/java/com/otilm/core/dao/entity/workflows/Trigger.java
+++ b/src/main/java/com/otilm/core/dao/entity/workflows/Trigger.java
@@ -51,12 +51,14 @@ public class Trigger extends UniquelyIdentified {
     private ResourceEvent event;
 
     @ManyToMany(fetch = FetchType.LAZY)
-    @JoinTable(name = "trigger_2_rule", joinColumns = @JoinColumn(name = "trigger_uuid"), inverseJoinColumns = @JoinColumn(name = "rule_uuid"))
+    @JoinTable(name = "trigger_2_rule", joinColumns = @JoinColumn(name = "trigger_uuid"),
+            inverseJoinColumns = @JoinColumn(name = "rule_uuid"))
     @ToString.Exclude
     private Set<Rule> rules;
 
     @ManyToMany(fetch = FetchType.LAZY)
-    @JoinTable(name = "trigger_2_action", joinColumns = @JoinColumn(name = "trigger_uuid"), inverseJoinColumns = @JoinColumn(name = "action_uuid"))
+    @JoinTable(name = "trigger_2_action", joinColumns = @JoinColumn(name = "trigger_uuid"),
+            inverseJoinColumns = @JoinColumn(name = "action_uuid"))
     @ToString.Exclude
     private Set<Action> actions;
 

--- a/src/main/java/com/otilm/core/dao/repository/CertificateRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CertificateRepository.java
@@ -58,12 +58,27 @@ public interface CertificateRepository
 
     Certificate findFirstByUuidIn(List<UUID> uuids);
 
-    @EntityGraph(attributePaths = {"certificateContent", "key", "key.items", "groups", "owner", "altKey",
-            "altKey.items", "raProfile"})
+    @EntityGraph(attributePaths = {
+            "certificateContent",
+            "key",
+            "key.items",
+            "groups",
+            "owner",
+            "altKey",
+            "altKey.items",
+            "raProfile"})
     Optional<Certificate> findWithAssociationsByUuid(UUID uuid);
 
-    @EntityGraph(attributePaths = {"certificateContent", "key", "key.items", "groups", "owner", "altKey",
-            "altKey.items", "raProfile", "raProfile.authorityInstanceReference",
+    @EntityGraph(attributePaths = {
+            "certificateContent",
+            "key",
+            "key.items",
+            "groups",
+            "owner",
+            "altKey",
+            "altKey.items",
+            "raProfile",
+            "raProfile.authorityInstanceReference",
             "raProfile.authorityInstanceReference.connectorInterface",
             "raProfile.authorityInstanceReference.connector"})
     Optional<Certificate> findWithAuthorityAssociationsByUuid(UUID uuid);
@@ -73,7 +88,10 @@ public interface CertificateRepository
      * to the connector), so every association the listener touches must be eagerly loaded here to avoid
      * {@link org.hibernate.LazyInitializationException}.
      */
-    @EntityGraph(attributePaths = {"certificateContent", "raProfile", "raProfile.authorityInstanceReference",
+    @EntityGraph(attributePaths = {
+            "certificateContent",
+            "raProfile",
+            "raProfile.authorityInstanceReference",
             "raProfile.authorityInstanceReference.connectorInterface",
             "raProfile.authorityInstanceReference.connector"})
     Optional<Certificate> findForPollingByUuid(UUID uuid);
@@ -84,14 +102,29 @@ public interface CertificateRepository
      * called inside an active transaction, otherwise the lock is released immediately on query completion.
      */
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @EntityGraph(attributePaths = {"certificateContent", "key", "key.items", "groups", "owner", "altKey",
-            "altKey.items", "raProfile", "raProfile.authorityInstanceReference",
+    @EntityGraph(attributePaths = {
+            "certificateContent",
+            "key",
+            "key.items",
+            "groups",
+            "owner",
+            "altKey",
+            "altKey.items",
+            "raProfile",
+            "raProfile.authorityInstanceReference",
             "raProfile.authorityInstanceReference.connectorInterface",
             "raProfile.authorityInstanceReference.connector"})
     Optional<Certificate> findAndLockWithAssociationsByUuid(UUID uuid);
 
-    @EntityGraph(attributePaths = {"certificateContent", "key", "key.items", "groups", "owner", "altKey",
-            "altKey.items", "raProfile"})
+    @EntityGraph(attributePaths = {
+            "certificateContent",
+            "key",
+            "key.items",
+            "groups",
+            "owner",
+            "altKey",
+            "altKey.items",
+            "raProfile"})
     List<Certificate> findWithAssociationsByUuidInOrderByCreatedDesc(List<UUID> uuids);
 
     /** Fetches a single certificate with all associations required by {@link Certificate#mapToChainDto()}. */
@@ -353,7 +386,8 @@ public interface CertificateRepository
             )
             ON CONFLICT (fingerprint)
             DO NOTHING
-            """, nativeQuery = true)
+            """,
+            nativeQuery = true)
     Integer insertWithFingerprintConflictResolve(@Param("cert") Certificate certificate);
 
     @Query("""

--- a/src/main/java/com/otilm/core/dao/repository/ComplianceProfileRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/ComplianceProfileRepository.java
@@ -17,8 +17,12 @@ public interface ComplianceProfileRepository extends SecurityFilterRepository<Co
     @EntityGraph(attributePaths = {"complianceRules", "complianceRules.internalRule", "associations"})
     Optional<ComplianceProfile> findWithAssociationsByUuid(UUID uuid);
 
-    @EntityGraph(attributePaths = {"associations", "complianceRules", "complianceRules.connector",
-            "complianceRules.internalRule", "complianceRules.internalRule.conditionItems"})
+    @EntityGraph(attributePaths = {
+            "associations",
+            "complianceRules",
+            "complianceRules.connector",
+            "complianceRules.internalRule",
+            "complianceRules.internalRule.conditionItems"})
     List<ComplianceProfile> findWithAssociationsByUuidIn(List<UUID> uuids);
 
     List<ComplianceProfile> findDistinctByComplianceRulesConnectorUuid(UUID connectorUuid);

--- a/src/main/java/com/otilm/core/dao/repository/CrlRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CrlRepository.java
@@ -32,7 +32,8 @@ public interface CrlRepository extends SecurityFilterRepository<Crl, Long> {
             :#{#crl.crlIssuerDn}, :#{#crl.crlNumber}, :#{#crl.nextUpdate}, :#{#crl.crlNumberDelta}, :#{#crl.nextUpdateDelta}, :#{#crl.lastRevocationDate})
             ON CONFLICT (issuer_dn, serial_number)
             DO NOTHING
-            """, nativeQuery = true)
+            """,
+            nativeQuery = true)
     void insertWithIssuerConflictResolve(@Param("crl") Crl crl);
 
     @Modifying

--- a/src/main/java/com/otilm/core/dao/repository/CryptographicKeyItemRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CryptographicKeyItemRepository.java
@@ -50,7 +50,8 @@ public interface CryptographicKeyItemRepository extends SecurityFilterRepository
                 :#{#cki.length}, :#{#cki.fingerprint}, :#{#cki.reason?.name() ?: null}, :#{#cki.complianceStatus.name()}, :#{#cki.createdAt},
                 :#{#cki.updatedAt}, :#{#cki.usageBitmask}
             ) ON CONFLICT (fingerprint) DO NOTHING
-            """, nativeQuery = true)
+            """,
+            nativeQuery = true)
     Integer insertWithFingerprintConflictResolve(@Param("cki") CryptographicKeyItem keyItem);
 
     @Query(value = """

--- a/src/main/java/com/otilm/core/dao/repository/RaProfileRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/RaProfileRepository.java
@@ -18,8 +18,11 @@ public interface RaProfileRepository extends SecurityFilterRepository<RaProfile,
      * (e.g. request-attribute resolution under {@code Propagation.NOT_SUPPORTED}) do not depend on open-session-in-view
      * for the lazy collection.
      */
-    @EntityGraph(attributePaths = {"authorityInstanceReference", "authorityInstanceReference.connectorInterface",
-            "authorityInstanceReference.connector", "authorityInstanceReference.connector.functionGroups"})
+    @EntityGraph(attributePaths = {
+            "authorityInstanceReference",
+            "authorityInstanceReference.connectorInterface",
+            "authorityInstanceReference.connector",
+            "authorityInstanceReference.connector.functionGroups"})
     Optional<RaProfile> findWithAuthorityByUuid(UUID uuid);
 
     Optional<RaProfile> findByName(String name);

--- a/src/main/java/com/otilm/core/dao/repository/notifications/PendingNotificationRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/notifications/PendingNotificationRepository.java
@@ -30,7 +30,8 @@ public interface PendingNotificationRepository extends SecurityFilterRepository<
             VALUES (:uuid, :profileUuid, :resource, :objectUuid, :event, :version, 1, :lastSentAt)
             ON CONFLICT (notification_profile_uuid, resource, object_uuid, event)
             DO UPDATE SET repetitions = pending_notification.repetitions + 1, last_sent_at = EXCLUDED.last_sent_at
-            """, nativeQuery = true)
+            """,
+            nativeQuery = true)
     void upsertSent(@Param("uuid") UUID uuid, @Param("profileUuid") UUID profileUuid,
             @Param("resource") String resource, @Param("objectUuid") UUID objectUuid, @Param("event") String event,
             @Param("version") int version, @Param("lastSentAt") OffsetDateTime lastSentAt);

--- a/src/main/java/com/otilm/core/dao/repository/signing/SigningProfileVersionRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/signing/SigningProfileVersionRepository.java
@@ -13,7 +13,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface SigningProfileVersionRepository extends JpaRepository<SigningProfileVersion, UUID> {
 
-    @EntityGraph(attributePaths = {"certificate", "certificate.certificateContent", "certificate.key",
+    @EntityGraph(attributePaths = {
+            "certificate",
+            "certificate.certificateContent",
+            "certificate.key",
             "certificate.key.items",})
     Optional<SigningProfileVersion> findWithAssociationsBySigningProfileUuidAndVersion(UUID signingProfileUuid,
             int version);

--- a/src/main/java/com/otilm/core/dao/repository/signing/TimeQualityConfigurationRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/signing/TimeQualityConfigurationRepository.java
@@ -16,6 +16,7 @@ public interface TimeQualityConfigurationRepository extends SecurityFilterReposi
     @Query("SELECT t.name FROM TimeQualityConfiguration t ORDER BY t.name")
     List<String> findAllNames();
 
-    @Query(value = "SELECT DISTINCT unnest(ntp_servers) FROM {h-schema}time_quality_configuration ORDER BY 1", nativeQuery = true)
+    @Query(value = "SELECT DISTINCT unnest(ntp_servers) FROM {h-schema}time_quality_configuration ORDER BY 1",
+            nativeQuery = true)
     List<String> findAllNtpServers();
 }

--- a/src/main/java/com/otilm/core/dao/repository/workflows/TriggerAssociationRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/workflows/TriggerAssociationRepository.java
@@ -16,8 +16,13 @@ public interface TriggerAssociationRepository extends SecurityFilterRepository<T
 
     List<TriggerAssociation> findAllByResourceAndObjectUuidOrderByTriggerOrderAsc(Resource resource, UUID objectUuid);
 
-    @EntityGraph(attributePaths = {"trigger", "trigger.rules", "trigger.rules.conditions",
-            "trigger.rules.conditions.items", "trigger.actions", "trigger.actions.executions",
+    @EntityGraph(attributePaths = {
+            "trigger",
+            "trigger.rules",
+            "trigger.rules.conditions",
+            "trigger.rules.conditions.items",
+            "trigger.actions",
+            "trigger.actions.executions",
             "trigger.actions.executions.items"})
     List<TriggerAssociation> findAllByEventAndResourceAndObjectUuidOrderByTriggerOrderAsc(ResourceEvent resourceEvent,
             Resource resource, UUID objectUuid);

--- a/src/main/java/com/otilm/core/dao/repository/workflows/TriggerHistoryRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/workflows/TriggerHistoryRepository.java
@@ -28,7 +28,11 @@ public interface TriggerHistoryRepository extends SecurityFilterRepository<Trigg
     @Query("UPDATE TriggerHistory t SET t.triggerAssociationUuid = NULL WHERE t.triggerAssociationUuid = :uuid")
     int removeTriggerAssociation(@Param("uuid") UUID uuid);
 
-    @EntityGraph(attributePaths = {"records", "triggerAssociation", "records.execution", "records.execution.items",
+    @EntityGraph(attributePaths = {
+            "records",
+            "triggerAssociation",
+            "records.execution",
+            "records.execution.items",
             "records.execution.items.notificationProfile"})
     Page<TriggerHistory> findByObjectUuidAndObjectResourceOrderByTriggeredAtDesc(UUID objectUuid,
             Resource objectResource, Pageable pageable);
@@ -51,7 +55,8 @@ public interface TriggerHistoryRepository extends SecurityFilterRepository<Trigg
             LEFT JOIN {h-schema}trigger tr ON t.trigger_uuid = tr.uuid
             WHERE t.event_history_uuid IN :uuids
             GROUP BY t.event_history_uuid
-            """, nativeQuery = true)
+            """,
+            nativeQuery = true)
     List<Object[]> countStatsByEventHistoryUuids(@Param("uuids") List<UUID> uuids);
 
     /**
@@ -86,7 +91,11 @@ public interface TriggerHistoryRepository extends SecurityFilterRepository<Trigg
               AND (t.objectUuid IN :objectUuids OR t.objectUuid IS NULL)
             ORDER BY t.eventHistoryUuid ASC, t.objectUuid ASC NULLS LAST, t.triggeredAt DESC
             """)
-    @EntityGraph(attributePaths = {"records", "triggerAssociation", "records.execution", "records.execution.items",
+    @EntityGraph(attributePaths = {
+            "records",
+            "triggerAssociation",
+            "records.execution",
+            "records.execution.items",
             "records.execution.items.notificationProfile"})
     List<TriggerHistory> findByEventHistoryUuidsAndObjectUuids(@Param("eventHistoryUuids") List<UUID> eventHistoryUuids,
             @Param("objectUuids") List<UUID> objectUuids);

--- a/src/main/java/com/otilm/core/logging/AuditLogExportDto.java
+++ b/src/main/java/com/otilm/core/logging/AuditLogExportDto.java
@@ -13,9 +13,27 @@ import java.util.UUID;
 import lombok.Builder;
 
 @Builder
-@JsonPropertyOrder({"id", "version", "loggedAt", "timestamp", "module", "operation", "operationResult", "resource",
-        "resourceObjects", "affiliatedResource", "affiliatedObjects", "actorType", "actorAuthMethod", "actorUuid",
-        "actorName", "ipAddress", "userAgent", "message", "operationData", "additionalData"})
+@JsonPropertyOrder({
+        "id",
+        "version",
+        "loggedAt",
+        "timestamp",
+        "module",
+        "operation",
+        "operationResult",
+        "resource",
+        "resourceObjects",
+        "affiliatedResource",
+        "affiliatedObjects",
+        "actorType",
+        "actorAuthMethod",
+        "actorUuid",
+        "actorName",
+        "ipAddress",
+        "userAgent",
+        "message",
+        "operationData",
+        "additionalData"})
 public record AuditLogExportDto(long id, String version, OffsetDateTime loggedAt, OffsetDateTime timestamp,
         Module module, Resource resource, String resourceObjects, Resource affiliatedResource, String affiliatedObjects,
         ActorType actorType, AuthMethod actorAuthMethod, UUID actorUuid, String actorName, String ipAddress,

--- a/src/main/java/com/otilm/core/messaging/jms/configuration/JmsConfig.java
+++ b/src/main/java/com/otilm/core/messaging/jms/configuration/JmsConfig.java
@@ -28,7 +28,9 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 @EnableJms
 @Configuration
-@EnableConfigurationProperties({MessagingProperties.class, MessagingConcurrencyProperties.class,
+@EnableConfigurationProperties({
+        MessagingProperties.class,
+        MessagingConcurrencyProperties.class,
         StatusPollProperties.class})
 public class JmsConfig {
     private static final Logger logger = getLogger(JmsConfig.class);

--- a/src/main/java/com/otilm/core/messaging/jms/configuration/MessagingConcurrencyProperties.java
+++ b/src/main/java/com/otilm/core/messaging/jms/configuration/MessagingConcurrencyProperties.java
@@ -8,14 +8,23 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "messaging.concurrency")
 @Validated
 public record MessagingConcurrencyProperties(
-        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?", message = "must be a number or range (e.g. '5' or '3-10')") String actions,
-        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?", message = "must be a number or range (e.g. '5' or '3-10')") String auditLogs,
-        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?", message = "must be a number or range (e.g. '5' or '3-10')") String events,
-        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?", message = "must be a number or range (e.g. '5' or '3-10')") String notifications,
-        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?", message = "must be a number or range (e.g. '5' or '3-10')") String scheduler,
-        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?", message = "must be a number or range (e.g. '5' or '3-10')") String validation,
-        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?", message = "must be a number or range (e.g. '5' or '3-10')") String timeQualityConfigRequest,
-        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?", message = "must be a number or range (e.g. '5' or '3-10')") String timeQualityResults,
-        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?", message = "must be a number or range (e.g. '5' or '3-10')") String providerStatusPoll) {
+        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?",
+                message = "must be a number or range (e.g. '5' or '3-10')") String actions,
+        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?",
+                message = "must be a number or range (e.g. '5' or '3-10')") String auditLogs,
+        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?",
+                message = "must be a number or range (e.g. '5' or '3-10')") String events,
+        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?",
+                message = "must be a number or range (e.g. '5' or '3-10')") String notifications,
+        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?",
+                message = "must be a number or range (e.g. '5' or '3-10')") String scheduler,
+        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?",
+                message = "must be a number or range (e.g. '5' or '3-10')") String validation,
+        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?",
+                message = "must be a number or range (e.g. '5' or '3-10')") String timeQualityConfigRequest,
+        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?",
+                message = "must be a number or range (e.g. '5' or '3-10')") String timeQualityResults,
+        @NotBlank @Pattern(regexp = "\\d+(-\\d+)?",
+                message = "must be a number or range (e.g. '5' or '3-10')") String providerStatusPoll) {
 
 }

--- a/src/main/java/com/otilm/core/model/auth/ResourceSyncRequestDto.java
+++ b/src/main/java/com/otilm/core/model/auth/ResourceSyncRequestDto.java
@@ -13,7 +13,8 @@ public class ResourceSyncRequestDto {
     @Schema(description = "Action Names", requiredMode = Schema.RequiredMode.REQUIRED, example = "list")
     private List<String> actions;
 
-    @Schema(description = "Is endpoint for listing objects flag - true = Yes; false = No", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "Is endpoint for listing objects flag - true = Yes; false = No",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String listObjectsEndpoint;
 
     public Resource getName() {

--- a/src/main/java/com/otilm/core/model/auth/SyncRequestDto.java
+++ b/src/main/java/com/otilm/core/model/auth/SyncRequestDto.java
@@ -12,7 +12,8 @@ public class SyncRequestDto {
     @Schema(description = "Request Method", requiredMode = Schema.RequiredMode.REQUIRED, example = "GET")
     private String method;
 
-    @Schema(description = "Context of the request", requiredMode = Schema.RequiredMode.REQUIRED, example = "/v1/clients")
+    @Schema(description = "Context of the request", requiredMode = Schema.RequiredMode.REQUIRED,
+            example = "/v1/clients")
     private String routeTemplate;
 
     @Schema(description = "Name of the resource", requiredMode = Schema.RequiredMode.REQUIRED, example = "client")
@@ -21,7 +22,8 @@ public class SyncRequestDto {
     @Schema(description = "Action Name", requiredMode = Schema.RequiredMode.REQUIRED, example = "list")
     private ResourceAction actionName;
 
-    @Schema(description = "Is endpoint for listing objects flag - true = Yes; false = No", requiredMode = Schema.RequiredMode.REQUIRED, example = "false", defaultValue = "false")
+    @Schema(description = "Is endpoint for listing objects flag - true = Yes; false = No",
+            requiredMode = Schema.RequiredMode.REQUIRED, example = "false", defaultValue = "false")
     private boolean isListingEndpoint;
 
     public String getName() {

--- a/src/main/java/com/otilm/core/model/cbom/BomCreateResponseDto.java
+++ b/src/main/java/com/otilm/core/model/cbom/BomCreateResponseDto.java
@@ -14,11 +14,13 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class BomCreateResponseDto implements Serializable {
 
     @NotNull
-    @Schema(description = "CycloneDX serial number (URN, RFC-4122)", example = "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "CycloneDX serial number (URN, RFC-4122)",
+            example = "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79", requiredMode = Schema.RequiredMode.REQUIRED)
     private String serialNumber;
 
     @NotNull
-    @Schema(description = "CycloneDX integer version number for the BOM document", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "CycloneDX integer version number for the BOM document", example = "1",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer version;
 
     @NotNull

--- a/src/main/java/com/otilm/core/model/cbom/BomEntryDto.java
+++ b/src/main/java/com/otilm/core/model/cbom/BomEntryDto.java
@@ -14,15 +14,18 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class BomEntryDto {
 
     @NotNull
-    @Schema(description = "BOM serial number", example = "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "BOM serial number", example = "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String serialNumber;
 
     @NotNull
-    @Schema(description = "BOM Version - number or `original` string", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "BOM Version - number or `original` string", example = "1",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String version;
 
     @NotNull
-    @Schema(description = "RFC 3339 timestamp when this CBOM was created", example = "2026-01-25T21:35:05Z", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "RFC 3339 timestamp when this CBOM was created", example = "2026-01-25T21:35:05Z",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private OffsetDateTime timestamp;
 
     @NotNull

--- a/src/main/java/com/otilm/core/model/cbom/BomVersionDto.java
+++ b/src/main/java/com/otilm/core/model/cbom/BomVersionDto.java
@@ -13,7 +13,8 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class BomVersionDto {
 
     @NotNull
-    @Schema(description = "CycloneDX version number for the CBOM document", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "CycloneDX version number for the CBOM document", example = "1",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String version;
 
     @NotNull

--- a/src/main/java/com/otilm/core/model/cbom/CryptoAssetCountDto.java
+++ b/src/main/java/com/otilm/core/model/cbom/CryptoAssetCountDto.java
@@ -11,7 +11,8 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @Getter
 public class CryptoAssetCountDto implements Serializable {
 
-    @Schema(description = "Total number of crypto components", example = "0", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "Total number of crypto components", example = "0",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer total;
 
     @Override

--- a/src/main/java/com/otilm/core/model/cbom/CryptoAssetsDto.java
+++ b/src/main/java/com/otilm/core/model/cbom/CryptoAssetsDto.java
@@ -13,7 +13,8 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @Getter
 public class CryptoAssetsDto implements Serializable {
 
-    @Schema(description = "Total number of cryptographic assets", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "Total number of cryptographic assets", example = "1",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer total;
 
     @NotNull

--- a/src/main/java/com/otilm/core/model/compliance/ComplianceResultDto.java
+++ b/src/main/java/com/otilm/core/model/compliance/ComplianceResultDto.java
@@ -21,7 +21,8 @@ public class ComplianceResultDto implements Serializable {
     private ComplianceStatus status;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
-    @Schema(description = "Date of the most recent compliance check", requiredMode = Schema.RequiredMode.REQUIRED, example = "2025-09-11T13:45:30.123Z")
+    @Schema(description = "Date of the most recent compliance check", requiredMode = Schema.RequiredMode.REQUIRED,
+            example = "2025-09-11T13:45:30.123Z")
     private OffsetDateTime timestamp;
 
     @Schema(description = "Overall compliance check result message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)

--- a/src/main/java/com/otilm/core/provisioning/ProxyProvisioningApiClient.java
+++ b/src/main/java/com/otilm/core/provisioning/ProxyProvisioningApiClient.java
@@ -18,15 +18,24 @@ import org.springframework.web.service.annotation.PostExchange;
 public interface ProxyProvisioningApiClient {
 
     @PostExchange
-    @Retryable(retryFor = RestClientException.class, maxAttemptsExpression = "${provisioning.api.retry.max-attempts}", backoff = @Backoff(delayExpression = "${provisioning.api.retry.delay}", maxDelayExpression = "${provisioning.api.retry.max-delay}", multiplierExpression = "${provisioning.api.retry.multiplier}"))
+    @Retryable(retryFor = RestClientException.class, maxAttemptsExpression = "${provisioning.api.retry.max-attempts}",
+            backoff = @Backoff(delayExpression = "${provisioning.api.retry.delay}",
+                    maxDelayExpression = "${provisioning.api.retry.max-delay}",
+                    multiplierExpression = "${provisioning.api.retry.multiplier}"))
     void provisionProxy(@RequestBody ProxyProvisioningRequestDTO request);
 
     @GetExchange("/{proxyCode}/installation")
-    @Retryable(retryFor = RestClientException.class, maxAttemptsExpression = "${provisioning.api.retry.max-attempts}", backoff = @Backoff(delayExpression = "${provisioning.api.retry.delay}", maxDelayExpression = "${provisioning.api.retry.max-delay}", multiplierExpression = "${provisioning.api.retry.multiplier}"))
+    @Retryable(retryFor = RestClientException.class, maxAttemptsExpression = "${provisioning.api.retry.max-attempts}",
+            backoff = @Backoff(delayExpression = "${provisioning.api.retry.delay}",
+                    maxDelayExpression = "${provisioning.api.retry.max-delay}",
+                    multiplierExpression = "${provisioning.api.retry.multiplier}"))
     InstallationInstructionsDTO getInstallationInstructions(@PathVariable String proxyCode,
             @RequestParam String format);
 
     @DeleteExchange("/{proxyCode}")
-    @Retryable(retryFor = RestClientException.class, maxAttemptsExpression = "${provisioning.api.retry.max-attempts}", backoff = @Backoff(delayExpression = "${provisioning.api.retry.delay}", maxDelayExpression = "${provisioning.api.retry.max-delay}", multiplierExpression = "${provisioning.api.retry.multiplier}"))
+    @Retryable(retryFor = RestClientException.class, maxAttemptsExpression = "${provisioning.api.retry.max-attempts}",
+            backoff = @Backoff(delayExpression = "${provisioning.api.retry.delay}",
+                    maxDelayExpression = "${provisioning.api.retry.max-delay}",
+                    multiplierExpression = "${provisioning.api.retry.multiplier}"))
     void decommissionProxy(@PathVariable String proxyCode);
 }

--- a/src/main/java/com/otilm/core/provisioning/TrustedCertificateProvisioningApiClient.java
+++ b/src/main/java/com/otilm/core/provisioning/TrustedCertificateProvisioningApiClient.java
@@ -20,20 +20,34 @@ import org.springframework.web.service.annotation.PostExchange;
 public interface TrustedCertificateProvisioningApiClient {
 
     @GetExchange
-    @Retryable(retryFor = RestClientException.class, maxAttemptsExpression = "${provisioning.api.retry.max-attempts}", backoff = @Backoff(delayExpression = "${provisioning.api.retry.delay}", maxDelayExpression = "${provisioning.api.retry.max-delay}", multiplierExpression = "${provisioning.api.retry.multiplier}"))
+    @Retryable(retryFor = RestClientException.class, maxAttemptsExpression = "${provisioning.api.retry.max-attempts}",
+            backoff = @Backoff(delayExpression = "${provisioning.api.retry.delay}",
+                    maxDelayExpression = "${provisioning.api.retry.max-delay}",
+                    multiplierExpression = "${provisioning.api.retry.multiplier}"))
     List<TrustedCertificateProvisioningDTO> listTrustedCertificates();
 
     @GetExchange("/{uuid}")
-    @Retryable(retryFor = RestClientException.class, noRetryFor = HttpClientErrorException.NotFound.class, maxAttemptsExpression = "${provisioning.api.retry.max-attempts}", backoff = @Backoff(delayExpression = "${provisioning.api.retry.delay}", maxDelayExpression = "${provisioning.api.retry.max-delay}", multiplierExpression = "${provisioning.api.retry.multiplier}"))
+    @Retryable(retryFor = RestClientException.class, noRetryFor = HttpClientErrorException.NotFound.class,
+            maxAttemptsExpression = "${provisioning.api.retry.max-attempts}",
+            backoff = @Backoff(delayExpression = "${provisioning.api.retry.delay}",
+                    maxDelayExpression = "${provisioning.api.retry.max-delay}",
+                    multiplierExpression = "${provisioning.api.retry.multiplier}"))
     TrustedCertificateProvisioningDTO getTrustedCertificate(@PathVariable String uuid);
 
     @PostExchange
-    @Retryable(retryFor = RestClientException.class, maxAttemptsExpression = "${provisioning.api.retry.max-attempts}", backoff = @Backoff(delayExpression = "${provisioning.api.retry.delay}", maxDelayExpression = "${provisioning.api.retry.max-delay}", multiplierExpression = "${provisioning.api.retry.multiplier}"))
+    @Retryable(retryFor = RestClientException.class, maxAttemptsExpression = "${provisioning.api.retry.max-attempts}",
+            backoff = @Backoff(delayExpression = "${provisioning.api.retry.delay}",
+                    maxDelayExpression = "${provisioning.api.retry.max-delay}",
+                    multiplierExpression = "${provisioning.api.retry.multiplier}"))
     TrustedCertificateProvisioningDTO createTrustedCertificate(
             @RequestBody TrustedCertificateProvisioningRequestDTO request);
 
     @DeleteExchange("/{uuid}")
-    @Retryable(retryFor = RestClientException.class, noRetryFor = HttpClientErrorException.NotFound.class, maxAttemptsExpression = "${provisioning.api.retry.max-attempts}", backoff = @Backoff(delayExpression = "${provisioning.api.retry.delay}", maxDelayExpression = "${provisioning.api.retry.max-delay}", multiplierExpression = "${provisioning.api.retry.multiplier}"))
+    @Retryable(retryFor = RestClientException.class, noRetryFor = HttpClientErrorException.NotFound.class,
+            maxAttemptsExpression = "${provisioning.api.retry.max-attempts}",
+            backoff = @Backoff(delayExpression = "${provisioning.api.retry.delay}",
+                    maxDelayExpression = "${provisioning.api.retry.max-delay}",
+                    multiplierExpression = "${provisioning.api.retry.multiplier}"))
     void deleteTrustedCertificate(@PathVariable String uuid);
 
 }

--- a/src/main/java/com/otilm/core/service/handler/CertificateHandler.java
+++ b/src/main/java/com/otilm/core/service/handler/CertificateHandler.java
@@ -235,7 +235,8 @@ public class CertificateHandler {
      * committed certificate backs the given UUIDs (see {@link #uploadKeyInternal}). Callers use the result to keep the
      * discovery status visible when key association could not complete.
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.DEFAULT, rollbackFor = NoSuchAlgorithmException.class)
+    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.DEFAULT,
+            rollbackFor = NoSuchAlgorithmException.class)
     public boolean uploadDiscoveredCertificateKey(PublicKey publicKey, List<UUID> certificateUuids)
             throws NoSuchAlgorithmException {
         UUID keyUuid = uploadKeyInternal(publicKey, certificateUuids, "certKey_");
@@ -250,7 +251,8 @@ public class CertificateHandler {
      * @return true if the alternative key was associated with the certificates, false if the upload was skipped because
      * no committed certificate backs the given UUIDs.
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.DEFAULT, rollbackFor = NoSuchAlgorithmException.class)
+    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.DEFAULT,
+            rollbackFor = NoSuchAlgorithmException.class)
     public boolean uploadDiscoveredCertificateAltKey(PublicKey publicKey, List<UUID> certificateUuids)
             throws NoSuchAlgorithmException {
         UUID keyUuid = uploadKeyInternal(publicKey, certificateUuids, "altCertKey_");

--- a/src/main/java/com/otilm/core/service/impl/AcmeAccountServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/AcmeAccountServiceImpl.java
@@ -58,13 +58,15 @@ public class AcmeAccountServiceImpl implements AcmeAccountExternalService, AcmeA
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.ACME_ACCOUNT, action = ResourceAction.REVOKE, parentResource = Resource.ACME_PROFILE, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.ACME_ACCOUNT, action = ResourceAction.REVOKE,
+            parentResource = Resource.ACME_PROFILE, parentAction = ResourceAction.DETAIL)
     public void revokeAccount(SecuredParentUUID acmeProfileUuid, SecuredUUID uuid) throws NotFoundException {
         revokeAccount(uuid);
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.ACME_ACCOUNT, action = ResourceAction.ENABLE, parentResource = Resource.ACME_PROFILE, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.ACME_ACCOUNT, action = ResourceAction.ENABLE,
+            parentResource = Resource.ACME_PROFILE, parentAction = ResourceAction.DETAIL)
     public void enableAccount(SecuredParentUUID acmeProfileUuid, SecuredUUID uuid) throws NotFoundException {
         AcmeAccount account = getAcmeAccountEntity(uuid);
         if (!account.getStatus().equals(AccountStatus.VALID)) {
@@ -75,7 +77,8 @@ public class AcmeAccountServiceImpl implements AcmeAccountExternalService, AcmeA
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.ACME_ACCOUNT, action = ResourceAction.ENABLE, parentResource = Resource.ACME_PROFILE, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.ACME_ACCOUNT, action = ResourceAction.ENABLE,
+            parentResource = Resource.ACME_PROFILE, parentAction = ResourceAction.DETAIL)
     public void disableAccount(SecuredParentUUID acmeProfileUuid, SecuredUUID uuid) throws NotFoundException {
         AcmeAccount account = getAcmeAccountEntity(uuid);
         if (!account.getStatus().equals(AccountStatus.VALID)) {
@@ -135,7 +138,8 @@ public class AcmeAccountServiceImpl implements AcmeAccountExternalService, AcmeA
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.ACME_ACCOUNT, action = ResourceAction.LIST, parentResource = Resource.ACME_PROFILE, parentAction = ResourceAction.LIST)
+    @ExternalAuthorization(resource = Resource.ACME_ACCOUNT, action = ResourceAction.LIST,
+            parentResource = Resource.ACME_PROFILE, parentAction = ResourceAction.LIST)
     public List<AcmeAccountListResponseDto> listAcmeAccounts(SecurityFilter filter) {
         filter.setParentRefProperty("acmeProfileUuid");
         return acmeAccountRepository
@@ -146,7 +150,8 @@ public class AcmeAccountServiceImpl implements AcmeAccountExternalService, AcmeA
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.ACME_ACCOUNT, action = ResourceAction.DETAIL, parentResource = Resource.ACME_PROFILE, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.ACME_ACCOUNT, action = ResourceAction.DETAIL,
+            parentResource = Resource.ACME_PROFILE, parentAction = ResourceAction.DETAIL)
     public AcmeAccountResponseDto getAcmeAccount(SecuredParentUUID acmeProfileUuid, SecuredUUID uuid)
             throws NotFoundException {
         AcmeAccount acmeAccount = getAcmeAccountEntity(uuid);

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -548,7 +548,8 @@ public class CertificateServiceImpl
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.LIST, parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.MEMBERS)
+    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.LIST,
+            parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.MEMBERS)
     public CertificateResponseDto listCertificates(SecurityFilter filter, CertificateSearchRequestDto request) {
         setupSecurityFilter(filter);
         RequestValidatorHelper.revalidateSearchRequestDto(request);
@@ -954,7 +955,8 @@ public class CertificateServiceImpl
 
     @Async
     @Override
-    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.UPDATE, parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.UPDATE,
+            parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.DETAIL)
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void bulkUpdateCertificatesObjects(SecurityFilter filter, MultipleCertificateObjectUpdateDto request)
             throws NotSupportedException {
@@ -1022,7 +1024,8 @@ public class CertificateServiceImpl
 
     @Override
     @Async
-    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.DELETE, parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.DELETE,
+            parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.DETAIL)
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void bulkDeleteCertificate(SecurityFilter filter, RemoveCertificateDto request)
             throws NotSupportedException {
@@ -1282,7 +1285,8 @@ public class CertificateServiceImpl
     }
 
     @Override
-    @Cacheable(value = CacheConfig.CERTIFICATE_CHAIN_CACHE, key = "#certificateUuid + '_' + #withEndCertificate", sync = true)
+    @Cacheable(value = CacheConfig.CERTIFICATE_CHAIN_CACHE, key = "#certificateUuid + '_' + #withEndCertificate",
+            sync = true)
     public List<X509Certificate> getCertificateChainForSigning(UUID certificateUuid, boolean withEndCertificate)
             throws CertificateException {
         List<String> contents = certificateRepository
@@ -1824,7 +1828,9 @@ public class CertificateServiceImpl
     // transaction is still clean, so it can record a shaped reason and commit it -- from a runtime one, which has
     // already marked the transaction rollback-only. Spring's default happens to agree, but the caller's correctness
     // should not rest on a default that a class-level rollbackFor could silently reverse.
-    @Transactional(noRollbackFor = {NoSuchAlgorithmException.class, CertificateEncodingException.class,
+    @Transactional(noRollbackFor = {
+            NoSuchAlgorithmException.class,
+            CertificateEncodingException.class,
             NotFoundException.class})
     public DiscoveredCertificateImport createDiscoveredCertificateAtomic(X509Certificate certificate)
             throws NoSuchAlgorithmException, CertificateEncodingException, NotFoundException {
@@ -2075,7 +2081,8 @@ public class CertificateServiceImpl
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.LIST, parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.MEMBERS)
+    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.LIST,
+            parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.MEMBERS)
     public Long statisticsCertificateCount(SecurityFilter filter, boolean includeArchived) {
         setupSecurityFilter(filter);
         if (includeArchived) {
@@ -2087,7 +2094,8 @@ public class CertificateServiceImpl
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.LIST, parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.MEMBERS)
+    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.LIST,
+            parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.MEMBERS)
     public StatisticsDto addCertificateStatistics(SecurityFilter filter, StatisticsDto dto, boolean includeArchived) {
         setupSecurityFilter(filter);
 
@@ -2695,7 +2703,8 @@ public class CertificateServiceImpl
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.LIST, parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.LIST)
+    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.LIST,
+            parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.LIST)
     public List<CertificateDto> listScepCaCertificates(SecurityFilter filter, boolean intuneEnabled) {
         setupSecurityFilter(filter);
         List<Certificate> certificates = certificateRepository
@@ -2705,7 +2714,8 @@ public class CertificateServiceImpl
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.LIST, parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.LIST)
+    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.LIST,
+            parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.LIST)
     public List<CertificateDto> listCmpSigningCertificates(SecurityFilter filter) {
         setupSecurityFilter(filter);
 
@@ -2717,7 +2727,8 @@ public class CertificateServiceImpl
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.LIST, parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.LIST)
+    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.LIST,
+            parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.LIST)
     public List<CertificateDto> listDigitalSigningCertificates(SecurityFilter filter,
             SigningWorkflowType signingWorkflowType, boolean qualifiedTimestamp) {
         setupSecurityFilter(filter);

--- a/src/main/java/com/otilm/core/service/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/ClientOperationServiceImpl.java
@@ -303,7 +303,8 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public void checkAccessPermissions(SecuredUUID raProfileUuid, SecuredParentUUID authorityUuid) {
 
     }

--- a/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
@@ -283,7 +283,8 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
     // ----------------------------------------------------------------------------------------------
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.LIST, parentResource = Resource.TOKEN, parentAction = ResourceAction.MEMBERS)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.LIST,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.MEMBERS)
     public CryptographicKeyResponseDto listCryptographicKeys(SecurityFilter filter, SearchRequestDto request) {
         filter.setParentRefProperty(CryptographicKey_.tokenInstanceReferenceUuid.getName());
         RequestValidatorHelper.revalidateSearchRequestDto(request);
@@ -407,7 +408,8 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.CREATE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.CREATE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public KeyDetailDto createKey(UUID tokenInstanceUuid, SecuredParentUUID tokenProfileUuid, KeyRequestType type,
             KeyRequestDto request) throws AlreadyExistException, ValidationException, ConnectorException,
             AttributeException, NotFoundException {
@@ -561,7 +563,8 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.ENABLE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.ENABLE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void disableKey(List<String> uuids) {
         logger.debug("Request to disable the key with UUID {} ", uuids);
         for (String keyUuid : new LinkedHashSet<>(uuids)) {
@@ -581,7 +584,8 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.ENABLE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.ENABLE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void enableKey(List<String> uuids) {
         logger.debug("Request to enable the key with UUID {} ", uuids);
         for (String keyUuid : new LinkedHashSet<>(uuids)) {
@@ -601,13 +605,15 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.ENABLE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.ENABLE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void enableKeyItems(List<String> uuids) {
         setKeyItemsEnabled(uuids, true, true);
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.ENABLE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.ENABLE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void disableKeyItems(List<String> uuids) {
         setKeyItemsEnabled(uuids, true, false);
     }
@@ -663,7 +669,8 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.DELETE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.DELETE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void deleteKey(List<String> uuids) throws ConnectorException {
         logger.debug("Request to deleted the keys with UUIDs {}", uuids);
         for (String uuid : uuids) {
@@ -691,7 +698,8 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.DELETE, parentResource = Resource.TOKEN, parentAction = ResourceAction.MEMBERS)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.DELETE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.MEMBERS)
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void deleteKeyItems(SecurityFilter filterForTokenInstance, List<String> keyItemUuids)
             throws ConnectorException {
@@ -837,7 +845,8 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.DELETE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.DELETE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void destroyKey(List<String> uuids) throws ConnectorException, NotFoundException {
         logger.debug("Request to destroy the key with UUIDs {}", uuids);
         for (String uuid : uuids) {
@@ -849,13 +858,15 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.DELETE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.DELETE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void destroyKeyItems(List<String> keyItemUuids) throws ConnectorException {
         destroyKeyItems(keyItemUuids, true);
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.ANY, parentResource = Resource.TOKEN_PROFILE, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.ANY,
+            parentResource = Resource.TOKEN_PROFILE, parentAction = ResourceAction.DETAIL)
     public List<BaseAttribute> listCreateKeyAttributes(UUID tokenInstanceUuid, SecuredParentUUID tokenProfileUuid,
             KeyRequestType type) throws ConnectorException, NotFoundException {
         logger.debug("Request to list the attributes for creating a new key on Token profile: {}", tokenProfileUuid);
@@ -889,7 +900,8 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.UPDATE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.UPDATE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void syncKeys(SecuredParentUUID tokenInstanceUuid)
             throws ConnectorException, AttributeException, NotFoundException {
         TokenInstanceReference tokenInstanceReference = tokenInstanceService.getTokenInstanceEntity(tokenInstanceUuid);
@@ -944,7 +956,8 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.UPDATE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.UPDATE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void compromiseKey(BulkCompromiseKeyRequestDto request) {
         List<UUID> uuids = request.getUuids();
         logger.debug("Request to mark the key as compromised with UUIDs {}", uuids);
@@ -961,13 +974,15 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.UPDATE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.UPDATE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void compromiseKeyItems(BulkCompromiseKeyItemRequestDto request) {
         compromiseKeyItems(request.getUuids(), true, request.getReason());
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.UPDATE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.UPDATE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void updateKeyUsages(BulkKeyUsageRequestDto request) {
         logger.debug("Request to update the key usages with UUIDs {}", request.getUuids());
         for (UUID uuid : request.getUuids()) {
@@ -999,7 +1014,8 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.UPDATE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.UPDATE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void updateKeyItemUsages(BulkKeyItemUsageRequestDto request) {
         setKeyItemsUsages(request.getUuids(), request.getUsage(), true);
     }

--- a/src/main/java/com/otilm/core/service/impl/CryptographicOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicOperationServiceImpl.java
@@ -152,7 +152,8 @@ public class CryptographicOperationServiceImpl
     // ----------------------------------------------------------------------------------------------
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.ANY, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.ANY,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     @Transactional
     public List<BaseAttribute> listCipherAttributes(SecuredParentUUID tokenInstanceUuid, SecuredUUID tokenProfileUuid,
             UUID uuid, UUID keyItemUuid, KeyAlgorithm keyAlgorithm) throws ConnectorException, NotFoundException {
@@ -164,7 +165,8 @@ public class CryptographicOperationServiceImpl
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.ENCRYPT, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.ENCRYPT,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     @Transactional
     public EncryptDataResponseDto encryptData(SecuredParentUUID tokenInstanceUuid, SecuredUUID tokenProfileUuid,
             UUID uuid, UUID keyItemUuid, CipherDataRequestDto request) throws ConnectorException, NotFoundException {
@@ -219,7 +221,8 @@ public class CryptographicOperationServiceImpl
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.DECRYPT, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.DECRYPT,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     @Transactional
     public DecryptDataResponseDto decryptData(SecuredParentUUID tokenInstanceUuid, SecuredUUID tokenProfileUuid,
             UUID uuid, UUID keyItemUuid, CipherDataRequestDto request) throws ConnectorException, NotFoundException {
@@ -274,7 +277,8 @@ public class CryptographicOperationServiceImpl
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.ANY, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.ANY,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     @Transactional
     public List<BaseAttribute> listSignatureAttributes(SecuredParentUUID tokenInstanceUuid,
             SecuredUUID tokenProfileUuid, UUID uuid, UUID keyItemUuid, KeyAlgorithm keyAlgorithm)
@@ -289,7 +293,8 @@ public class CryptographicOperationServiceImpl
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.SIGN, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.SIGN,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     @Transactional
     public SignDataResponseDto signData(SecuredParentUUID tokenInstanceUuid, SecuredUUID tokenProfileUuid, UUID uuid,
             UUID keyItemUuid, SignDataRequestDto request) throws ConnectorException, NotFoundException {
@@ -311,7 +316,8 @@ public class CryptographicOperationServiceImpl
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.SIGN, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.SIGN,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public SignDataResponseDto signDataWithoutEventHistory(SecuredParentUUID tokenInstanceUuid,
             SecuredUUID tokenProfileUuid, UUID uuid, UUID keyItemUuid, SignDataRequestDto request)
             throws ConnectorException, NotFoundException {
@@ -362,7 +368,8 @@ public class CryptographicOperationServiceImpl
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.VERIFY, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.CRYPTOGRAPHIC_KEY, action = ResourceAction.VERIFY,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     @Transactional
     public VerifyDataResponseDto verifyData(SecuredParentUUID tokenInstanceUuid, SecuredUUID tokenProfileUuid,
             UUID uuid, UUID keyItemUuid, VerifyDataRequestDto request) throws ConnectorException, NotFoundException {

--- a/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
@@ -95,7 +95,8 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
         refreshCache();
     }
 
-    @Scheduled(fixedRateString = "${settings.cache.refresh-interval}", timeUnit = TimeUnit.SECONDS, initialDelayString = "${settings.cache.refresh-interval}")
+    @Scheduled(fixedRateString = "${settings.cache.refresh-interval}", timeUnit = TimeUnit.SECONDS,
+            initialDelayString = "${settings.cache.refresh-interval}")
     public void refreshCache() {
         // Read the source data without holding OidHandler's monitor, then publish optimistically: if a
         // mutator published while these queries ran, the snapshot is stale and is abandoned rather than

--- a/src/main/java/com/otilm/core/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/EventServiceImpl.java
@@ -121,8 +121,11 @@ public class EventServiceImpl implements EventExternalService {
                 .countStatsByEventHistoryUuids(eventHistoryUuids)
                 .stream()
                 .collect(Collectors
-                        .toMap(row -> (UUID) row[0], row -> new int[]{((Number) row[1]).intValue(),
-                                ((Number) row[2]).intValue(), ((Number) row[3]).intValue()}));
+                        .toMap(row -> (UUID) row[0],
+                                row -> new int[]{
+                                        ((Number) row[1]).intValue(),
+                                        ((Number) row[2]).intValue(),
+                                        ((Number) row[3]).intValue()}));
 
         // Batch 2: paginated object UUIDs for all event histories in one window-function query
         int objectsPageNumber = request.getObjectsPagination().getPageNumber();

--- a/src/main/java/com/otilm/core/service/impl/LocationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/LocationServiceImpl.java
@@ -226,7 +226,8 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.CREATE, parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.CREATE,
+            parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
     public LocationDto addLocation(SecuredParentUUID entityUuid, AddLocationRequestDto dto)
             throws AlreadyExistException, LocationException, ConnectorException, AttributeException, NotFoundException {
         if (StringUtils.isBlank(dto.getName())) {
@@ -286,7 +287,8 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.DETAIL, parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.DETAIL,
+            parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
     public LocationDto getLocation(SecuredParentUUID entityUuid, SecuredUUID locationUuid) throws NotFoundException {
         Location location = locationRepository
                 .findByUuid(locationUuid)
@@ -317,7 +319,8 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.UPDATE, parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.UPDATE,
+            parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
     public LocationDto editLocation(SecuredParentUUID entityUuid, SecuredUUID locationUuid, EditLocationRequestDto dto)
             throws ConnectorException, LocationException, AttributeException, NotFoundException {
         Location location = locationRepository
@@ -374,7 +377,8 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.DELETE, parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.DELETE,
+            parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
     public void deleteLocation(SecuredParentUUID entityUuid, SecuredUUID locationUuid) throws NotFoundException {
         Location location = locationRepository
                 .findByUuid(locationUuid)
@@ -388,7 +392,8 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.ENABLE, parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.ENABLE,
+            parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
     public void enableLocation(SecuredParentUUID entityUuid, SecuredUUID locationUuid) throws NotFoundException {
         Location location = locationRepository
                 .findByUuid(locationUuid)
@@ -401,7 +406,8 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.ENABLE, parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.ENABLE,
+            parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
     public void disableLocation(SecuredParentUUID entityUuid, SecuredUUID locationUuid) throws NotFoundException {
         Location location = locationRepository
                 .findByUuid(locationUuid)
@@ -414,7 +420,8 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.ANY, parentResource = Resource.ENTITY, parentAction = ResourceAction.ANY)
+    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.ANY, parentResource = Resource.ENTITY,
+            parentAction = ResourceAction.ANY)
     public List<BaseAttribute> listPushAttributes(SecuredParentUUID entityUuid, SecuredUUID locationUuid)
             throws NotFoundException, LocationException {
         Location location = locationRepository
@@ -438,7 +445,8 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.ANY, parentResource = Resource.ENTITY, parentAction = ResourceAction.ANY)
+    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.ANY, parentResource = Resource.ENTITY,
+            parentAction = ResourceAction.ANY)
     public List<BaseAttribute> listCsrAttributes(SecuredParentUUID entityUuid, SecuredUUID locationUuid)
             throws NotFoundException, LocationException {
         Location location = locationRepository
@@ -462,7 +470,8 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.UPDATE, parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.UPDATE,
+            parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
     public LocationDto removeCertificateFromLocation(SecuredParentUUID entityUuid, SecuredUUID locationUuid,
             String certificateUuid) throws NotFoundException, LocationException {
         Location location = locationRepository
@@ -572,7 +581,8 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.UPDATE, parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.UPDATE,
+            parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
     public LocationDto pushCertificateToLocation(SecuredParentUUID entityUuid, SecuredUUID locationUuid,
             String certificateUuid, PushToLocationRequestDto request)
             throws NotFoundException, LocationException, AttributeException {
@@ -727,7 +737,8 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.UPDATE, parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.UPDATE,
+            parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
     public LocationDto issueCertificateToLocation(SecuredParentUUID entityUuid, SecuredUUID locationUuid,
             String raProfileUuid, IssueToLocationRequestDto request)
             throws ConnectorException, LocationException, NotFoundException {
@@ -798,7 +809,8 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.UPDATE, parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.UPDATE,
+            parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
     public LocationDto updateLocationContent(SecuredParentUUID entityUuid, SecuredUUID locationUuid)
             throws NotFoundException, LocationException {
         Location location = locationRepository
@@ -868,7 +880,8 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.UPDATE, parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.UPDATE,
+            parentResource = Resource.ENTITY, parentAction = ResourceAction.DETAIL)
     public LocationDto renewCertificateInLocation(SecuredParentUUID entityUuid, SecuredUUID locationUuid,
             String certificateUuid) throws ConnectorException, LocationException, NotFoundException {
         Location location = locationRepository

--- a/src/main/java/com/otilm/core/service/impl/RaProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/RaProfileServiceImpl.java
@@ -110,7 +110,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     private AuthorityProviderAdapterFactory authorityProviderAdapterFactory;
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.LIST, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.LIST)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.LIST,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.LIST)
     public List<RaProfileDto> listRaProfiles(SecurityFilter filter, Optional<Boolean> enabled) {
         filter.setParentRefProperty("authorityInstanceReferenceUuid");
         return enabled
@@ -135,7 +136,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.CREATE, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.CREATE,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public RaProfileDto addRaProfile(SecuredParentUUID authorityInstanceUuid, AddRaProfileRequestDto request)
             throws AlreadyExistException, ValidationException, ConnectorException, AttributeException,
             NotFoundException {
@@ -198,7 +200,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public RaProfileDto getRaProfile(SecuredParentUUID authorityUuid, SecuredUUID uuid) throws NotFoundException {
         RaProfile raProfile = raProfileRepository
                 .findByUuid(uuid)
@@ -222,7 +225,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public RaProfileDto editRaProfile(SecuredParentUUID authorityInstanceUuid, SecuredUUID uuid,
             EditRaProfileRequestDto request) throws ConnectorException, AttributeException, NotFoundException {
         RaProfile raProfile = raProfileRepository
@@ -255,7 +259,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public RaProfileDto updateRaProfileValidationConfiguration(SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid, RaProfileCertificateValidationSettingsUpdateDto request)
             throws NotFoundException {
@@ -273,7 +278,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public RaProfileDto updateRaProfileRequestAttributesConfiguration(SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid, RaProfileCertificateRequestAttributesUpdateDto request)
             throws NotFoundException {
@@ -285,7 +291,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DELETE, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DELETE,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public void deleteRaProfile(SecuredParentUUID authorityUuid, SecuredUUID uuid) throws NotFoundException {
         deleteRaProfileInt(uuid);
     }
@@ -297,7 +304,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ENABLE, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ENABLE,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public void enableRaProfile(SecuredParentUUID authorityUuid, SecuredUUID uuid) throws NotFoundException {
         RaProfile entity = raProfileRepository
                 .findByUuid(uuid)
@@ -308,7 +316,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ENABLE, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ENABLE,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public void disableRaProfile(SecuredParentUUID authorityUuid, SecuredUUID uuid) throws NotFoundException {
         RaProfile entity = raProfileRepository
                 .findByUuid(uuid)
@@ -382,7 +391,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     // TODO - use acme service to obtain ACME profile
     public RaProfileAcmeDetailResponseDto getAcmeForRaProfile(SecuredParentUUID authorityUuid, SecuredUUID uuid)
             throws NotFoundException {
@@ -390,7 +400,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public RaProfileAcmeDetailResponseDto activateAcmeForRaProfile(SecuredParentUUID authorityUuid, SecuredUUID uuid,
             SecuredUUID acmeProfileUuid, ActivateAcmeForRaProfileRequestDto request)
             throws ConnectorException, ValidationException, AttributeException, NotFoundException {
@@ -435,7 +446,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public void deactivateAcmeForRaProfile(SecuredParentUUID authorityUuid, SecuredUUID uuid) throws NotFoundException {
         RaProfile raProfile = getRaProfileEntity(uuid);
         raProfile.setAcmeProfile(null);
@@ -447,7 +459,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public RaProfileScepDetailResponseDto activateScepForRaProfile(SecuredParentUUID authorityUuid, SecuredUUID uuid,
             SecuredUUID scepProfileUuid, ActivateScepForRaProfileRequestDto request)
             throws ConnectorException, ValidationException, AttributeException, NotFoundException {
@@ -482,7 +495,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public void deactivateScepForRaProfile(SecuredParentUUID authorityUuid, SecuredUUID uuid) throws NotFoundException {
         RaProfile raProfile = getRaProfileEntity(uuid);
         raProfile.setScepProfile(null);
@@ -499,14 +513,16 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     // -----------------------------------------------------------------------------------------------------------------
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public RaProfileCmpDetailResponseDto getCmpForRaProfile(SecuredParentUUID authorityInstanceUuid,
             SecuredUUID raProfileUuid) throws NotFoundException {
         return getRaProfileEntity(raProfileUuid).mapToCmpDto();
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public RaProfileCmpDetailResponseDto activateCmpForRaProfile(SecuredParentUUID authorityUuid, SecuredUUID uuid,
             SecuredUUID cmpProfileUuid, ActivateCmpForRaProfileRequestDto request)
             throws ConnectorException, ValidationException, AttributeException, NotFoundException {
@@ -548,7 +564,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public void deactivateCmpForRaProfile(SecuredParentUUID authorityUuid, SecuredUUID uuid) throws NotFoundException {
         RaProfile raProfile = getRaProfileEntity(uuid);
         raProfile.setCmpProfile(null);
@@ -575,7 +592,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.ANY)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.ANY)
     public List<BaseAttribute> listRevokeCertificateAttributes(SecuredParentUUID authorityUuid, SecuredUUID uuid)
             throws ConnectorException, NotFoundException {
         RaProfile raProfile = getRaProfileEntity(uuid);
@@ -583,7 +601,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.ANY)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.ANY)
     public List<BaseAttribute> listIssueCertificateAttributes(SecuredParentUUID authorityUuid, SecuredUUID uuid)
             throws ConnectorException, NotFoundException {
         RaProfile raProfile = getRaProfileEntity(uuid);
@@ -612,7 +631,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.LIST, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.LIST)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.LIST,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.LIST)
     public Long statisticsRaProfilesCount(SecurityFilter filter) {
         filter.setParentRefProperty("authorityInstanceReferenceUuid");
         return raProfileRepository.countUsingSecurityFilter(filter, null);
@@ -639,7 +659,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.DETAIL, parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.MEMBERS)
+    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.DETAIL,
+            parentResource = Resource.RA_PROFILE, parentAction = ResourceAction.MEMBERS)
     public void evaluateCertificateRaProfilePermissions(SecuredUUID certificateUuid, SecuredParentUUID raProfileUuid) {
     }
 
@@ -651,7 +672,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public RaProfileScepDetailResponseDto getScepForRaProfile(SecuredParentUUID authorityInstanceUuid,
             SecuredUUID raProfileUuid) throws NotFoundException {
         return getRaProfileEntity(raProfileUuid).mapToScepDto();
@@ -753,7 +775,8 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public List<CertificateDetailDto> getAuthorityCertificateChain(SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid) throws ConnectorException, NotFoundException {
         RaProfile raProfile = getRaProfileEntity(raProfileUuid);

--- a/src/main/java/com/otilm/core/service/impl/SecretServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SecretServiceImpl.java
@@ -275,7 +275,8 @@ public class SecretServiceImpl implements SecretExternalService, SecretInternalS
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.SECRET, action = ResourceAction.LIST, parentResource = Resource.VAULT_PROFILE, parentAction = ResourceAction.MEMBERS)
+    @ExternalAuthorization(resource = Resource.SECRET, action = ResourceAction.LIST,
+            parentResource = Resource.VAULT_PROFILE, parentAction = ResourceAction.MEMBERS)
     public PaginationResponseDto<SecretDto> listSecrets(SearchRequestDto searchRequest, SecurityFilter securityFilter) {
         TriFunction<Root<Secret>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause = (root, cb,
                 cq) -> FilterPredicatesBuilder.getFiltersPredicate(cb, cq, root, searchRequest.getFilters());
@@ -302,7 +303,8 @@ public class SecretServiceImpl implements SecretExternalService, SecretInternalS
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.SECRET, action = ResourceAction.CREATE, parentResource = Resource.VAULT, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.SECRET, action = ResourceAction.CREATE, parentResource = Resource.VAULT,
+            parentAction = ResourceAction.DETAIL)
     public SecretDetailDto createSecret(SecretRequestDto secretRequest, SecuredParentUUID sourceVaultProfileUuid,
             SecuredUUID vaultInstanceUuid) throws NotFoundException, AttributeException, AlreadyExistException {
         if (secretRepository.existsByName(secretRequest.getName())) {
@@ -379,7 +381,8 @@ public class SecretServiceImpl implements SecretExternalService, SecretInternalS
         return secretDetailDto;
     }
 
-    @ExternalAuthorization(resource = Resource.SECRET, action = ResourceAction.CREATE, parentResource = Resource.VAULT, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.SECRET, action = ResourceAction.CREATE, parentResource = Resource.VAULT,
+            parentAction = ResourceAction.DETAIL)
     private void checkCreateSecretPermissions(SecuredParentUUID vaultInstanceUuid, SecuredUUID sourceVaultProfileUuid) {
         // empty to evaluate permissions
     }
@@ -1138,7 +1141,8 @@ public class SecretServiceImpl implements SecretExternalService, SecretInternalS
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.SECRET, action = ResourceAction.LIST, parentResource = Resource.VAULT_PROFILE, parentAction = ResourceAction.MEMBERS)
+    @ExternalAuthorization(resource = Resource.SECRET, action = ResourceAction.LIST,
+            parentResource = Resource.VAULT_PROFILE, parentAction = ResourceAction.MEMBERS)
     public List<NameAndUuidDto> listResourceObjects(SecurityFilter filter, List<SearchFilterRequestDto> filters,
             PaginationRequestDto pagination) {
         filter.setParentRefProperty(Secret_.SOURCE_VAULT_PROFILE_UUID);
@@ -1215,14 +1219,16 @@ public class SecretServiceImpl implements SecretExternalService, SecretInternalS
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.SECRET, action = ResourceAction.LIST, parentResource = Resource.VAULT_PROFILE, parentAction = ResourceAction.MEMBERS)
+    @ExternalAuthorization(resource = Resource.SECRET, action = ResourceAction.LIST,
+            parentResource = Resource.VAULT_PROFILE, parentAction = ResourceAction.MEMBERS)
     public Long statisticsSecretCount(SecurityFilter filter) {
         filter.setParentRefProperty(Secret_.SOURCE_VAULT_PROFILE_UUID);
         return secretRepository.countUsingSecurityFilter(filter, null);
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.SECRET, action = ResourceAction.LIST, parentResource = Resource.VAULT_PROFILE, parentAction = ResourceAction.MEMBERS)
+    @ExternalAuthorization(resource = Resource.SECRET, action = ResourceAction.LIST,
+            parentResource = Resource.VAULT_PROFILE, parentAction = ResourceAction.MEMBERS)
     public StatisticsDto addSecretStatistics(SecurityFilter filter, StatisticsDto dto) {
         filter.setParentRefProperty(Secret_.SOURCE_VAULT_PROFILE_UUID);
         long start = System.nanoTime();

--- a/src/main/java/com/otilm/core/service/impl/SettingServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SettingServiceImpl.java
@@ -124,7 +124,8 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
     }
 
     @Override
-    @Scheduled(fixedRateString = "${settings.cache.refresh-interval}", timeUnit = TimeUnit.SECONDS, initialDelayString = "${settings.cache.refresh-interval}")
+    @Scheduled(fixedRateString = "${settings.cache.refresh-interval}", timeUnit = TimeUnit.SECONDS,
+            initialDelayString = "${settings.cache.refresh-interval}")
     public void refreshCache() {
         settingsCache.cacheSettings(SettingsSection.PLATFORM, getPlatformSettings());
         settingsCache.cacheSettings(SettingsSection.LOGGING, getLoggingSettings());

--- a/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
@@ -204,7 +204,8 @@ public class SigningProfileServiceImpl implements SigningProfileExternalService,
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TIME_QUALITY_CONFIGURATION, action = ResourceAction.DETAIL, parentResource = Resource.SIGNING_PROFILE, parentAction = ResourceAction.LIST)
+    @ExternalAuthorization(resource = Resource.TIME_QUALITY_CONFIGURATION, action = ResourceAction.DETAIL,
+            parentResource = Resource.SIGNING_PROFILE, parentAction = ResourceAction.LIST)
     @Transactional(readOnly = true)
     public List<SimplifiedSigningProfileDto> listSigningProfilesAssociatedTimeQualityConfiguration(
             SecuredUUID timeQualityConfigurationUuid, SecurityFilter filter) {
@@ -216,7 +217,8 @@ public class SigningProfileServiceImpl implements SigningProfileExternalService,
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TIME_QUALITY_CONFIGURATION, action = ResourceAction.DETAIL, parentResource = Resource.SIGNING_PROFILE, parentAction = ResourceAction.LIST)
+    @ExternalAuthorization(resource = Resource.TIME_QUALITY_CONFIGURATION, action = ResourceAction.DETAIL,
+            parentResource = Resource.SIGNING_PROFILE, parentAction = ResourceAction.LIST)
     @Transactional(readOnly = true)
     public SecuredList<SigningProfile> listSigningProfileEntitiesAssociatedTimeQualityConfiguration(
             SecuredUUID timeQualityConfigurationUuid, SecurityFilter filter) {
@@ -226,7 +228,8 @@ public class SigningProfileServiceImpl implements SigningProfileExternalService,
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TSP_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.SIGNING_PROFILE, parentAction = ResourceAction.LIST)
+    @ExternalAuthorization(resource = Resource.TSP_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.SIGNING_PROFILE, parentAction = ResourceAction.LIST)
     @Transactional(readOnly = true)
     public SecuredList<SigningProfile> listSigningProfilesAssociatedWithTsp(SecuredUUID tspProfileUuid,
             SecurityFilter filter) {

--- a/src/main/java/com/otilm/core/service/impl/SigningRecordServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SigningRecordServiceImpl.java
@@ -104,7 +104,8 @@ public class SigningRecordServiceImpl implements SigningRecordExternalService, S
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.SIGNING_RECORD, action = ResourceAction.LIST, parentResource = Resource.SIGNING_PROFILE, parentAction = ResourceAction.LIST)
+    @ExternalAuthorization(resource = Resource.SIGNING_RECORD, action = ResourceAction.LIST,
+            parentResource = Resource.SIGNING_PROFILE, parentAction = ResourceAction.LIST)
     @Transactional(readOnly = true)
     public PaginationResponseDto<SigningRecordListDto> listSigningRecords(SearchRequestDto request,
             SecurityFilter filter) {
@@ -112,7 +113,8 @@ public class SigningRecordServiceImpl implements SigningRecordExternalService, S
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.SIGNING_RECORD, action = ResourceAction.LIST, parentResource = Resource.SIGNING_PROFILE, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.SIGNING_RECORD, action = ResourceAction.LIST,
+            parentResource = Resource.SIGNING_PROFILE, parentAction = ResourceAction.DETAIL)
     @Transactional(readOnly = true)
     public PaginationResponseDto<SigningRecordListDto> listSigningRecordsForProfile(UUID signingProfileUuid,
             SearchRequestDto request, SecurityFilter filter) {
@@ -120,7 +122,8 @@ public class SigningRecordServiceImpl implements SigningRecordExternalService, S
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.SIGNING_RECORD, action = ResourceAction.LIST, parentResource = Resource.SIGNING_PROFILE, parentAction = ResourceAction.LIST)
+    @ExternalAuthorization(resource = Resource.SIGNING_RECORD, action = ResourceAction.LIST,
+            parentResource = Resource.SIGNING_PROFILE, parentAction = ResourceAction.LIST)
     @Transactional(readOnly = true)
     public SigningRecordStatisticsDto getSigningRecordStatistics(SigningRecordStatisticsPeriod period,
             SecurityFilter filter) {

--- a/src/main/java/com/otilm/core/service/impl/TokenProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/TokenProfileServiceImpl.java
@@ -115,7 +115,8 @@ public class TokenProfileServiceImpl implements TokenProfileExternalService, Tok
     // Service Implementations
     // -------------------------------------------------------------------------------------
     @Override
-    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.LIST, parentResource = Resource.TOKEN, parentAction = ResourceAction.LIST)
+    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.LIST,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.LIST)
     public List<TokenProfileDto> listTokenProfiles(Optional<Boolean> enabled, SecurityFilter filter) {
         logger.info("Listing token profiles");
         filter.setParentRefProperty("tokenInstanceReferenceUuid");
@@ -135,7 +136,8 @@ public class TokenProfileServiceImpl implements TokenProfileExternalService, Tok
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public TokenProfileDetailDto getTokenProfile(SecuredParentUUID tokenInstanceUuid, SecuredUUID uuid)
             throws NotFoundException {
         logger.info("Getting token profile with uuid: {}", uuid);
@@ -155,7 +157,8 @@ public class TokenProfileServiceImpl implements TokenProfileExternalService, Tok
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.CREATE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.CREATE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public TokenProfileDetailDto createTokenProfile(SecuredParentUUID tokenInstanceUuid,
             AddTokenProfileRequestDto request) throws AlreadyExistException, ValidationException, ConnectorException,
             AttributeException, NotFoundException {
@@ -196,7 +199,8 @@ public class TokenProfileServiceImpl implements TokenProfileExternalService, Tok
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.UPDATE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.UPDATE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public TokenProfileDetailDto editTokenProfile(SecuredParentUUID tokenInstanceUuid, SecuredUUID uuid,
             EditTokenProfileRequestDto request) throws ConnectorException, AttributeException, NotFoundException {
         logger.info("Editing token profile with uuid: {}", uuid);
@@ -227,7 +231,8 @@ public class TokenProfileServiceImpl implements TokenProfileExternalService, Tok
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.DELETE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.DELETE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void deleteTokenProfile(SecuredParentUUID tokenInstanceUuid, SecuredUUID uuid) throws NotFoundException {
         logger.info("Deleting token profile with uuid: {}", uuid);
         deleteProfileInternal(uuid, false);
@@ -241,21 +246,24 @@ public class TokenProfileServiceImpl implements TokenProfileExternalService, Tok
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.ENABLE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.ENABLE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void disableTokenProfile(SecuredParentUUID tokenInstanceUuid, SecuredUUID uuid) throws NotFoundException {
         logger.info("Disabling token profile with uuid: {}", uuid);
         disableProfileInternal(uuid);
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.ENABLE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.ENABLE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void enableTokenProfile(SecuredParentUUID tokenInstanceUuid, SecuredUUID uuid) throws NotFoundException {
         logger.info("Enabling token profile with uuid: {}", uuid);
         enableProfileInternal(uuid);
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.DELETE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.DELETE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void deleteTokenProfile(List<SecuredUUID> uuids) {
         logger.info("Deleting token profiles with uuids: {}", uuids);
         for (SecuredUUID uuid : uuids) {
@@ -270,7 +278,8 @@ public class TokenProfileServiceImpl implements TokenProfileExternalService, Tok
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.ENABLE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.ENABLE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void disableTokenProfile(List<SecuredUUID> uuids) {
         logger.info("Disabling token profiles with uuids: {}", uuids);
         for (SecuredUUID uuid : uuids) {
@@ -283,7 +292,8 @@ public class TokenProfileServiceImpl implements TokenProfileExternalService, Tok
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.ENABLE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.ENABLE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void enableTokenProfile(List<SecuredUUID> uuids) {
         logger.info("Enabling token profiles with uuids: {}", uuids);
         for (SecuredUUID uuid : uuids) {
@@ -296,7 +306,8 @@ public class TokenProfileServiceImpl implements TokenProfileExternalService, Tok
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.UPDATE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.UPDATE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void updateKeyUsages(List<SecuredUUID> uuids, List<KeyUsage> usages) {
         logger.info("Request to update the key usages for {} with usages {}", uuids, usages);
         // Iterate through the keys
@@ -313,7 +324,8 @@ public class TokenProfileServiceImpl implements TokenProfileExternalService, Tok
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.UPDATE, parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.TOKEN_PROFILE, action = ResourceAction.UPDATE,
+            parentResource = Resource.TOKEN, parentAction = ResourceAction.DETAIL)
     public void updateKeyUsages(SecuredParentUUID tokenInstanceUuid, SecuredUUID tokenProfileUuid,
             List<KeyUsage> usages) throws NotFoundException {
         TokenProfile tokenProfile = getTokenProfileEntity(tokenProfileUuid);

--- a/src/main/java/com/otilm/core/service/impl/TspProfileBasicCredentialServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/TspProfileBasicCredentialServiceImpl.java
@@ -62,7 +62,8 @@ public class TspProfileBasicCredentialServiceImpl
     private CacheEvictor cacheEvictor;
 
     @Override
-    @ExternalAuthorization(resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL, action = ResourceAction.LIST, parentResource = Resource.TSP_PROFILE, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL, action = ResourceAction.LIST,
+            parentResource = Resource.TSP_PROFILE, parentAction = ResourceAction.DETAIL)
     @Transactional(readOnly = true)
     public List<TspBasicCredentialDto> list(SecuredParentUUID tspProfileUuid) throws NotFoundException {
         TspProfile profile = getTspProfile(tspProfileUuid);
@@ -74,7 +75,8 @@ public class TspProfileBasicCredentialServiceImpl
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL, action = ResourceAction.DETAIL, parentResource = Resource.TSP_PROFILE, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL, action = ResourceAction.DETAIL,
+            parentResource = Resource.TSP_PROFILE, parentAction = ResourceAction.DETAIL)
     @Transactional(readOnly = true)
     public TspBasicCredentialDto get(SecuredParentUUID tspProfileUuid, SecuredUUID uuid) throws NotFoundException {
         TspProfileBasicCredential row = getCredentialScoped(tspProfileUuid, uuid);
@@ -82,7 +84,8 @@ public class TspProfileBasicCredentialServiceImpl
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL, action = ResourceAction.CREATE, parentResource = Resource.TSP_PROFILE, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL, action = ResourceAction.CREATE,
+            parentResource = Resource.TSP_PROFILE, parentAction = ResourceAction.DETAIL)
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public TspBasicCredentialDto create(SecuredParentUUID tspProfileUuid, TspBasicCredentialCreateRequestDto request)
             throws AlreadyExistException, AttributeException, ConnectorCommunicationException, NotFoundException {
@@ -118,7 +121,8 @@ public class TspProfileBasicCredentialServiceImpl
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL, action = ResourceAction.UPDATE, parentResource = Resource.TSP_PROFILE, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL, action = ResourceAction.UPDATE,
+            parentResource = Resource.TSP_PROFILE, parentAction = ResourceAction.DETAIL)
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public TspBasicCredentialDto update(SecuredParentUUID tspProfileUuid, SecuredUUID uuid,
             TspBasicCredentialUpdateRequestDto request)
@@ -158,7 +162,8 @@ public class TspProfileBasicCredentialServiceImpl
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL, action = ResourceAction.DELETE, parentResource = Resource.TSP_PROFILE, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.TSP_PROFILE_BASIC_CREDENTIAL, action = ResourceAction.DELETE,
+            parentResource = Resource.TSP_PROFILE, parentAction = ResourceAction.DETAIL)
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void delete(SecuredParentUUID tspProfileUuid, SecuredUUID uuid)
             throws AttributeException, ConnectorCommunicationException, NotFoundException {

--- a/src/main/java/com/otilm/core/service/impl/TspProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/TspProfileServiceImpl.java
@@ -125,7 +125,8 @@ public class TspProfileServiceImpl implements TspProfileExternalService, TspProf
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.TSP_PROFILE, action = ResourceAction.LIST, parentResource = Resource.SIGNING_PROFILE, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.TSP_PROFILE, action = ResourceAction.LIST,
+            parentResource = Resource.SIGNING_PROFILE, parentAction = ResourceAction.DETAIL)
     @Transactional(readOnly = true)
     public SecuredList<TspProfile> listTspProfilesUsingSigningProfileAsDefault(SecuredUUID signingProfileUuid,
             SecurityFilter filter) {

--- a/src/main/java/com/otilm/core/service/impl/VaultProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/VaultProfileServiceImpl.java
@@ -108,7 +108,8 @@ public class VaultProfileServiceImpl implements VaultProfileExternalService, Vau
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.LIST, parentResource = Resource.VAULT, parentAction = ResourceAction.LIST)
+    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.LIST,
+            parentResource = Resource.VAULT, parentAction = ResourceAction.LIST)
     public PaginationResponseDto<VaultProfileDto> listVaultProfiles(SearchRequestDto request,
             SecurityFilter securityFilter) {
         securityFilter.setParentRefProperty(VaultProfile_.VAULT_INSTANCE_UUID);
@@ -132,7 +133,8 @@ public class VaultProfileServiceImpl implements VaultProfileExternalService, Vau
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.VAULT, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.VAULT, parentAction = ResourceAction.DETAIL)
     public VaultProfileDetailDto getVaultProfileDetails(SecuredParentUUID vaultUuid, SecuredUUID vaultProfileUuid)
             throws NotFoundException {
         VaultProfile vaultProfile = vaultProfileRepository
@@ -161,7 +163,8 @@ public class VaultProfileServiceImpl implements VaultProfileExternalService, Vau
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.UPDATE, parentResource = Resource.VAULT, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.UPDATE,
+            parentResource = Resource.VAULT, parentAction = ResourceAction.DETAIL)
     public VaultProfileDetailDto updateVaultProfile(SecuredParentUUID securedParentUUID, SecuredUUID securedUUID,
             VaultProfileUpdateRequestDto request) throws NotFoundException, AttributeException {
         VaultProfile vaultProfile = vaultProfileRepository
@@ -191,7 +194,8 @@ public class VaultProfileServiceImpl implements VaultProfileExternalService, Vau
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.DELETE, parentResource = Resource.VAULT, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.DELETE,
+            parentResource = Resource.VAULT, parentAction = ResourceAction.DETAIL)
     public void deleteVaultProfile(SecuredParentUUID securedParentUUID, SecuredUUID securedUUID)
             throws NotFoundException {
         VaultProfile vaultProfile = vaultProfileRepository
@@ -212,7 +216,8 @@ public class VaultProfileServiceImpl implements VaultProfileExternalService, Vau
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.CREATE, parentResource = Resource.VAULT, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.CREATE,
+            parentResource = Resource.VAULT, parentAction = ResourceAction.DETAIL)
     public VaultProfileDetailDto createVaultProfile(SecuredParentUUID securedParentUUID, VaultProfileRequestDto request)
             throws NotFoundException, ValidationException, AttributeException, AlreadyExistException {
         if (vaultProfileRepository.existsByName(request.getName())) {
@@ -250,7 +255,8 @@ public class VaultProfileServiceImpl implements VaultProfileExternalService, Vau
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.ENABLE, parentResource = Resource.VAULT, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.ENABLE,
+            parentResource = Resource.VAULT, parentAction = ResourceAction.DETAIL)
     public void enableVaultProfile(SecuredParentUUID securedParentUUID, SecuredUUID securedUUID)
             throws NotFoundException {
         VaultProfile vaultProfile = vaultProfileRepository
@@ -261,7 +267,8 @@ public class VaultProfileServiceImpl implements VaultProfileExternalService, Vau
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.ENABLE, parentResource = Resource.VAULT, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.ENABLE,
+            parentResource = Resource.VAULT, parentAction = ResourceAction.DETAIL)
     public void disableVaultProfile(SecuredParentUUID securedParentUUID, SecuredUUID securedUUID)
             throws NotFoundException {
         VaultProfile vaultProfile = vaultProfileRepository
@@ -272,7 +279,8 @@ public class VaultProfileServiceImpl implements VaultProfileExternalService, Vau
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.VAULT, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.VAULT, parentAction = ResourceAction.DETAIL)
     public List<BaseAttribute> listSecretAttributes(SecuredParentUUID vaultUUID, SecuredUUID vaultProfileUUID,
             SecretType secretType) throws NotFoundException, ConnectorException, AttributeException {
         VaultInstance vaultInstance = vaultInstanceRepository
@@ -346,7 +354,8 @@ public class VaultProfileServiceImpl implements VaultProfileExternalService, Vau
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.LIST, parentResource = Resource.VAULT, parentAction = ResourceAction.LIST)
+    @ExternalAuthorization(resource = Resource.VAULT_PROFILE, action = ResourceAction.LIST,
+            parentResource = Resource.VAULT, parentAction = ResourceAction.LIST)
     public Long statisticsVaultProfileCount(SecurityFilter filter) {
         filter.setParentRefProperty(VaultProfile_.VAULT_INSTANCE_UUID);
         return vaultProfileRepository.countUsingSecurityFilter(filter, null);

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -387,7 +387,8 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public List<BaseAttribute> listIssueCertificateAttributes(SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid) throws ConnectorException, NotFoundException {
         RaProfile raProfile = raProfileRepository
@@ -397,7 +398,8 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public List<BaseAttribute> listRegisterCertificateAttributes(SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid) throws ConnectorException, NotFoundException {
         RaProfile raProfile = raProfileRepository
@@ -407,7 +409,8 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public void validateIssueCertificateAttributes(SecuredParentUUID authorityUuid, SecuredUUID raProfileUuid,
             List<RequestAttribute> attributes) throws ConnectorException, ValidationException, NotFoundException {
         RaProfile raProfile = raProfileRepository
@@ -511,7 +514,8 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
     @Override
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public ClientCertificateDataResponseDto issueCertificate(final SecuredParentUUID authorityUuid,
             final SecuredUUID raProfileUuid, final ClientCertificateIssueRequestDto request,
             final CertificateProtocolInfo protocolInfo) throws NotFoundException, CertificateException,
@@ -568,7 +572,8 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
     @Override
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public ClientCertificateDataResponseDto registerCertificate(SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid, ClientCertificateRegistrationDto request)
             throws NotFoundException, ConnectorException, AttributeException {
@@ -1156,7 +1161,8 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
     @Override
     @Transactional(readOnly = true)
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public AvailableOperationsDto listAvailableOperations(SecuredParentUUID authorityUuid, SecuredUUID raProfileUuid)
             throws NotFoundException {
         RaProfile raProfile = raProfileRepository
@@ -1787,7 +1793,8 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
     @Override
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public ClientCertificateDataResponseDto issueExistingCertificate(final SecuredParentUUID authorityUuid,
             final SecuredUUID raProfileUuid, final String certificateUuid,
             final ClientCertificateIssueRequestDto request) throws NotFoundException {
@@ -1917,7 +1924,8 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
     @Override
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public ClientCertificateDataResponseDto renewCertificate(SecuredParentUUID authorityUuid, SecuredUUID raProfileUuid,
             String certificateUuid, ClientCertificateRenewRequestDto request)
             throws NotFoundException, CertificateOperationException, CertificateRequestException {
@@ -2146,7 +2154,8 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
     @Override
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public ClientCertificateDataResponseDto rekeyCertificate(SecuredParentUUID authorityUuid, SecuredUUID raProfileUuid,
             String certificateUuid, ClientCertificateRekeyRequestDto request)
             throws NotFoundException, CertificateException, CertificateOperationException, CertificateRequestException {
@@ -2418,7 +2427,8 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public void revokeCertificate(SecuredParentUUID authorityUuid, SecuredUUID raProfileUuid, String certificateUuid,
             ClientCertificateRevocationDto request) throws ConnectorException, AttributeException, NotFoundException {
         Certificate certificate = validateOldCertificateForOperation(certificateUuid, raProfileUuid.toString(),
@@ -2748,7 +2758,8 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public List<BaseAttribute> listRevokeCertificateAttributes(SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid) throws ConnectorException, NotFoundException {
         RaProfile raProfile = raProfileRepository
@@ -2758,7 +2769,8 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public void validateRevokeCertificateAttributes(SecuredParentUUID authorityUuid, SecuredUUID raProfileUuid,
             List<RequestAttribute> attributes) throws ConnectorException, ValidationException, NotFoundException {
         RaProfile raProfile = raProfileRepository
@@ -3089,7 +3101,8 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
      * checkIssuePermissions below gates the actual issuance authority on CERTIFICATE. Mirrors what
      * issueCertificateAction does before persisting in the synchronous flow.
      */
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public CertificateDetailDto manuallyIssueCertificate(SecuredParentUUID authorityUuid, SecuredUUID raProfileUuid,
             String certificateUuid, UploadCertificateRequestDto request) throws NotFoundException, CertificateException,
             AlreadyExistException, ConnectorException, AttributeException {
@@ -3242,7 +3255,8 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
      * checkRevokePermissions gates the actual revocation authority on CERTIFICATE.
      */
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public void manuallyConfirmRevoke(SecuredParentUUID authorityUuid, SecuredUUID raProfileUuid,
             String certificateUuid) throws NotFoundException {
         certificateService.checkRevokePermissions();
@@ -3331,7 +3345,8 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
     @Override
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL,
+            parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public CertificateDetailDto cancelPendingCertificateOperation(SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid, String certificateUuid, CancelPendingCertificateRequestDto request)
             throws NotFoundException {

--- a/src/main/java/com/otilm/core/signing/record/SigningRecordConfig.java
+++ b/src/main/java/com/otilm/core/signing/record/SigningRecordConfig.java
@@ -11,8 +11,11 @@ import org.springframework.context.annotation.Configuration;
  * lets the strategy stay agnostic of it — and lets tests construct the queue with a capacity they can drive directly.
  */
 @Configuration
-@EnableConfigurationProperties({SigningRecordOutboxProperties.class, SigningRecordBestEffortProperties.class,
-        SigningRecordRetentionProperties.class, SigningRecordDeleteAfterRetrievalProperties.class,})
+@EnableConfigurationProperties({
+        SigningRecordOutboxProperties.class,
+        SigningRecordBestEffortProperties.class,
+        SigningRecordRetentionProperties.class,
+        SigningRecordDeleteAfterRetrievalProperties.class,})
 public class SigningRecordConfig {
 
     @Bean

--- a/src/test/java/com/otilm/core/architecture/WireMockPortsGuardTest.java
+++ b/src/test/java/com/otilm/core/architecture/WireMockPortsGuardTest.java
@@ -30,7 +30,8 @@ class WireMockPortsGuardTest {
     private static final Path TEST_YML = Path.of("src/test/resources/application.yml");
 
     @ParameterizedTest(name = "{0} is pinned to port {1}")
-    @CsvSource({WireMockPorts.AUTH_SERVICE_URL_KEY + "," + WireMockPorts.AUTH_SERVICE,
+    @CsvSource({
+            WireMockPorts.AUTH_SERVICE_URL_KEY + "," + WireMockPorts.AUTH_SERVICE,
             WireMockPorts.SCHEDULER_URL_KEY + "," + WireMockPorts.SCHEDULER,
             WireMockPorts.PROVISIONING_API_URL_KEY + "," + WireMockPorts.PROVISIONING_API})
     void testYmlBindsStubUrlToNamedPort(String propertyKey, int expectedPort) throws IOException {

--- a/src/test/java/com/otilm/core/certificate/request/X509RequestContentParserTest.java
+++ b/src/test/java/com/otilm/core/certificate/request/X509RequestContentParserTest.java
@@ -429,7 +429,8 @@ class X509RequestContentParserTest {
             ExtensionsGenerator extGen = new ExtensionsGenerator();
             extGen
                     .addExtension(Extension.subjectAlternativeName, false,
-                            new GeneralNames(new GeneralName[]{new GeneralName(GeneralName.dNSName, "host.example.com"),
+                            new GeneralNames(new GeneralName[]{
+                                    new GeneralName(GeneralName.dNSName, "host.example.com"),
                                     new GeneralName(GeneralName.rfc822Name, "admin@example.com")}));
             extGen.addExtension(Extension.extendedKeyUsage, false, new ExtendedKeyUsage(KeyPurposeId.id_kp_serverAuth));
             builder.addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extGen.generate());

--- a/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
@@ -1554,8 +1554,10 @@ class EventHandlersITest extends BaseSpringBootTest {
 
         // test event data handling
         EventData eventData = EventDataBuilder
-                .getCertificateStatusChangedEventData(certificate, new CertificateValidationStatus[]{
-                        CertificateValidationStatus.INACTIVE, CertificateValidationStatus.VALID});
+                .getCertificateStatusChangedEventData(certificate,
+                        new CertificateValidationStatus[]{
+                                CertificateValidationStatus.INACTIVE,
+                                CertificateValidationStatus.VALID});
         final NotificationMessage messageCertificateStatusChanged = new NotificationMessage(
                 ResourceEvent.CERTIFICATE_STATUS_CHANGED, Resource.CERTIFICATE, certificate.getUuid(),
                 notificationProfileUuids, null, eventData);

--- a/src/test/java/com/otilm/core/integration/service/v3/V3AsyncPollITest.java
+++ b/src/test/java/com/otilm/core/integration/service/v3/V3AsyncPollITest.java
@@ -61,7 +61,8 @@ import static org.awaitility.Awaitility.await;
 // times, past that limit, to prove an in-progress cert is never failed by running out of attempts.
 // delays[0] just fills the required non-null delays list. Its value does not matter, because
 // makePollDueNow() back-dates the row instead of waiting for the configured interval.
-@TestPropertySource(properties = {"provider.status-poll.by-kind.REGISTER.delays[0]=PT0S",
+@TestPropertySource(properties = {
+        "provider.status-poll.by-kind.REGISTER.delays[0]=PT0S",
         "provider.status-poll.by-kind.REGISTER.max-attempts=2"})
 class V3AsyncPollITest extends BaseMessagingIntTest {
 

--- a/src/test/java/com/otilm/core/integration/service/writer/CrlInsertVsValidateITest.java
+++ b/src/test/java/com/otilm/core/integration/service/writer/CrlInsertVsValidateITest.java
@@ -164,10 +164,11 @@ class CrlInsertVsValidateITest extends BaseSpringBootTest {
 
         X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(issuer, serial, start, end, subject,
                 eeKeyPair.getPublic());
-        DistributionPoint[] dps = new DistributionPoint[]{new DistributionPoint(
-                new DistributionPointName(new GeneralNames(
-                        new GeneralName(GeneralName.uniformResourceIdentifier, new DERIA5String(crlUrl)))),
-                null, null)};
+        DistributionPoint[] dps = new DistributionPoint[]{
+                new DistributionPoint(
+                        new DistributionPointName(new GeneralNames(
+                                new GeneralName(GeneralName.uniformResourceIdentifier, new DERIA5String(crlUrl)))),
+                        null, null)};
         builder.addExtension(Extension.cRLDistributionPoints, false, new CRLDistPoint(dps));
 
         ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSA").build(caKeyPair.getPrivate());

--- a/src/test/java/com/otilm/core/oid/OidHandlerTest.java
+++ b/src/test/java/com/otilm/core/oid/OidHandlerTest.java
@@ -27,7 +27,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class OidHandlerTest {
 
-    private static final OidCategory[] TOUCHED = {OidCategory.RDN_ATTRIBUTE_TYPE, OidCategory.GENERIC,
+    private static final OidCategory[] TOUCHED = {
+            OidCategory.RDN_ATTRIBUTE_TYPE,
+            OidCategory.GENERIC,
             OidCategory.EXTENDED_KEY_USAGE};
 
     private static final Map<OidCategory, Map<String, OidRecord>> saved = new EnumMap<>(OidCategory.class);

--- a/src/test/java/com/otilm/core/security/authz/SecuredResourceTest.java
+++ b/src/test/java/com/otilm/core/security/authz/SecuredResourceTest.java
@@ -44,7 +44,8 @@ class SecuredResourceTest {
 
     @Test
     void throwsWhenMoreThanOneSecuredResourceArgumentPresent() {
-        Object[] arguments = new Object[]{SecuredResource.fromResource(Resource.CERTIFICATE),
+        Object[] arguments = new Object[]{
+                SecuredResource.fromResource(Resource.CERTIFICATE),
                 SecuredResource.fromResource(Resource.RA_PROFILE)};
         Assertions.assertThrows(ValidationException.class, () -> SecuredResource.fromArguments(arguments));
     }

--- a/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplChallengePasswordTest.java
+++ b/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplChallengePasswordTest.java
@@ -51,11 +51,12 @@ class ScepServiceImplChallengePasswordTest {
      */
     @ParameterizedTest(name = "request password [{0}], authenticated renewal {1}")
     @CsvSource(nullValues = "NULL", value = {
-            "mysecretpassword, false", // matches PROFILE_PASSWORD on an initial
-                                       // enrollment
-            "NULL,             true", // renewal omits the attribute
-            "'',               true" // renewal sends the attribute empty
-    })
+            // matches PROFILE_PASSWORD on an initial enrollment
+            "mysecretpassword, false",
+            // renewal omits the attribute
+            "NULL,             true",
+            // renewal sends the attribute empty
+            "'',               true"})
     void acceptedChallengePassword(String requestChallengePassword, boolean authenticatedRenewal) {
         when(profile.getChallengePassword()).thenReturn(PROFILE_PASSWORD);
 
@@ -69,10 +70,12 @@ class ScepServiceImplChallengePasswordTest {
      */
     @ParameterizedTest(name = "request password [{0}], authenticated renewal {1}")
     @CsvSource(nullValues = "NULL", value = {
-            "wrong, false", // wrong password on an initial enrollment
-            "wrong, true", // wrong password on an otherwise authenticated renewal
-            "'',    false" // empty attribute where the shared secret is required
-    })
+            // wrong password on an initial enrollment
+            "wrong, false",
+            // wrong password on an otherwise authenticated renewal
+            "wrong, true",
+            // empty attribute where the shared secret is required
+            "'',    false"})
     void rejectedChallengePassword(String requestChallengePassword, boolean authenticatedRenewal) {
         when(profile.getChallengePassword()).thenReturn(PROFILE_PASSWORD);
 

--- a/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplChallengePasswordTest.java
+++ b/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplChallengePasswordTest.java
@@ -50,8 +50,9 @@ class ScepServiceImplChallengePasswordTest {
      * guide) are commonly configured to send on renewal. A password carrying a value is accepted only when it matches.
      */
     @ParameterizedTest(name = "request password [{0}], authenticated renewal {1}")
-    @CsvSource(nullValues = "NULL", value = {"mysecretpassword, false", // matches PROFILE_PASSWORD on an initial
-                                                                        // enrollment
+    @CsvSource(nullValues = "NULL", value = {
+            "mysecretpassword, false", // matches PROFILE_PASSWORD on an initial
+                                       // enrollment
             "NULL,             true", // renewal omits the attribute
             "'',               true" // renewal sends the attribute empty
     })
@@ -67,7 +68,8 @@ class ScepServiceImplChallengePasswordTest {
      * required.
      */
     @ParameterizedTest(name = "request password [{0}], authenticated renewal {1}")
-    @CsvSource(nullValues = "NULL", value = {"wrong, false", // wrong password on an initial enrollment
+    @CsvSource(nullValues = "NULL", value = {
+            "wrong, false", // wrong password on an initial enrollment
             "wrong, true", // wrong password on an otherwise authenticated renewal
             "'',    false" // empty attribute where the shared secret is required
     })

--- a/src/test/java/com/otilm/core/util/BaseSpringBootTest.java
+++ b/src/test/java/com/otilm/core/util/BaseSpringBootTest.java
@@ -36,7 +36,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest
-@TestPropertySource(properties = {WireMockPorts.AUTH_SERVICE_URL_PROPERTY, WireMockPorts.SCHEDULER_URL_PROPERTY,
+@TestPropertySource(properties = {
+        WireMockPorts.AUTH_SERVICE_URL_PROPERTY,
+        WireMockPorts.SCHEDULER_URL_PROPERTY,
         WireMockPorts.PROVISIONING_API_URL_PROPERTY})
 @TestExecutionListeners(value = MockBeanResetListener.class, mergeMode = MergeMode.MERGE_WITH_DEFAULTS)
 public class BaseSpringBootTest {

--- a/src/test/java/com/otilm/core/util/BaseSpringBootTestNoAuth.java
+++ b/src/test/java/com/otilm/core/util/BaseSpringBootTestNoAuth.java
@@ -11,7 +11,9 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
-@TestPropertySource(properties = {WireMockPorts.AUTH_SERVICE_URL_PROPERTY, WireMockPorts.SCHEDULER_URL_PROPERTY,
+@TestPropertySource(properties = {
+        WireMockPorts.AUTH_SERVICE_URL_PROPERTY,
+        WireMockPorts.SCHEDULER_URL_PROPERTY,
         WireMockPorts.PROVISIONING_API_URL_PROPERTY})
 public class BaseSpringBootTestNoAuth {
 

--- a/src/test/java/com/otilm/core/util/ProxyCodeHelperTest.java
+++ b/src/test/java/com/otilm/core/util/ProxyCodeHelperTest.java
@@ -58,8 +58,11 @@ class ProxyCodeHelperTest {
     // DIACRITICS REMOVAL
 
     @ParameterizedTest
-    @CsvSource({"'Příliš žluťoučký kůň', 'proxy-prilis-zlutoucky-kun'", "'Müller Straße', 'proxy-muller-strae'",
-            "'Łódź Świętokrzyska', 'proxy-lodz-swietokrzyska'", "'São Paulo', 'proxy-sao-paulo'"})
+    @CsvSource({
+            "'Příliš žluťoučký kůň', 'proxy-prilis-zlutoucky-kun'",
+            "'Müller Straße', 'proxy-muller-strae'",
+            "'Łódź Świętokrzyska', 'proxy-lodz-swietokrzyska'",
+            "'São Paulo', 'proxy-sao-paulo'"})
     @DisplayName("Should remove diacritics from various languages")
     void testCalculateCode_DiacriticsRemoval(String input, String expected) {
         ProxyCodeHelper helper = new ProxyCodeHelper("proxy-");
@@ -84,8 +87,11 @@ class ProxyCodeHelperTest {
     // SPECIAL CHARACTERS
 
     @ParameterizedTest
-    @CsvSource({"'Test@Proxy#123', 'proxy-testproxy123'", "'Test(Proxy)Name', 'proxy-testproxyname'",
-            "'Test/Proxy\\Name', 'proxy-testproxyname'", "'Test.Proxy_Name', 'proxy-testproxyname'"})
+    @CsvSource({
+            "'Test@Proxy#123', 'proxy-testproxy123'",
+            "'Test(Proxy)Name', 'proxy-testproxyname'",
+            "'Test/Proxy\\Name', 'proxy-testproxyname'",
+            "'Test.Proxy_Name', 'proxy-testproxyname'"})
     @DisplayName("Should remove special characters")
     void testCalculateCode_SpecialCharactersRemoval(String input, String expected) {
         ProxyCodeHelper helper = new ProxyCodeHelper("proxy-");

--- a/src/test/java/com/otilm/core/util/mocks/CryptographyProviderConnectorMock.java
+++ b/src/test/java/com/otilm/core/util/mocks/CryptographyProviderConnectorMock.java
@@ -38,7 +38,8 @@ public class CryptographyProviderConnectorMock extends BaseConnectorMock {
     }
 
     private static List<EndpointDto> cryptographyProviderEndpoints() {
-        String[][] specs = {{"POST", "/v1/cryptographyProvider/tokens", "createTokenInstance"},
+        String[][] specs = {
+                {"POST", "/v1/cryptographyProvider/tokens", "createTokenInstance"},
                 {"GET", "/v1/cryptographyProvider/tokens", "listTokenInstances"},
                 {"GET", "/v1/cryptographyProvider/tokens/{uuid}", "getTokenInstance"},
                 {"POST", "/v1/cryptographyProvider/tokens/{uuid}", "updateTokenInstance"},
@@ -46,28 +47,42 @@ public class CryptographyProviderConnectorMock extends BaseConnectorMock {
                 {"GET", "/v1/cryptographyProvider/tokens/{uuid}/status", "getTokenInstanceStatus"},
                 {"PATCH", "/v1/cryptographyProvider/tokens/{uuid}/activate", "activateTokenInstance"},
                 {"PATCH", "/v1/cryptographyProvider/tokens/{uuid}/deactivate", "deactivateTokenInstance"},
-                {"GET", "/v1/cryptographyProvider/tokens/{uuid}/activate/attributes",
+                {
+                        "GET",
+                        "/v1/cryptographyProvider/tokens/{uuid}/activate/attributes",
                         "listTokenInstanceActivationAttributes"},
-                {"POST", "/v1/cryptographyProvider/tokens/{uuid}/activate/attributes/validate",
+                {
+                        "POST",
+                        "/v1/cryptographyProvider/tokens/{uuid}/activate/attributes/validate",
                         "validateTokenInstanceActivationAttributes"},
                 {"GET", "/v1/cryptographyProvider/tokens/{uuid}/tokenProfile/attributes", "listTokenProfileAttributes"},
-                {"POST", "/v1/cryptographyProvider/tokens/{uuid}/tokenProfile/attributes/validate",
+                {
+                        "POST",
+                        "/v1/cryptographyProvider/tokens/{uuid}/tokenProfile/attributes/validate",
                         "validateTokenProfileAttributes"},
                 {"GET", "/v1/cryptographyProvider/tokens/{uuid}/keys", "listKeys"},
                 {"GET", "/v1/cryptographyProvider/tokens/{uuid}/keys/{keyUuid}", "getKey"},
                 {"DELETE", "/v1/cryptographyProvider/tokens/{uuid}/keys/{keyUuid}", "destroyKey"},
                 {"POST", "/v1/cryptographyProvider/tokens/{uuid}/keys/pair", "createKeyPair"},
                 {"GET", "/v1/cryptographyProvider/tokens/{uuid}/keys/pair/attributes", "listCreateKeyPairAttributes"},
-                {"POST", "/v1/cryptographyProvider/tokens/{uuid}/keys/pair/attributes/validate",
+                {
+                        "POST",
+                        "/v1/cryptographyProvider/tokens/{uuid}/keys/pair/attributes/validate",
                         "validateCreateKeyPairAttributes"},
                 {"POST", "/v1/cryptographyProvider/tokens/{uuid}/keys/secret", "createSecretKey"},
-                {"GET", "/v1/cryptographyProvider/tokens/{uuid}/keys/secret/attributes",
+                {
+                        "GET",
+                        "/v1/cryptographyProvider/tokens/{uuid}/keys/secret/attributes",
                         "listCreateSecretKeyAttributes"},
-                {"POST", "/v1/cryptographyProvider/tokens/{uuid}/keys/secret/attributes/validate",
+                {
+                        "POST",
+                        "/v1/cryptographyProvider/tokens/{uuid}/keys/secret/attributes/validate",
                         "validateCreateSecretKeyAttributes"},
                 {"POST", "/v1/cryptographyProvider/tokens/{uuid}/keys/random", "randomData"},
                 {"GET", "/v1/cryptographyProvider/tokens/{uuid}/keys/random/attributes", "listRandomAttributes"},
-                {"POST", "/v1/cryptographyProvider/tokens/{uuid}/keys/random/attributes/validate",
+                {
+                        "POST",
+                        "/v1/cryptographyProvider/tokens/{uuid}/keys/random/attributes/validate",
                         "validateRandomAttributes"},
                 {"POST", "/v1/cryptographyProvider/tokens/{uuid}/keys/{keyUuid}/encrypt", "encryptData"},
                 {"POST", "/v1/cryptographyProvider/tokens/{uuid}/keys/{keyUuid}/decrypt", "decryptData"},

--- a/src/test/java/com/otilm/core/util/serialnumber/InstanceIdResolverTest.java
+++ b/src/test/java/com/otilm/core/util/serialnumber/InstanceIdResolverTest.java
@@ -298,9 +298,23 @@ class InstanceIdResolverTest {
         @Test
         void shouldProduceValueInValidRange() {
             // given — worst case: all 0xFF bytes
-            byte[] ipv6 = {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
-                    (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
-                    (byte) 0xFF, (byte) 0xFF};
+            byte[] ipv6 = {
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF};
 
             // when
             int id = InstanceIdResolver.extractIdFromAddress(ipv6);


### PR DESCRIPTION
Applies the profile change from OmniTrustILM/dependencies#147.

Three commits, kept separate on purpose:
1. `Chop annotation member arrays and wrap annotation arguments` — 124 files, pure formatter output
2. `Record the reformatting commit in .git-blame-ignore-revs`
3. `Hoist comments out of annotation argument lists` — 3 files, authored

The hoist is separate so the blame-ignore entry does not hide it. It moves comments out of annotation parentheses in `Certificate`, `Location` and `ScepServiceImplChallengePasswordTest`; comment text is unchanged. One of them was being shredded one word per line, the others are the same fragile pattern.

Lines over the 120 margin drop from 1919 to 1411. Fluent builder chains are unaffected — `alignment_for_assignment` was rejected upstream precisely because it packed them onto one line.

**Do not merge before OmniTrustILM/dependencies#147** — CI resolves `build-tools` from the published snapshot, so `spotless:check` will fail until that lands on `main`.