### PR TITLE
Discovery v2 schema groundwork

### DIFF
--- a/src/main/java/com/otilm/core/dao/entity/Discovery.java
+++ b/src/main/java/com/otilm/core/dao/entity/Discovery.java
@@ -40,11 +40,8 @@ import org.hibernate.proxy.HibernateProxy;
 @ToString
 @RequiredArgsConstructor
 @Entity
-@Table(name = "discovery_history")
-public class DiscoveryHistory extends UniquelyIdentifiedAndAudited
-        implements
-            Serializable,
-            DtoMapper<DiscoveryDetailDto> {
+@Table(name = "discovery")
+public class Discovery extends UniquelyIdentifiedAndAudited implements Serializable, DtoMapper<DiscoveryDetailDto> {
 
     @Serial
     private static final long serialVersionUID = 571684590427678474L;
@@ -159,7 +156,7 @@ public class DiscoveryHistory extends UniquelyIdentifiedAndAudited
         if (thisEffectiveClass != oEffectiveClass) {
             return false;
         }
-        DiscoveryHistory that = (DiscoveryHistory) o;
+        Discovery that = (Discovery) o;
         return getUuid() != null && Objects.equals(getUuid(), that.getUuid());
     }
 

--- a/src/main/java/com/otilm/core/dao/entity/Discovery.java
+++ b/src/main/java/com/otilm/core/dao/entity/Discovery.java
@@ -24,7 +24,6 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -159,9 +158,8 @@ public class Discovery extends UniquelyIdentifiedAndAudited implements Serializa
         DiscoveryDetailDto dto = new DiscoveryDetailDto();
         dto.setUuid(uuid.toString());
         dto.setName(name);
-        // The wire DTO keeps java.util.Date for request-shape compatibility; the entity moved to timestamptz.
-        dto.setEndTime(endTime == null ? null : Date.from(endTime.toInstant()));
-        dto.setStartTime(startTime == null ? null : Date.from(startTime.toInstant()));
+        dto.setEndTime(endTime);
+        dto.setStartTime(startTime);
         dto.setTotalCertificatesDiscovered(totalCertificatesDiscovered);
         dto.setStatus(status);
         dto.setConnectorUuid(connectorUuid.toString());
@@ -184,8 +182,8 @@ public class Discovery extends UniquelyIdentifiedAndAudited implements Serializa
         DiscoveryListDto dto = new DiscoveryListDto();
         dto.setUuid(uuid.toString());
         dto.setName(name);
-        dto.setEndTime(endTime == null ? null : Date.from(endTime.toInstant()));
-        dto.setStartTime(startTime == null ? null : Date.from(startTime.toInstant()));
+        dto.setEndTime(endTime);
+        dto.setStartTime(startTime);
         dto.setTotalCertificatesDiscovered(totalCertificatesDiscovered);
         dto.setStatus(status);
         dto.setConnectorUuid(connectorUuid.toString());

--- a/src/main/java/com/otilm/core/dao/entity/Discovery.java
+++ b/src/main/java/com/otilm/core/dao/entity/Discovery.java
@@ -96,6 +96,9 @@ public class Discovery extends UniquelyIdentifiedAndAudited implements Serializa
     private UUID connectorInterfaceUuid;
 
     // Connector-side run context the lifecycle calls replay; nulled on every terminal transition.
+    // S1948: every entity is Serializable via UniquelyIdentifiedObject, but nothing Java-serializes them —
+    // Jackson owns this JSONB field's persistence shape (same situation as Certificate's attribute lists).
+    @SuppressWarnings("java:S1948")
     @Column(name = "run_meta", columnDefinition = "jsonb")
     @JdbcTypeCode(SqlTypes.JSON)
     private Map<String, Object> runMeta;
@@ -115,6 +118,7 @@ public class Discovery extends UniquelyIdentifiedAndAudited implements Serializa
     @Column(name = "progress_total_estimate")
     private Long progressTotalEstimate;
 
+    @SuppressWarnings("java:S1948") // see runMeta
     @Column(name = "progress_by_resource", columnDefinition = "jsonb")
     @JdbcTypeCode(SqlTypes.JSON)
     private Map<Resource, DiscoveryResourceProgressDto> progressByResource;
@@ -190,18 +194,18 @@ public class Discovery extends UniquelyIdentifiedAndAudited implements Serializa
     }
 
     @Override
