### PR TITLE
Pin httpcore5 5.4.3 to clear CVE-2026-54399 from the image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
             <version>5.6.1</version>
         </dependency>
         <!-- Explicit httpcore5 pins: CVE-2026-54399 is fixed in core5 5.4.3, but every released httpclient5,
-             5.6.1 included, still manages the vulnerable 5.4 line. Drop both once a httpclient5 release
+             5.6.1 included, still pulls in an httpcore5 below 5.4.3. Drop both once a httpclient5 release
              manages httpcore5 >= 5.4.3. -->
         <dependency>
             <groupId>org.apache.httpcomponents.core5</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,20 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.5.1</version>
+            <version>5.6.1</version>
+        </dependency>
+        <!-- Explicit httpcore5 pins: CVE-2026-54399 is fixed in core5 5.4.3, but every released httpclient5,
+             5.6.1 included, still manages the vulnerable 5.4 line. Drop both once a httpclient5 release
+             manages httpcore5 >= 5.4.3. -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+            <version>5.4.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5-h2</artifactId>
+            <version>5.4.3</version>
         </dependency>
 
         <!-- this dependency is included to avoid warning -->


### PR DESCRIPTION
Unblocks every Docker image build: Trivy fails the image lanes on **CVE-2026-54399** (HIGH) in `httpcore5 5.3.6`, which arrives transitively through the `httpclient5 5.5.1` this pom declares directly.

## Why explicit core5 pins

The CVE is fixed in `httpcore5 5.4.3`, but **no released httpclient5 manages a fixed core yet** — current `5.6.1` still pulls in an `httpcore5` below `5.4.3`. So bumping the client alone cannot clear the scan:

| Artifact | Before | After |
|---|---|---|
| `httpclient5` | 5.5.1 (direct) | 5.6.1 |
| `httpcore5` | 5.3.6 (transitive) | **5.4.3 (pinned)** |
| `httpcore5-h2` | transitive | **5.4.3 (pinned)** |

The pom comment marks both pins as droppable once a httpclient5 release manages core5 >= 5.4.3.

## Verification

- `mvn dependency:tree` resolves `client5 5.6.1` + `core5 5.4.3` + `h2 5.4.3` — the vulnerable artifact is out of the graph.
- Local full compile is currently impossible on any main-based branch here: the local interfaces snapshot carries the unmerged discovery renames from interfaces#830, and a clean `main` checkout fails with the identical 38 rename errors — none of them in the http-consuming classes (`PlatformHttpClients`, the Intune SCEP clients), which resolve cleanly against the 5.6.1 API. CI compiles against the published snapshot and is the authoritative check, together with the Trivy lane this PR exists to turn green.

## Related

- `csc-api` also declares `httpclient5`, but version-less — it inherits Spring Boot's managed version, so its exposure depends on its Boot line and needs its own check.
- The `dependencies` BOM manages no httpcomponents artifacts today; centralizing them there only helps once consumer repos drop their explicit versions, so it is a separate cleanup, not this fix.

