### PR TITLE
Centralize application ObjectMapper recipes in one factory

### DIFF
--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -1,9 +1,7 @@
 package com.otilm.core.attribute.engine;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.otilm.api.exception.AttributeException;
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.exception.ValidationError;
@@ -66,6 +64,7 @@ import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.oid.OidHandler;
 import com.otilm.core.oid.OidRecord;
 import com.otilm.core.security.authz.SecurityResourceFilter;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import com.otilm.core.util.AttributeDefinitionUtils;
 import com.otilm.core.util.AuthHelper;
 import com.otilm.core.util.SearchHelper;
@@ -106,11 +105,7 @@ public class AttributeEngine {
     private static final Pattern UUID_REGEX = Pattern
             .compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
 
-    private static final ObjectMapper ATTRIBUTES_OBJECT_MAPPER = JsonMapper
-            .builder()
-            .findAndAddModules()
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-            .build();
+    private static final ObjectMapper ATTRIBUTES_OBJECT_MAPPER = ObjectMapperFactory.attributeContent();
 
     @PersistenceContext
     private EntityManager entityManager;

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeVersionHelper.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeVersionHelper.java
@@ -1,9 +1,7 @@
 package com.otilm.core.attribute.engine;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.client.attribute.RequestAttributeV2;
 import com.otilm.api.model.client.attribute.RequestAttributeV3;
@@ -29,6 +27,7 @@ import com.otilm.api.model.common.attribute.v3.GroupAttributeV3;
 import com.otilm.api.model.common.attribute.v3.content.BaseAttributeContentV3;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContent;
 import com.otilm.core.dao.entity.AttributeDefinition;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import com.otilm.core.util.SecretEncodingVersion;
 import com.otilm.core.util.SecretsUtil;
 import java.io.Serializable;
@@ -44,11 +43,7 @@ public class AttributeVersionHelper {
     private AttributeVersionHelper() {
         /* Prevent instantiation of utility class */ }
 
-    private static final ObjectMapper ATTRIBUTES_OBJECT_MAPPER = JsonMapper
-            .builder()
-            .findAndAddModules()
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-            .build();
+    private static final ObjectMapper ATTRIBUTES_OBJECT_MAPPER = ObjectMapperFactory.attributeContent();
 
     public static ResponseAttribute getResponseAttribute(UUID uuid, String name, String label,
             List<? extends AttributeContent> content, AttributeContentType contentType, AttributeType attributeType,

--- a/src/main/java/com/otilm/core/config/WebAppConfig.java
+++ b/src/main/java/com/otilm/core/config/WebAppConfig.java
@@ -1,14 +1,11 @@
 package com.otilm.core.config;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.otilm.api.model.client.dashboard.SigningRecordStatisticsPeriod;
 import com.otilm.api.model.common.enums.cryptography.KeyAlgorithm;
 import com.otilm.api.model.core.oid.OidCategory;
 import com.otilm.core.auth.oauth2.AuthenticationSnapshotRequestFilter;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
@@ -28,7 +25,6 @@ import org.springframework.format.FormatterRegistry;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.ResourceHttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -41,13 +37,7 @@ public class WebAppConfig implements WebMvcConfigurer {
 
     @Bean(name = "jacksonObjectMapper")
     public ObjectMapper jsonObjectMapper() {
-        return Jackson2ObjectMapperBuilder
-                .json()
-                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS,
-                        DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
-                .modules(new JavaTimeModule())
-                .serializationInclusion(JsonInclude.Include.NON_NULL)
-                .build();
+        return ObjectMapperFactory.wire();
     }
 
     @Override

--- a/src/main/java/com/otilm/core/dao/entity/CertificateEventHistory.java
+++ b/src/main/java/com/otilm/core/dao/entity/CertificateEventHistory.java
@@ -2,10 +2,10 @@ package com.otilm.core.dao.entity;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.otilm.api.model.core.certificate.CertificateEvent;
 import com.otilm.api.model.core.certificate.CertificateEventHistoryDto;
 import com.otilm.api.model.core.certificate.CertificateEventStatus;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import com.otilm.core.util.DtoMapper;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -68,7 +68,7 @@ public class CertificateEventHistory extends UniquelyIdentifiedAndAudited
         try {
             certificateEventHistoryDto
                     .setAdditionalInformation(
-                            new ObjectMapper().readValue(additionalInformation, new TypeReference<>() {
+                            ObjectMapperFactory.storage().readValue(additionalInformation, new TypeReference<>() {
                             }));
         } catch (JsonProcessingException | IllegalArgumentException e) {
             certificateEventHistoryDto.setAdditionalInformation(null);

--- a/src/main/java/com/otilm/core/dao/entity/CryptographicKeyEventHistory.java
+++ b/src/main/java/com/otilm/core/dao/entity/CryptographicKeyEventHistory.java
@@ -2,10 +2,10 @@ package com.otilm.core.dao.entity;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.otilm.api.model.core.cryptography.key.KeyEvent;
 import com.otilm.api.model.core.cryptography.key.KeyEventHistoryDto;
 import com.otilm.api.model.core.cryptography.key.KeyEventStatus;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import com.otilm.core.util.DtoMapper;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -65,7 +65,7 @@ public class CryptographicKeyEventHistory extends UniquelyIdentifiedAndAudited
         try {
             keyEventHistoryDto
                     .setAdditionalInformation(
-                            new ObjectMapper().readValue(additionalInformation, new TypeReference<>() {
+                            ObjectMapperFactory.storage().readValue(additionalInformation, new TypeReference<>() {
                             }));
         } catch (JsonProcessingException | IllegalArgumentException e) {
             keyEventHistoryDto.setAdditionalInformation(null);

--- a/src/main/java/com/otilm/core/dao/entity/workflows/ExecutionItem.java
+++ b/src/main/java/com/otilm/core/dao/entity/workflows/ExecutionItem.java
@@ -1,7 +1,6 @@
 package com.otilm.core.dao.entity.workflows;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.otilm.api.model.common.attribute.v3.content.BaseAttributeContentV3;
 import com.otilm.api.model.core.search.FilterFieldSource;
@@ -9,6 +8,7 @@ import com.otilm.api.model.core.workflows.ExecutionItemDto;
 import com.otilm.core.dao.converter.ObjectToJsonConverter;
 import com.otilm.core.dao.entity.UniquelyIdentified;
 import com.otilm.core.dao.entity.notifications.NotificationProfile;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
@@ -82,8 +82,7 @@ public class ExecutionItem extends UniquelyIdentified {
         if (fieldSource != FilterFieldSource.CUSTOM) {
             executionItemDto.setData((Serializable) data);
         } else if (data != null) {
-            ObjectMapper mapper = new ObjectMapper()
-                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            ObjectMapper mapper = ObjectMapperFactory.lenientStorage();
             List<BaseAttributeContentV3<?>> contentItems = mapper.convertValue(data, new TypeReference<>() {
             });
             executionItemDto

--- a/src/main/java/com/otilm/core/intune/scepvalidation/IntuneClient.java
+++ b/src/main/java/com/otilm/core/intune/scepvalidation/IntuneClient.java
@@ -37,6 +37,7 @@ import com.google.gson.JsonParser;
 import com.microsoft.aad.adal4j.AuthenticationException;
 import com.microsoft.aad.adal4j.AuthenticationResult;
 import com.microsoft.aad.adal4j.ClientCredential;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import java.io.IOException;
 import java.net.Authenticator;
 import java.net.InetSocketAddress;
@@ -453,7 +454,7 @@ class IntuneClient {
 
             // MODIFICATION - Changed the implementation to work with com.fasterxml.jackson.databind.JsonNode instead of
             // org.json.JSONObject
-            ObjectMapper objectMapper = new ObjectMapper();
+            ObjectMapper objectMapper = ObjectMapperFactory.storage();
             String canonicalFormat = JsonParser.parseString(httpEntityStr).toString();
             jsonResult = objectMapper.readTree(canonicalFormat);
 

--- a/src/main/java/com/otilm/core/intune/scepvalidation/IntuneRevocationClient.java
+++ b/src/main/java/com/otilm/core/intune/scepvalidation/IntuneRevocationClient.java
@@ -37,6 +37,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.otilm.core.intune.carequest.CARevocationRequest;
 import com.otilm.core.intune.carequest.CARevocationResult;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
@@ -50,7 +51,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IntuneRevocationClient extends IntuneClient {
 
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMapperFactory.storage();
     private String serviceVersion = "5019-05-05";
     public final static String CONNECTOR_SERVICE_NAME = "PkiConnectorFEService";
     public final static String DOWNLOADREVOCATIONREQUESTS_URL = "CertificateAuthorityRequests/downloadRevocationRequests";

--- a/src/main/java/com/otilm/core/intune/scepvalidation/IntuneScepServiceClient.java
+++ b/src/main/java/com/otilm/core/intune/scepvalidation/IntuneScepServiceClient.java
@@ -225,7 +225,6 @@ public class IntuneScepServiceClient extends IntuneClient {
             throw new IllegalArgumentException("The argument 'errorDescription' is missing");
         }
 
-        ObjectMapper objectMapper = ObjectMapperFactory.storage();
         ObjectNode requestBody = objectMapper.createObjectNode();
         requestBody
                 .put("notification",

--- a/src/main/java/com/otilm/core/intune/scepvalidation/IntuneScepServiceClient.java
+++ b/src/main/java/com/otilm/core/intune/scepvalidation/IntuneScepServiceClient.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.otilm.core.intune.scepvalidation.IntuneScepServiceException.ErrorCode;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Properties;
@@ -50,7 +51,7 @@ The important modification are marked with the comment "MODIFICATION"
  */
 public class IntuneScepServiceClient extends IntuneClient {
 
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMapperFactory.storage();
     private String serviceVersion = "2018-02-20";
     public final static String VALIDATION_SERVICE_NAME = "ScepRequestValidationFEService";
     private final static String VALIDATION_URL = "ScepActions/validateRequest";
@@ -224,7 +225,7 @@ public class IntuneScepServiceClient extends IntuneClient {
             throw new IllegalArgumentException("The argument 'errorDescription' is missing");
         }
 
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = ObjectMapperFactory.storage();
         ObjectNode requestBody = objectMapper.createObjectNode();
         requestBody
                 .put("notification",

--- a/src/main/java/com/otilm/core/logging/LoggerWrapper.java
+++ b/src/main/java/com/otilm/core/logging/LoggerWrapper.java
@@ -1,9 +1,7 @@
 package com.otilm.core.logging;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.logging.enums.Module;
 import com.otilm.api.model.core.logging.enums.Operation;
@@ -11,6 +9,7 @@ import com.otilm.api.model.core.logging.enums.OperationResult;
 import com.otilm.api.model.core.logging.records.LogRecord;
 import com.otilm.api.model.core.logging.records.ResourceObjectIdentity;
 import com.otilm.api.model.core.logging.records.ResourceRecord;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -22,13 +21,7 @@ import org.slf4j.LoggerFactory;
 @Getter
 public class LoggerWrapper {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-    static {
-        OBJECT_MAPPER.findAndRegisterModules();
-        OBJECT_MAPPER.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    }
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.auditLog();
 
     private final Logger logger;
     private final Module module;

--- a/src/main/java/com/otilm/core/messaging/jms/configuration/JmsConfig.java
+++ b/src/main/java/com/otilm/core/messaging/jms/configuration/JmsConfig.java
@@ -3,7 +3,7 @@ package com.otilm.core.messaging.jms.configuration;
 import com.azure.core.credential.TokenCredential;
 import com.azure.identity.ClientSecretCredentialBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import jakarta.jms.ConnectionFactory;
 import org.apache.qpid.jms.JmsConnectionExtensions;
 import org.apache.qpid.jms.JmsConnectionFactory;
@@ -174,11 +174,7 @@ public class JmsConfig {
 
     @Bean
     public MessageConverter messageConverter(Jackson2ObjectMapperBuilder objectMapperBuilder) {
-        ObjectMapper objectMapper = objectMapperBuilder
-                .createXmlMapper(false)
-                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .build()
-                .findAndRegisterModules();
+        ObjectMapper objectMapper = ObjectMapperFactory.jmsMessage(objectMapperBuilder);
 
         MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
         converter.setObjectMapper(objectMapper);

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/ActionsListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/ActionsListener.java
@@ -49,7 +49,7 @@ public class ActionsListener implements MessageProcessor<ActionMessage> {
 
     private SecretInternalService secretService;
 
-    private final ObjectMapper mapper = new ObjectMapper();
+    private ObjectMapper mapper;
 
     private NotificationProducer notificationProducer;
 
@@ -187,6 +187,11 @@ public class ActionsListener implements MessageProcessor<ActionMessage> {
     }
 
     // SETTERs
+
+    @Autowired
+    public void setMapper(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
 
     @Autowired
     public void setApprovalProfileRelationRepository(

--- a/src/main/java/com/otilm/core/security/exception/AuthenticationServiceException.java
+++ b/src/main/java/com/otilm/core/security/exception/AuthenticationServiceException.java
@@ -1,10 +1,10 @@
 package com.otilm.core.security.exception;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.otilm.api.exception.PlatformException;
 import com.otilm.api.model.common.AuthenticationServiceExceptionDto;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
@@ -16,8 +16,7 @@ public class AuthenticationServiceException extends AuthenticationException impl
 
     public AuthenticationServiceException(String message) {
         super("Authentication Service Exception");
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        ObjectMapper mapper = ObjectMapperFactory.lenientStorage();
 
         try {
             this.exception = mapper.readValue(message, AuthenticationServiceExceptionDto.class);

--- a/src/main/java/com/otilm/core/serialization/ObjectMapperFactory.java
+++ b/src/main/java/com/otilm/core/serialization/ObjectMapperFactory.java
@@ -1,0 +1,121 @@
+package com.otilm.core.serialization;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvGenerator;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+/**
+ * Factory for every kind of {@link ObjectMapper} in the platform, centralized at one place.
+ */
+public final class ObjectMapperFactory {
+
+    private ObjectMapperFactory() {
+    }
+
+    /**
+     * The wire recipe: HTTP request and response bodies, and anything shaped to match them. Exposed as the
+     * {@code jacksonObjectMapper} bean, which callers inside the container should inject rather than call this.
+     */
+    public static ObjectMapper wire() {
+        return Jackson2ObjectMapperBuilder
+                .json()
+                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS,
+                        DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
+                .modules(new JavaTimeModule())
+                .serializationInclusion(JsonInclude.Include.NON_NULL)
+                .build();
+    }
+
+    /**
+     * The audit-log recipe, pinned as the audit subsystem has always built it rather than derived from {@link #wire()}.
+     * Null members survive, because an audit line records that a member was absent.
+     */
+    public static ObjectMapper auditLog() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.findAndRegisterModules();
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return mapper;
+    }
+
+    /**
+     * Jackson's own defaults, for JSON that is persisted. No migration guards those columns, so a shape change here
+     * splits a table into rows written before it and rows written after.
+     */
+    public static ObjectMapper storage() {
+        return new ObjectMapper();
+    }
+
+    /**
+     * {@link #storage()} for payloads produced elsewhere, where an unrecognized member is expected rather than
+     * exceptional.
+     */
+    public static ObjectMapper lenientStorage() {
+        return storage()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    }
+
+    /**
+     * The ACME-request recipe. An unrecognised member is rejected, because RFC 8555 request bodies are exact.
+     */
+    public static ObjectMapper acmeRequest() {
+        return JsonMapper.builder().enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).build();
+    }
+
+    /**
+     * The attribute-content recipe. Unknown members are tolerated, because a definition may be written by an older
+     * connector version than the one reading it.
+     */
+    public static ObjectMapper attributeContent() {
+        return JsonMapper
+                .builder()
+                .findAndAddModules()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .build();
+    }
+
+    /**
+     * The secret-thumbprint recipe. The ordering settings are load-bearing: the serialized bytes are hashed, so a
+     * different key order would rewrite every stored thumbprint.
+     */
+    public static ObjectMapper secretThumbprint() {
+        return JsonMapper
+                .builder()
+                .findAndAddModules()
+                .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+                .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+                .build();
+    }
+
+    /**
+     * The JMS-message recipe. It takes the container's builder as a parameter, which a static context cannot reach, so
+     * that Spring Boot's Jackson autoconfiguration still applies.
+     */
+    public static ObjectMapper jmsMessage(Jackson2ObjectMapperBuilder builder) {
+        return builder
+                .createXmlMapper(false)
+                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build()
+                .findAndRegisterModules();
+    }
+
+    /**
+     * The CSV-export recipe, here because a {@link CsvMapper} carries the same Jackson defaults as any other mapper. It
+     * is returned as its own type because callers need {@code schemaFor}.
+     */
+    public static CsvMapper csvExport() {
+        CsvMapper mapper = new CsvMapper();
+        mapper.findAndRegisterModules();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.enable(CsvGenerator.Feature.ESCAPE_QUOTE_CHAR_WITH_ESCAPE_CHAR);
+        return mapper;
+    }
+}

--- a/src/main/java/com/otilm/core/serialization/ObjectMapperFactory.java
+++ b/src/main/java/com/otilm/core/serialization/ObjectMapperFactory.java
@@ -46,6 +46,18 @@ public final class ObjectMapperFactory {
     }
 
     /**
+     * The audit-export recipe, pinned as the export has always built it. It discovers every module on the classpath,
+     * because the exported columns are open-typed and may hold any producer's JDK8 value.
+     */
+    public static ObjectMapper auditLogExport() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.findAndRegisterModules();
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        return mapper;
+    }
+
+    /**
      * Jackson's own defaults, for JSON that is persisted. No migration guards those columns, so a shape change here
      * splits a table into rows written before it and rows written after.
      */

--- a/src/main/java/com/otilm/core/serialization/ObjectMapperFactory.java
+++ b/src/main/java/com/otilm/core/serialization/ObjectMapperFactory.java
@@ -58,9 +58,15 @@ public final class ObjectMapperFactory {
      * exceptional.
      */
     public static ObjectMapper lenientStorage() {
-        return storage()
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        return storage().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    /**
+     * {@link #lenientStorage()} for utilities that serialize whatever object they are handed, where a value with no
+     * visible properties is written as an empty object rather than failing.
+     */
+    public static ObjectMapper emptyBeanTolerantStorage() {
+        return lenientStorage().configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
     }
 
     /**

--- a/src/main/java/com/otilm/core/service/impl/AuditLogServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/AuditLogServiceImpl.java
@@ -28,6 +28,7 @@ import com.otilm.core.logging.LoggingHelper;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import com.otilm.core.service.AuditLogExternalService;
 import com.otilm.core.service.AuditLogInternalService;
 import com.otilm.core.settings.SettingsCache;
@@ -58,7 +59,7 @@ public class AuditLogServiceImpl implements AuditLogExternalService, AuditLogInt
 
     private static final LoggerWrapper logger = new LoggerWrapper(AuditLogServiceImpl.class, null, null);
 
-    private ObjectMapper objectMapper;
+    private static final ObjectMapper MAPPER = ObjectMapperFactory.auditLogExport();
 
     @Value("${export.auditLog.fileName.prefix:audit-logs}")
     private String fileNamePrefix;
@@ -68,11 +69,6 @@ public class AuditLogServiceImpl implements AuditLogExternalService, AuditLogInt
 
     @PersistenceContext
     private EntityManager entityManager;
-
-    @Autowired
-    public void setObjectMapper(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
     @Autowired
     public void setAuditLogRepository(AuditLogRepository auditLogRepository) {
@@ -148,13 +144,13 @@ public class AuditLogServiceImpl implements AuditLogExternalService, AuditLogInt
             builder.message(a.getMessage());
 
             try {
-                builder.operationData(objectMapper.writeValueAsString(a.getLogRecord().operationData()));
+                builder.operationData(MAPPER.writeValueAsString(a.getLogRecord().operationData()));
             } catch (JsonProcessingException e) {
                 builder.operationData("ERROR_SERIALIZATION");
             }
 
             try {
-                builder.additionalData(objectMapper.writeValueAsString(a.getLogRecord().additionalData()));
+                builder.additionalData(MAPPER.writeValueAsString(a.getLogRecord().additionalData()));
             } catch (JsonProcessingException e) {
                 builder.additionalData("ERROR_SERIALIZATION");
             }

--- a/src/main/java/com/otilm/core/service/impl/AuditLogServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/AuditLogServiceImpl.java
@@ -1,9 +1,7 @@
 package com.otilm.core.service.impl;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.otilm.api.model.client.certificate.SearchFilterRequestDto;
 import com.otilm.api.model.client.certificate.SearchRequestDto;
 import com.otilm.api.model.core.audit.AuditLogDto;
@@ -60,13 +58,7 @@ public class AuditLogServiceImpl implements AuditLogExternalService, AuditLogInt
 
     private static final LoggerWrapper logger = new LoggerWrapper(AuditLogServiceImpl.class, null, null);
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-
-    static {
-        MAPPER.findAndRegisterModules();
-        MAPPER.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-    }
+    private ObjectMapper objectMapper;
 
     @Value("${export.auditLog.fileName.prefix:audit-logs}")
     private String fileNamePrefix;
@@ -76,6 +68,11 @@ public class AuditLogServiceImpl implements AuditLogExternalService, AuditLogInt
 
     @PersistenceContext
     private EntityManager entityManager;
+
+    @Autowired
+    public void setObjectMapper(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     @Autowired
     public void setAuditLogRepository(AuditLogRepository auditLogRepository) {
@@ -151,13 +148,13 @@ public class AuditLogServiceImpl implements AuditLogExternalService, AuditLogInt
             builder.message(a.getMessage());
 
             try {
-                builder.operationData(MAPPER.writeValueAsString(a.getLogRecord().operationData()));
+                builder.operationData(objectMapper.writeValueAsString(a.getLogRecord().operationData()));
             } catch (JsonProcessingException e) {
                 builder.operationData("ERROR_SERIALIZATION");
             }
 
             try {
-                builder.additionalData(MAPPER.writeValueAsString(a.getLogRecord().additionalData()));
+                builder.additionalData(objectMapper.writeValueAsString(a.getLogRecord().additionalData()));
             } catch (JsonProcessingException e) {
                 builder.additionalData("ERROR_SERIALIZATION");
             }

--- a/src/main/java/com/otilm/core/service/impl/CallbackServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CallbackServiceImpl.java
@@ -1,6 +1,5 @@
 package com.otilm.core.service.impl;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.otilm.api.clients.ApiClientConnectorInfo;
 import com.otilm.api.exception.AttributeException;
@@ -44,6 +43,7 @@ import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import com.otilm.core.service.CallbackExternalService;
 import com.otilm.core.service.CoreCallbackService;
 import com.otilm.core.service.CredentialInternalService;
@@ -612,8 +612,7 @@ public class CallbackServiceImpl implements CallbackExternalService {
         // response.
         // This method will take the attribute definition and store it in the database. In the other methods where there
         // group attributes, we can retrieve them and merge them with the code.
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        ObjectMapper mapper = ObjectMapperFactory.lenientStorage();
         try {
             List<BaseAttribute> callbackAttributes = mapper
                     .convertValue(callbackResponse,

--- a/src/main/java/com/otilm/core/service/impl/CredentialServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CredentialServiceImpl.java
@@ -1,6 +1,5 @@
 package com.otilm.core.service.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.otilm.api.exception.AlreadyExistException;
 import com.otilm.api.exception.AttributeException;
 import com.otilm.api.exception.ConnectorException;
@@ -39,6 +38,7 @@ import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import com.otilm.core.service.ConnectorExternalService;
 import com.otilm.core.service.ConnectorInternalService;
 import com.otilm.core.service.CredentialExternalService;
@@ -321,7 +321,8 @@ public class CredentialServiceImpl implements CredentialExternalService, Credent
                                         credentialUuid = (String) map.get("uuid");
                                     } else {
                                         try {
-                                            credentialUuid = (String) ((Map) (new ObjectMapper()
+                                            credentialUuid = (String) ((Map) (ObjectMapperFactory
+                                                    .storage()
                                                     .convertValue(bodyKeyValue, ObjectAttributeContentV2.class))
                                                     .getData()).get("uuid");
                                         } catch (Exception e) {

--- a/src/main/java/com/otilm/core/service/impl/ExportProcessor.java
+++ b/src/main/java/com/otilm/core/service/impl/ExportProcessor.java
@@ -1,11 +1,10 @@
 package com.otilm.core.service.impl;
 
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.dataformat.csv.CsvGenerator;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.otilm.api.model.core.audit.ExportResultDto;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -22,13 +21,7 @@ public class ExportProcessor {
 
     private static final DateTimeFormatter EXPORT_DATE_TIME_FORMAT = DateTimeFormatter
             .ofPattern("yyyy-MM-dd'T'HH-mm-ss");
-    private static final CsvMapper CSV_MAPPER = new CsvMapper();
-
-    static {
-        CSV_MAPPER.findAndRegisterModules();
-        CSV_MAPPER.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        CSV_MAPPER.enable(CsvGenerator.Feature.ESCAPE_QUOTE_CHAR_WITH_ESCAPE_CHAR);
-    }
+    private static final CsvMapper CSV_MAPPER = ObjectMapperFactory.csvExport();
 
     @Value("${export.encoding:UTF-8}")
     private String encoding;

--- a/src/main/java/com/otilm/core/service/impl/SecretServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SecretServiceImpl.java
@@ -76,6 +76,7 @@ import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import com.otilm.core.service.AttributeResourceService;
 import com.otilm.core.service.ResourceObjectAssociationService;
 import com.otilm.core.service.SecretExternalService;
@@ -121,7 +122,7 @@ import org.springframework.stereotype.Service;
 public class SecretServiceImpl implements SecretExternalService, SecretInternalService, AttributeResourceService {
     private static final Logger logger = LoggerFactory.getLogger(SecretServiceImpl.class);
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = ObjectMapperFactory.storage();
 
     private AttributeEngine attributeEngine;
     private ConnectorRequestAttributesBuilder connectorRequestAttributesBuilder;

--- a/src/main/java/com/otilm/core/service/impl/SettingServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SettingServiceImpl.java
@@ -39,6 +39,7 @@ import com.otilm.core.dao.entity.Setting;
 import com.otilm.core.dao.repository.SettingRepository;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authz.ExternalAuthorization;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import com.otilm.core.service.SettingExternalService;
 import com.otilm.core.service.SettingInternalService;
 import com.otilm.core.service.TriggerExternalService;
@@ -92,18 +93,20 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
     private static final String DESERIALIZATION_ERROR_MESSAGE = "Cannot deserialize OAuth2 Provider Settings for provider '%s'.";
     private static final Logger logger = LoggerFactory.getLogger(SettingServiceImpl.class);
 
-    private final ObjectMapper mapper;
+    private final ObjectMapper wireMapper;
     private final SettingsCache settingsCache;
     private final SettingRepository settingRepository;
 
     private TriggerExternalService triggerService;
     private TriggerInternalService triggerInternalService;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    /** Settings are persisted, so they keep Jackson's storage shape rather than the wire mapper's null suppression. */
+    private final ObjectMapper storageMapper = ObjectMapperFactory.storage();
 
     @Autowired
-    public SettingServiceImpl(SettingsCache settingsCache, SettingRepository settingRepository, ObjectMapper mapper) {
-        this.mapper = mapper;
+    public SettingServiceImpl(SettingsCache settingsCache, SettingRepository settingRepository,
+            ObjectMapper wireMapper) {
+        this.wireMapper = wireMapper;
         this.settingsCache = settingsCache;
         this.settingRepository = settingRepository;
     }
@@ -176,7 +179,7 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
         if (certificateSettings != null && certificateSettings.get(CERTIFICATES_VALIDATION_SETTINGS_NAME) != null) {
             try {
                 certificateSettingsDto
-                        .setValidation(objectMapper
+                        .setValidation(storageMapper
                                 .readValue(certificateSettings.get(CERTIFICATES_VALIDATION_SETTINGS_NAME).getValue(),
                                         CertificateValidationSettingsDto.class));
             } catch (JsonProcessingException e) {
@@ -196,7 +199,7 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
         if (certificateSettings != null && certificateSettings.get(CERTIFICATES_REGISTRATION_SETTINGS_NAME) != null) {
             try {
                 certificateSettingsDto
-                        .setRegistration(objectMapper
+                        .setRegistration(storageMapper
                                 .readValue(certificateSettings.get(CERTIFICATES_REGISTRATION_SETTINGS_NAME).getValue(),
                                         CertificateRegistrationSettingsDto.class));
             } catch (JsonProcessingException e) {
@@ -307,7 +310,7 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
                     validation.setFrequency(null);
                     validation.setExpiringThreshold(null);
                 }
-                certificatesValidationSetting.setValue(objectMapper.writeValueAsString(validation));
+                certificatesValidationSetting.setValue(storageMapper.writeValueAsString(validation));
             } catch (JsonProcessingException e) {
                 logger.warn("Failed to serialize platform certificates validation settings", e);
                 throw new ValidationException("Cannot serialize platform certificates settings.");
@@ -339,7 +342,7 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
             Setting registrationSetting = certificateSetting(certificateSettings,
                     CERTIFICATES_REGISTRATION_SETTINGS_NAME);
             try {
-                registrationSetting.setValue(objectMapper.writeValueAsString(registration));
+                registrationSetting.setValue(storageMapper.writeValueAsString(registration));
             } catch (JsonProcessingException e) {
                 logger.warn("Failed to serialize platform certificates registration settings", e);
                 throw new ValidationException("Cannot serialize platform certificates settings.");
@@ -414,7 +417,7 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
             if ((setting = auditLoggingSettings.get(LOGGING_RESOURCES_NAME)) != null) {
                 ResourceLoggingSettingsDto resources;
                 try {
-                    resources = mapper.readValue(setting.getValue(), ResourceLoggingSettingsDto.class);
+                    resources = wireMapper.readValue(setting.getValue(), ResourceLoggingSettingsDto.class);
                 } catch (JsonProcessingException e) {
                     logger.warn("Cannot deserialize audit logs resource settings. Returning default settings.");
                     resources = new ResourceLoggingSettingsDto();
@@ -430,7 +433,7 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
         if (eventLoggingSettings != null && (setting = eventLoggingSettings.get(LOGGING_RESOURCES_NAME)) != null) {
             ResourceLoggingSettingsDto resources;
             try {
-                resources = mapper.readValue(setting.getValue(), ResourceLoggingSettingsDto.class);
+                resources = wireMapper.readValue(setting.getValue(), ResourceLoggingSettingsDto.class);
             } catch (JsonProcessingException e) {
                 logger.warn("Cannot deserialize event logs resource settings. Returning default settings.");
                 resources = new ResourceLoggingSettingsDto();
@@ -479,8 +482,8 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
         }
         try {
             setting
-                    .setValue(mapper
-                            .writeValueAsString(mapper
+                    .setValue(wireMapper
+                            .writeValueAsString(wireMapper
                                     .convertValue(loggingSettingsDto.getAuditLogs(),
                                             ResourceLoggingSettingsDto.class)));
             settingRepository.save(setting);
@@ -497,7 +500,7 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
             setting.setName(LOGGING_RESOURCES_NAME);
         }
         try {
-            setting.setValue(mapper.writeValueAsString(loggingSettingsDto.getEventLogs()));
+            setting.setValue(wireMapper.writeValueAsString(loggingSettingsDto.getEventLogs()));
             settingRepository.save(setting);
         } catch (JsonProcessingException e) {
             throw new ValidationException("Cannot serialize event logging resources settings: " + e.getMessage());
@@ -517,7 +520,7 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
         for (Setting oauth2Provider : oauth2ProviderSettings) {
             OAuth2ProviderSettingsDto oAuth2ProviderSettings;
             try {
-                oAuth2ProviderSettings = objectMapper
+                oAuth2ProviderSettings = storageMapper
                         .readValue(oauth2Provider.getValue(), OAuth2ProviderSettingsDto.class);
                 if (!withClientSecret) {
                     oAuth2ProviderSettings.setClientSecret(null);
@@ -589,7 +592,7 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
         OAuth2ProviderSettingsResponseDto settingsDto = null;
         if (setting != null) {
             try {
-                settingsDto = objectMapper.readValue(setting.getValue(), OAuth2ProviderSettingsResponseDto.class);
+                settingsDto = storageMapper.readValue(setting.getValue(), OAuth2ProviderSettingsResponseDto.class);
                 if (!withClientSecret) {
                     settingsDto.setClientSecret(null);
                 }
@@ -635,7 +638,7 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
         } else if (!isNewProvider) {
             OAuth2ProviderSettingsDto storedProviderSettings;
             try {
-                storedProviderSettings = objectMapper.readValue(setting.getValue(), OAuth2ProviderSettingsDto.class);
+                storedProviderSettings = storageMapper.readValue(setting.getValue(), OAuth2ProviderSettingsDto.class);
             } catch (JsonProcessingException e) {
                 throw new ValidationException(DESERIALIZATION_ERROR_MESSAGE.formatted(providerName));
             }
@@ -648,10 +651,10 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
             if (settingsDto instanceof OAuth2ProviderSettingsDto s) {
                 fullSettingsDto = s;
             } else {
-                fullSettingsDto = objectMapper.convertValue(settingsDto, OAuth2ProviderSettingsDto.class);
+                fullSettingsDto = storageMapper.convertValue(settingsDto, OAuth2ProviderSettingsDto.class);
                 fullSettingsDto.setName(providerName);
             }
-            setting.setValue(objectMapper.writeValueAsString(fullSettingsDto));
+            setting.setValue(storageMapper.writeValueAsString(fullSettingsDto));
         } catch (JsonProcessingException e) {
             throw new ValidationException(
                     "Cannot serialize OAuth2 provider settings for provider '%s'.".formatted(providerName));

--- a/src/main/java/com/otilm/core/tasks/DiscoveryCertificateTask.java
+++ b/src/main/java/com/otilm/core/tasks/DiscoveryCertificateTask.java
@@ -34,11 +34,16 @@ public class DiscoveryCertificateTask implements ScheduledJobTask {
 
     private DiscoveryInternalService discoveryInternalService;
 
-    private final ObjectMapper mapper = new ObjectMapper();
+    private ObjectMapper mapper;
 
     private PlatformTransactionManager transactionManager;
 
     private final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss.FFF");
+
+    @Autowired
+    public void setMapper(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
 
     @Autowired
     public void setTransactionManager(PlatformTransactionManager transactionManager) {

--- a/src/main/java/com/otilm/core/util/AcmeJsonProcessor.java
+++ b/src/main/java/com/otilm/core/util/AcmeJsonProcessor.java
@@ -3,12 +3,14 @@ package com.otilm.core.util;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JWSObject;
+import com.otilm.core.serialization.ObjectMapperFactory;
 
 /**
  * Class contains the static method for processing the JSON entities from ACME request.
  */
 public class AcmeJsonProcessor {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.acmeRequest();
 
     /**
      * Class to parse the information from source JSON to the requested format

--- a/src/main/java/com/otilm/core/util/AuthHelper.java
+++ b/src/main/java/com/otilm/core/util/AuthHelper.java
@@ -1,7 +1,5 @@
 package com.otilm.core.util;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.otilm.api.exception.ValidationError;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.common.NameAndUuidDto;
@@ -24,6 +22,7 @@ import com.otilm.core.security.authz.opa.OpaClient;
 import com.otilm.core.security.authz.opa.dto.OpaObjectAccessResult;
 import com.otilm.core.security.authz.opa.dto.OpaRequestDetails;
 import com.otilm.core.security.authz.opa.dto.OpaRequestedResource;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import com.otilm.core.service.AuditLogInternalService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
@@ -237,9 +236,7 @@ public class AuthHelper {
                     .getContext()
                     .getAuthentication()
                     .getPrincipal();
-            ObjectMapper objectMapper = new ObjectMapper();
-            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-            userProfileDto = objectMapper.readValue(userDetails.getRawData(), UserProfileDto.class);
+            userProfileDto = ObjectMapperFactory.wire().readValue(userDetails.getRawData(), UserProfileDto.class);
         } catch (Exception e) {
             throw new ValidationException(
                     ValidationError.create("Cannot retrieve profile information for Unknown/Anonymous user"));

--- a/src/main/java/com/otilm/core/util/CertificateUtil.java
+++ b/src/main/java/com/otilm/core/util/CertificateUtil.java
@@ -29,6 +29,7 @@ import com.otilm.core.dao.entity.DiscoveryCertificate;
 import com.otilm.core.model.request.CertificateRequest;
 import com.otilm.core.model.request.CrmfCertificateRequest;
 import com.otilm.core.model.request.Pkcs10CertificateRequest;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import com.otilm.core.settings.SettingsCache;
 import jakarta.annotation.Nullable;
 import jakarta.xml.bind.DatatypeConverter;
@@ -93,7 +94,9 @@ import org.slf4j.LoggerFactory;
 
 public class CertificateUtil {
     public static final String EMPTY_COMMON_NAME_PLACEHOLDER = "<empty>";
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+    /** Key ordering makes the persisted JSON depend on the SAN contents alone, not on the map implementation. */
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory
+            .storage()
             .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
 
     private static final Map<String, KeyAlgorithm> CERTIFICATE_ALGORITHM_FROM_PROVIDER = new HashMap<>();

--- a/src/main/java/com/otilm/core/util/CryptographicHelper.java
+++ b/src/main/java/com/otilm/core/util/CryptographicHelper.java
@@ -19,7 +19,7 @@ public class CryptographicHelper {
     private CryptographicHelper() {
     }
 
-    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.lenientStorage();
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.emptyBeanTolerantStorage();
 
     public static String serializeKeyValue(KeyFormat keyFormat, KeyValue value) {
         if (value == null || keyFormat == null) {

--- a/src/main/java/com/otilm/core/util/CryptographicHelper.java
+++ b/src/main/java/com/otilm/core/util/CryptographicHelper.java
@@ -1,9 +1,7 @@
 package com.otilm.core.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.otilm.api.exception.ValidationError;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.common.enums.cryptography.KeyFormat;
@@ -13,6 +11,7 @@ import com.otilm.api.model.connector.cryptography.key.value.KeyValue;
 import com.otilm.api.model.connector.cryptography.key.value.PrkiKeyValue;
 import com.otilm.api.model.connector.cryptography.key.value.RawKeyValue;
 import com.otilm.api.model.connector.cryptography.key.value.SpkiKeyValue;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import java.util.Map;
 
 public class CryptographicHelper {
@@ -20,9 +19,7 @@ public class CryptographicHelper {
     private CryptographicHelper() {
     }
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-            .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.lenientStorage();
 
     public static String serializeKeyValue(KeyFormat keyFormat, KeyValue value) {
         if (value == null || keyFormat == null) {

--- a/src/main/java/com/otilm/core/util/DatabaseAttributeMigration.java
+++ b/src/main/java/com/otilm/core/util/DatabaseAttributeMigration.java
@@ -1,6 +1,7 @@
 package com.otilm.core.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.common.properties.DataAttributeProperties;
@@ -8,7 +9,6 @@ import com.otilm.api.model.common.attribute.v2.DataAttributeV2;
 import com.otilm.api.model.common.attribute.v2.content.BaseAttributeContentV2;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.core.attribute.engine.AttributeEngine;
-import com.otilm.core.serialization.ObjectMapperFactory;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -25,7 +25,13 @@ import org.slf4j.LoggerFactory;
 public class DatabaseAttributeMigration {
 
     private static final Logger logger = LoggerFactory.getLogger(DatabaseAttributeMigration.class);
-    private static final ObjectMapper ATTRIBUTES_OBJECT_MAPPER = ObjectMapperFactory.lenientStorage();
+
+    /**
+     * A pinned mapper, not a factory recipe. This is the body of migration {@code V202402171510}, which must keep
+     * producing the shape it wrote on its first run.
+     */
+    private static final ObjectMapper ATTRIBUTES_OBJECT_MAPPER = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     private static Map<String, UUID> attributeNameDefinitionMapping = new HashMap<>();
     private static final Map<UUID, Map<String, UUID>> definitionsItemsContentMapping = new HashMap<>();

--- a/src/main/java/com/otilm/core/util/DatabaseAttributeMigration.java
+++ b/src/main/java/com/otilm/core/util/DatabaseAttributeMigration.java
@@ -1,7 +1,6 @@
 package com.otilm.core.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.common.properties.DataAttributeProperties;
@@ -9,6 +8,7 @@ import com.otilm.api.model.common.attribute.v2.DataAttributeV2;
 import com.otilm.api.model.common.attribute.v2.content.BaseAttributeContentV2;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -25,8 +25,7 @@ import org.slf4j.LoggerFactory;
 public class DatabaseAttributeMigration {
 
     private static final Logger logger = LoggerFactory.getLogger(DatabaseAttributeMigration.class);
-    private static final ObjectMapper ATTRIBUTES_OBJECT_MAPPER = new ObjectMapper()
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    private static final ObjectMapper ATTRIBUTES_OBJECT_MAPPER = ObjectMapperFactory.lenientStorage();
 
     private static Map<String, UUID> attributeNameDefinitionMapping = new HashMap<>();
     private static final Map<UUID, Map<String, UUID>> definitionsItemsContentMapping = new HashMap<>();

--- a/src/main/java/com/otilm/core/util/MetaDefinitions.java
+++ b/src/main/java/com/otilm/core/util/MetaDefinitions.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.otilm.api.model.core.certificate.CertificateValidationCheck;
 import com.otilm.api.model.core.certificate.CertificateValidationCheckDto;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -11,7 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 public class MetaDefinitions {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.storage();
 
     public static String serialize(Map<String, Object> metaData) {
         try {

--- a/src/main/java/com/otilm/core/util/SecretsUtil.java
+++ b/src/main/java/com/otilm/core/util/SecretsUtil.java
@@ -1,10 +1,7 @@
 package com.otilm.core.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.otilm.api.model.connector.secrets.content.ApiKeySecretContent;
 import com.otilm.api.model.connector.secrets.content.BasicAuthSecretContent;
 import com.otilm.api.model.connector.secrets.content.GenericSecretContent;
@@ -14,6 +11,7 @@ import com.otilm.api.model.connector.secrets.content.KeyValueSecretContent;
 import com.otilm.api.model.connector.secrets.content.PrivateKeySecretContent;
 import com.otilm.api.model.connector.secrets.content.SecretContent;
 import com.otilm.api.model.connector.secrets.content.SecretKeySecretContent;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -50,12 +48,7 @@ public class SecretsUtil {
     private static final String algorithm = "PBEWithSHA256And256BitAES-CBC-BC";
     private static final int iterations = 1000;
 
-    private static final ObjectMapper objectMapper = JsonMapper
-            .builder()
-            .findAndAddModules()
-            .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
-            .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
-            .build();
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.secretThumbprint();
 
     /**
      * Encrypts and encodes the given secret using the PBEWithSHA256And256BitAES-CBC-BC algorithm.

--- a/src/main/java/com/otilm/core/util/SerializationUtil.java
+++ b/src/main/java/com/otilm/core/util/SerializationUtil.java
@@ -1,16 +1,14 @@
 package com.otilm.core.util;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.otilm.api.model.core.acme.Identifier;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import java.util.ArrayList;
 import java.util.List;
 
 public class SerializationUtil {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.lenientStorage();
 
     public static String serializeIdentifiers(List<Identifier> identifiers) {
         try {
@@ -53,7 +51,6 @@ public class SerializationUtil {
     }
 
     public static Object deserialize(String object, Class returnType) {
-        OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         if (object == null || object.isEmpty()) {
             return new ArrayList<>();
         }
@@ -65,7 +62,6 @@ public class SerializationUtil {
     }
 
     public static <T> T convertValue(Object source, Class<T> returnType) {
-        OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         if (source == null) {
             return null;
         }

--- a/src/main/java/com/otilm/core/util/SerializationUtil.java
+++ b/src/main/java/com/otilm/core/util/SerializationUtil.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class SerializationUtil {
-    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.lenientStorage();
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.emptyBeanTolerantStorage();
 
     public static String serializeIdentifiers(List<Identifier> identifiers) {
         try {

--- a/src/main/java/com/otilm/core/validation/certificate/X509CertificateValidator.java
+++ b/src/main/java/com/otilm/core/validation/certificate/X509CertificateValidator.java
@@ -15,6 +15,7 @@ import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.CrlEntry;
 import com.otilm.core.dao.entity.RaProfile;
 import com.otilm.core.dao.repository.CertificateRepository;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import com.otilm.core.service.CrlService;
 import com.otilm.core.service.writer.CertificateValidationWriter;
 import com.otilm.core.settings.SettingsCache;
@@ -44,7 +45,7 @@ import org.springframework.stereotype.Service;
 @Service("X.509")
 public class X509CertificateValidator implements ICertificateValidator {
     private static final Logger logger = LoggerFactory.getLogger(X509CertificateValidator.class);
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.storage();
     private CertificateRepository certificateRepository;
 
     private CrlService crlService;

--- a/src/main/java/db/migration/V202506131400__NotificationSettingsToEventSettings.java
+++ b/src/main/java/db/migration/V202506131400__NotificationSettingsToEventSettings.java
@@ -1,6 +1,6 @@
 package db.migration;
 
-import com.otilm.core.serialization.ObjectMapperFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.otilm.core.util.DatabaseMigration;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
@@ -12,6 +12,11 @@ import java.util.stream.Collectors;
 
 @SuppressWarnings("java:S101")
 public class V202506131400__NotificationSettingsToEventSettings extends BaseJavaMigration {
+
+    /**
+     * A pinned mapper, not a factory recipe. A migration must keep producing the shape it wrote on its first run.
+     */
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private static final Map<String, String> NOTIFICATION_TYPE_TO_RESOURCE = Map.ofEntries(
             Map.entry("certificate_status_changed", "CERTIFICATE"),
@@ -34,7 +39,7 @@ public class V202506131400__NotificationSettingsToEventSettings extends BaseJava
                 String value = notificationSettings.getString("value");
                 TypeReference<Map<String, String>> typeReference = new TypeReference<>() {
                 };
-                Map<String, String> typeToInstanceMap = ObjectMapperFactory.storage().readValue(value, typeReference);
+                Map<String, String> typeToInstanceMap = MAPPER.readValue(value, typeReference);
                 Map<String, List<String>> instanceToTypes = typeToInstanceMap.entrySet()
                         .stream()
                         .collect(Collectors.groupingBy(

--- a/src/main/java/db/migration/V202506131400__NotificationSettingsToEventSettings.java
+++ b/src/main/java/db/migration/V202506131400__NotificationSettingsToEventSettings.java
@@ -1,8 +1,8 @@
 package db.migration;
 
+import com.otilm.core.serialization.ObjectMapperFactory;
 import com.otilm.core.util.DatabaseMigration;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
 
@@ -34,7 +34,7 @@ public class V202506131400__NotificationSettingsToEventSettings extends BaseJava
                 String value = notificationSettings.getString("value");
                 TypeReference<Map<String, String>> typeReference = new TypeReference<>() {
                 };
-                Map<String, String> typeToInstanceMap = new ObjectMapper().readValue(value, typeReference);
+                Map<String, String> typeToInstanceMap = ObjectMapperFactory.storage().readValue(value, typeReference);
                 Map<String, List<String>> instanceToTypes = typeToInstanceMap.entrySet()
                         .stream()
                         .collect(Collectors.groupingBy(

--- a/src/main/java/db/migration/V202507311051__MigrateToComplianceProfilesV2.java
+++ b/src/main/java/db/migration/V202507311051__MigrateToComplianceProfilesV2.java
@@ -39,6 +39,10 @@ public class V202507311051__MigrateToComplianceProfilesV2 extends BaseJavaMigrat
 
     private static final Logger logger = LoggerFactory.getLogger(V202507311051__MigrateToComplianceProfilesV2.class);
 
+    /**
+     * A pinned copy of the wire recipe. A migration must keep producing the shape it wrote on its first run, so it
+     * cannot follow a factory recipe that may evolve.
+     */
     private static final ObjectMapper mapper = Jackson2ObjectMapperBuilder.json()
             .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
             .modules(new JavaTimeModule())

--- a/src/main/java/db/migration/V202509191412__LogRecordsRefactor.java
+++ b/src/main/java/db/migration/V202509191412__LogRecordsRefactor.java
@@ -1,5 +1,6 @@
 package db.migration;
 
+import com.otilm.core.serialization.ObjectMapperFactory;
 import com.otilm.core.util.DatabaseMigration;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,7 +17,7 @@ import java.sql.Statement;
 @SuppressWarnings("java:S101")
 public class V202509191412__LogRecordsRefactor extends BaseJavaMigration {
 
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = ObjectMapperFactory.storage();
 
     @Override
     public Integer getChecksum() {

--- a/src/main/java/db/migration/V202509191412__LogRecordsRefactor.java
+++ b/src/main/java/db/migration/V202509191412__LogRecordsRefactor.java
@@ -1,6 +1,5 @@
 package db.migration;
 
-import com.otilm.core.serialization.ObjectMapperFactory;
 import com.otilm.core.util.DatabaseMigration;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -17,7 +16,10 @@ import java.sql.Statement;
 @SuppressWarnings("java:S101")
 public class V202509191412__LogRecordsRefactor extends BaseJavaMigration {
 
-    private static final ObjectMapper mapper = ObjectMapperFactory.storage();
+    /**
+     * A pinned mapper, not a factory recipe. A migration must keep producing the shape it wrote on its first run.
+     */
+    private static final ObjectMapper mapper = new ObjectMapper();
 
     @Override
     public Integer getChecksum() {

--- a/src/test/java/com/otilm/core/architecture/ObjectMapperCentralizationArchTest.java
+++ b/src/test/java/com/otilm/core/architecture/ObjectMapperCentralizationArchTest.java
@@ -12,7 +12,6 @@ import com.tngtech.archunit.core.importer.Location;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
-import db.migration.V202507311051__MigrateToComplianceProfilesV2;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
@@ -21,6 +20,9 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
  * Keeps every production {@link ObjectMapper} recipe inside {@link ObjectMapperFactory}, because Jackson 3 changes
  * defaults with no compiler signature. Mapper builders and subclasses count too: a constructor-only rule stays green
  * while {@code Jackson2ObjectMapperBuilder.json().build()} recreates a decentralized recipe.
+ * <p>
+ * Java migrations are exempt: each pins its own mapper, because a migration must keep producing the shape it wrote on
+ * its first run.
  */
 @AnalyzeClasses(packages = {"com.otilm.core", "db.migration"},
         importOptions = ObjectMapperCentralizationArchTest.OnlyThisModule.class)
@@ -48,7 +50,9 @@ class ObjectMapperCentralizationArchTest {
     @ArchTest
     static final ArchRule onlyTheFactoryConstructsObjectMappers = noClasses()
             .that()
-            .doNotBelongToAnyOf(ObjectMapperFactory.class, V202507311051__MigrateToComplianceProfilesV2.class)
+            .doNotBelongToAnyOf(ObjectMapperFactory.class)
+            .and()
+            .resideOutsideOfPackage("db.migration..")
             .should()
             .callCodeUnitWhere(BUILDS_AN_OBJECT_MAPPER)
             .because("production mappers come from ObjectMapperFactory, so the Jackson 3 migration has one recipe set "

--- a/src/test/java/com/otilm/core/architecture/ObjectMapperCentralizationArchTest.java
+++ b/src/test/java/com/otilm/core/architecture/ObjectMapperCentralizationArchTest.java
@@ -1,0 +1,68 @@
+package com.otilm.core.architecture;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.MapperBuilder;
+import com.otilm.core.serialization.ObjectMapperFactory;
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaCall;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.core.importer.Location;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import db.migration.V202507311051__MigrateToComplianceProfilesV2;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * Keeps every production {@link ObjectMapper} recipe inside {@link ObjectMapperFactory}, because Jackson 3 changes
+ * defaults with no compiler signature. Mapper builders and subclasses count too: a constructor-only rule stays green
+ * while {@code Jackson2ObjectMapperBuilder.json().build()} recreates a decentralized recipe.
+ */
+@AnalyzeClasses(packages = {"com.otilm.core", "db.migration"},
+        importOptions = ObjectMapperCentralizationArchTest.OnlyThisModule.class)
+class ObjectMapperCentralizationArchTest {
+
+    /**
+     * A call that creates a mapper: a constructor of {@link ObjectMapper} or a subclass, or a builder's
+     * {@code build()}. Matching the return type instead would also reject accessors and chained {@code configure()}
+     * calls.
+     */
+    private static final DescribedPredicate<JavaCall<?>> BUILDS_AN_OBJECT_MAPPER = new DescribedPredicate<>(
+            "construct an ObjectMapper, directly or through a mapper builder") {
+
+        @Override
+        public boolean test(JavaCall<?> call) {
+            JavaClass owner = call.getTargetOwner();
+            if (JavaConstructor.CONSTRUCTOR_NAME.equals(call.getName())) {
+                return owner.isAssignableTo(ObjectMapper.class);
+            }
+            return "build".equals(call.getName()) && (owner.isAssignableTo(Jackson2ObjectMapperBuilder.class)
+                    || owner.isAssignableTo(MapperBuilder.class));
+        }
+    };
+
+    @ArchTest
+    static final ArchRule onlyTheFactoryConstructsObjectMappers = noClasses()
+            .that()
+            .doNotBelongToAnyOf(ObjectMapperFactory.class, V202507311051__MigrateToComplianceProfilesV2.class)
+            .should()
+            .callCodeUnitWhere(BUILDS_AN_OBJECT_MAPPER)
+            .because("production mappers come from ObjectMapperFactory, so the Jackson 3 migration has one recipe set "
+                    + "to review instead of one per construction site");
+
+    /**
+     * Restricts the import to this module's own output. The {@code interfaces} artifact publishes into
+     * {@code com.otilm.core} as well, and its mappers are not ours to centralize.
+     */
+    static class OnlyThisModule implements ImportOption {
+
+        @Override
+        public boolean includes(Location location) {
+            return location.contains("/target/classes/");
+        }
+    }
+}

--- a/src/test/java/com/otilm/core/architecture/ObjectMapperCentralizationArchTest.java
+++ b/src/test/java/com/otilm/core/architecture/ObjectMapperCentralizationArchTest.java
@@ -3,6 +3,7 @@ package com.otilm.core.architecture;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.cfg.MapperBuilder;
 import com.otilm.core.serialization.ObjectMapperFactory;
+import com.otilm.core.util.DatabaseAttributeMigration;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaCall;
 import com.tngtech.archunit.core.domain.JavaClass;
@@ -22,7 +23,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
  * while {@code Jackson2ObjectMapperBuilder.json().build()} recreates a decentralized recipe.
  * <p>
  * Java migrations are exempt: each pins its own mapper, because a migration must keep producing the shape it wrote on
- * its first run.
+ * its first run. {@link DatabaseAttributeMigration} is exempt too, as the body of migration {@code V202402171510}.
  */
 @AnalyzeClasses(packages = {"com.otilm.core", "db.migration"},
         importOptions = ObjectMapperCentralizationArchTest.OnlyThisModule.class)
@@ -50,7 +51,7 @@ class ObjectMapperCentralizationArchTest {
     @ArchTest
     static final ArchRule onlyTheFactoryConstructsObjectMappers = noClasses()
             .that()
-            .doNotBelongToAnyOf(ObjectMapperFactory.class)
+            .doNotBelongToAnyOf(ObjectMapperFactory.class, DatabaseAttributeMigration.class)
             .and()
             .resideOutsideOfPackage("db.migration..")
             .should()

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/ActionsListenerTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/ActionsListenerTest.java
@@ -12,6 +12,7 @@ import com.otilm.core.messaging.jms.configuration.MessagingProperties;
 import com.otilm.core.messaging.jms.producers.NotificationProducer;
 import com.otilm.core.messaging.model.ActionMessage;
 import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.serialization.ObjectMapperFactory;
 import com.otilm.core.service.ApprovalInternalService;
 import com.otilm.core.service.SecretInternalService;
 import com.otilm.core.service.v2.ClientOperationInternalService;
@@ -68,6 +69,7 @@ class ActionsListenerTest {
         listener.setNotificationProducer(notificationProducer);
         listener.setAuthHelper(authHelper);
         listener.setMessagingProperties(messagingProperties);
+        listener.setMapper(ObjectMapperFactory.wire());
 
         // Only the failure-path tests read this; lenient() avoids strict-stubbing complaints
         // from happy-path tests that never invoke it.

--- a/src/test/java/com/otilm/core/serialization/ObjectMapperFactoryTest.java
+++ b/src/test/java/com/otilm/core/serialization/ObjectMapperFactoryTest.java
@@ -1,0 +1,65 @@
+package com.otilm.core.serialization;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the recipes whose behaviour is not obvious from the factory method alone.
+ */
+class ObjectMapperFactoryTest {
+
+    /**
+     * The exported columns are open-typed, so a producer anywhere may hand the export a JDK8 value.
+     */
+    @Test
+    void auditLogExportSerializesJdk8TypesThroughTheirDiscoveredModule() throws JsonProcessingException {
+        Map<String, Object> additionalData = new LinkedHashMap<>();
+        additionalData.put("present", Optional.of("value"));
+        additionalData.put("count", OptionalInt.of(3));
+
+        String json = ObjectMapperFactory.auditLogExport().writeValueAsString(additionalData);
+
+        assertThat(json).isEqualTo("{\"present\":\"value\",\"count\":3}");
+    }
+
+    @Test
+    void auditLogExportWritesAnEmptyOptionalWithoutFailing() {
+        assertThatCode(() -> ObjectMapperFactory.auditLogExport().writeValueAsString(Optional.empty()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void auditLogExportWritesDatesAsTextAndDropsNullMembers() throws JsonProcessingException {
+        Map<String, Object> additionalData = new LinkedHashMap<>();
+        additionalData.put("at", OffsetDateTime.of(2024, 5, 6, 7, 8, 9, 0, ZoneOffset.UTC));
+        additionalData.put("absent", null);
+
+        String json = ObjectMapperFactory.auditLogExport().writeValueAsString(additionalData);
+
+        assertThat(json).isEqualTo("{\"at\":\"2024-05-06T07:08:09Z\"}");
+    }
+
+    /**
+     * Guards the reason the export keeps its own recipe. An explicit module list suppresses discovery, and the export
+     * would record {@code ERROR_SERIALIZATION} instead of data.
+     */
+    @Test
+    void wireDoesNotRegisterTheDiscoveredJdk8Module() {
+        ObjectMapper wire = ObjectMapperFactory.wire();
+
+        assertThatThrownBy(() -> wire.writeValueAsString(Map.of("present", Optional.of("value"))))
+                .isInstanceOf(InvalidDefinitionException.class);
+    }
+}

--- a/src/test/java/com/otilm/core/serialization/golden/AcmeProtocolGoldenTest.java
+++ b/src/test/java/com/otilm/core/serialization/golden/AcmeProtocolGoldenTest.java
@@ -128,8 +128,8 @@ class AcmeProtocolGoldenTest {
     }
 
     /**
-     * Jackson's default {@code FAIL_ON_UNKNOWN_PROPERTIES} turns an ACME client adding a member into a parse failure.
-     * Driven through {@code generalBodyJsonParser} so the assertion follows production's own call.
+     * An ACME client adding a member must be a parse failure. {@code acmeRequest()} enables
+     * {@code FAIL_ON_UNKNOWN_PROPERTIES} explicitly, so a Jackson default change cannot loosen this silently.
      */
     @Test
     void inboundJwsEnvelopeParserRejectsUnknownMembers() {


### PR DESCRIPTION
Replaces every bare `new ObjectMapper()` in `src/main/java` with a recipe from one reviewed factory, so the Jackson 3 migration has a single place to change instead of 26 independent ones.

### 26 sites, 6 configurations, 4 recipes

| Recipe | Sites | Why |
|---|---|---|
| `wire()` | HTTP bodies, plus the 4 converged below | the existing `WebAppConfig` recipe |
| `auditLog()` | `LoggerWrapper` | the wire recipe without null suppression — an audit line records that a member was absent |
| `storage()` | persisted JSON | Jackson's defaults, preserved |
| `lenientStorage()` | payloads produced elsewhere | `storage()` + the two leniency flags those sites already set |

`WebAppConfig#jsonObjectMapper` now delegates to `wire()`, so the bean and every static caller are the same recipe by construction rather than by agreement.

### What changed behaviour, and what deliberately did not

Converged onto the wire mapper — four sites whose JSON never reaches the database:

- **`AuditLogServiceImpl`** already built the wire recipe by hand; it injects the bean now. Byte-identical.
- **`ActionsListener`**, **`DiscoveryCertificateTask`** convert in-process payloads and *gain the time module they were missing*, turning a latent failure on any `java.time` member into a working one.
- **`AuthHelper`** reads a user profile from a `static` method, so it takes the recipe rather than the bean.

Persisted JSON stayed on `storage()` deliberately. No migration guards those columns, so a shape change there splits a table into rows written before it and rows written after — the failure mode #2000 documents. That risk is not worth uniformity.

### Two deliberate exceptions, per the DoD

- **`AcmeJsonProcessor`** stays independent. `AcmeProtocolGoldenTest#inboundJwsEnvelopeParserRejectsUnknownMembers` pins it as strict on unknown members; the wire mapper is lenient. Folding it in would silently relax an RFC 8555 parser. This answers the DoD's open question.
- **`CertificateUtil`** keeps `ORDER_MAP_ENTRIES_BY_KEYS` so a re-written subject-alternative-name column stays byte-stable.

Both now source their base from the factory with the delta stated in Javadoc, so they are one line to review rather than a hidden divergence.

### Three things this turned up

- **`SerializationUtil` reconfigured its shared static mapper on every `deserialize` and `convertValue` call**, mutating it under concurrent callers. A data race, independent of Jackson 3. The flag belongs to the recipe now.
- **`SettingServiceImpl` held an injected mapper *and* a bespoke one, and wrote settings into the same column with both.** Renamed to `wireMapper` / `storageMapper` so the divergence is legible. Not folded together — that would change stored settings.
- **The two Flyway migrations were safe to edit** only because both are already `isAltered` in `DatabaseMigration.JavaMigrationChecksums`. Had they not been, editing the source would have failed `JavaMigrationChecksumTest` and refused startup on every deployment that already ran them.

### Golden files

**No golden was regenerated, because none changed.** All 78 pass untouched. That is the evidence that no pinned surface moved, and it is why there is no separate regeneration commit — the DoD asks for one only if there are diffs to explain.

### The guard

`ObjectMapperCentralizationArchTest` forbids `new ObjectMapper()` outside the factory. Without it the 26 sites regrow one commit at a time and the next one is invisible in review. Its import is scoped to this module's `target/classes`, since `interfaces` shares the package prefix.
