### PR TITLE
Classify catch (IOException) sites ahead of the Jackson 3 migration

### DIFF
--- a/src/main/java/com/otilm/core/service/impl/ExportProcessor.java
+++ b/src/main/java/com/otilm/core/service/impl/ExportProcessor.java
@@ -81,6 +81,10 @@ public class ExportProcessor {
                 result.setFileContent(os.toByteArray());
             }
         } catch (IOException e) {
+            // Deliberately broad: this block covers both the Jackson CSV write and the genuine stream and zip IO
+            // around it. It cannot be narrowed on Jackson 2, where JsonProcessingException is an IOException subtype.
+            // When Jackson 3 makes its exceptions unchecked they stop matching IOException, and a failing
+            // writeValue would escape unwrapped — the Jackson 3 step has to add a JacksonException branch here.
             throw new IllegalStateException(e);
         }
         return result;


### PR DESCRIPTION
Closes #2013.

Jackson 3 makes its exceptions unchecked: `JsonProcessingException` stops being an `IOException`,
so a `catch (IOException)` written to handle a Jackson failure keeps compiling but never runs.
This PR classifies every such site while we are still on Spring Boot 3.5, so the framework bump
does not have to.

## Classification of all 48 `catch (IOException)` sites in `src/main/java`

The issue quotes 47; the count has drifted to 48 since it was filed.

**Jackson-motivated: 1 (stays broad, comment added)**

| Site | Why it stays broad |
| --- | --- |
| `service/impl/ExportProcessor.java:83` | The `try` covers `ObjectWriter.writeValue` (Jackson CSV) **and** `OutputStreamWriter` / `ByteArrayOutputStream` / `ZipOutputStream` IO. It cannot be split on Jackson 2, where `JsonProcessingException` is an `IOException` subtype — a `JsonProcessingException \| IOException` multi-catch does not compile, and a separate preceding catch with an identical body is the same handler written twice. Left broad with a comment naming what the Jackson 3 step must do: add a `JacksonException` branch, or `writeValue` failures escape unwrapped instead of becoming `IllegalStateException`. |

**Genuine IO: 47 (unchanged)**

| Category | Count | Sites |
| --- | --- | --- |
| BouncyCastle ASN.1 / PKCS / CMS decoding, CRL and OCSP extraction | 34 | `ScepRequest` 145, 155, 163, 218, 323, 375 · `ScepServiceImpl` 657, 673, 688, 741, 1024, 1082 · `CryptographyUtil` 125, 135, 146, 165 · `ClientOperationServiceImpl` 2894, 3063, 3071 · `RegisterWireBuilder` 197, 216 · `TspResponseBuilder` 32, 44 · `TspRequestParser` 86, 98 · `CertificateUtil` 341, 471 · `AcmeServiceImpl` 712 · `CmpServiceImpl` 309 · `CrmfIrCrMessageHandler` 170 · `Pkcs10CertificateRequest` 75 · `CertificateDiscoveredEventHandler` 908 · `X509CertificateValidator` 298, 366 |
| PEM writing to a stream | 2 | `CertificateServiceImpl` 1372 · `X509ObjectToString` 25 |
| Servlet / filter-chain IO | 5 | `PlatformOAuth2FailureHandler` 62 · `PlatformAuthenticationSuccessHandler` 117 · `PlatformLogoutSuccessHandler` 57 · `OAuth2LoginFilter` 155 · `CachedBodyServletInputStream` 25 |
| Network IO (`HttpURLConnection`, `openStream`) | 3 | `SettingServiceImpl` 724, 745 · `OcspUtil` 200 |
| File / classpath reading | 1 | `DatabaseMigration` 38 |
| Flyway Java migrations (certificate and CSR parsing) | 2 | `V202508130940__CertificateRelations` 122 · `V202311071500__IssuerAndSubjectDnMigration` 70 |

Method used: only four files that contain a `catch (IOException)` reference Jackson at all
(`ExportProcessor`, `SettingServiceImpl`, `CertificateUtil`, `X509CertificateValidator`), and in
three of those the catches guard ASN.1 or network code, not the Jackson calls elsewhere in the file.
Indirect propagation was checked separately: the methods that declare `throws IOException` while
doing Jackson work are the Intune clients (`IntuneClient.PostRequest`, `ParseResponseToJSON`,
`IntuneScepServiceClient.Post`), and every call into them from `ScepServiceImpl` is already guarded
by `catch (Exception)`, which survives the unchecked change. `CertificateUtil`'s three
`throws IOException` methods are pure ASN.1.

## Note for the migration (core#2016)

Separate from the silent-handler problem and **not** fixed here, because the compiler will point at
it: `throws IOException` clauses that exist only because of a Jackson call become
"exception is never thrown" errors once Jackson 3 lands. The affected declarations are in the Intune
clients, `SessionConfig`, `RawJsonDeserializer` and `V202509191412__LogRecordsRefactor`.

## Verification

- Diff is comment-only, so behaviour on 3.5 is unchanged by construction.
- Spotless and Checkstyle gates pass locally.
- `mvn -B verify` was not run locally: this machine's `interfaces` 2.20.0-SNAPSHOT is a local build
  carrying the reverted `ContentSigningWorkflow*` names, so `main` itself does not compile here.
  Unrelated to this change — CI builds against the deployed snapshot.