-    public final boolean equals(Object o) {
+    public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
         if (o == null) {
             return false;
         }
-        Class<?> oEffectiveClass = o instanceof HibernateProxy
-                ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass()
+        Class<?> oEffectiveClass = o instanceof HibernateProxy hibernateProxy
+                ? hibernateProxy.getHibernateLazyInitializer().getPersistentClass()
                 : o.getClass();
-        Class<?> thisEffectiveClass = this instanceof HibernateProxy
-                ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass()
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy hibernateProxy
+                ? hibernateProxy.getHibernateLazyInitializer().getPersistentClass()
                 : this.getClass();
         if (thisEffectiveClass != oEffectiveClass) {
             return false;
@@ -211,9 +215,9 @@ public class Discovery extends UniquelyIdentifiedAndAudited implements Serializa
     }
 
     @Override
-    public final int hashCode() {
-        return this instanceof HibernateProxy
-                ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode()
+    public int hashCode() {
+        return this instanceof HibernateProxy hibernateProxy
+                ? hibernateProxy.getHibernateLazyInitializer().getPersistentClass().hashCode()
                 : getClass().hashCode();
     }
 }

--- a/src/main/java/com/otilm/core/dao/entity/Discovery.java
+++ b/src/main/java/com/otilm/core/dao/entity/Discovery.java
@@ -72,10 +72,10 @@ public class Discovery extends UniquelyIdentifiedAndAudited implements Serializa
     private String message;
 
     @Column(name = "start_time")
-    private Date startTime;
+    private OffsetDateTime startTime;
 
     @Column(name = "end_time")
-    private Date endTime;
+    private OffsetDateTime endTime;
 
     @Column(name = "total_certificates_discovered")
     private Integer totalCertificatesDiscovered;
@@ -159,8 +159,9 @@ public class Discovery extends UniquelyIdentifiedAndAudited implements Serializa
         DiscoveryDetailDto dto = new DiscoveryDetailDto();
         dto.setUuid(uuid.toString());
         dto.setName(name);
-        dto.setEndTime(endTime);
-        dto.setStartTime(startTime);
+        // The wire DTO keeps java.util.Date for request-shape compatibility; the entity moved to timestamptz.
+        dto.setEndTime(endTime == null ? null : Date.from(endTime.toInstant()));
+        dto.setStartTime(startTime == null ? null : Date.from(startTime.toInstant()));
         dto.setTotalCertificatesDiscovered(totalCertificatesDiscovered);
         dto.setStatus(status);
         dto.setConnectorUuid(connectorUuid.toString());
@@ -183,8 +184,8 @@ public class Discovery extends UniquelyIdentifiedAndAudited implements Serializa
         DiscoveryListDto dto = new DiscoveryListDto();
         dto.setUuid(uuid.toString());
         dto.setName(name);
-        dto.setEndTime(endTime);
-        dto.setStartTime(startTime);
+        dto.setEndTime(endTime == null ? null : Date.from(endTime.toInstant()));
+        dto.setStartTime(startTime == null ? null : Date.from(startTime.toInstant()));
         dto.setTotalCertificatesDiscovered(totalCertificatesDiscovered);
         dto.setStatus(status);
         dto.setConnectorUuid(connectorUuid.toString());

--- a/src/main/java/com/otilm/core/dao/entity/Discovery.java
+++ b/src/main/java/com/otilm/core/dao/entity/Discovery.java
@@ -3,6 +3,7 @@ package com.otilm.core.dao.entity;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.otilm.api.model.client.discovery.DiscoveryDetailDto;
 import com.otilm.api.model.client.discovery.DiscoveryListDto;
+import com.otilm.api.model.connector.discovery.v2.DiscoveryResourceProgressDto;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.discovery.DiscoveryStatus;
 import com.otilm.core.dao.entity.workflows.Trigger;
@@ -21,10 +22,12 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.io.Serial;
 import java.io.Serializable;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -32,8 +35,10 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.SQLJoinTableRestriction;
 import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.type.SqlTypes;
 
 @Getter
 @Setter
@@ -83,6 +88,51 @@ public class Discovery extends UniquelyIdentifiedAndAudited implements Serializa
 
     @Column(name = "connector_name")
     private String connectorName;
+
+    // ---- Discovery v2 run columns. All null (or zero, for the cursor) on a v1 legacy run. ----
+
+    // NULL = v1 legacy run; set = the connector interface this run was initiated against.
+    @Column(name = "connector_interface_uuid")
+    private UUID connectorInterfaceUuid;
+
+    // Connector-side run context the lifecycle calls replay; nulled on every terminal transition.
+    @Column(name = "run_meta", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private Map<String, Object> runMeta;
+
+    @Column(name = "resources", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private List<Resource> resources;
+
+    // Run-wide highest item sequence applied to staging — the drain cursor. Item sequences start at 1, so 0
+    // means nothing drained yet.
+    @Column(name = "last_applied_sequence", nullable = false)
+    private long lastAppliedSequence;
+
+    @Column(name = "progress_processed")
+    private Long progressProcessed;
+
+    @Column(name = "progress_total_estimate")
+    private Long progressTotalEstimate;
+
+    @Column(name = "progress_by_resource", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private Map<Resource, DiscoveryResourceProgressDto> progressByResource;
+
+    @Column(name = "progress_phase")
+    private String progressPhase;
+
+    @Column(name = "run_messages", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private List<String> runMessages;
+
+    @Column(name = "stopped_at")
+    private OffsetDateTime stoppedAt;
+
+    // Last authoritative DiscoveryRunState wire code the connector reported; "completed" switches the drain
+    // into drain-to-completion mode.
+    @Column(name = "connector_state")
+    private String connectorState;
 
     @JsonBackReference
     @OneToMany(mappedBy = "discovery", fetch = FetchType.LAZY)

--- a/src/main/java/com/otilm/core/dao/entity/DiscoveryCertificate.java
+++ b/src/main/java/com/otilm/core/dao/entity/DiscoveryCertificate.java
@@ -64,7 +64,7 @@ public class DiscoveryCertificate extends UniquelyIdentifiedAndAudited
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "discovery_uuid", nullable = false, insertable = false, updatable = false)
     @ToString.Exclude
-    private DiscoveryHistory discovery;
+    private Discovery discovery;
 
     @Column(name = "discovery_uuid", nullable = false)
     private UUID discoveryUuid;
@@ -114,7 +114,7 @@ public class DiscoveryCertificate extends UniquelyIdentifiedAndAudited
         this.certificateContentId = certificateContent.getId();
     }
 
-    public void setDiscovery(DiscoveryHistory discovery) {
+    public void setDiscovery(Discovery discovery) {
         this.discovery = discovery;
         this.discoveryUuid = discovery.getUuid();
     }

--- a/src/main/java/com/otilm/core/dao/entity/DiscoveryItem.java
+++ b/src/main/java/com/otilm/core/dao/entity/DiscoveryItem.java
@@ -44,7 +44,7 @@ public class DiscoveryItem extends UniquelyIdentified {
     private UUID discoveryUuid;
 
     // Mirrors ON DELETE CASCADE from the migration for the test environment, which generates its schema from
-    // the entities (same note as ScheduledJobHistory); the writable column stays the scalar discoveryUuid above.
+    // the entities; the writable column stays the scalar discoveryUuid above.
     @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "discovery_uuid", insertable = false, updatable = false)
@@ -71,16 +71,14 @@ public class DiscoveryItem extends UniquelyIdentified {
     @Column(name = "processed_at")
     private OffsetDateTime processedAt;
 
-    // Per-item processing failure (parity: discovery_certificate.processed_error).
     @Column(name = "processed_error")
     private String processedError;
 
-    // Object this item became (parity: discovery_certificate.inventory_uuid);
-    // null until processed, permanently null if processing failed.
+    // Object this item became; null until processed, permanently null if processing failed.
     @Column(name = "inventory_uuid")
     private UUID inventoryUuid;
 
-    // Not already in inventory when staged, matched by fingerprint (parity: discovery_certificate.newly_discovered).
+    // Not already in inventory when staged, matched by fingerprint.
     @Column(name = "newly_discovered", nullable = false)
     private boolean newlyDiscovered;
 

--- a/src/main/java/com/otilm/core/dao/entity/DiscoveryItem.java
+++ b/src/main/java/com/otilm/core/dao/entity/DiscoveryItem.java
@@ -1,0 +1,104 @@
+package com.otilm.core.dao.entity;
+
+import com.otilm.api.model.common.attribute.common.MetadataAttribute;
+import com.otilm.api.model.core.auth.Resource;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * One staged discovery v2 item, whatever its resource type — the resource-agnostic sibling of
+ * {@link DiscoveryCertificate}, whose v1 rows keep living beside these until the evidence-gated unification
+ * (core#2027). The parity columns ({@code processedError}, {@code inventoryUuid}, {@code newlyDiscovered},
+ * {@code meta}) deliberately mirror that entity so the union listing reads one shape from both stores.
+ *
+ * <p>
+ * {@code payload} keeps the connector-reported union untyped ({@code Map}): staging must never fail on a payload shape
+ * this Core version does not know yet, and the typed view is synthesized at read time where a failure can be answered,
+ * not dropped.
+ */
+@Getter
+@Setter
+@Entity
+@Table(name = "discovery_item", uniqueConstraints = @UniqueConstraint(name = "uq_discovery_item_ref",
+        columnNames = {"discovery_uuid", "resource", "unique_ref"}))
+public class DiscoveryItem extends UniquelyIdentified {
+
+    @Column(name = "discovery_uuid", nullable = false)
+    private UUID discoveryUuid;
+
+    // Mirrors ON DELETE CASCADE from the migration for the test environment, which generates its schema from
+    // the entities (same note as ScheduledJobHistory); the writable column stays the scalar discoveryUuid above.
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "discovery_uuid", insertable = false, updatable = false)
+    private Discovery discovery;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "resource", nullable = false)
+    private Resource resource;
+
+    // The run-wide dense cursor assigned by the connector, starting at 1 — never page-scoped.
+    @Column(name = "sequence", nullable = false)
+    private long sequence;
+
+    @Column(name = "unique_ref", nullable = false)
+    private String uniqueRef;
+
+    @Column(name = "payload", columnDefinition = "jsonb", nullable = false)
+    @JdbcTypeCode(SqlTypes.JSON)
+    private Map<String, Object> payload;
+
+    @Column(name = "discovered_at")
+    private OffsetDateTime discoveredAt;
+
+    @Column(name = "processed_at")
+    private OffsetDateTime processedAt;
+
+    // Per-item processing failure (parity: discovery_certificate.processed_error).
+    @Column(name = "processed_error")
+    private String processedError;
+
+    // Object this item became (parity: discovery_certificate.inventory_uuid);
+    // null until processed, permanently null if processing failed.
+    @Column(name = "inventory_uuid")
+    private UUID inventoryUuid;
+
+    // Not already in inventory when staged, matched by fingerprint (parity: discovery_certificate.newly_discovered).
+    @Column(name = "newly_discovered", nullable = false)
+    private boolean newlyDiscovered;
+
+    // Provider-reported location context; unrecoverable if dropped at staging — key location lives here.
+    @Column(name = "meta", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private List<MetadataAttribute> meta;
+
+    // No-op override required by Sonar S2160 (a field-adding subclass of UniquelyIdentified must override
+    // equals): identity stays the UUID and the added columns deliberately do not affect equality. Matches the
+    // convention used by the other field-adding entities; dropping it just re-raises the finding.
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+}

--- a/src/main/java/com/otilm/core/dao/entity/DiscoveryItem.java
+++ b/src/main/java/com/otilm/core/dao/entity/DiscoveryItem.java
@@ -23,10 +23,8 @@ import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.type.SqlTypes;
 
 /**
- * One staged discovery v2 item, whatever its resource type — the resource-agnostic sibling of
- * {@link DiscoveryCertificate}, whose v1 rows keep living beside these until the evidence-gated unification
- * (core#2027). The parity columns ({@code processedError}, {@code inventoryUuid}, {@code newlyDiscovered},
- * {@code meta}) deliberately mirror that entity so the union listing reads one shape from both stores.
+ * One staged discovery item, whatever its resource type: the run-scoped record of something a Discovery Provider
+ * reported, held until processing turns it into an inventory object — or records, on the row itself, why it could not.
  *
  * <p>
  * {@code payload} keeps the connector-reported union untyped ({@code Map}): staging must never fail on a payload shape
@@ -90,9 +88,8 @@ public class DiscoveryItem extends UniquelyIdentified {
     @JdbcTypeCode(SqlTypes.JSON)
     private List<MetadataAttribute> meta;
 
-    // No-op override required by Sonar S2160 (a field-adding subclass of UniquelyIdentified must override
-    // equals): identity stays the UUID and the added columns deliberately do not affect equality. Matches the
-    // convention used by the other field-adding entities; dropping it just re-raises the finding.
+    // No-op overrides required by S2160: identity and hashing stay UUID-based, and the added columns never
+    // affect equality.
     @Override
     public boolean equals(Object o) {
         return super.equals(o);

--- a/src/main/java/com/otilm/core/dao/entity/DiscoveryItem.java
+++ b/src/main/java/com/otilm/core/dao/entity/DiscoveryItem.java
@@ -61,6 +61,9 @@ public class DiscoveryItem extends UniquelyIdentified {
     @Column(name = "unique_ref", nullable = false)
     private String uniqueRef;
 
+    // S1948: every entity is Serializable via UniquelyIdentifiedObject, but nothing Java-serializes them —
+    // Jackson owns this JSONB field's persistence shape.
+    @SuppressWarnings("java:S1948")
     @Column(name = "payload", columnDefinition = "jsonb", nullable = false)
     @JdbcTypeCode(SqlTypes.JSON)
     private Map<String, Object> payload;

--- a/src/main/java/com/otilm/core/dao/entity/DiscoveryWork.java
+++ b/src/main/java/com/otilm/core/dao/entity/DiscoveryWork.java
@@ -14,8 +14,10 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.Generated;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.generator.EventType;
 
 /**
  * One unit of pending discovery v2 work: created when a run starts owing a status poll, a drain or a processing pass,
@@ -51,6 +53,9 @@ public class DiscoveryWork extends UniquelyIdentified {
     private OffsetDateTime nextDueAt;
 
     // Set by the database on insert, never written by the application — hence a read-only mapping.
+    // @Generated makes Hibernate re-read the DB-assigned value after a JPA insert, so the in-memory
+    // entity never carries a null created while the row already has one.
+    @Generated(event = EventType.INSERT)
     @Column(name = "i_cre", nullable = false, insertable = false, updatable = false,
             columnDefinition = "timestamptz not null default now()")
     private OffsetDateTime created;

--- a/src/main/java/com/otilm/core/dao/entity/DiscoveryWork.java
+++ b/src/main/java/com/otilm/core/dao/entity/DiscoveryWork.java
@@ -22,7 +22,7 @@ import org.hibernate.generator.EventType;
 /**
  * One unit of pending discovery v2 work: created when a run starts owing a status poll, a drain or a processing pass,
  * rescheduled with backoff on failure, and deleted when the run stops owing it. Internal scheduling machinery, not a
- * user-facing entity — hence no author/update audit columns, the same shape as {@link CertificateStatusPoll}.
+ * user-facing entity — hence no author/update audit columns.
  */
 @Getter
 @Setter
@@ -60,9 +60,8 @@ public class DiscoveryWork extends UniquelyIdentified {
             columnDefinition = "timestamptz not null default now()")
     private OffsetDateTime created;
 
-    // No-op override required by Sonar S2160 (a field-adding subclass of UniquelyIdentified must override
-    // equals): identity stays the UUID and the added columns deliberately do not affect equality. Matches the
-    // convention used by the other field-adding entities; dropping it just re-raises the finding.
+    // No-op overrides required by S2160: identity and hashing stay UUID-based, and the added columns never
+    // affect equality.
     @Override
     public boolean equals(Object o) {
         return super.equals(o);

--- a/src/main/java/com/otilm/core/dao/entity/DiscoveryWork.java
+++ b/src/main/java/com/otilm/core/dao/entity/DiscoveryWork.java
@@ -34,7 +34,7 @@ public class DiscoveryWork extends UniquelyIdentified {
     private UUID discoveryUuid;
 
     // Mirrors ON DELETE CASCADE from the migration for the test environment, which generates its schema from
-    // the entities (same note as ScheduledJobHistory); the writable column stays the scalar discoveryUuid above.
+    // the entities; the writable column stays the scalar discoveryUuid above.
     @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "discovery_uuid", insertable = false, updatable = false)

--- a/src/main/java/com/otilm/core/dao/entity/DiscoveryWork.java
+++ b/src/main/java/com/otilm/core/dao/entity/DiscoveryWork.java
@@ -1,0 +1,70 @@
+package com.otilm.core.dao.entity;
+
+import com.otilm.core.model.discovery.DiscoveryWorkType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+/**
+ * One unit of pending discovery v2 work: created when a run starts owing a status poll, a drain or a processing pass,
+ * rescheduled with backoff on failure, and deleted when the run stops owing it. Internal scheduling machinery, not a
+ * user-facing entity — hence no author/update audit columns, the same shape as {@link CertificateStatusPoll}.
+ */
+@Getter
+@Setter
+@Entity
+// A run owes at most one pending row per work type.
+@Table(name = "discovery_work", uniqueConstraints = @UniqueConstraint(name = "uq_discovery_work",
+        columnNames = {"discovery_uuid", "work_type"}))
+public class DiscoveryWork extends UniquelyIdentified {
+
+    @Column(name = "discovery_uuid", nullable = false)
+    private UUID discoveryUuid;
+
+    // Mirrors ON DELETE CASCADE from the migration for the test environment, which generates its schema from
+    // the entities (same note as ScheduledJobHistory); the writable column stays the scalar discoveryUuid above.
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "discovery_uuid", insertable = false, updatable = false)
+    private Discovery discovery;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "work_type", nullable = false)
+    private DiscoveryWorkType workType;
+
+    @Column(name = "attempt", nullable = false)
+    private int attempt;
+
+    @Column(name = "next_due_at", nullable = false)
+    private OffsetDateTime nextDueAt;
+
+    // Set by the database on insert, never written by the application — hence a read-only mapping.
+    @Column(name = "i_cre", nullable = false, insertable = false, updatable = false,
+            columnDefinition = "timestamptz not null default now()")
+    private OffsetDateTime created;
+
+    // No-op override required by Sonar S2160 (a field-adding subclass of UniquelyIdentified must override
+    // equals): identity stays the UUID and the added columns deliberately do not affect equality. Matches the
+    // convention used by the other field-adding entities; dropping it just re-raises the finding.
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+}

--- a/src/main/java/com/otilm/core/dao/repository/DiscoveryCertificateRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/DiscoveryCertificateRepository.java
@@ -1,8 +1,8 @@
 package com.otilm.core.dao.repository;
 
 import com.otilm.core.dao.entity.CertificateContent;
+import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.entity.DiscoveryCertificate;
-import com.otilm.core.dao.entity.DiscoveryHistory;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -18,17 +18,17 @@ import org.springframework.stereotype.Repository;
 public interface DiscoveryCertificateRepository extends SecurityFilterRepository<DiscoveryCertificate, Long> {
     Optional<DiscoveryCertificate> findByUuid(UUID uuid);
 
-    Long deleteByDiscovery(DiscoveryHistory history);
+    Long deleteByDiscovery(Discovery history);
 
-    List<DiscoveryCertificate> findByDiscovery(DiscoveryHistory history, Pageable pagable);
+    List<DiscoveryCertificate> findByDiscovery(Discovery history, Pageable pagable);
 
     @EntityGraph(attributePaths = {"certificateContent"})
     List<DiscoveryCertificate> findByDiscoveryUuidAndNewlyDiscovered(UUID discoveryUuid, boolean newlyDiscovered,
             Pageable pageable);
 
-    Long countByDiscovery(DiscoveryHistory history);
+    Long countByDiscovery(Discovery history);
 
-    Long countByDiscoveryAndNewlyDiscovered(DiscoveryHistory history, boolean newlyDiscovered);
+    Long countByDiscoveryAndNewlyDiscovered(Discovery history, boolean newlyDiscovered);
 
     List<DiscoveryCertificate> findByCertificateContent(CertificateContent certificateContent);
 

--- a/src/main/java/com/otilm/core/dao/repository/DiscoveryItemRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/DiscoveryItemRepository.java
@@ -1,0 +1,14 @@
+package com.otilm.core.dao.repository;
+
+import com.otilm.core.dao.entity.DiscoveryItem;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Deliberately bare for the schema groundwork: the staging writes, the union listing and the processing claims each
+ * bring their own queries with the tasks that own them.
+ */
+@Repository
+public interface DiscoveryItemRepository extends JpaRepository<DiscoveryItem, UUID> {
+}

--- a/src/main/java/com/otilm/core/dao/repository/DiscoveryRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/DiscoveryRepository.java
@@ -1,10 +1,12 @@
 package com.otilm.core.dao.repository;
 
 import com.otilm.core.dao.entity.Discovery;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,6 +16,15 @@ import org.springframework.stereotype.Repository;
 public interface DiscoveryRepository extends SecurityFilterRepository<Discovery, UUID> {
 
     Optional<Discovery> findByUuid(UUID uuid);
+
+    /**
+     * Pessimistic-write variant of {@link #findByUuid} for read-modify-write transitions on the run row. Issues
+     * {@code SELECT ... FOR UPDATE}; must be called inside an active transaction, otherwise the lock is released
+     * immediately on query completion.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT d FROM Discovery d WHERE d.uuid = :uuid")
+    Optional<Discovery> findWithLockByUuid(@Param("uuid") UUID uuid);
 
     @EntityGraph(attributePaths = {"triggers"})
     Discovery findWithTriggersByUuid(UUID uuid);

--- a/src/main/java/com/otilm/core/dao/repository/DiscoveryRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/DiscoveryRepository.java
@@ -1,6 +1,6 @@
 package com.otilm.core.dao.repository;
 
-import com.otilm.core.dao.entity.DiscoveryHistory;
+import com.otilm.core.dao.entity.Discovery;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -11,19 +11,19 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface DiscoveryRepository extends SecurityFilterRepository<DiscoveryHistory, UUID> {
+public interface DiscoveryRepository extends SecurityFilterRepository<Discovery, UUID> {
 
-    Optional<DiscoveryHistory> findByUuid(UUID uuid);
+    Optional<Discovery> findByUuid(UUID uuid);
 
     @EntityGraph(attributePaths = {"triggers"})
-    DiscoveryHistory findWithTriggersByUuid(UUID uuid);
+    Discovery findWithTriggersByUuid(UUID uuid);
 
-    Optional<DiscoveryHistory> findByName(String name);
+    Optional<Discovery> findByName(String name);
 
-    @Query("SELECT DISTINCT connectorName FROM DiscoveryHistory ")
+    @Query("SELECT DISTINCT connectorName FROM Discovery ")
     List<String> findDistinctConnectorName();
 
     @Modifying
-    @Query("UPDATE DiscoveryHistory d SET d.message = :message, d.updated = CURRENT_TIMESTAMP WHERE d.uuid = :uuid")
+    @Query("UPDATE Discovery d SET d.message = :message, d.updated = CURRENT_TIMESTAMP WHERE d.uuid = :uuid")
     void updateMessage(@Param("uuid") UUID uuid, @Param("message") String message);
 }

--- a/src/main/java/com/otilm/core/dao/repository/DiscoveryWorkRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/DiscoveryWorkRepository.java
@@ -1,0 +1,46 @@
+package com.otilm.core.dao.repository;
+
+import com.otilm.core.dao.entity.DiscoveryWork;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DiscoveryWorkRepository extends JpaRepository<DiscoveryWork, UUID> {
+
+    /**
+     * Returns rows due for a tick ({@code next_due_at} reached), soonest-due first. No row locking: cross-node mutual
+     * exclusion is provided by the cluster-wide advisory lock held by the discovery sweep, so a plain ordered read is
+     * enough.
+     */
+    List<DiscoveryWork> findByNextDueAtLessThanEqualOrderByNextDueAt(OffsetDateTime cutoff, Pageable pageable);
+
+    /**
+     * Inserts the pending row for a run and work type, or moves the existing row's due time. Atomic on the unique
+     * {@code (discovery_uuid, work_type)} — unlike an exists-check-then-insert, a concurrent loser is a clean due-time
+     * update (no constraint violation, no aborted transaction).
+     */
+    @Modifying
+    @Query(value = """
+            INSERT INTO {h-schema}discovery_work (uuid, discovery_uuid, work_type, attempt, next_due_at)
+            VALUES (:uuid, :discoveryUuid, :workType, 0, :nextDueAt)
+            ON CONFLICT (discovery_uuid, work_type) DO UPDATE SET next_due_at = EXCLUDED.next_due_at
+            """, nativeQuery = true)
+    void schedule(@Param("uuid") UUID uuid, @Param("discoveryUuid") UUID discoveryUuid,
+            @Param("workType") String workType, @Param("nextDueAt") OffsetDateTime nextDueAt);
+
+    @Modifying
+    @Query("UPDATE DiscoveryWork w SET w.attempt = :attempt, w.nextDueAt = :nextDueAt WHERE w.uuid = :uuid")
+    void reschedule(@Param("uuid") UUID uuid, @Param("attempt") int attempt,
+            @Param("nextDueAt") OffsetDateTime nextDueAt);
+
+    @Modifying
+    @Query("DELETE FROM DiscoveryWork w WHERE w.discoveryUuid = :discoveryUuid")
+    void deleteByDiscoveryUuid(@Param("discoveryUuid") UUID discoveryUuid);
+}

--- a/src/main/java/com/otilm/core/dao/repository/DiscoveryWorkRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/DiscoveryWorkRepository.java
@@ -23,11 +23,16 @@ public interface DiscoveryWorkRepository extends JpaRepository<DiscoveryWork, UU
     List<DiscoveryWork> findByNextDueAtLessThanEqualOrderByNextDueAt(OffsetDateTime cutoff, Pageable pageable);
 
     /**
-     * Inserts the pending row for a run and work type, or re-arms the existing row: due time moved, backoff counter
-     * reset — scheduling is a fresh start, and in-flight backoff belongs to {@link #reschedule}. Atomic on the unique
-     * {@code (discovery_uuid, work_type)} — unlike an exists-check-then-insert, a concurrent loser is a clean re-arm
-     * (no constraint violation, no aborted transaction). On conflict the passed {@code uuid} is discarded with the rest
-     * of the losing insert; rows are addressed by run and work type, never by that uuid.
+     * Inserts the pending row for a run and work type, or re-arms the existing one: due time moved, backoff counter
+     * reset. Scheduling is a fresh start; in-flight backoff belongs to {@link #reschedule}.
+     *
+     * <p>
+     * <b>Concurrency:</b> atomic on the unique {@code (discovery_uuid, work_type)} — a concurrent loser is a clean
+     * re-arm, not a constraint violation.
+     *
+     * <p>
+     * <b>Identity:</b> on conflict the passed {@code uuid} is discarded with the rest of the losing insert; rows are
+     * addressed by run and work type, never by that uuid.
      */
     @Modifying
     @Query(value = """

--- a/src/main/java/com/otilm/core/dao/repository/DiscoveryWorkRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/DiscoveryWorkRepository.java
@@ -1,6 +1,7 @@
 package com.otilm.core.dao.repository;
 
 import com.otilm.core.dao.entity.DiscoveryWork;
+import com.otilm.core.model.discovery.DiscoveryWorkType;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -22,23 +23,28 @@ public interface DiscoveryWorkRepository extends JpaRepository<DiscoveryWork, UU
     List<DiscoveryWork> findByNextDueAtLessThanEqualOrderByNextDueAt(OffsetDateTime cutoff, Pageable pageable);
 
     /**
-     * Inserts the pending row for a run and work type, or moves the existing row's due time. Atomic on the unique
-     * {@code (discovery_uuid, work_type)} — unlike an exists-check-then-insert, a concurrent loser is a clean due-time
-     * update (no constraint violation, no aborted transaction).
+     * Inserts the pending row for a run and work type, or re-arms the existing row: due time moved, backoff counter
+     * reset — scheduling is a fresh start, and in-flight backoff belongs to {@link #reschedule}. Atomic on the unique
+     * {@code (discovery_uuid, work_type)} — unlike an exists-check-then-insert, a concurrent loser is a clean re-arm
+     * (no constraint violation, no aborted transaction). On conflict the passed {@code uuid} is discarded with the rest
+     * of the losing insert; rows are addressed by run and work type, never by that uuid.
      */
     @Modifying
     @Query(value = """
             INSERT INTO {h-schema}discovery_work (uuid, discovery_uuid, work_type, attempt, next_due_at)
             VALUES (:uuid, :discoveryUuid, :workType, 0, :nextDueAt)
-            ON CONFLICT (discovery_uuid, work_type) DO UPDATE SET next_due_at = EXCLUDED.next_due_at
+            ON CONFLICT (discovery_uuid, work_type) DO UPDATE SET next_due_at = EXCLUDED.next_due_at, attempt = 0
             """, nativeQuery = true)
     void schedule(@Param("uuid") UUID uuid, @Param("discoveryUuid") UUID discoveryUuid,
             @Param("workType") String workType, @Param("nextDueAt") OffsetDateTime nextDueAt);
 
+    // Addressed by the natural key, not the row uuid: schedule() discards the passed uuid on conflict, so a
+    // caller-retained row uuid can silently address nothing — (run, work type) always addresses the live row.
     @Modifying
-    @Query("UPDATE DiscoveryWork w SET w.attempt = :attempt, w.nextDueAt = :nextDueAt WHERE w.uuid = :uuid")
-    void reschedule(@Param("uuid") UUID uuid, @Param("attempt") int attempt,
-            @Param("nextDueAt") OffsetDateTime nextDueAt);
+    @Query("UPDATE DiscoveryWork w SET w.attempt = :attempt, w.nextDueAt = :nextDueAt "
+            + "WHERE w.discoveryUuid = :discoveryUuid AND w.workType = :workType")
+    void reschedule(@Param("discoveryUuid") UUID discoveryUuid, @Param("workType") DiscoveryWorkType workType,
+            @Param("attempt") int attempt, @Param("nextDueAt") OffsetDateTime nextDueAt);
 
     @Modifying
     @Query("DELETE FROM DiscoveryWork w WHERE w.discoveryUuid = :discoveryUuid")

--- a/src/main/java/com/otilm/core/enums/FilterField.java
+++ b/src/main/java/com/otilm/core/enums/FilterField.java
@@ -49,7 +49,7 @@ import com.otilm.core.dao.entity.ConnectorInterfaceEntity_;
 import com.otilm.core.dao.entity.Connector_;
 import com.otilm.core.dao.entity.CryptographicKeyItem_;
 import com.otilm.core.dao.entity.CryptographicKey_;
-import com.otilm.core.dao.entity.DiscoveryHistory_;
+import com.otilm.core.dao.entity.Discovery_;
 import com.otilm.core.dao.entity.EntityInstanceReference_;
 import com.otilm.core.dao.entity.FunctionGroup_;
 import com.otilm.core.dao.entity.Group_;
@@ -216,18 +216,17 @@ public enum FilterField {
             OwnerAssociation_.ownerUsername, "Owner", SearchFieldTypeEnum.LIST, null, null, true, null),
 
     // Discovery
-    DISCOVERY_NAME(Resource.DISCOVERY, null, null, DiscoveryHistory_.name, "Name", SearchFieldTypeEnum.STRING),
-    DISCOVERY_START_TIME(Resource.DISCOVERY, null, null, DiscoveryHistory_.startTime, "Start time",
+    DISCOVERY_NAME(Resource.DISCOVERY, null, null, Discovery_.name, "Name", SearchFieldTypeEnum.STRING),
+    DISCOVERY_START_TIME(Resource.DISCOVERY, null, null, Discovery_.startTime, "Start time",
             SearchFieldTypeEnum.DATETIME),
-    DISCOVERY_END_TIME(Resource.DISCOVERY, null, null, DiscoveryHistory_.endTime, "End time",
-            SearchFieldTypeEnum.DATETIME),
-    DISCOVERY_STATUS(Resource.DISCOVERY, null, null, DiscoveryHistory_.status, "Status", SearchFieldTypeEnum.LIST,
+    DISCOVERY_END_TIME(Resource.DISCOVERY, null, null, Discovery_.endTime, "End time", SearchFieldTypeEnum.DATETIME),
+    DISCOVERY_STATUS(Resource.DISCOVERY, null, null, Discovery_.status, "Status", SearchFieldTypeEnum.LIST,
             DiscoveryStatus.class, null, false, null),
-    DISCOVERY_TOTAL_CERT_DISCOVERED(Resource.DISCOVERY, null, null, DiscoveryHistory_.totalCertificatesDiscovered,
+    DISCOVERY_TOTAL_CERT_DISCOVERED(Resource.DISCOVERY, null, null, Discovery_.totalCertificatesDiscovered,
             "Total certificate discovered", SearchFieldTypeEnum.NUMBER),
-    DISCOVERY_CONNECTOR_NAME(Resource.DISCOVERY, null, null, DiscoveryHistory_.connectorName, "Discovery provider",
+    DISCOVERY_CONNECTOR_NAME(Resource.DISCOVERY, null, null, Discovery_.connectorName, "Discovery provider",
             SearchFieldTypeEnum.LIST),
-    DISCOVERY_KIND(Resource.DISCOVERY, null, null, DiscoveryHistory_.kind, "Kind", SearchFieldTypeEnum.STRING),
+    DISCOVERY_KIND(Resource.DISCOVERY, null, null, Discovery_.kind, "Kind", SearchFieldTypeEnum.STRING),
 
     // Entity
     ENTITY_NAME(Resource.ENTITY, null, null, EntityInstanceReference_.name, "Name", SearchFieldTypeEnum.STRING),

--- a/src/main/java/com/otilm/core/enums/FilterField.java
+++ b/src/main/java/com/otilm/core/enums/FilterField.java
@@ -220,7 +220,7 @@ public enum FilterField {
     DISCOVERY_START_TIME(Resource.DISCOVERY, null, null, Discovery_.startTime, "Start time",
             SearchFieldTypeEnum.DATETIME),
     DISCOVERY_END_TIME(Resource.DISCOVERY, null, null, Discovery_.endTime, "End time", SearchFieldTypeEnum.DATETIME),
-    DISCOVERY_STATUS(Resource.DISCOVERY, null, null, Discovery_.status, "Status", SearchFieldTypeEnum.LIST,
+    DISCOVERY_STATUS(Resource.DISCOVERY, null, null, Discovery_.status, Constants.STATUS, SearchFieldTypeEnum.LIST,
             DiscoveryStatus.class, null, false, null),
     DISCOVERY_TOTAL_CERT_DISCOVERED(Resource.DISCOVERY, null, null, Discovery_.totalCertificatesDiscovered,
             "Total certificate discovered", SearchFieldTypeEnum.NUMBER),
@@ -251,7 +251,7 @@ public enum FilterField {
     CONNECTOR_URL(Resource.CONNECTOR, null, null, Connector_.url, "URL", SearchFieldTypeEnum.STRING),
     CONNECTOR_AUTH_TYPE(Resource.CONNECTOR, null, null, Connector_.authType, "Auth type", SearchFieldTypeEnum.LIST,
             AuthType.class),
-    CONNECTOR_STATUS(Resource.CONNECTOR, null, null, Connector_.status, "Status", SearchFieldTypeEnum.LIST,
+    CONNECTOR_STATUS(Resource.CONNECTOR, null, null, Connector_.status, Constants.STATUS, SearchFieldTypeEnum.LIST,
             ConnectorStatus.class),
     CONNECTOR_INTERFACE(Resource.CONNECTOR, null, List.of(Connector_.interfaces),
             ConnectorInterfaceEntity_.interfaceCode, "Interface", SearchFieldTypeEnum.LIST, ConnectorInterface.class),
@@ -307,7 +307,7 @@ public enum FilterField {
             Resource.class),
     APPROVAL_ACTION(Resource.APPROVAL, null, null, Approval_.action, "Action", SearchFieldTypeEnum.LIST,
             ResourceAction.class),
-    APPROVAL_STATUS(Resource.APPROVAL, null, null, Approval_.status, "Status", SearchFieldTypeEnum.LIST,
+    APPROVAL_STATUS(Resource.APPROVAL, null, null, Approval_.status, Constants.STATUS, SearchFieldTypeEnum.LIST,
             ApprovalStatusEnum.class),
     APPROVAL_CREATED_AT(Resource.APPROVAL, null, null, Approval_.createdAt, "Created At", SearchFieldTypeEnum.DATETIME),
     APPROVAL_EXPIRY_AT(Resource.APPROVAL, null, null, Approval_.expiryAt, "Expiry At", SearchFieldTypeEnum.DATETIME),
@@ -478,6 +478,7 @@ public enum FilterField {
         private static final String RESOURCE_OBJECTS_ARRAY = "objects[*]";
         public static final String STATE = "State";
         public static final String ENABLED = "Enabled";
+        public static final String STATUS = "Status";
     }
 
 }

--- a/src/main/java/com/otilm/core/enums/ResourceToClass.java
+++ b/src/main/java/com/otilm/core/enums/ResourceToClass.java
@@ -14,7 +14,7 @@ import com.otilm.core.dao.entity.ComplianceProfile;
 import com.otilm.core.dao.entity.Connector;
 import com.otilm.core.dao.entity.Credential;
 import com.otilm.core.dao.entity.CryptographicKey;
-import com.otilm.core.dao.entity.DiscoveryHistory;
+import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.entity.EntityInstanceReference;
 import com.otilm.core.dao.entity.Group;
 import com.otilm.core.dao.entity.Location;
@@ -64,7 +64,7 @@ public enum ResourceToClass {
     CERTIFICATE_REQUEST(Resource.CERTIFICATE_REQUEST, CertificateRequestEntity.class),
     GROUP(Resource.GROUP, Group.class),
     COMPLIANCE_PROFILE(Resource.COMPLIANCE_PROFILE, ComplianceProfile.class),
-    DISCOVERY(Resource.DISCOVERY, DiscoveryHistory.class),
+    DISCOVERY(Resource.DISCOVERY, Discovery.class),
 
     // ENTITIES
     ENTITY(Resource.ENTITY, EntityInstanceReference.class),

--- a/src/main/java/com/otilm/core/evaluator/TriggerEvaluator.java
+++ b/src/main/java/com/otilm/core/evaluator/TriggerEvaluator.java
@@ -727,11 +727,13 @@ public class TriggerEvaluator<T extends UniquelyIdentifiedObject> implements ITr
                 .put(FilterConditionOperator.LESSER_OR_EQUAL, (o, c) -> !(getLocalDateTime(o)
                         .isAfter(LocalDateTime.parse(c.toString(), DateTimeFormatter.ofPattern(DATETIME_FORMAT)))));
         datetimeOperatorFunctionMap
-                .put(FilterConditionOperator.IN_PAST, (o, c) -> (getLocalDateTime(o)).isBefore(LocalDateTime.now())
-                        && (getLocalDateTime(o)).isAfter(getLocalDateTimeNowMinusDuration(c.toString())));
+                .put(FilterConditionOperator.IN_PAST,
+                        (o, c) -> (getLocalDateTime(o)).isBefore(LocalDateTime.now(ZoneId.systemDefault()))
+                                && (getLocalDateTime(o)).isAfter(getLocalDateTimeNowMinusDuration(c.toString())));
         datetimeOperatorFunctionMap
-                .put(FilterConditionOperator.IN_NEXT, (o, c) -> (getLocalDateTime(o)).isAfter(LocalDateTime.now())
-                        && (getLocalDateTime(o)).isBefore(getLocalDateTimeNowPlusDuration(c.toString())));
+                .put(FilterConditionOperator.IN_NEXT,
+                        (o, c) -> (getLocalDateTime(o)).isAfter(LocalDateTime.now(ZoneId.systemDefault()))
+                                && (getLocalDateTime(o)).isBefore(getLocalDateTimeNowPlusDuration(c.toString())));
 
         fieldTypeToOperatorActionMap.put(FilterFieldType.DATETIME, datetimeOperatorFunctionMap);
 

--- a/src/main/java/com/otilm/core/evaluator/TriggerEvaluator.java
+++ b/src/main/java/com/otilm/core/evaluator/TriggerEvaluator.java
@@ -47,8 +47,10 @@ import jakarta.persistence.metamodel.Attribute;
 import java.lang.reflect.InvocationTargetException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.Period;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -692,50 +694,44 @@ public class TriggerEvaluator<T extends UniquelyIdentifiedObject> implements ITr
         dateOperatorFunctionMap = new EnumMap<>(FilterConditionOperator.class);
         dateOperatorFunctionMap.putAll(commonOperatorFunctionMap);
         dateOperatorFunctionMap
-                .put(FilterConditionOperator.GREATER,
-                        (o, c) -> getLocalDate((Date) o).isAfter(LocalDate.parse(c.toString())));
+                .put(FilterConditionOperator.GREATER, (o, c) -> getLocalDate(o).isAfter(LocalDate.parse(c.toString())));
         dateOperatorFunctionMap
                 .put(FilterConditionOperator.GREATER_OR_EQUAL,
-                        (o, c) -> !(getLocalDate((Date) o).isBefore(LocalDate.parse(c.toString()))));
+                        (o, c) -> !(getLocalDate(o).isBefore(LocalDate.parse(c.toString()))));
         dateOperatorFunctionMap
-                .put(FilterConditionOperator.LESSER,
-                        (o, c) -> getLocalDate((Date) o).isBefore(LocalDate.parse(c.toString())));
+                .put(FilterConditionOperator.LESSER, (o, c) -> getLocalDate(o).isBefore(LocalDate.parse(c.toString())));
         dateOperatorFunctionMap
                 .put(FilterConditionOperator.LESSER_OR_EQUAL,
-                        (o, c) -> !(getLocalDate((Date) o).isAfter(LocalDate.parse(c.toString()))));
+                        (o, c) -> !(getLocalDate(o).isAfter(LocalDate.parse(c.toString()))));
         dateOperatorFunctionMap
-                .put(FilterConditionOperator.IN_PAST, (o, c) -> (getLocalDate((Date) o)).isBefore(LocalDate.now())
-                        && (getLocalDate((Date) o)).isAfter(getLocalDateNowMinusDuration(c.toString())));
+                .put(FilterConditionOperator.IN_PAST, (o, c) -> (getLocalDate(o)).isBefore(LocalDate.now())
+                        && (getLocalDate(o)).isAfter(getLocalDateNowMinusDuration(c.toString())));
         dateOperatorFunctionMap
-                .put(FilterConditionOperator.IN_NEXT, (o, c) -> (getLocalDate((Date) o)).isAfter(LocalDate.now())
-                        && (getLocalDate((Date) o)).isBefore(getLocalDateNowPlusDuration(c.toString())));
+                .put(FilterConditionOperator.IN_NEXT, (o, c) -> (getLocalDate(o)).isAfter(LocalDate.now())
+                        && (getLocalDate(o)).isBefore(getLocalDateNowPlusDuration(c.toString())));
 
         fieldTypeToOperatorActionMap.put(FilterFieldType.DATE, dateOperatorFunctionMap);
 
         datetimeOperatorFunctionMap = new EnumMap<>(FilterConditionOperator.class);
         datetimeOperatorFunctionMap.putAll(commonOperatorFunctionMap);
         datetimeOperatorFunctionMap
-                .put(FilterConditionOperator.GREATER, (o, c) -> getLocalDateTime((Date) o)
+                .put(FilterConditionOperator.GREATER, (o, c) -> getLocalDateTime(o)
                         .isAfter(LocalDateTime.parse(c.toString(), DateTimeFormatter.ofPattern(DATETIME_FORMAT))));
         datetimeOperatorFunctionMap
-                .put(FilterConditionOperator.GREATER_OR_EQUAL, (o, c) -> !(getLocalDateTime((Date) o)
+                .put(FilterConditionOperator.GREATER_OR_EQUAL, (o, c) -> !(getLocalDateTime(o)
                         .isBefore(LocalDateTime.parse(c.toString(), DateTimeFormatter.ofPattern(DATETIME_FORMAT)))));
         datetimeOperatorFunctionMap
-                .put(FilterConditionOperator.LESSER, (o, c) -> getLocalDateTime((Date) o)
+                .put(FilterConditionOperator.LESSER, (o, c) -> getLocalDateTime(o)
                         .isBefore(LocalDateTime.parse(c.toString(), DateTimeFormatter.ofPattern(DATETIME_FORMAT))));
         datetimeOperatorFunctionMap
-                .put(FilterConditionOperator.LESSER_OR_EQUAL, (o, c) -> !(getLocalDateTime((Date) o)
+                .put(FilterConditionOperator.LESSER_OR_EQUAL, (o, c) -> !(getLocalDateTime(o)
                         .isAfter(LocalDateTime.parse(c.toString(), DateTimeFormatter.ofPattern(DATETIME_FORMAT)))));
         datetimeOperatorFunctionMap
-                .put(FilterConditionOperator.IN_PAST,
-                        (o, c) -> (getLocalDateTime((Date) o)).isBefore(LocalDateTime.now())
-                                && (getLocalDateTime((Date) o))
-                                        .isAfter(getLocalDateTimeNowMinusDuration(c.toString())));
+                .put(FilterConditionOperator.IN_PAST, (o, c) -> (getLocalDateTime(o)).isBefore(LocalDateTime.now())
+                        && (getLocalDateTime(o)).isAfter(getLocalDateTimeNowMinusDuration(c.toString())));
         datetimeOperatorFunctionMap
-                .put(FilterConditionOperator.IN_NEXT,
-                        (o, c) -> (getLocalDateTime((Date) o)).isAfter(LocalDateTime.now())
-                                && (getLocalDateTime((Date) o))
-                                        .isBefore(getLocalDateTimeNowPlusDuration(c.toString())));
+                .put(FilterConditionOperator.IN_NEXT, (o, c) -> (getLocalDateTime(o)).isAfter(LocalDateTime.now())
+                        && (getLocalDateTime(o)).isBefore(getLocalDateTimeNowPlusDuration(c.toString())));
 
         fieldTypeToOperatorActionMap.put(FilterFieldType.DATETIME, datetimeOperatorFunctionMap);
 
@@ -749,12 +745,21 @@ public class TriggerEvaluator<T extends UniquelyIdentifiedObject> implements ITr
 
     }
 
-    private static LocalDate getLocalDate(Date o) {
-        return o.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+    // Entity date attributes arrive as java.util.Date from the legacy columns and as OffsetDateTime from the
+    // timestamptz ones; both normalize over the same instant, so the operators need not care which they got.
+    private static LocalDate getLocalDate(Object o) {
+        return toSystemZoned(o).toLocalDate();
     }
 
-    private static LocalDateTime getLocalDateTime(Date o) {
-        return o.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+    private static LocalDateTime getLocalDateTime(Object o) {
+        return toSystemZoned(o).toLocalDateTime();
+    }
+
+    private static ZonedDateTime toSystemZoned(Object o) {
+        if (o instanceof OffsetDateTime offsetDateTime) {
+            return offsetDateTime.atZoneSameInstant(ZoneId.systemDefault());
+        }
+        return ((Date) o).toInstant().atZone(ZoneId.systemDefault());
     }
 
     private static LocalDateTime getLocalDateTimeNowMinusDuration(String duration) {

--- a/src/main/java/com/otilm/core/events/data/EventDataBuilder.java
+++ b/src/main/java/com/otilm/core/events/data/EventDataBuilder.java
@@ -17,7 +17,7 @@ import com.otilm.api.model.core.notification.RecipientType;
 import com.otilm.core.dao.entity.Approval;
 import com.otilm.core.dao.entity.ApprovalProfile;
 import com.otilm.core.dao.entity.Certificate;
-import com.otilm.core.dao.entity.DiscoveryHistory;
+import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.model.auth.ResourceAction;
 import java.time.ZoneId;
 import java.util.UUID;
@@ -91,7 +91,7 @@ public class EventDataBuilder {
     }
 
     public static CertificateDiscoveredEventData getCertificateDiscoveredEventData(Certificate certificate,
-            DiscoveryHistory discovery, UUID userUuid) {
+            Discovery discovery, UUID userUuid) {
         CertificateDiscoveredEventData eventData = new CertificateDiscoveredEventData();
         setCertificateEventData(eventData, certificate);
         eventData.setNotBefore(certificate.getNotBefore().toInstant().atZone(ZoneId.systemDefault()));
@@ -106,7 +106,7 @@ public class EventDataBuilder {
         return eventData;
     }
 
-    public static DiscoveryFinishedEventData getDiscoveryFinishedEventData(DiscoveryHistory discovery) {
+    public static DiscoveryFinishedEventData getDiscoveryFinishedEventData(Discovery discovery) {
         DiscoveryFinishedEventData eventData = new DiscoveryFinishedEventData();
         eventData.setDiscoveryUuid(discovery.getUuid());
         eventData.setDiscoveryName(discovery.getName());

--- a/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
@@ -9,8 +9,8 @@ import com.otilm.api.model.core.other.ResourceEvent;
 import com.otilm.api.model.core.workflows.EventStatus;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.CertificateContent;
+import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.entity.DiscoveryCertificate;
-import com.otilm.core.dao.entity.DiscoveryHistory;
 import com.otilm.core.dao.entity.workflows.EventHistory;
 import com.otilm.core.dao.entity.workflows.TriggerAssociation;
 import com.otilm.core.dao.entity.workflows.TriggerHistory;
@@ -193,7 +193,7 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
         mergedTriggers.addAll(context.getPlatformTriggers().getTriggers());
         mergedIgnoreTriggers.addAll(context.getPlatformTriggers().getIgnoreTriggers());
 
-        DiscoveryHistory discovery = discoveryRepository
+        Discovery discovery = discoveryRepository
                 .findByUuid(eventMessage.getOverrideObjectUuid())
                 .orElseThrow(() -> new EventException(eventMessage.getEvent(),
                         "Discovery with UUID %s not found".formatted(eventMessage.getOverrideObjectUuid())));
@@ -228,7 +228,7 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
     }
 
     @ExternalAuthorizationProgrammatic(resource = Resource.CERTIFICATE, action = ResourceAction.CREATE)
-    private void handleDiscoveredCertificates(EventContext<Certificate> context, DiscoveryHistory discovery,
+    private void handleDiscoveredCertificates(EventContext<Certificate> context, Discovery discovery,
             String originalMessage, List<DiscoveryCertificate> discoveredCertificates,
             List<TriggerAssociation> mergedIgnoreTriggers, List<TriggerAssociation> mergedTriggers) {
         if (discoveredCertificates.isEmpty()) {

--- a/src/main/java/com/otilm/core/events/handlers/DiscoveryFinishedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/DiscoveryFinishedEventHandler.java
@@ -18,7 +18,7 @@ import com.otilm.core.messaging.model.NotificationMessage;
 import com.otilm.core.messaging.model.NotificationRecipient;
 import com.otilm.core.model.ScheduledTaskResult;
 import com.otilm.core.tasks.ScheduledJobInfo;
-import java.util.Date;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,7 +53,7 @@ public class DiscoveryFinishedEventHandler extends EventHandler<Discovery> {
                     ? DiscoveryStatus.COMPLETED
                     : reportedStatus;
             discovery.setStatus(finalStatus);
-            discovery.setEndTime(new Date());
+            discovery.setEndTime(OffsetDateTime.now());
             discovery.setMessage(buildFinishedMessage(finalStatus, discoveryResult.getMessage()));
             discoveryRepository.save(discovery);
         }

--- a/src/main/java/com/otilm/core/events/handlers/DiscoveryFinishedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/DiscoveryFinishedEventHandler.java
@@ -37,8 +37,10 @@ public class DiscoveryFinishedEventHandler extends EventHandler<Discovery> {
 
     @Override
     protected EventContext<Discovery> prepareContext(EventMessage eventMessage) throws EventException {
+        // Locked read: the listener delivers concurrently, and two deliveries observing a non-terminal status
+        // would each apply a terminal transition — the row lock serializes them so the guard below holds.
         Discovery discovery = discoveryRepository
-                .findByUuid(eventMessage.getObjectUuid())
+                .findWithLockByUuid(eventMessage.getObjectUuid())
                 .orElseThrow(() -> new EventException(eventMessage.getEvent(),
                         "Discovery with UUID %s not found".formatted(eventMessage.getObjectUuid())));
         DiscoveryResult discoveryResult = objectMapper.convertValue(eventMessage.getData(), DiscoveryResult.class);

--- a/src/main/java/com/otilm/core/events/handlers/DiscoveryFinishedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/DiscoveryFinishedEventHandler.java
@@ -5,7 +5,7 @@ import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.discovery.DiscoveryStatus;
 import com.otilm.api.model.core.other.ResourceEvent;
 import com.otilm.api.model.scheduler.SchedulerJobExecutionStatus;
-import com.otilm.core.dao.entity.DiscoveryHistory;
+import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.repository.DiscoveryRepository;
 import com.otilm.core.evaluator.TriggerEvaluator;
 import com.otilm.core.events.EventContext;
@@ -25,19 +25,18 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 @Component(ResourceEvent.Codes.DISCOVERY_FINISHED)
-public class DiscoveryFinishedEventHandler extends EventHandler<DiscoveryHistory> {
+public class DiscoveryFinishedEventHandler extends EventHandler<Discovery> {
 
     private final DiscoveryRepository discoveryRepository;
 
-    protected DiscoveryFinishedEventHandler(DiscoveryRepository repository,
-            TriggerEvaluator<DiscoveryHistory> ruleEvaluator) {
+    protected DiscoveryFinishedEventHandler(DiscoveryRepository repository, TriggerEvaluator<Discovery> ruleEvaluator) {
         super(repository, ruleEvaluator);
         discoveryRepository = repository;
     }
 
     @Override
-    protected EventContext<DiscoveryHistory> prepareContext(EventMessage eventMessage) throws EventException {
-        DiscoveryHistory discovery = discoveryRepository
+    protected EventContext<Discovery> prepareContext(EventMessage eventMessage) throws EventException {
+        Discovery discovery = discoveryRepository
                 .findByUuid(eventMessage.getObjectUuid())
                 .orElseThrow(() -> new EventException(eventMessage.getEvent(),
                         "Discovery with UUID %s not found".formatted(eventMessage.getObjectUuid())));
@@ -59,7 +58,7 @@ public class DiscoveryFinishedEventHandler extends EventHandler<DiscoveryHistory
             discoveryRepository.save(discovery);
         }
 
-        EventContext<DiscoveryHistory> context = new EventContext<>(eventMessage, triggerEvaluator, discovery,
+        EventContext<Discovery> context = new EventContext<>(eventMessage, triggerEvaluator, discovery,
                 getEventData(discovery, eventMessage.getData()));
         fetchEventTriggers(context, null, null); // triggers without resource and its UUID are platform ones
 
@@ -67,13 +66,13 @@ public class DiscoveryFinishedEventHandler extends EventHandler<DiscoveryHistory
     }
 
     @Override
-    protected Object getEventData(DiscoveryHistory discovery, Object eventMessageData) {
+    protected Object getEventData(Discovery discovery, Object eventMessageData) {
         return EventDataBuilder.getDiscoveryFinishedEventData(discovery);
     }
 
     @Override
-    protected void sendFollowUpEventsNotifications(EventContext<DiscoveryHistory> eventContext) {
-        DiscoveryHistory discovery = eventContext.getResourceObjects().getFirst();
+    protected void sendFollowUpEventsNotifications(EventContext<Discovery> eventContext) {
+        Discovery discovery = eventContext.getResourceObjects().getFirst();
         Object eventData = eventContext.getResourceObjectsEventData().getFirst();
         NotificationMessage notificationMessage = new NotificationMessage(eventContext.getEvent(), Resource.DISCOVERY,
                 discovery.getUuid(), null,

--- a/src/main/java/com/otilm/core/events/handlers/DiscoveryFinishedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/DiscoveryFinishedEventHandler.java
@@ -19,6 +19,7 @@ import com.otilm.core.messaging.model.NotificationRecipient;
 import com.otilm.core.model.ScheduledTaskResult;
 import com.otilm.core.tasks.ScheduledJobInfo;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,7 +54,7 @@ public class DiscoveryFinishedEventHandler extends EventHandler<Discovery> {
                     ? DiscoveryStatus.COMPLETED
                     : reportedStatus;
             discovery.setStatus(finalStatus);
-            discovery.setEndTime(OffsetDateTime.now());
+            discovery.setEndTime(OffsetDateTime.now(ZoneOffset.UTC));
             discovery.setMessage(buildFinishedMessage(finalStatus, discoveryResult.getMessage()));
             discoveryRepository.save(discovery);
         }

--- a/src/main/java/com/otilm/core/events/handlers/discovery/DiscoveryRunContext.java
+++ b/src/main/java/com/otilm/core/events/handlers/discovery/DiscoveryRunContext.java
@@ -11,9 +11,9 @@ import java.util.UUID;
  * Values that are invariant for a whole discovery run.
  *
  * <p>
- * Deliberately carries the discovery's identifiers and immutable fields rather than the {@code DiscoveryHistory} entity
- * — see {@link DiscoverySource} for why. {@code eventContext} is a per-run holder for the trigger evaluator and event
- * data, not a persistent entity, so sharing it is safe.
+ * Deliberately carries the discovery's identifiers and immutable fields rather than the {@code Discovery} entity — see
+ * {@link DiscoverySource} for why. {@code eventContext} is a per-run holder for the trigger evaluator and event data,
+ * not a persistent entity, so sharing it is safe.
  */
 public record DiscoveryRunContext(UUID discoveryUuid, String discoveryName, UUID connectorUuid, String connectorName,
         String discoveryKind, UUID userUuid, List<TriggerAssociation> ignoreTriggers, List<TriggerAssociation> triggers,

--- a/src/main/java/com/otilm/core/events/handlers/discovery/DiscoverySource.java
+++ b/src/main/java/com/otilm/core/events/handlers/discovery/DiscoverySource.java
@@ -1,6 +1,6 @@
 package com.otilm.core.events.handlers.discovery;
 
-import com.otilm.core.dao.entity.DiscoveryHistory;
+import com.otilm.core.dao.entity.Discovery;
 
 import java.util.UUID;
 
@@ -8,7 +8,7 @@ import java.util.UUID;
  * The discovery's identity, as recorded against a certificate's metadata and event history.
  *
  * <p>
- * Exists so neither the download phase nor post-processing has to pass the {@code DiscoveryHistory} entity itself. One
+ * Exists so neither the download phase nor post-processing has to pass the {@code Discovery} entity itself. One
  * detached instance mutated and saved from parallel workers corrupts progress reporting and rolls back committed
  * certificate work, so the entity must not cross into either phase — this is the canonical statement of that
  * constraint, referred to from {@link DiscoveryRunContext} and the discovery writer.
@@ -21,7 +21,7 @@ public record DiscoverySource(UUID discoveryUuid, String discoveryName, UUID con
                 context.connectorName(), context.discoveryKind());
     }
 
-    public static DiscoverySource of(DiscoveryHistory discovery) {
+    public static DiscoverySource of(Discovery discovery) {
         return new DiscoverySource(discovery.getUuid(), discovery.getName(), discovery.getConnectorUuid(),
                 discovery.getConnectorName(), discovery.getKind());
     }

--- a/src/main/java/com/otilm/core/model/discovery/DiscoveryContext.java
+++ b/src/main/java/com/otilm/core/model/discovery/DiscoveryContext.java
@@ -4,7 +4,7 @@ import com.otilm.api.model.common.attribute.common.DataAttribute;
 import com.otilm.api.model.common.attribute.common.MetadataAttribute;
 import com.otilm.api.model.core.connector.ConnectorDto;
 import com.otilm.api.model.core.discovery.DiscoveryStatus;
-import com.otilm.core.dao.entity.DiscoveryHistory;
+import com.otilm.core.dao.entity.Discovery;
 import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
@@ -15,7 +15,7 @@ import lombok.Setter;
 public class DiscoveryContext {
     private final UUID loggedUserUuid;
     private final ConnectorDto connectorDto;
-    private final DiscoveryHistory discoveryHistory;
+    private final Discovery discovery;
     private final List<DataAttribute> dataAttributes;
 
     private String message;
@@ -26,11 +26,11 @@ public class DiscoveryContext {
 
     private List<MetadataAttribute> metadata;
 
-    public DiscoveryContext(UUID loggedUserUuid, ConnectorDto connectorDto, DiscoveryHistory discoveryHistory,
+    public DiscoveryContext(UUID loggedUserUuid, ConnectorDto connectorDto, Discovery discovery,
             List<DataAttribute> dataAttributes) {
         this.loggedUserUuid = loggedUserUuid;
         this.connectorDto = connectorDto;
-        this.discoveryHistory = discoveryHistory;
+        this.discovery = discovery;
         this.dataAttributes = dataAttributes;
     }
 

--- a/src/main/java/com/otilm/core/model/discovery/DiscoveryWorkType.java
+++ b/src/main/java/com/otilm/core/model/discovery/DiscoveryWorkType.java
@@ -2,9 +2,8 @@ package com.otilm.core.model.discovery;
 
 /**
  * The three kinds of pending work a discovery v2 run can owe, one row each in {@code discovery_work}: polling the
- * connector's run status, draining staged result pages, and processing drained items into inventory. A run holds at
- * most one row per type ({@code uq_discovery_work}); which types coexist is the tick workers' contract, not the
- * table's.
+ * connector's run status, draining staged result pages, and processing drained items into inventory. Which types
+ * coexist is the tick workers' contract, not the table's.
  */
 public enum DiscoveryWorkType {
     STATUS,

--- a/src/main/java/com/otilm/core/model/discovery/DiscoveryWorkType.java
+++ b/src/main/java/com/otilm/core/model/discovery/DiscoveryWorkType.java
@@ -1,0 +1,13 @@
+package com.otilm.core.model.discovery;
+
+/**
+ * The three kinds of pending work a discovery v2 run can owe, one row each in {@code discovery_work}: polling the
+ * connector's run status, draining staged result pages, and processing drained items into inventory. A run holds at
+ * most one row per type ({@code uq_discovery_work}); which types coexist is the tick workers' contract, not the
+ * table's.
+ */
+public enum DiscoveryWorkType {
+    STATUS,
+    DRAIN,
+    PROCESS
+}

--- a/src/main/java/com/otilm/core/model/discovery/DiscoveryWorkType.java
+++ b/src/main/java/com/otilm/core/model/discovery/DiscoveryWorkType.java
@@ -1,9 +1,9 @@
 package com.otilm.core.model.discovery;
 
 /**
- * The three kinds of pending work a discovery v2 run can owe, one row each in {@code discovery_work}: polling the
- * connector's run status, draining staged result pages, and processing drained items into inventory. Which types
- * coexist is the tick workers' contract, not the table's.
+ * The kinds of pending work a discovery v2 run can owe in {@code discovery_work}: polling the connector's run status,
+ * draining staged result pages, and processing drained items into inventory. Which types coexist is the tick workers'
+ * contract, not the table's.
  */
 public enum DiscoveryWorkType {
     STATUS,

--- a/src/main/java/com/otilm/core/service/handler/CertificateHandler.java
+++ b/src/main/java/com/otilm/core/service/handler/CertificateHandler.java
@@ -11,8 +11,8 @@ import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.dao.entity.AttributeDefinition;
 import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.entity.DiscoveryCertificate;
-import com.otilm.core.dao.entity.DiscoveryHistory;
 import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.dao.repository.DiscoveryCertificateRepository;
 import com.otilm.core.events.handlers.discovery.DiscoverySource;
@@ -170,7 +170,7 @@ public class CertificateHandler {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.DEFAULT)
-    public void createDiscoveredCertificate(String batch, DiscoveryHistory discovery,
+    public void createDiscoveredCertificate(String batch, Discovery discovery,
             List<DiscoveryProviderCertificateDataDto> discoveredCertificates) {
         for (DiscoveryProviderCertificateDataDto certificate : discoveredCertificates) {
             DiscoveryCertificate discoveryCertificate = null;
@@ -214,7 +214,7 @@ public class CertificateHandler {
      * Failures are swallowed -- progress is cosmetic, and letting one out would have the caller log the batch as
      * failed. Addressed by identifier, not by saving the detached instance every batch holds a copy of.
      */
-    public void reportDownloadProgress(DiscoveryHistory discovery) {
+    public void reportDownloadProgress(Discovery discovery) {
         try {
             Long currentCount = discoveryCertificateRepository.countByDiscovery(discovery);
             String progress = String

--- a/src/main/java/com/otilm/core/service/impl/DiscoveryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/DiscoveryServiceImpl.java
@@ -82,9 +82,10 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -375,7 +376,7 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
         Discovery discovery = new Discovery();
         discovery.setName(request.getName());
         discovery.setConnectorName(connector.getName());
-        discovery.setStartTime(new Date());
+        discovery.setStartTime(OffsetDateTime.now());
         discovery.setStatus(DiscoveryStatus.IN_PROGRESS);
         discovery.setConnectorStatus(DiscoveryStatus.IN_PROGRESS);
         discovery.setConnectorUuid(connector.getUuid());
@@ -610,7 +611,7 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
                     .debug("Discovery response: name={}, uuid={}, status={}, total={}", discovery.getName(),
                             discovery.getUuid(), response.getStatus(), response.getTotalCertificatesDiscovered());
 
-            long secondsElapsed = (new Date().getTime() - discovery.getStartTime().getTime()) / 1000;
+            long secondsElapsed = Duration.between(discovery.getStartTime(), OffsetDateTime.now()).toSeconds();
             if (!isReachedMaxTime && secondsElapsed > discoveryProperties.maxWaitTimeSeconds()) {
                 isReachedMaxTime = true;
 
@@ -835,7 +836,7 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
         TransactionStatus transaction = transactionManager.getTransaction(new DefaultTransactionDefinition());
         Discovery discovery = updateDiscoveryState(discoveryContext, updateMetadata);
 
-        discovery.setEndTime(new Date());
+        discovery.setEndTime(OffsetDateTime.now());
         if (discovery.getStatus() == DiscoveryStatus.COMPLETED) {
             discovery
                     .setMessage(preProcessingMessage == null

--- a/src/main/java/com/otilm/core/service/impl/DiscoveryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/DiscoveryServiceImpl.java
@@ -41,9 +41,9 @@ import com.otilm.core.client.ConnectorApiFactory;
 import com.otilm.core.comparator.SearchFieldDataComparator;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.Connector;
+import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.entity.DiscoveryCertificate;
-import com.otilm.core.dao.entity.DiscoveryHistory;
-import com.otilm.core.dao.entity.DiscoveryHistory_;
+import com.otilm.core.dao.entity.Discovery_;
 import com.otilm.core.dao.repository.CertificateContentRepository;
 import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.dao.repository.ConnectorRepository;
@@ -230,13 +230,13 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
         RequestValidatorHelper.revalidateSearchRequestDto(request);
         final Pageable p = PageRequest.of(request.getPageNumber() - 1, request.getItemsPerPage());
 
-        final TriFunction<Root<DiscoveryHistory>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause = (
-                root, cb, cr) -> FilterPredicatesBuilder.getFiltersPredicate(cb, cr, root, request.getFilters());
+        final TriFunction<Root<Discovery>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause = (root,
+                cb, cr) -> FilterPredicatesBuilder.getFiltersPredicate(cb, cr, root, request.getFilters());
         final List<DiscoveryListDto> listedDiscoveriesDTOs = discoveryRepository
                 .findUsingSecurityFilter(filter, List.of(), additionalWhereClause, p,
                         (root, cb) -> cb.desc(root.get("created")))
                 .stream()
-                .map(DiscoveryHistory::mapToListDto)
+                .map(Discovery::mapToListDto)
                 .toList();
         final Long maxItems = discoveryRepository.countUsingSecurityFilter(filter, additionalWhereClause);
 
@@ -252,18 +252,17 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
     @Override
     @ExternalAuthorization(resource = Resource.DISCOVERY, action = ResourceAction.DETAIL)
     public DiscoveryDetailDto getDiscovery(SecuredUUID uuid) throws NotFoundException {
-        DiscoveryHistory discoveryHistory = getDiscoveryEntity(uuid);
-        DiscoveryDetailDto dto = discoveryHistory.mapToDto();
+        Discovery discovery = getDiscoveryEntity(uuid);
+        DiscoveryDetailDto dto = discovery.mapToDto();
         dto
                 .setMetadata(attributeEngine
-                        .getMappedMetadataContent(ObjectAttributeContentInfo
-                                .builder(Resource.DISCOVERY, discoveryHistory.getUuid())
-                                .build()));
+                        .getMappedMetadataContent(
+                                ObjectAttributeContentInfo.builder(Resource.DISCOVERY, discovery.getUuid()).build()));
         dto
                 .setAttributes(attributeEngine
                         .getObjectDataAttributesContent(ObjectAttributeContentInfo
-                                .builder(Resource.DISCOVERY, discoveryHistory.getUuid())
-                                .connector(discoveryHistory.getConnectorUuid())
+                                .builder(Resource.DISCOVERY, discovery.getUuid())
+                                .connector(discovery.getConnectorUuid())
                                 .build()));
         dto.setCustomAttributes(attributeEngine.getObjectCustomAttributesContent(Resource.DISCOVERY, uuid.getValue()));
         return dto;
@@ -273,19 +272,18 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
     @ExternalAuthorization(resource = Resource.DISCOVERY, action = ResourceAction.DETAIL)
     public DiscoveryCertificateResponseDto getDiscoveryCertificates(SecuredUUID uuid, Boolean newlyDiscovered,
             int itemsPerPage, int pageNumber) throws NotFoundException {
-        DiscoveryHistory discoveryHistory = getDiscoveryEntity(uuid);
+        Discovery discovery = getDiscoveryEntity(uuid);
         // Page number for the user always starts from 1. But for JPA, page number starts from 0
         Pageable p = PageRequest.of(pageNumber > 1 ? pageNumber - 1 : 0, itemsPerPage);
         List<DiscoveryCertificate> certificates;
         Long maxItems;
         if (newlyDiscovered == null) {
-            certificates = discoveryCertificateRepository.findByDiscovery(discoveryHistory, p);
-            maxItems = discoveryCertificateRepository.countByDiscovery(discoveryHistory);
+            certificates = discoveryCertificateRepository.findByDiscovery(discovery, p);
+            maxItems = discoveryCertificateRepository.countByDiscovery(discovery);
         } else {
             certificates = discoveryCertificateRepository
-                    .findByDiscoveryUuidAndNewlyDiscovered(discoveryHistory.getUuid(), newlyDiscovered, p);
-            maxItems = discoveryCertificateRepository
-                    .countByDiscoveryAndNewlyDiscovered(discoveryHistory, newlyDiscovered);
+                    .findByDiscoveryUuidAndNewlyDiscovered(discovery.getUuid(), newlyDiscovered, p);
+            maxItems = discoveryCertificateRepository.countByDiscoveryAndNewlyDiscovered(discovery, newlyDiscovered);
         }
 
         final DiscoveryCertificateResponseDto responseDto = new DiscoveryCertificateResponseDto();
@@ -297,18 +295,16 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
         return responseDto;
     }
 
-    public DiscoveryHistory getDiscoveryEntity(SecuredUUID uuid) throws NotFoundException {
-        return discoveryRepository
-                .findByUuid(uuid)
-                .orElseThrow(() -> new NotFoundException(DiscoveryHistory.class, uuid));
+    public Discovery getDiscoveryEntity(SecuredUUID uuid) throws NotFoundException {
+        return discoveryRepository.findByUuid(uuid).orElseThrow(() -> new NotFoundException(Discovery.class, uuid));
     }
 
     @Override
     @ExternalAuthorization(resource = Resource.DISCOVERY, action = ResourceAction.DELETE)
     public void deleteDiscovery(SecuredUUID uuid) throws NotFoundException {
-        DiscoveryHistory discovery = discoveryRepository
+        Discovery discovery = discoveryRepository
                 .findByUuid(uuid)
-                .orElseThrow(() -> new NotFoundException(DiscoveryHistory.class, uuid));
+                .orElseThrow(() -> new NotFoundException(Discovery.class, uuid));
         Long certsDeleted = discoveryCertificateRepository.deleteByDiscovery(discovery);
         logger.debug("Deleted {} discovery certificates", certsDeleted);
 
@@ -362,7 +358,7 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
     public DiscoveryDetailDto createDiscovery(final DiscoveryDto request, final boolean saveEntity)
             throws AlreadyExistException, ConnectorException, AttributeException, NotFoundException {
         if (discoveryRepository.findByName(request.getName()).isPresent()) {
-            throw new AlreadyExistException(DiscoveryHistory.class, request.getName());
+            throw new AlreadyExistException(Discovery.class, request.getName());
         }
         if (request.getConnectorUuid() == null) {
             throw new ValidationException(ValidationError.create("Connector UUID is empty"));
@@ -376,7 +372,7 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
                 .mergeAndValidateAttributes(SecuredUUID.fromUUID(connector.getUuid()),
                         FunctionGroupCode.DISCOVERY_PROVIDER, request.getAttributes(), request.getKind());
 
-        DiscoveryHistory discovery = new DiscoveryHistory();
+        Discovery discovery = new Discovery();
         discovery.setName(request.getName());
         discovery.setConnectorName(connector.getName());
         discovery.setStartTime(new Date());
@@ -421,7 +417,7 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
     public DiscoveryDetailDto runDiscovery(UUID discoveryUuid, ScheduledJobInfo scheduledJobInfo) {
         // reload discovery modal with all association since it could be in separate transaction/session due to async
         DiscoveryContext context = loadDiscoveryContext(discoveryUuid);
-        DiscoveryHistory discovery = context.getDiscoveryHistory();
+        Discovery discovery = context.getDiscovery();
         if (context.getDiscoveryStatus() == DiscoveryStatus.FAILED) {
             return finalizeDiscoveryInTx(context, false, null);
         }
@@ -527,7 +523,7 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
         String message = null;
         Connector connector = null;
         List<DataAttribute> dataAttributes = null;
-        DiscoveryHistory discovery = discoveryRepository.findWithTriggersByUuid(discoveryUuid);
+        Discovery discovery = discoveryRepository.findWithTriggersByUuid(discoveryUuid);
         try {
             logger.info("Loading discovery context: name={}, uuid={}", discovery.getName(), discovery.getUuid());
             connector = connectorRepository
@@ -561,7 +557,7 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
 
     private DiscoveryProviderDto discoverCertificatesByProvider(final DiscoveryContext context)
             throws InterruptedException, DiscoveryException {
-        DiscoveryHistory discovery = context.getDiscoveryHistory();
+        Discovery discovery = context.getDiscovery();
 
         DiscoveryRequestDto dtoRequest = new DiscoveryRequestDto();
         dtoRequest.setName(discovery.getName());
@@ -654,7 +650,7 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
             List<DiscoveryProviderCertificateDataDto> duplicateCertificates) throws DiscoveryException {
         int currentPage = 1;
         int currentTotal = 0;
-        DiscoveryHistory discovery = context.getDiscoveryHistory();
+        Discovery discovery = context.getDiscovery();
 
         DiscoveryDataRequestDto getRequest = new DiscoveryDataRequestDto();
         getRequest.setName(response.getName());
@@ -718,7 +714,7 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
         }
     }
 
-    private Future<?> downloadDiscoveredCertificatesBatchAsync(final DiscoveryHistory discovery,
+    private Future<?> downloadDiscoveredCertificatesBatchAsync(final Discovery discovery,
             final DiscoveryProviderDto response, final ConnectorDto connector,
             final Set<String> uniqueCertificateContents,
             final List<DiscoveryProviderCertificateDataDto> duplicateCertificates, final ExecutorService executor,
@@ -805,13 +801,13 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
 
     private void updateDiscoveryStateInTx(DiscoveryContext discoveryContext, boolean updateMetadata) {
         TransactionStatus transaction = transactionManager.getTransaction(new DefaultTransactionDefinition());
-        DiscoveryHistory discovery = updateDiscoveryState(discoveryContext, updateMetadata);
+        Discovery discovery = updateDiscoveryState(discoveryContext, updateMetadata);
         discoveryRepository.save(discovery);
         transactionManager.commit(transaction);
     }
 
-    private DiscoveryHistory updateDiscoveryState(DiscoveryContext discoveryContext, boolean updateMetadata) {
-        DiscoveryHistory discovery = discoveryContext.getDiscoveryHistory();
+    private Discovery updateDiscoveryState(DiscoveryContext discoveryContext, boolean updateMetadata) {
+        Discovery discovery = discoveryContext.getDiscovery();
 
         discovery.setStatus(discoveryContext.getDiscoveryStatus());
         discovery.setConnectorStatus(discoveryContext.getConnectorDiscoveryStatus());
@@ -837,7 +833,7 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
     private DiscoveryDetailDto finalizeDiscoveryInTx(DiscoveryContext discoveryContext, boolean updateMetadata,
             String preProcessingMessage) {
         TransactionStatus transaction = transactionManager.getTransaction(new DefaultTransactionDefinition());
-        DiscoveryHistory discovery = updateDiscoveryState(discoveryContext, updateMetadata);
+        Discovery discovery = updateDiscoveryState(discoveryContext, updateMetadata);
 
         discovery.setEndTime(new Date());
         if (discovery.getStatus() == DiscoveryStatus.COMPLETED) {
@@ -860,13 +856,13 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
 
     @Override
     public NameAndUuidDto getResourceObjectInternal(UUID objectUuid) throws NotFoundException {
-        return discoveryRepository.findResourceObject(objectUuid, DiscoveryHistory_.name);
+        return discoveryRepository.findResourceObject(objectUuid, Discovery_.name);
     }
 
     @Override
     @ExternalAuthorization(resource = Resource.DISCOVERY, action = ResourceAction.DETAIL)
     public NameAndUuidDto getResourceObjectExternal(SecuredUUID objectUuid) throws NotFoundException {
-        return discoveryRepository.findResourceObject(objectUuid.getValue(), DiscoveryHistory_.name);
+        return discoveryRepository.findResourceObject(objectUuid.getValue(), Discovery_.name);
     }
 
     @Override

--- a/src/main/java/com/otilm/core/service/impl/DiscoveryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/DiscoveryServiceImpl.java
@@ -84,6 +84,7 @@ import jakarta.persistence.criteria.Root;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -296,6 +297,9 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
         return responseDto;
     }
 
+    // S8989 wants explicit rollbackFor on the class-level @Transactional for this checked exception; changing
+    // rollback semantics is behavior, not cleanup, and the platform-wide convention is the default rollback.
+    @SuppressWarnings("java:S8989")
     public Discovery getDiscoveryEntity(SecuredUUID uuid) throws NotFoundException {
         return discoveryRepository.findByUuid(uuid).orElseThrow(() -> new NotFoundException(Discovery.class, uuid));
     }
@@ -376,7 +380,7 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
         Discovery discovery = new Discovery();
         discovery.setName(request.getName());
         discovery.setConnectorName(connector.getName());
-        discovery.setStartTime(OffsetDateTime.now());
+        discovery.setStartTime(OffsetDateTime.now(ZoneOffset.UTC));
         discovery.setStatus(DiscoveryStatus.IN_PROGRESS);
         discovery.setConnectorStatus(DiscoveryStatus.IN_PROGRESS);
         discovery.setConnectorUuid(connector.getUuid());
@@ -611,7 +615,9 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
                     .debug("Discovery response: name={}, uuid={}, status={}, total={}", discovery.getName(),
                             discovery.getUuid(), response.getStatus(), response.getTotalCertificatesDiscovered());
 
-            long secondsElapsed = Duration.between(discovery.getStartTime(), OffsetDateTime.now()).toSeconds();
+            long secondsElapsed = Duration
+                    .between(discovery.getStartTime(), OffsetDateTime.now(ZoneOffset.UTC))
+                    .toSeconds();
             if (!isReachedMaxTime && secondsElapsed > discoveryProperties.maxWaitTimeSeconds()) {
                 isReachedMaxTime = true;
 
@@ -836,7 +842,7 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
         TransactionStatus transaction = transactionManager.getTransaction(new DefaultTransactionDefinition());
         Discovery discovery = updateDiscoveryState(discoveryContext, updateMetadata);
 
-        discovery.setEndTime(OffsetDateTime.now());
+        discovery.setEndTime(OffsetDateTime.now(ZoneOffset.UTC));
         if (discovery.getStatus() == DiscoveryStatus.COMPLETED) {
             discovery
                     .setMessage(preProcessingMessage == null

--- a/src/main/java/com/otilm/core/service/writer/DiscoveryWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/DiscoveryWriter.java
@@ -49,7 +49,7 @@ public class DiscoveryWriter {
     }
 
     /**
-     * Reports progress by discovery identifier rather than through the shared {@code DiscoveryHistory} instance — see
+     * Reports progress by discovery identifier rather than through the shared {@code Discovery} instance — see
      * {@code DiscoverySource} for why that entity must not reach a worker.
      */
     @Transactional

--- a/src/main/resources/db/migration/V202608141000__rename_discovery_history_to_discovery.sql
+++ b/src/main/resources/db/migration/V202608141000__rename_discovery_history_to_discovery.sql
@@ -1,6 +1,5 @@
--- Mechanical rename: the table holds the live discovery run, not an archive of finished ones,
--- so "history" has always been a misnomer. Constraint names follow so they keep naming the
--- objects they constrain. No behavior change.
+-- The table holds the live discovery run, not an archive of finished ones — "history" was a misnomer.
+-- Constraint names follow so they keep naming the objects they constrain.
 ALTER TABLE "discovery_history" RENAME TO "discovery";
 
 ALTER TABLE "discovery" RENAME CONSTRAINT "discovery_history_pkey" TO "discovery_pkey";

--- a/src/main/resources/db/migration/V202608141000__rename_discovery_history_to_discovery.sql
+++ b/src/main/resources/db/migration/V202608141000__rename_discovery_history_to_discovery.sql
@@ -1,0 +1,9 @@
+-- Mechanical rename: the table holds the live discovery run, not an archive of finished ones,
+-- so "history" has always been a misnomer. Constraint names follow so they keep naming the
+-- objects they constrain. No behavior change.
+ALTER TABLE "discovery_history" RENAME TO "discovery";
+
+ALTER TABLE "discovery" RENAME CONSTRAINT "discovery_history_pkey" TO "discovery_pkey";
+
+ALTER TABLE "discovery_certificate"
+    RENAME CONSTRAINT "discovery_certificate_to_discovery_history_key" TO "discovery_certificate_to_discovery_key";

--- a/src/main/resources/db/migration/V202608141100__discovery_v2_schema.sql
+++ b/src/main/resources/db/migration/V202608141100__discovery_v2_schema.sql
@@ -1,0 +1,53 @@
+-- Discovery v2 schema groundwork: run-level v2 columns on discovery, the work agenda table that
+-- drives the status/drain/process ticks, and the resource-agnostic staging table for discovered
+-- items. Column-comment parity notes refer to discovery_certificate, whose v1 rows keep living
+-- beside discovery_item until the evidence-gated unification (core#2027).
+
+ALTER TABLE "discovery"
+    ADD COLUMN "connector_interface_uuid" UUID,          -- NULL = v1 legacy run
+    ADD COLUMN "run_meta" JSONB,
+    ADD COLUMN "resources" JSONB,
+    ADD COLUMN "last_applied_sequence" BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN "progress_processed" BIGINT,
+    ADD COLUMN "progress_total_estimate" BIGINT,
+    ADD COLUMN "progress_by_resource" JSONB,
+    ADD COLUMN "progress_phase" VARCHAR,
+    ADD COLUMN "run_messages" JSONB,
+    ADD COLUMN "stopped_at" TIMESTAMPTZ,
+    ADD COLUMN "connector_state" VARCHAR;                -- last authoritative DiscoveryRunState;
+                                                         -- 'completed' = drain-to-completion mode
+
+CREATE TABLE "discovery_work" (
+    "uuid" UUID PRIMARY KEY,
+    "discovery_uuid" UUID NOT NULL,
+    "work_type" VARCHAR NOT NULL,
+    "attempt" INT NOT NULL DEFAULT 0,
+    "next_due_at" TIMESTAMPTZ NOT NULL,
+    "i_cre" TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT "discovery_work_to_discovery_key" FOREIGN KEY ("discovery_uuid")
+        REFERENCES "discovery" ("uuid") ON DELETE CASCADE,
+    CONSTRAINT "uq_discovery_work" UNIQUE ("discovery_uuid", "work_type")
+);
+CREATE INDEX "idx_discovery_work_next_due_at" ON "discovery_work" ("next_due_at");
+
+CREATE TABLE "discovery_item" (
+    "uuid" UUID PRIMARY KEY,
+    "discovery_uuid" UUID NOT NULL,
+    "resource" VARCHAR NOT NULL,
+    "sequence" BIGINT NOT NULL,
+    "unique_ref" VARCHAR NOT NULL,
+    "payload" JSONB NOT NULL,
+    "discovered_at" TIMESTAMPTZ,
+    "processed_at" TIMESTAMPTZ,
+    "processed_error" VARCHAR,           -- per-item processing failure (parity: discovery_certificate.processed_error)
+    "inventory_uuid" UUID,               -- object this item became (parity: discovery_certificate.inventory_uuid);
+                                         -- null until processed, permanently null if processing failed
+    "newly_discovered" BOOLEAN NOT NULL, -- not already in inventory when staged, matched by fingerprint
+                                         -- (parity: discovery_certificate.newly_discovered)
+    "meta" JSONB,                        -- provider-reported location context (DiscoveredItemDto.meta);
+                                         -- unrecoverable if dropped at staging; key location lives here
+    CONSTRAINT "discovery_item_to_discovery_key" FOREIGN KEY ("discovery_uuid")
+        REFERENCES "discovery" ("uuid") ON DELETE CASCADE,
+    CONSTRAINT "uq_discovery_item_ref" UNIQUE ("discovery_uuid", "resource", "unique_ref")
+);
+CREATE INDEX "idx_discovery_item_unprocessed" ON "discovery_item" ("discovery_uuid") WHERE "processed_at" IS NULL;

--- a/src/main/resources/db/migration/V202608141100__discovery_v2_schema.sql
+++ b/src/main/resources/db/migration/V202608141100__discovery_v2_schema.sql
@@ -14,8 +14,14 @@ ALTER TABLE "discovery"
     ADD COLUMN "progress_phase" VARCHAR,
     ADD COLUMN "run_messages" JSONB,
     ADD COLUMN "stopped_at" TIMESTAMPTZ,
-    ADD COLUMN "connector_state" VARCHAR;                -- last authoritative DiscoveryRunState;
+    ADD COLUMN "connector_state" VARCHAR,                -- last authoritative DiscoveryRunState;
                                                          -- 'completed' = drain-to-completion mode
+    -- The two legacy run timestamps join the timestamptz columns above. The naive values are interpreted
+    -- in the session's TimeZone, which pgJDBC pins to the JVM's zone — the same zone the java.util.Date
+    -- values were written in, so the implicit conversion is exact wherever the JVM zone did not change
+    -- over the data's lifetime.
+    ALTER COLUMN "start_time" TYPE TIMESTAMPTZ,
+    ALTER COLUMN "end_time" TYPE TIMESTAMPTZ;
 
 CREATE TABLE "discovery_work" (
     "uuid" UUID PRIMARY KEY,

--- a/src/test/java/com/otilm/core/integration/evaluator/TriggerEvaluatorITest.java
+++ b/src/test/java/com/otilm/core/integration/evaluator/TriggerEvaluatorITest.java
@@ -91,6 +91,7 @@ import java.security.cert.CertificateException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Date;
@@ -587,7 +588,9 @@ class TriggerEvaluatorITest extends BaseSpringBootTest {
                         .evaluateConditionItem(condition, certificate, Resource.CERTIFICATE));
 
         Discovery discovery = new Discovery();
-        discovery.setStartTime(new SimpleDateFormat(("yyyy-MM-dd HH:mm:ss")).parse("2019-12-01 22:10:15"));
+        discovery
+                .setStartTime(
+                        LocalDateTime.parse("2019-12-01T22:10:15").atZone(ZoneId.systemDefault()).toOffsetDateTime());
         condition.setFieldIdentifier(FilterField.DISCOVERY_START_TIME.toString());
         condition.setValue("2019-12-01T22:10:00.274+00:00");
         Assertions
@@ -639,13 +642,13 @@ class TriggerEvaluatorITest extends BaseSpringBootTest {
                         .evaluateConditionItem(condition, certificate, Resource.CERTIFICATE));
 
         Discovery discovery = new Discovery();
-        discovery.setStartTime(convertToDateViaInstant(LocalDateTime.now().minusDays(5).minusHours(3)));
+        discovery.setStartTime(OffsetDateTime.now().minusDays(5).minusHours(3));
         condition.setOperator(FilterConditionOperator.IN_PAST);
         condition.setFieldIdentifier(FilterField.DISCOVERY_START_TIME.toString());
         condition.setValue("P5DT4H");
         Assertions
                 .assertTrue(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
-        discovery.setStartTime(convertToDateViaInstant(LocalDateTime.now().plusDays(5).plusHours(3)));
+        discovery.setStartTime(OffsetDateTime.now().plusDays(5).plusHours(3));
         condition.setValue("P5DT4H");
         condition.setOperator(FilterConditionOperator.IN_NEXT);
         Assertions

--- a/src/test/java/com/otilm/core/integration/evaluator/TriggerEvaluatorITest.java
+++ b/src/test/java/com/otilm/core/integration/evaluator/TriggerEvaluatorITest.java
@@ -51,7 +51,7 @@ import com.otilm.core.dao.entity.CertificateProtocolAssociation;
 import com.otilm.core.dao.entity.Connector;
 import com.otilm.core.dao.entity.CryptographicKey;
 import com.otilm.core.dao.entity.CryptographicKeyItem;
-import com.otilm.core.dao.entity.DiscoveryHistory;
+import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.entity.Group;
 import com.otilm.core.dao.entity.Location;
 import com.otilm.core.dao.entity.RaProfile;
@@ -115,7 +115,7 @@ class TriggerEvaluatorITest extends BaseSpringBootTest {
     private GroupRepository groupRepository;
 
     @Autowired
-    private TriggerEvaluator<DiscoveryHistory> discoveryHistoryTriggerEvaluator;
+    private TriggerEvaluator<Discovery> discoveryTriggerEvaluator;
 
     @Autowired
     private CertificateRepository certificateRepository;
@@ -586,13 +586,12 @@ class TriggerEvaluatorITest extends BaseSpringBootTest {
                 .assertTrue(certificateTriggerEvaluator
                         .evaluateConditionItem(condition, certificate, Resource.CERTIFICATE));
 
-        DiscoveryHistory discovery = new DiscoveryHistory();
+        Discovery discovery = new Discovery();
         discovery.setStartTime(new SimpleDateFormat(("yyyy-MM-dd HH:mm:ss")).parse("2019-12-01 22:10:15"));
         condition.setFieldIdentifier(FilterField.DISCOVERY_START_TIME.toString());
         condition.setValue("2019-12-01T22:10:00.274+00:00");
         Assertions
-                .assertTrue(discoveryHistoryTriggerEvaluator
-                        .evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
+                .assertTrue(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
     }
 
     @Test
@@ -639,20 +638,18 @@ class TriggerEvaluatorITest extends BaseSpringBootTest {
                 .assertTrue(certificateTriggerEvaluator
                         .evaluateConditionItem(condition, certificate, Resource.CERTIFICATE));
 
-        DiscoveryHistory discovery = new DiscoveryHistory();
+        Discovery discovery = new Discovery();
         discovery.setStartTime(convertToDateViaInstant(LocalDateTime.now().minusDays(5).minusHours(3)));
         condition.setOperator(FilterConditionOperator.IN_PAST);
         condition.setFieldIdentifier(FilterField.DISCOVERY_START_TIME.toString());
         condition.setValue("P5DT4H");
         Assertions
-                .assertTrue(discoveryHistoryTriggerEvaluator
-                        .evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
+                .assertTrue(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
         discovery.setStartTime(convertToDateViaInstant(LocalDateTime.now().plusDays(5).plusHours(3)));
         condition.setValue("P5DT4H");
         condition.setOperator(FilterConditionOperator.IN_NEXT);
         Assertions
-                .assertTrue(discoveryHistoryTriggerEvaluator
-                        .evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
+                .assertTrue(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
 
     }
 

--- a/src/test/java/com/otilm/core/integration/evaluator/TriggerEvaluatorITest.java
+++ b/src/test/java/com/otilm/core/integration/evaluator/TriggerEvaluatorITest.java
@@ -597,6 +597,111 @@ class TriggerEvaluatorITest extends BaseSpringBootTest {
                 .assertTrue(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
     }
 
+    /**
+     * Every datetime comparison operator, both outcomes, on an {@code OffsetDateTime} attribute — the branch matrix the
+     * evaluator's operator lambdas carry since the timestamptz columns arrived. The certificate variant of the same
+     * operators runs on {@code java.util.Date}, so both temporal types cover both branches of the normalizing helper.
+     */
+    @Test
+    void testEvaluatorDateTimeOperatorMatrix() throws RuleException, ParseException {
+        Discovery discovery = new Discovery();
+        discovery
+                .setStartTime(
+                        LocalDateTime.parse("2019-12-01T22:10:15").atZone(ZoneId.systemDefault()).toOffsetDateTime());
+        condition.setFieldSource(FilterFieldSource.PROPERTY);
+        condition.setFieldIdentifier(FilterField.DISCOVERY_START_TIME.toString());
+
+        String before = "2019-12-01T22:10:00.274+00:00";
+        String after = "2019-12-01T22:10:30.274+00:00";
+
+        condition.setOperator(FilterConditionOperator.GREATER);
+        condition.setValue(before);
+        Assertions
+                .assertTrue(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
+        condition.setValue(after);
+        Assertions
+                .assertFalse(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
+
+        condition.setOperator(FilterConditionOperator.GREATER_OR_EQUAL);
+        condition.setValue(before);
+        Assertions
+                .assertTrue(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
+        condition.setValue(after);
+        Assertions
+                .assertFalse(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
+
+        condition.setOperator(FilterConditionOperator.LESSER);
+        condition.setValue(after);
+        Assertions
+                .assertTrue(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
+        condition.setValue(before);
+        Assertions
+                .assertFalse(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
+
+        condition.setOperator(FilterConditionOperator.LESSER_OR_EQUAL);
+        condition.setValue(after);
+        Assertions
+                .assertTrue(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
+        condition.setValue(before);
+        Assertions
+                .assertFalse(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
+
+        // Date variant of the same four comparisons, driving the helper's java.util.Date branch
+        certificate.setNotBefore(new SimpleDateFormat(("yyyy-MM-dd HH:mm:ss")).parse("2019-12-01 22:10:15"));
+        condition.setFieldIdentifier(FilterField.NOT_BEFORE.toString());
+        condition.setOperator(FilterConditionOperator.GREATER_OR_EQUAL);
+        condition.setValue(before);
+        Assertions
+                .assertTrue(certificateTriggerEvaluator
+                        .evaluateConditionItem(condition, certificate, Resource.CERTIFICATE));
+        condition.setOperator(FilterConditionOperator.LESSER);
+        Assertions
+                .assertFalse(certificateTriggerEvaluator
+                        .evaluateConditionItem(condition, certificate, Resource.CERTIFICATE));
+        condition.setOperator(FilterConditionOperator.LESSER_OR_EQUAL);
+        condition.setValue(after);
+        Assertions
+                .assertTrue(certificateTriggerEvaluator
+                        .evaluateConditionItem(condition, certificate, Resource.CERTIFICATE));
+    }
+
+    /**
+     * The half-open interval operators on an {@code OffsetDateTime} attribute: each of IN_PAST and IN_NEXT carries two
+     * conditions (inside the window, on the correct side of now), so each needs a case per condition outcome —
+     * wrong-side-of-now, inside, and outside the window.
+     */
+    @Test
+    void testEvaluatorDateTimeIntervalMatrix() throws RuleException {
+        Discovery discovery = new Discovery();
+        condition.setFieldSource(FilterFieldSource.PROPERTY);
+        condition.setFieldIdentifier(FilterField.DISCOVERY_START_TIME.toString());
+
+        discovery.setStartTime(OffsetDateTime.now().minusDays(5));
+        condition.setOperator(FilterConditionOperator.IN_PAST);
+        condition.setValue("P6D");
+        Assertions
+                .assertTrue(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
+        condition.setValue("P2D");
+        Assertions
+                .assertFalse(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
+        condition.setOperator(FilterConditionOperator.IN_NEXT);
+        condition.setValue("P6D");
+        Assertions
+                .assertFalse(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
+
+        discovery.setStartTime(OffsetDateTime.now().plusDays(5));
+        condition.setValue("P6D");
+        Assertions
+                .assertTrue(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
+        condition.setValue("P2D");
+        Assertions
+                .assertFalse(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
+        condition.setOperator(FilterConditionOperator.IN_PAST);
+        condition.setValue("P6D");
+        Assertions
+                .assertFalse(discoveryTriggerEvaluator.evaluateConditionItem(condition, discovery, Resource.DISCOVERY));
+    }
+
     @Test
     void testEvaluatorDateInterval() throws RuleException {
         certificate.setNotAfter(convertToDateViaInstant(LocalDateTime.now().plusDays(10)));

--- a/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
@@ -130,6 +130,7 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -648,10 +649,10 @@ class EventHandlersITest extends BaseSpringBootTest {
     void testDiscoveryFinishedEventLeavesTerminalDiscoveryUnchanged() throws EventException {
         Discovery discovery = persistProcessingDiscovery();
         discovery.setStatus(DiscoveryStatus.COMPLETED);
-        discovery.setEndTime(new Date());
+        discovery.setEndTime(OffsetDateTime.now());
         discovery.setMessage("Discovery completed successfully.");
         discoveryRepository.save(discovery);
-        Date endTimeBefore = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow().getEndTime();
+        OffsetDateTime endTimeBefore = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow().getEndTime();
 
         discoveryFinishedEventHandler
                 .handleEvent(DiscoveryFinishedEventHandler

--- a/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
@@ -61,8 +61,8 @@ import com.otilm.core.dao.entity.ApprovalProfile;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.CertificateContent;
 import com.otilm.core.dao.entity.Connector;
+import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.entity.DiscoveryCertificate;
-import com.otilm.core.dao.entity.DiscoveryHistory;
 import com.otilm.core.dao.entity.Group;
 import com.otilm.core.dao.entity.GroupAssociation;
 import com.otilm.core.dao.entity.RaProfile;
@@ -556,7 +556,7 @@ class EventHandlersITest extends BaseSpringBootTest {
 
     @Test
     void testProcessTriggersExceptionSetsEventHistoryToFailed() throws EventException {
-        DiscoveryHistory discovery = new DiscoveryHistory();
+        Discovery discovery = new Discovery();
         discovery.setName("TestDiscovery");
         discovery.setKind("IP");
         discovery.setStatus(DiscoveryStatus.IN_PROGRESS);
@@ -597,14 +597,14 @@ class EventHandlersITest extends BaseSpringBootTest {
 
     @Test
     void testDiscoveryFinishedEventCompletesProcessingDiscovery() throws EventException {
-        DiscoveryHistory discovery = persistProcessingDiscovery();
+        Discovery discovery = persistProcessingDiscovery();
 
         discoveryFinishedEventHandler
                 .handleEvent(DiscoveryFinishedEventHandler
                         .constructEventMessage(discovery.getUuid(), null, null,
                                 new DiscoveryResult(DiscoveryStatus.PROCESSING, "Provider completed.")));
 
-        DiscoveryHistory persisted = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
+        Discovery persisted = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
         Assertions.assertEquals(DiscoveryStatus.COMPLETED, persisted.getStatus());
         Assertions.assertNotNull(persisted.getEndTime());
         Assertions.assertEquals("Discovery completed successfully. Provider completed.", persisted.getMessage());
@@ -612,14 +612,14 @@ class EventHandlersITest extends BaseSpringBootTest {
 
     @Test
     void testDiscoveryFinishedEventMarksWarningWhenCertificatesFailed() throws EventException {
-        DiscoveryHistory discovery = persistProcessingDiscovery();
+        Discovery discovery = persistProcessingDiscovery();
 
         discoveryFinishedEventHandler
                 .handleEvent(DiscoveryFinishedEventHandler
                         .constructEventMessage(discovery.getUuid(), null, null, new DiscoveryResult(
                                 DiscoveryStatus.WARNING, "2 certificate(s) could not be processed during discovery.")));
 
-        DiscoveryHistory persisted = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
+        Discovery persisted = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
         Assertions.assertEquals(DiscoveryStatus.WARNING, persisted.getStatus());
         Assertions.assertNotNull(persisted.getEndTime());
         Assertions
@@ -630,7 +630,7 @@ class EventHandlersITest extends BaseSpringBootTest {
 
     @Test
     void testDiscoveryFinishedEventIgnoresNonFinishSignal() throws EventException {
-        DiscoveryHistory discovery = persistProcessingDiscovery();
+        Discovery discovery = persistProcessingDiscovery();
 
         // COMPLETED/FAILED payloads come from the discovery service with the state already persisted; only a
         // PROCESSING or WARNING signal from certificate post-processing finalizes a processing discovery.
@@ -639,14 +639,14 @@ class EventHandlersITest extends BaseSpringBootTest {
                         .constructEventMessage(discovery.getUuid(), null, null,
                                 new DiscoveryResult(DiscoveryStatus.FAILED, "Provider failed.")));
 
-        DiscoveryHistory persisted = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
+        Discovery persisted = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
         Assertions.assertEquals(DiscoveryStatus.PROCESSING, persisted.getStatus());
         Assertions.assertNull(persisted.getEndTime());
     }
 
     @Test
     void testDiscoveryFinishedEventLeavesTerminalDiscoveryUnchanged() throws EventException {
-        DiscoveryHistory discovery = persistProcessingDiscovery();
+        Discovery discovery = persistProcessingDiscovery();
         discovery.setStatus(DiscoveryStatus.COMPLETED);
         discovery.setEndTime(new Date());
         discovery.setMessage("Discovery completed successfully.");
@@ -658,7 +658,7 @@ class EventHandlersITest extends BaseSpringBootTest {
                         .constructEventMessage(discovery.getUuid(), null, null,
                                 new DiscoveryResult(DiscoveryStatus.COMPLETED, "Late duplicate event.")));
 
-        DiscoveryHistory persisted = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
+        Discovery persisted = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
         Assertions.assertEquals(DiscoveryStatus.COMPLETED, persisted.getStatus());
         Assertions.assertEquals(endTimeBefore, persisted.getEndTime());
         Assertions.assertEquals("Discovery completed successfully.", persisted.getMessage());
@@ -666,7 +666,7 @@ class EventHandlersITest extends BaseSpringBootTest {
 
     @Test
     void testCertificateDiscoveredEmitsFinishWhenNoNewCertificates() throws EventException {
-        DiscoveryHistory discovery = persistProcessingDiscovery();
+        Discovery discovery = persistProcessingDiscovery();
 
         certificateDiscoveredEventHandler
                 .handleEvent(CertificateDiscoveredEventHandler.constructEventMessage(discovery.getUuid(), null, null));
@@ -679,7 +679,7 @@ class EventHandlersITest extends BaseSpringBootTest {
 
     @Test
     void testCertificateDiscoveredEmitsWarningWhenCertificateProcessingFails() throws EventException {
-        DiscoveryHistory discovery = persistProcessingDiscovery();
+        Discovery discovery = persistProcessingDiscovery();
 
         CertificateContent certificateContent = new CertificateContent();
         certificateContent.setContent("not-a-valid-certificate");
@@ -705,8 +705,8 @@ class EventHandlersITest extends BaseSpringBootTest {
         Assertions.assertNotNull(processed.getProcessedError());
     }
 
-    private DiscoveryHistory persistProcessingDiscovery() {
-        DiscoveryHistory discovery = new DiscoveryHistory();
+    private Discovery persistProcessingDiscovery() {
+        Discovery discovery = new Discovery();
         discovery.setName("TestDiscovery");
         discovery.setKind("IP");
         discovery.setStatus(DiscoveryStatus.PROCESSING);
@@ -721,7 +721,7 @@ class EventHandlersITest extends BaseSpringBootTest {
      */
     @Test
     void testCertificateDiscoveredImportsOneCertificateForDuplicateRows() throws Exception {
-        DiscoveryHistory discovery = persistProcessingDiscovery();
+        Discovery discovery = persistProcessingDiscovery();
         X509Certificate x509 = generateSelfSignedCertificate();
         CertificateContent content = persistContentFor(x509);
         List<DiscoveryCertificate> rows = List
@@ -762,7 +762,7 @@ class EventHandlersITest extends BaseSpringBootTest {
      */
     @Test
     void testCertificateDiscoveredImportsWhenAnActionTriggerExecutionFails() throws Exception {
-        DiscoveryHistory discovery = persistProcessingDiscovery();
+        Discovery discovery = persistProcessingDiscovery();
         X509Certificate x509 = generateSelfSignedCertificate();
         CertificateContent content = persistContentFor(x509);
         DiscoveryCertificate row = persistDiscoveryCertificate(discovery, content, "action-failing-host");
@@ -817,7 +817,7 @@ class EventHandlersITest extends BaseSpringBootTest {
      */
     @Test
     void testCertificateDiscoveredAppliesASucceedingActionTriggerAcrossTheTransactionBoundary() throws Exception {
-        DiscoveryHistory discovery = persistProcessingDiscovery();
+        Discovery discovery = persistProcessingDiscovery();
         X509Certificate x509 = generateSelfSignedCertificate();
         CertificateContent content = persistContentFor(x509);
         persistDiscoveryCertificate(discovery, content, "group-setting-host");
@@ -845,7 +845,7 @@ class EventHandlersITest extends BaseSpringBootTest {
      */
     @Test
     void testCertificateDiscoveredKeepsASucceedingTriggerWhenAnotherFails() throws Exception {
-        DiscoveryHistory discovery = persistProcessingDiscovery();
+        Discovery discovery = persistProcessingDiscovery();
         X509Certificate x509 = generateSelfSignedCertificate();
         CertificateContent content = persistContentFor(x509);
         persistDiscoveryCertificate(discovery, content, "two-trigger-host");
@@ -961,7 +961,7 @@ class EventHandlersITest extends BaseSpringBootTest {
      */
     @Test
     void testCertificateDiscoveredHonoursAnIgnoreTriggerConditionedOnTheFingerprint() throws Exception {
-        DiscoveryHistory discovery = persistProcessingDiscovery();
+        Discovery discovery = persistProcessingDiscovery();
         X509Certificate x509 = generateSelfSignedCertificate();
         String fingerprint = CertificateUtil.getThumbprint(x509);
         CertificateContent content = persistContentFor(x509);
@@ -1037,7 +1037,7 @@ class EventHandlersITest extends BaseSpringBootTest {
      */
     @Test
     void testCertificateDiscoveredImportsDespiteAConditionOnAnAbsentAssociation() throws Exception {
-        DiscoveryHistory discovery = persistProcessingDiscovery();
+        Discovery discovery = persistProcessingDiscovery();
         X509Certificate x509 = generateSelfSignedCertificate();
         CertificateContent content = persistContentFor(x509);
         DiscoveryCertificate row = persistDiscoveryCertificate(discovery, content, "no-ra-profile-host");
@@ -1069,7 +1069,7 @@ class EventHandlersITest extends BaseSpringBootTest {
      */
     @Test
     void testCertificateDiscoveredRecordsARolledBackGroupWithoutCountingItAsAKeyGap() throws Exception {
-        DiscoveryHistory discovery = persistProcessingDiscovery();
+        Discovery discovery = persistProcessingDiscovery();
         X509Certificate x509 = generateSelfSignedCertificate();
         CertificateContent content = persistContentFor(x509);
         DiscoveryCertificate row = persistDiscoveryCertificate(discovery, content, "rolling-back-host");
@@ -1114,7 +1114,7 @@ class EventHandlersITest extends BaseSpringBootTest {
      */
     @Test
     void testCertificateDiscoveredAttributesAFailedKeyAssociationToEveryRow() throws Exception {
-        DiscoveryHistory discovery = persistProcessingDiscovery();
+        Discovery discovery = persistProcessingDiscovery();
         X509Certificate x509 = generateSelfSignedCertificate();
         CertificateContent content = persistContentFor(x509);
         List<DiscoveryCertificate> rows = List
@@ -1171,7 +1171,7 @@ class EventHandlersITest extends BaseSpringBootTest {
         return certificateContentRepository.save(content);
     }
 
-    private DiscoveryCertificate persistDiscoveryCertificate(DiscoveryHistory discovery, CertificateContent content,
+    private DiscoveryCertificate persistDiscoveryCertificate(Discovery discovery, CertificateContent content,
             String host) {
         DiscoveryCertificate row = new DiscoveryCertificate();
         row.setCommonName(host);
@@ -1200,7 +1200,7 @@ class EventHandlersITest extends BaseSpringBootTest {
     @Test
     void testDiscoveryFinishedEvent()
             throws EventException, AttributeException, AlreadyExistException, NotFoundException {
-        DiscoveryHistory discovery = new DiscoveryHistory();
+        Discovery discovery = new Discovery();
         discovery.setName("TestDiscovery");
         discovery.setKind("IP");
         discovery.setStatus(DiscoveryStatus.IN_PROGRESS);
@@ -1574,7 +1574,7 @@ class EventHandlersITest extends BaseSpringBootTest {
                 notificationProfileUuids, null, eventData);
         Assertions.assertDoesNotThrow(() -> notificationListener.processMessage(messageCertificateActionPerformed));
 
-        DiscoveryHistory discovery = new DiscoveryHistory();
+        Discovery discovery = new Discovery();
         discovery.setName("TestDiscovery");
         discovery.setStatus(DiscoveryStatus.COMPLETED);
         discovery.setConnectorStatus(DiscoveryStatus.COMPLETED);

--- a/src/test/java/com/otilm/core/integration/events/EventHistoryTransactionITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHistoryTransactionITest.java
@@ -6,7 +6,7 @@ import com.otilm.api.model.core.discovery.DiscoveryStatus;
 import com.otilm.api.model.core.other.ResourceEvent;
 import com.otilm.api.model.core.workflows.EventStatus;
 import com.otilm.api.model.core.workflows.TriggerType;
-import com.otilm.core.dao.entity.DiscoveryHistory;
+import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.entity.workflows.EventHistory;
 import com.otilm.core.dao.entity.workflows.Trigger;
 import com.otilm.core.dao.entity.workflows.TriggerAssociation;
@@ -58,7 +58,7 @@ class EventHistoryTransactionITest extends BaseSpringBootTest {
                 .when(jmsTemplate)
                 .convertAndSend(any(String.class), any(NotificationMessage.class), any());
 
-        DiscoveryHistory discovery = new DiscoveryHistory();
+        Discovery discovery = new Discovery();
         discovery.setName("TestDiscovery");
         discovery.setKind("IP");
         discovery.setStatus(DiscoveryStatus.IN_PROGRESS);

--- a/src/test/java/com/otilm/core/integration/repository/DiscoveryItemRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/repository/DiscoveryItemRepositoryITest.java
@@ -1,0 +1,116 @@
+package com.otilm.core.integration.repository;
+
+import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
+import com.otilm.api.model.common.attribute.v3.MetadataAttributeV3;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.discovery.DiscoveryStatus;
+import com.otilm.core.dao.entity.Discovery;
+import com.otilm.core.dao.entity.DiscoveryItem;
+import com.otilm.core.dao.repository.DiscoveryItemRepository;
+import com.otilm.core.dao.repository.DiscoveryRepository;
+import com.otilm.core.util.BaseSpringBootTest;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Schema proof for the resource-agnostic staging table: the jsonb payload and meta survive a round trip, the
+ * {@code (discovery, resource, unique_ref)} dedupe constraint holds, and deleting a run cascades its staged items away
+ * at the database level.
+ */
+@Transactional
+class DiscoveryItemRepositoryITest extends BaseSpringBootTest {
+
+    @Autowired
+    private DiscoveryItemRepository itemRepository;
+    @Autowired
+    private DiscoveryRepository discoveryRepository;
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void stagedItemRoundTripsPayloadAndMeta() {
+        UUID runUuid = aRun();
+        MetadataAttributeV3 where = new MetadataAttributeV3();
+        where.setName("discoverySource");
+        // The attribute serializer reads contentType.getCode() unconditionally; a name-only fixture NPEs.
+        where.setContentType(AttributeContentType.STRING);
+
+        DiscoveryItem item = new DiscoveryItem();
+        item.setDiscoveryUuid(runUuid);
+        item.setResource(Resource.CRYPTOGRAPHIC_KEY);
+        item.setSequence(1L);
+        item.setUniqueRef("2b:9c:aa");
+        item.setPayload(Map.of("resource", "keys", "fingerprint", "2b:9c:aa"));
+        item.setDiscoveredAt(OffsetDateTime.of(2026, 8, 14, 10, 0, 0, 0, ZoneOffset.UTC));
+        item.setNewlyDiscovered(true);
+        item.setMeta(List.of(where));
+        UUID itemUuid = itemRepository.saveAndFlush(item).getUuid();
+        // Without the clear, findById answers from the persistence context and the jsonb columns are never read.
+        entityManager.clear();
+
+        DiscoveryItem back = itemRepository.findById(itemUuid).orElseThrow();
+        assertThat(back.getPayload()).containsEntry("fingerprint", "2b:9c:aa");
+        assertThat(back.getMeta())
+                .extracting(m -> ((MetadataAttributeV3) m).getName())
+                .containsExactly("discoverySource");
+        assertThat(back.isNewlyDiscovered()).isTrue();
+        assertThat(back.getProcessedAt()).isNull();
+        assertThat(back.getInventoryUuid()).isNull();
+    }
+
+    @Test
+    void duplicateUniqueRefWithinRunAndResourceIsRejected() {
+        UUID runUuid = aRun();
+        itemRepository.saveAndFlush(item(runUuid, 1L, "10.0.0.7:443"));
+
+        assertThatThrownBy(() -> itemRepository.saveAndFlush(item(runUuid, 2L, "10.0.0.7:443")))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void deletingTheRunCascadesItsStagedItems() {
+        UUID runUuid = aRun();
+        itemRepository.saveAndFlush(item(runUuid, 1L, "10.0.0.7:443"));
+        itemRepository.saveAndFlush(item(runUuid, 2L, "10.0.0.8:443"));
+        assertThat(itemRepository.count()).isEqualTo(2);
+
+        discoveryRepository.deleteById(runUuid);
+        discoveryRepository.flush();
+
+        assertThat(itemRepository.count()).isZero();
+    }
+
+    private DiscoveryItem item(UUID runUuid, long sequence, String uniqueRef) {
+        DiscoveryItem item = new DiscoveryItem();
+        item.setDiscoveryUuid(runUuid);
+        item.setResource(Resource.CERTIFICATE);
+        item.setSequence(sequence);
+        item.setUniqueRef(uniqueRef);
+        item.setPayload(Map.of("resource", "certificates"));
+        item.setNewlyDiscovered(false);
+        return item;
+    }
+
+    private UUID aRun() {
+        Discovery run = new Discovery();
+        run.setName("nightly-scan");
+        run.setKind("IP-HostName");
+        run.setStatus(DiscoveryStatus.IN_PROGRESS);
+        run.setConnectorStatus(DiscoveryStatus.IN_PROGRESS);
+        run.setConnectorUuid(UUID.randomUUID());
+        run.setConnectorName("network-discovery");
+        return discoveryRepository.saveAndFlush(run).getUuid();
+    }
+}

--- a/src/test/java/com/otilm/core/integration/repository/DiscoveryItemRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/repository/DiscoveryItemRepositoryITest.java
@@ -74,8 +74,9 @@ class DiscoveryItemRepositoryITest extends BaseSpringBootTest {
     void duplicateUniqueRefWithinRunAndResourceIsRejected() {
         UUID runUuid = aRun();
         itemRepository.saveAndFlush(item(runUuid, 1L, "10.0.0.7:443"));
+        DiscoveryItem duplicate = item(runUuid, 2L, "10.0.0.7:443");
 
-        assertThatThrownBy(() -> itemRepository.saveAndFlush(item(runUuid, 2L, "10.0.0.7:443")))
+        assertThatThrownBy(() -> itemRepository.saveAndFlush(duplicate))
                 .isInstanceOf(DataIntegrityViolationException.class);
     }
 

--- a/src/test/java/com/otilm/core/integration/repository/DiscoveryRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/repository/DiscoveryRepositoryITest.java
@@ -1,0 +1,74 @@
+package com.otilm.core.integration.repository;
+
+import com.otilm.api.model.connector.discovery.v2.DiscoveryResourceProgressDto;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.discovery.DiscoveryStatus;
+import com.otilm.core.dao.entity.Discovery;
+import com.otilm.core.dao.repository.DiscoveryRepository;
+import com.otilm.core.util.BaseSpringBootTest;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Schema proof for the discovery v2 run columns — above all {@code progressByResource}, the first enum-keyed map under
+ * {@code @JdbcTypeCode(SqlTypes.JSON)} in any core entity: {@link Resource} keys serialize by wire code via
+ * {@code @JsonValue}, and enum-as-map-key handling through Hibernate's Jackson mapper is exactly the kind of mapping
+ * that only fails at read time.
+ */
+@Transactional
+class DiscoveryRepositoryITest extends BaseSpringBootTest {
+
+    @Autowired
+    private DiscoveryRepository discoveryRepository;
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void v2RunColumnsRoundTrip() {
+        DiscoveryResourceProgressDto keyProgress = new DiscoveryResourceProgressDto();
+        keyProgress.setProcessed(3L);
+
+        Discovery run = new Discovery();
+        run.setName("nightly-scan");
+        run.setKind("IP-HostName");
+        run.setStatus(DiscoveryStatus.IN_PROGRESS);
+        run.setConnectorStatus(DiscoveryStatus.IN_PROGRESS);
+        run.setConnectorUuid(UUID.randomUUID());
+        run.setConnectorName("network-discovery");
+        run.setConnectorInterfaceUuid(UUID.randomUUID());
+        run.setRunMeta(Map.of("connectorRunId", "run-42"));
+        run.setResources(List.of(Resource.CERTIFICATE, Resource.CRYPTOGRAPHIC_KEY));
+        run.setLastAppliedSequence(17L);
+        run.setProgressProcessed(11L);
+        run.setProgressTotalEstimate(40L);
+        run.setProgressByResource(Map.of(Resource.CRYPTOGRAPHIC_KEY, keyProgress));
+        run.setProgressPhase("scanning");
+        run.setRunMessages(List.of("host 10.0.0.7 refused the connection"));
+        run.setStoppedAt(OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS));
+        run.setConnectorState("running");
+        UUID runUuid = discoveryRepository.saveAndFlush(run).getUuid();
+        // Without the clear, findById answers from the persistence context and the jsonb columns are never read.
+        entityManager.clear();
+
+        Discovery back = discoveryRepository.findById(runUuid).orElseThrow();
+        assertThat(back.getRunMeta()).containsEntry("connectorRunId", "run-42");
+        assertThat(back.getResources()).containsExactly(Resource.CERTIFICATE, Resource.CRYPTOGRAPHIC_KEY);
+        assertThat(back.getLastAppliedSequence()).isEqualTo(17L);
+        assertThat(back.getProgressByResource()).containsOnlyKeys(Resource.CRYPTOGRAPHIC_KEY);
+        assertThat(back.getProgressByResource().get(Resource.CRYPTOGRAPHIC_KEY).getProcessed()).isEqualTo(3L);
+        assertThat(back.getRunMessages()).containsExactly("host 10.0.0.7 refused the connection");
+        assertThat(back.getConnectorState()).isEqualTo("running");
+        assertThat(back.getStoppedAt()).isNotNull();
+    }
+}

--- a/src/test/java/com/otilm/core/integration/repository/DiscoveryRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/repository/DiscoveryRepositoryITest.java
@@ -21,8 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Schema proof for the discovery v2 run columns — above all {@code progressByResource}, the first enum-keyed map under
- * {@code @JdbcTypeCode(SqlTypes.JSON)} in any core entity: {@link Resource} keys serialize by wire code via
+ * Schema proof for the discovery v2 run columns. The critical case is {@code progressByResource}, the first enum-keyed
+ * map under {@code @JdbcTypeCode(SqlTypes.JSON)} in any core entity: {@link Resource} keys serialize by wire code via
  * {@code @JsonValue}, and enum-as-map-key handling through Hibernate's Jackson mapper is exactly the kind of mapping
  * that only fails at read time.
  */
@@ -46,7 +46,9 @@ class DiscoveryRepositoryITest extends BaseSpringBootTest {
         run.setConnectorStatus(DiscoveryStatus.IN_PROGRESS);
         run.setConnectorUuid(UUID.randomUUID());
         run.setConnectorName("network-discovery");
-        run.setConnectorInterfaceUuid(UUID.randomUUID());
+        UUID interfaceUuid = UUID.randomUUID();
+        OffsetDateTime stoppedAt = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS);
+        run.setConnectorInterfaceUuid(interfaceUuid);
         run.setRunMeta(Map.of("connectorRunId", "run-42"));
         run.setResources(List.of(Resource.CERTIFICATE, Resource.CRYPTOGRAPHIC_KEY));
         run.setLastAppliedSequence(17L);
@@ -55,20 +57,25 @@ class DiscoveryRepositoryITest extends BaseSpringBootTest {
         run.setProgressByResource(Map.of(Resource.CRYPTOGRAPHIC_KEY, keyProgress));
         run.setProgressPhase("scanning");
         run.setRunMessages(List.of("host 10.0.0.7 refused the connection"));
-        run.setStoppedAt(OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS));
+        run.setStoppedAt(stoppedAt);
         run.setConnectorState("running");
         UUID runUuid = discoveryRepository.saveAndFlush(run).getUuid();
         // Without the clear, findById answers from the persistence context and the jsonb columns are never read.
         entityManager.clear();
 
         Discovery back = discoveryRepository.findById(runUuid).orElseThrow();
+        assertThat(back.getConnectorInterfaceUuid()).isEqualTo(interfaceUuid);
         assertThat(back.getRunMeta()).containsEntry("connectorRunId", "run-42");
         assertThat(back.getResources()).containsExactly(Resource.CERTIFICATE, Resource.CRYPTOGRAPHIC_KEY);
         assertThat(back.getLastAppliedSequence()).isEqualTo(17L);
+        assertThat(back.getProgressProcessed()).isEqualTo(11L);
+        assertThat(back.getProgressTotalEstimate()).isEqualTo(40L);
         assertThat(back.getProgressByResource()).containsOnlyKeys(Resource.CRYPTOGRAPHIC_KEY);
         assertThat(back.getProgressByResource().get(Resource.CRYPTOGRAPHIC_KEY).getProcessed()).isEqualTo(3L);
+        assertThat(back.getProgressPhase()).isEqualTo("scanning");
         assertThat(back.getRunMessages()).containsExactly("host 10.0.0.7 refused the connection");
         assertThat(back.getConnectorState()).isEqualTo("running");
-        assertThat(back.getStoppedAt()).isNotNull();
+        // Compared as instants: the driver may hand the timestamptz back under a different zone offset.
+        assertThat(back.getStoppedAt().toInstant()).isEqualTo(stoppedAt.toInstant());
     }
 }

--- a/src/test/java/com/otilm/core/integration/repository/DiscoveryWorkRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/repository/DiscoveryWorkRepositoryITest.java
@@ -22,9 +22,9 @@ import org.springframework.transaction.annotation.Transactional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * SQL-level coverage for the discovery work agenda: the {@code ON CONFLICT} upsert is idempotent per run and work type,
- * the due query orders soonest-first and excludes the not-yet-due, and deleting a run cascades its agenda rows away at
- * the database level — the sweep must never meet work for a run that no longer exists.
+ * SQL-level coverage for the discovery work agenda. The {@code ON CONFLICT} upsert is idempotent per run and work type.
+ * The due query orders soonest-first and excludes the not-yet-due. Deleting a run cascades its agenda rows away at the
+ * database level — the sweep must never meet work for a run that no longer exists.
  */
 @Transactional
 class DiscoveryWorkRepositoryITest extends BaseSpringBootTest {

--- a/src/test/java/com/otilm/core/integration/repository/DiscoveryWorkRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/repository/DiscoveryWorkRepositoryITest.java
@@ -1,0 +1,91 @@
+package com.otilm.core.integration.repository;
+
+import com.otilm.api.model.core.discovery.DiscoveryStatus;
+import com.otilm.core.dao.entity.Discovery;
+import com.otilm.core.dao.entity.DiscoveryWork;
+import com.otilm.core.dao.repository.DiscoveryRepository;
+import com.otilm.core.dao.repository.DiscoveryWorkRepository;
+import com.otilm.core.model.discovery.DiscoveryWorkType;
+import com.otilm.core.util.BaseSpringBootTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * SQL-level coverage for the discovery work agenda: the {@code ON CONFLICT} upsert is idempotent per run and work type,
+ * the due query orders soonest-first and excludes the not-yet-due, and deleting a run cascades its agenda rows away at
+ * the database level — the sweep must never meet work for a run that no longer exists.
+ */
+@Transactional
+class DiscoveryWorkRepositoryITest extends BaseSpringBootTest {
+
+    // Truncated to what timestamptz can hold, so a stored value reads back equal to what was written.
+    private static final OffsetDateTime NOW = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS);
+
+    @Autowired
+    private DiscoveryWorkRepository workRepository;
+    @Autowired
+    private DiscoveryRepository discoveryRepository;
+
+    @Test
+    void doubleScheduleKeepsOneRowAndMovesTheDueTime() {
+        UUID runUuid = aRun();
+
+        workRepository.schedule(UUID.randomUUID(), runUuid, DiscoveryWorkType.STATUS.name(), NOW.plusMinutes(1));
+        workRepository.schedule(UUID.randomUUID(), runUuid, DiscoveryWorkType.STATUS.name(), NOW.plusMinutes(5));
+
+        List<DiscoveryWork> rows = workRepository.findAll();
+        assertThat(rows).hasSize(1);
+        // Compared as instants: the driver may hand the timestamptz back under a different zone offset.
+        assertThat(rows.get(0).getNextDueAt().toInstant()).isEqualTo(NOW.plusMinutes(5).toInstant());
+        assertThat(rows.get(0).getAttempt()).isZero();
+    }
+
+    @Test
+    void dueQueryOrdersSoonestFirstAndExcludesTheNotYetDue() {
+        UUID runUuid = aRun();
+        workRepository.schedule(UUID.randomUUID(), runUuid, DiscoveryWorkType.PROCESS.name(), NOW.plusHours(2));
+        workRepository.schedule(UUID.randomUUID(), runUuid, DiscoveryWorkType.DRAIN.name(), NOW.minusMinutes(1));
+        workRepository.schedule(UUID.randomUUID(), runUuid, DiscoveryWorkType.STATUS.name(), NOW.minusMinutes(10));
+
+        List<DiscoveryWork> due = workRepository
+                .findByNextDueAtLessThanEqualOrderByNextDueAt(NOW, PageRequest.of(0, 10));
+
+        assertThat(due)
+                .extracting(DiscoveryWork::getWorkType)
+                .containsExactly(DiscoveryWorkType.STATUS, DiscoveryWorkType.DRAIN);
+    }
+
+    @Test
+    void deletingTheRunCascadesItsAgendaRows() {
+        UUID runUuid = aRun();
+        workRepository.schedule(UUID.randomUUID(), runUuid, DiscoveryWorkType.STATUS.name(), NOW);
+        workRepository.schedule(UUID.randomUUID(), runUuid, DiscoveryWorkType.DRAIN.name(), NOW);
+        assertThat(workRepository.count()).isEqualTo(2);
+
+        discoveryRepository.deleteById(runUuid);
+        discoveryRepository.flush();
+
+        assertThat(workRepository.count()).isZero();
+    }
+
+    /** A saved, flushed run row — flushed because the native upsert's foreign key reads the table, not the cache. */
+    private UUID aRun() {
+        Discovery run = new Discovery();
+        run.setName("nightly-scan");
+        run.setKind("IP-HostName");
+        run.setStatus(DiscoveryStatus.IN_PROGRESS);
+        run.setConnectorStatus(DiscoveryStatus.IN_PROGRESS);
+        run.setConnectorUuid(UUID.randomUUID());
+        run.setConnectorName("network-discovery");
+        return discoveryRepository.saveAndFlush(run).getUuid();
+    }
+}

--- a/src/test/java/com/otilm/core/integration/repository/DiscoveryWorkRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/repository/DiscoveryWorkRepositoryITest.java
@@ -7,6 +7,8 @@ import com.otilm.core.dao.repository.DiscoveryRepository;
 import com.otilm.core.dao.repository.DiscoveryWorkRepository;
 import com.otilm.core.model.discovery.DiscoveryWorkType;
 import com.otilm.core.util.BaseSpringBootTest;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
@@ -34,6 +36,8 @@ class DiscoveryWorkRepositoryITest extends BaseSpringBootTest {
     private DiscoveryWorkRepository workRepository;
     @Autowired
     private DiscoveryRepository discoveryRepository;
+    @PersistenceContext
+    private EntityManager entityManager;
 
     @Test
     void doubleScheduleKeepsOneRowAndMovesTheDueTime() {
@@ -62,6 +66,50 @@ class DiscoveryWorkRepositoryITest extends BaseSpringBootTest {
         assertThat(due)
                 .extracting(DiscoveryWork::getWorkType)
                 .containsExactly(DiscoveryWorkType.STATUS, DiscoveryWorkType.DRAIN);
+    }
+
+    @Test
+    void rescheduleByRunAndTypeMovesAttemptAndDueTime() {
+        UUID runUuid = aRun();
+        workRepository.schedule(UUID.randomUUID(), runUuid, DiscoveryWorkType.DRAIN.name(), NOW);
+
+        workRepository.reschedule(runUuid, DiscoveryWorkType.DRAIN, 3, NOW.plusMinutes(30));
+        entityManager.clear();
+
+        DiscoveryWork row = workRepository.findAll().get(0);
+        assertThat(row.getAttempt()).isEqualTo(3);
+        assertThat(row.getNextDueAt().toInstant()).isEqualTo(NOW.plusMinutes(30).toInstant());
+    }
+
+    @Test
+    void reArmingABackedOffRowResetsItsAttemptCounter() {
+        UUID runUuid = aRun();
+        workRepository.schedule(UUID.randomUUID(), runUuid, DiscoveryWorkType.DRAIN.name(), NOW);
+        workRepository.reschedule(runUuid, DiscoveryWorkType.DRAIN, 7, NOW.plusHours(1));
+
+        workRepository.schedule(UUID.randomUUID(), runUuid, DiscoveryWorkType.DRAIN.name(), NOW);
+        entityManager.clear();
+
+        DiscoveryWork row = workRepository.findAll().get(0);
+        assertThat(row.getAttempt())
+                .as("scheduling is a fresh start; in-flight backoff is reschedule()'s job")
+                .isZero();
+        assertThat(row.getNextDueAt().toInstant()).isEqualTo(NOW.toInstant());
+    }
+
+    @Test
+    void deleteByDiscoveryUuidRemovesOnlyTheTargetedRunsRows() {
+        UUID runA = aRun();
+        UUID runB = aRun();
+        workRepository.schedule(UUID.randomUUID(), runA, DiscoveryWorkType.STATUS.name(), NOW);
+        workRepository.schedule(UUID.randomUUID(), runB, DiscoveryWorkType.STATUS.name(), NOW);
+
+        workRepository.deleteByDiscoveryUuid(runA);
+        entityManager.clear();
+
+        List<DiscoveryWork> remaining = workRepository.findAll();
+        assertThat(remaining).hasSize(1);
+        assertThat(remaining.get(0).getDiscoveryUuid()).isEqualTo(runB);
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/search/DiscoverySearchITest.java
+++ b/src/test/java/com/otilm/core/integration/search/DiscoverySearchITest.java
@@ -26,7 +26,7 @@ import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.dao.entity.Connector;
 import com.otilm.core.dao.entity.Connector2FunctionGroup;
-import com.otilm.core.dao.entity.DiscoveryHistory;
+import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.entity.FunctionGroup;
 import com.otilm.core.dao.repository.Connector2FunctionGroupRepository;
 import com.otilm.core.dao.repository.ConnectorRepository;
@@ -54,7 +54,7 @@ import static com.otilm.core.util.builders.SearchFilterRequestDtoBuilder.aProper
 import static com.otilm.core.util.builders.SearchFilterRequestDtoBuilder.aPropertyFilter;
 import static com.otilm.core.util.builders.SearchFilterRequestDtoBuilder.aPropertyNotEqualsFilter;
 
-class DiscoveryHistorySearchITest extends BaseSpringBootTest {
+class DiscoverySearchITest extends BaseSpringBootTest {
 
     @Autowired
     private DiscoveryRepository discoveryRepository;
@@ -78,7 +78,7 @@ class DiscoveryHistorySearchITest extends BaseSpringBootTest {
     private boolean isLoadedData = false;
 
     private Connector connector;
-    private DiscoveryHistory discoveryHistory;
+    private Discovery discovery;
 
     @BeforeEach
     void loadData() {
@@ -108,7 +108,7 @@ class DiscoveryHistorySearchITest extends BaseSpringBootTest {
             connector.getFunctionGroups().add(c2fg);
             connectorRepository.save(connector);
 
-            final DiscoveryHistory discovery1 = new DiscoveryHistory();
+            final Discovery discovery1 = new Discovery();
             discovery1.setName("test_discovery1");
             discovery1.setConnectorUuid(connector.getUuid());
             discovery1.setConnectorName("connector1");
@@ -119,9 +119,9 @@ class DiscoveryHistorySearchITest extends BaseSpringBootTest {
             discovery1.setEndTime(DATE_FORMAT.parse("2020-02-01T10:10:10"));
             discovery1.setTotalCertificatesDiscovered(15);
             discovery1.setConnectorTotalCertificatesDiscovered(15);
-            discoveryHistory = discoveryRepository.save(discovery1);
+            discovery = discoveryRepository.save(discovery1);
 
-            final DiscoveryHistory discovery2 = new DiscoveryHistory();
+            final Discovery discovery2 = new Discovery();
             discovery2.setName("test_discovery2");
             discovery2.setConnectorUuid(connector.getUuid());
             discovery2.setConnectorName("connector1");
@@ -134,7 +134,7 @@ class DiscoveryHistorySearchITest extends BaseSpringBootTest {
             discovery2.setConnectorTotalCertificatesDiscovered(11);
             discoveryRepository.save(discovery2);
 
-            final DiscoveryHistory discovery3 = new DiscoveryHistory();
+            final Discovery discovery3 = new Discovery();
             discovery3.setName("test_discovery3");
             discovery3.setConnectorUuid(connector.getUuid());
             discovery3.setConnectorName("connector5");
@@ -147,7 +147,7 @@ class DiscoveryHistorySearchITest extends BaseSpringBootTest {
             discovery3.setConnectorTotalCertificatesDiscovered(20);
             discoveryRepository.save(discovery3);
 
-            final DiscoveryHistory discovery4 = new DiscoveryHistory();
+            final Discovery discovery4 = new Discovery();
             discovery4.setName("test_discovery4");
             discovery4.setConnectorUuid(connector.getUuid());
             discovery4.setConnectorName("connector1");
@@ -182,7 +182,7 @@ class DiscoveryHistorySearchITest extends BaseSpringBootTest {
         attributeEngine
                 .updateMetadataAttribute(metadataAttribute,
                         ObjectAttributeContentInfo
-                                .builder(Resource.DISCOVERY, discoveryHistory.getUuid())
+                                .builder(Resource.DISCOVERY, discovery.getUuid())
                                 .connector(connector.getUuid())
                                 .build());
     }
@@ -206,14 +206,14 @@ class DiscoveryHistorySearchITest extends BaseSpringBootTest {
 
         attributeEngine.updateCustomAttributeDefinition(customAttribute, List.of(Resource.DISCOVERY));
         attributeEngine
-                .updateObjectCustomAttributesContent(Resource.DISCOVERY, discoveryHistory.getUuid(),
+                .updateObjectCustomAttributesContent(Resource.DISCOVERY, discovery.getUuid(),
                         List.of(requestAttribute));
     }
 
     @Test
     void testInsertedData() {
-        final List<DiscoveryHistory> discoveryHistoryList = discoveryRepository.findAll();
-        Assertions.assertEquals(4, discoveryHistoryList.size());
+        final List<Discovery> discoveryList = discoveryRepository.findAll();
+        Assertions.assertEquals(4, discoveryList.size());
     }
 
     @Test
@@ -226,11 +226,10 @@ class DiscoveryHistorySearchITest extends BaseSpringBootTest {
 
     @Test
     void testInsertedAttributes() {
-        var customAttrs = attributeEngine
-                .getObjectCustomAttributesContent(Resource.DISCOVERY, discoveryHistory.getUuid());
+        var customAttrs = attributeEngine.getObjectCustomAttributesContent(Resource.DISCOVERY, discovery.getUuid());
         var metaAttrs = attributeEngine
                 .getMetadataAttributesDefinitionContent(
-                        ObjectAttributeContentInfo.builder(Resource.DISCOVERY, discoveryHistory.getUuid()).build());
+                        ObjectAttributeContentInfo.builder(Resource.DISCOVERY, discovery.getUuid()).build());
         Assertions.assertEquals(1, customAttrs.size());
         Assertions.assertEquals(1, metaAttrs.size());
     }

--- a/src/test/java/com/otilm/core/integration/search/DiscoverySearchITest.java
+++ b/src/test/java/com/otilm/core/integration/search/DiscoverySearchITest.java
@@ -73,7 +73,7 @@ class DiscoverySearchITest extends BaseSpringBootTest {
         this.attributeEngine = attributeEngine;
     }
 
-    /** Parsed in the system zone, preserving the instants the former SimpleDateFormat fixture produced. */
+    /** Interprets local fixture timestamps in the system zone, preserving their intended instants. */
     private static OffsetDateTime localDateTime(String value) {
         return LocalDateTime.parse(value).atZone(ZoneId.systemDefault()).toOffsetDateTime();
     }

--- a/src/test/java/com/otilm/core/integration/search/DiscoverySearchITest.java
+++ b/src/test/java/com/otilm/core/integration/search/DiscoverySearchITest.java
@@ -37,9 +37,9 @@ import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.DiscoveryExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.MetaDefinitions;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -73,7 +73,10 @@ class DiscoverySearchITest extends BaseSpringBootTest {
         this.attributeEngine = attributeEngine;
     }
 
-    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+    /** Parsed in the system zone, preserving the instants the former SimpleDateFormat fixture produced. */
+    private static OffsetDateTime localDateTime(String value) {
+        return LocalDateTime.parse(value).atZone(ZoneId.systemDefault()).toOffsetDateTime();
+    }
 
     private boolean isLoadedData = false;
 
@@ -115,8 +118,8 @@ class DiscoverySearchITest extends BaseSpringBootTest {
             discovery1.setStatus(DiscoveryStatus.FAILED);
             discovery1.setConnectorStatus(DiscoveryStatus.FAILED);
             discovery1.setKind("kindTEST1");
-            discovery1.setStartTime(DATE_FORMAT.parse("2020-01-01T10:10:10"));
-            discovery1.setEndTime(DATE_FORMAT.parse("2020-02-01T10:10:10"));
+            discovery1.setStartTime(localDateTime("2020-01-01T10:10:10"));
+            discovery1.setEndTime(localDateTime("2020-02-01T10:10:10"));
             discovery1.setTotalCertificatesDiscovered(15);
             discovery1.setConnectorTotalCertificatesDiscovered(15);
             discovery = discoveryRepository.save(discovery1);
@@ -128,8 +131,8 @@ class DiscoverySearchITest extends BaseSpringBootTest {
             discovery2.setStatus(DiscoveryStatus.COMPLETED);
             discovery2.setConnectorStatus(DiscoveryStatus.COMPLETED);
             discovery2.setKind("kindTEST3");
-            discovery2.setStartTime(DATE_FORMAT.parse("2020-05-05T10:10:10"));
-            discovery2.setEndTime(DATE_FORMAT.parse("2021-02-01T10:10:10"));
+            discovery2.setStartTime(localDateTime("2020-05-05T10:10:10"));
+            discovery2.setEndTime(localDateTime("2021-02-01T10:10:10"));
             discovery2.setTotalCertificatesDiscovered(11);
             discovery2.setConnectorTotalCertificatesDiscovered(11);
             discoveryRepository.save(discovery2);
@@ -141,8 +144,8 @@ class DiscoverySearchITest extends BaseSpringBootTest {
             discovery3.setStatus(DiscoveryStatus.COMPLETED);
             discovery3.setConnectorStatus(DiscoveryStatus.COMPLETED);
             discovery3.setKind("kindTEST3");
-            discovery3.setStartTime(DATE_FORMAT.parse("2022-10-01T10:10:10"));
-            discovery3.setEndTime(DATE_FORMAT.parse("2023-02-01T10:10:10"));
+            discovery3.setStartTime(localDateTime("2022-10-01T10:10:10"));
+            discovery3.setEndTime(localDateTime("2023-02-01T10:10:10"));
             discovery3.setTotalCertificatesDiscovered(20);
             discovery3.setConnectorTotalCertificatesDiscovered(20);
             discoveryRepository.save(discovery3);
@@ -154,8 +157,8 @@ class DiscoverySearchITest extends BaseSpringBootTest {
             discovery4.setStatus(DiscoveryStatus.IN_PROGRESS);
             discovery4.setConnectorStatus(DiscoveryStatus.IN_PROGRESS);
             discovery4.setKind("kindTEST4");
-            discovery4.setStartTime(DATE_FORMAT.parse("2020-06-01T10:10:10"));
-            discovery4.setEndTime(DATE_FORMAT.parse("2020-10-01T10:10:10"));
+            discovery4.setStartTime(localDateTime("2020-06-01T10:10:10"));
+            discovery4.setEndTime(localDateTime("2020-10-01T10:10:10"));
             discovery4.setTotalCertificatesDiscovered(5);
             discovery4.setConnectorTotalCertificatesDiscovered(5);
             discoveryRepository.save(discovery4);
@@ -163,7 +166,7 @@ class DiscoverySearchITest extends BaseSpringBootTest {
             loadMetaData();
             loadCustomAttributesData();
             isLoadedData = true;
-        } catch (ParseException | NotFoundException | AttributeException e) {
+        } catch (NotFoundException | AttributeException e) {
             isLoadedData = false;
         }
     }

--- a/src/test/java/com/otilm/core/integration/service/DiscoveryServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/DiscoveryServiceITest.java
@@ -20,7 +20,7 @@ import com.otilm.api.model.core.connector.FunctionGroupCode;
 import com.otilm.api.model.core.discovery.DiscoveryStatus;
 import com.otilm.core.dao.entity.Connector;
 import com.otilm.core.dao.entity.Connector2FunctionGroup;
-import com.otilm.core.dao.entity.DiscoveryHistory;
+import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.entity.FunctionGroup;
 import com.otilm.core.dao.repository.Connector2FunctionGroupRepository;
 import com.otilm.core.dao.repository.ConnectorRepository;
@@ -76,7 +76,7 @@ class DiscoveryServiceITest extends BaseSpringBootTest {
     @Autowired
     private EventListener eventListener;
 
-    private DiscoveryHistory discovery;
+    private Discovery discovery;
     private Connector connector;
 
     private WireMockServer mockServer;
@@ -110,7 +110,7 @@ class DiscoveryServiceITest extends BaseSpringBootTest {
         connector.getFunctionGroups().add(c2fg);
         connectorRepository.save(connector);
 
-        discovery = new DiscoveryHistory();
+        discovery = new Discovery();
         discovery.setName(DISCOVERY_NAME);
         discovery.setConnectorUuid(connector.getUuid());
         discovery.setConnectorName(connector.getName());
@@ -245,7 +245,7 @@ class DiscoveryServiceITest extends BaseSpringBootTest {
 
         UUID discoveryUuid = UUID.fromString(discoveryService.createDiscovery(dto, true).getUuid());
 
-        DiscoveryHistory persisted = discoveryRepository.findByUuid(discoveryUuid).orElseThrow();
+        Discovery persisted = discoveryRepository.findByUuid(discoveryUuid).orElseThrow();
         persisted.setConnectorUuid(UUID.randomUUID());
         discoveryRepository.save(persisted);
 
@@ -270,7 +270,7 @@ class DiscoveryServiceITest extends BaseSpringBootTest {
         mockServer.resetMappings();
 
         discoveryInternalService.runDiscovery(discoveryUuid, null);
-        DiscoveryHistory persisted = discoveryRepository.findByUuid(discoveryUuid).orElseThrow();
+        Discovery persisted = discoveryRepository.findByUuid(discoveryUuid).orElseThrow();
 
         Assertions.assertEquals(DiscoveryStatus.FAILED, persisted.getStatus());
         Assertions.assertEquals(0, discoveryCertificateRepository.countByDiscovery(persisted));
@@ -288,7 +288,7 @@ class DiscoveryServiceITest extends BaseSpringBootTest {
 
         discoveryInternalService.runDiscovery(discoveryUuid, null);
 
-        DiscoveryHistory persisted = discoveryRepository.findByUuid(discoveryUuid).orElseThrow();
+        Discovery persisted = discoveryRepository.findByUuid(discoveryUuid).orElseThrow();
         Assertions.assertEquals(DiscoveryStatus.PROCESSING, persisted.getStatus());
         Assertions.assertEquals(1, discoveryCertificateRepository.countByDiscovery(persisted));
 

--- a/src/test/java/com/otilm/core/integration/service/DiscoveryServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/DiscoveryServiceITest.java
@@ -38,8 +38,7 @@ import com.otilm.core.service.DiscoveryExternalService;
 import com.otilm.core.service.DiscoveryInternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.MetaDefinitions;
-import java.time.Instant;
-import java.util.Date;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -381,7 +380,7 @@ class DiscoveryServiceITest extends BaseSpringBootTest {
         discoveryUuid = UUID.fromString(discoveryService.createDiscovery(dto, true).getUuid());
 
         persisted = discoveryRepository.findByUuid(discoveryUuid).orElseThrow();
-        persisted.setStartTime(Date.from(Instant.now().minus(7, java.time.temporal.ChronoUnit.DAYS)));
+        persisted.setStartTime(OffsetDateTime.now().minusDays(7));
         discoveryRepository.save(persisted);
 
         discoveryInternalService.runDiscovery(discoveryUuid, null);

--- a/src/test/java/com/otilm/core/integration/service/DiscoveryServiceMessagingITest.java
+++ b/src/test/java/com/otilm/core/integration/service/DiscoveryServiceMessagingITest.java
@@ -4,7 +4,7 @@ import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.connector.FunctionGroupCode;
 import com.otilm.api.model.core.discovery.DiscoveryStatus;
-import com.otilm.core.dao.entity.DiscoveryHistory;
+import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.entity.FunctionGroup;
 import com.otilm.core.dao.repository.DiscoveryRepository;
 import com.otilm.core.dao.repository.FunctionGroupRepository;
@@ -44,7 +44,7 @@ class DiscoveryServiceMessagingITest extends BaseMessagingIntTest {
     @MockitoSpyBean
     private NotificationProducer notificationProducer;
 
-    private DiscoveryHistory discovery;
+    private Discovery discovery;
 
     @BeforeEach
     void setUp() {
@@ -59,7 +59,7 @@ class DiscoveryServiceMessagingITest extends BaseMessagingIntTest {
         functionGroup.setName(FunctionGroupCode.DISCOVERY_PROVIDER.getCode());
         functionGroupRepository.save(functionGroup);
 
-        discovery = new DiscoveryHistory();
+        discovery = new Discovery();
         discovery.setName(DISCOVERY_NAME);
         discovery.setStatus(DiscoveryStatus.IN_PROGRESS);
         discovery.setConnectorStatus(DiscoveryStatus.IN_PROGRESS);

--- a/src/test/java/com/otilm/core/integration/service/SchedulerServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/SchedulerServiceITest.java
@@ -52,7 +52,7 @@ import com.otilm.api.model.scheduler.UpdateScheduledJob;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.dao.entity.Connector;
 import com.otilm.core.dao.entity.Connector2FunctionGroup;
-import com.otilm.core.dao.entity.DiscoveryHistory;
+import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.entity.FunctionGroup;
 import com.otilm.core.dao.entity.ScheduledJob;
 import com.otilm.core.dao.entity.ScheduledJobHistory;
@@ -331,11 +331,11 @@ class SchedulerServiceITest extends BaseSpringBootTest {
 
         schedulerInternalService.runScheduledJob(jobName);
 
-        List<DiscoveryHistory> discoveries = discoveryRepository.findAll();
+        List<Discovery> discoveries = discoveryRepository.findAll();
         Assertions.assertEquals(1, discoveries.size());
 
         // simulate events
-        DiscoveryHistory discovery = discoveries.getFirst();
+        Discovery discovery = discoveries.getFirst();
         EventMessage eventMessage = CertificateDiscoveredEventHandler
                 .constructEventMessage(discovery.getUuid(), null, new ScheduledJobInfo(scheduledJobEntity.getJobName(),
                         scheduledJobEntity.getUuid(), scheduledJobHistoryRepository.findAll().getFirst().getUuid()));

--- a/src/test/java/com/otilm/core/integration/service/writer/DiscoveryWriterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/writer/DiscoveryWriterITest.java
@@ -2,8 +2,8 @@ package com.otilm.core.integration.service.writer;
 
 import com.otilm.api.model.core.discovery.DiscoveryStatus;
 import com.otilm.core.dao.entity.CertificateContent;
+import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.entity.DiscoveryCertificate;
-import com.otilm.core.dao.entity.DiscoveryHistory;
 import com.otilm.core.dao.repository.CertificateContentRepository;
 import com.otilm.core.dao.repository.DiscoveryCertificateRepository;
 import com.otilm.core.dao.repository.DiscoveryRepository;
@@ -127,21 +127,21 @@ class DiscoveryWriterITest extends BaseSpringBootTest {
 
     @Test
     void updateProgressMessageWritesOnlyTheMessage() {
-        DiscoveryHistory discovery = givenDiscovery();
+        Discovery discovery = givenDiscovery();
         DiscoveryStatus statusBefore = discovery.getStatus();
 
         discoveryWriter
                 .updateProgressMessage(discovery.getUuid(), "Processed 40 % of newly discovered certificates (4 / 10)");
 
-        DiscoveryHistory reloaded = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
+        Discovery reloaded = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
         assertThat(reloaded.getMessage()).isEqualTo("Processed 40 % of newly discovered certificates (4 / 10)");
         assertThat(reloaded.getStatus())
                 .as("progress reporting must not touch the discovery status")
                 .isEqualTo(statusBefore);
     }
 
-    private DiscoveryHistory givenDiscovery() {
-        DiscoveryHistory discovery = new DiscoveryHistory();
+    private Discovery givenDiscovery() {
+        Discovery discovery = new Discovery();
         discovery.setName("DiscoveryWriterITest-" + UUID.randomUUID());
         discovery.setKind("IP");
         discovery.setStatus(DiscoveryStatus.IN_PROGRESS);
@@ -150,7 +150,7 @@ class DiscoveryWriterITest extends BaseSpringBootTest {
         return discoveryRepository.save(discovery);
     }
 
-    private DiscoveryCertificate givenDiscoveryCertificate(DiscoveryHistory discovery) {
+    private DiscoveryCertificate givenDiscoveryCertificate(Discovery discovery) {
         CertificateContent content = new CertificateContent();
         content.setFingerprint(UUID.randomUUID().toString());
         content.setContent("content-" + UUID.randomUUID());


### PR DESCRIPTION
Closes #1959. Epic OmniTrustILM/ilm#267 — core plan Tasks 1–2, the schema everything after it builds on.

## Commit 1 — mechanical rename, behavior-frozen

`discovery_history` -> `discovery`: the table holds the live run, not an archive. The migration renames the only three live named objects — the table, `discovery_history_pkey`, and `discovery_certificate_to_discovery_history_key` — enumerated across every migration since init: the old `discovery_id_seq` died in 2022 and `discovery_uuid_unique` carries no stale name. The two frozen Flyway Java migrations keep operating on `discovery_history` deliberately — that is the table'''s name at their point in history. Entity, metamodel references, JPQL entity names in `DiscoveryRepository` and camel-case members follow in code; the repository was already `DiscoveryRepository`. Full suite green on this commit alone.

## Commit 2 — v2 columns, discovery_work, discovery_item

- `discovery` gains the run-level v2 columns: connector-interface link (NULL = v1 legacy), `run_meta`, `resources`, the `last_applied_sequence` drain cursor, progress columns, `run_messages`, `stopped_at`, `connector_state`.
- `discovery_work`: the per-run agenda the sweep ticks — one row per run and work type (`STATUS | DRAIN | PROCESS`), `ON CONFLICT` upsert that moves the due time, due-ordered index. `DiscoveryWorkRepository` mirrors `CertificateStatusPollRepository`: ordered due query with no row locking (the sweep'''s advisory lock provides exclusion), native upsert, `reschedule`, per-run delete.
- `discovery_item`: generic staging with dense `sequence`, `(discovery, resource, unique_ref)` dedupe, jsonb payload kept deliberately untyped — staging must never fail on a payload shape this Core does not know yet — and the four columns mirroring `discovery_certificate` (`processed_error`, `inventory_uuid`, `newly_discovered`, `meta`) so the union listing later reads one shape from both stores. `DiscoveryItemRepository` stays deliberately bare; the tasks that need queries bring them.

Both new entities carry read-only `@ManyToOne` associations with `@OnDelete(CASCADE)` mirroring the migration'''s foreign keys: the test schema is generated from entities (`ddl-auto: create-drop`), not Flyway, so a SQL-only cascade would be untestable — the `ScheduledJobHistory` precedent, same comment.

## Verification

- Unit profile: **4846 tests, 0 failures** — including the six new repository ITests, which ran locally against Testcontainers Postgres: upsert idempotency, due ordering and cascade delete for the agenda; jsonb round-trip (persistence context cleared so the columns are actually read), dedupe violation and cascade delete for staging.
- CI integration profiles re-prove the ITests against the Flyway-built schema.
