### PR TITLE
Verify the data-to-be-signed is bound to the authorized document

### DIFF
--- a/src/main/java/com/otilm/core/signing/contentsigning/DocumentDigest.java
+++ b/src/main/java/com/otilm/core/signing/contentsigning/DocumentDigest.java
@@ -1,0 +1,53 @@
+package com.otilm.core.signing.contentsigning;
+
+import com.otilm.api.model.common.enums.cryptography.DigestAlgorithm;
+import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.Objects;
+
+/**
+ * A document digest and the algorithm that produced it. A digest cannot be interpreted without its algorithm, so the
+ * two travel as one value.
+ */
+public record DocumentDigest(DigestAlgorithm algorithm, byte[] value) {
+
+    /**
+     * Copies the digest in, so a caller that reuses its buffer cannot change what was authorized after the fact.
+     */
+    public DocumentDigest {
+        Objects.requireNonNull(algorithm, "algorithm");
+        Objects.requireNonNull(value, "value");
+        value = value.clone();
+    }
+
+    /** Copies the digest out, so a consumer cannot reach back through the accessor and alter it. */
+    @Override
+    public byte[] value() {
+        return value.clone();
+    }
+
+    /** Whether the digest is as long as its algorithm produces; a shorter or longer one came from no document. */
+    public boolean hasLengthOfItsAlgorithm() {
+        return value.length == algorithm.getDigestSizeBytes();
+    }
+
+    /**
+     * A record's generated members would compare the array by identity, which is never what a digest comparison means.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof DocumentDigest digest && algorithm == digest.algorithm
+                && Arrays.equals(value, digest.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(algorithm, Arrays.hashCode(value));
+    }
+
+    /** A digest is not customer content, so it stays legible in a log line. */
+    @Override
+    public String toString() {
+        return "DocumentDigest[algorithm=" + algorithm.getCode() + ", value=" + HexFormat.of().formatHex(value) + "]";
+    }
+}

--- a/src/main/java/com/otilm/core/signing/contentsigning/DocumentDigest.java
+++ b/src/main/java/com/otilm/core/signing/contentsigning/DocumentDigest.java
@@ -1,6 +1,7 @@
 package com.otilm.core.signing.contentsigning;
 
 import com.otilm.api.model.common.enums.cryptography.DigestAlgorithm;
+import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.HexFormat;
 import java.util.Objects;
@@ -26,6 +27,11 @@ public record DocumentDigest(DigestAlgorithm algorithm, byte[] value) {
         return value.clone();
     }
 
+    /** The digest length, free of the copy {@link #value()} has to make. */
+    public int length() {
+        return value.length;
+    }
+
     /** Whether the digest is as long as its algorithm produces; a shorter or longer one came from no document. */
     public boolean hasLengthOfItsAlgorithm() {
         return value.length == algorithm.getDigestSizeBytes();
@@ -33,11 +39,13 @@ public record DocumentDigest(DigestAlgorithm algorithm, byte[] value) {
 
     /**
      * A record's generated members would compare the array by identity, which is never what a digest comparison means.
+     * The comparison runs in time independent of where two digests first differ, matching the one the binding check
+     * relies on.
      */
     @Override
     public boolean equals(Object other) {
         return other instanceof DocumentDigest digest && algorithm == digest.algorithm
-                && Arrays.equals(value, digest.value);
+                && MessageDigest.isEqual(value, digest.value);
     }
 
     @Override

--- a/src/main/java/com/otilm/core/signing/contentsigning/DocumentDigest.java
+++ b/src/main/java/com/otilm/core/signing/contentsigning/DocumentDigest.java
@@ -37,11 +37,7 @@ public record DocumentDigest(DigestAlgorithm algorithm, byte[] value) {
         return value.length == algorithm.getDigestSizeBytes();
     }
 
-    /**
-     * A record's generated members would compare the array by identity, which is never what a digest comparison means.
-     * The comparison runs in time independent of where two digests first differ, matching the one the binding check
-     * relies on.
-     */
+    /** Compares the digest by value in constant time, which a record's generated {@code equals} would not do. */
     @Override
     public boolean equals(Object other) {
         return other instanceof DocumentDigest digest && algorithm == digest.algorithm

--- a/src/main/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifier.java
+++ b/src/main/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifier.java
@@ -33,11 +33,14 @@ public final class DtbsBindingVerifier {
      * Verifies the echo a {@code computeDtbs} response carries against the authorized digest.
      *
      * @throws IllegalArgumentException if the authorized digest is not as long as its algorithm produces
-     * @throws SigningEngineException if the echo is missing, unusable or bound to a different document
+     * @throws SigningEngineException if the response or its echo is missing, unusable or bound to a different document
      */
     public static void verify(DocumentDigest authorized, ComputeDtbsResponseDto response)
             throws SigningEngineException {
-        Objects.requireNonNull(response, "response");
+        requireWellFormedAuthorizedDigest(authorized);
+        if (response == null) {
+            throw brokenEcho("connector returned no computeDtbs response");
+        }
         verifyEcho(authorized, echoOf(response));
     }
 

--- a/src/main/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifier.java
+++ b/src/main/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifier.java
@@ -1,0 +1,110 @@
+package com.otilm.core.signing.contentsigning;
+
+import com.otilm.api.model.connector.signatures.contentsigning.common.ComputeDtbsResponseDto;
+import com.otilm.core.signing.engine.error.SigningEngineException;
+import com.otilm.core.signing.engine.error.SigningEngineFailure;
+import java.security.MessageDigest;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Verifies that the data-to-be-signed a formatting connector produced is bound to the document the caller authorized,
+ * by comparing the connector's echoed {@code documentDigest} against the authorized digest. The engine runs this before
+ * it releases the signing key, so a connector bug or a document mix-up cannot get an unauthorized document signed.
+ *
+ * <p>
+ * The rule is family-blind: PAdES, XAdES, CAdES and JAdES all satisfy it the same way. The platform never parses the
+ * data-to-be-signed and never re-derives the digest from the document — the connector must echo the digest it actually
+ * committed to, and the authorized digest is the one computed once when the operation was accepted. Raw signing needs
+ * no echo at all, because there the client submits the digest itself.
+ * </p>
+ */
+public final class DtbsBindingVerifier {
+
+    private static final String STEP = "computeDtbs";
+
+    private static final String MISMATCH_CLIENT_MESSAGE = "The document the signature would cover is not the document that was authorized";
+
+    private static final String BROKEN_ECHO_CLIENT_MESSAGE = "Internal error during signature formatting";
+
+    private DtbsBindingVerifier() {
+    }
+
+    /**
+     * Verifies the echo a {@code computeDtbs} response carries against the authorized digest.
+     *
+     * @throws SigningEngineException if the echo is missing, unusable or bound to a different document
+     */
+    public static void verify(DocumentDigest authorized, ComputeDtbsResponseDto response)
+            throws SigningEngineException {
+        Objects.requireNonNull(response, "response");
+        verify(authorized, echoOf(response));
+    }
+
+    /**
+     * Verifies an echoed digest against the authorized digest.
+     *
+     * @param echoed the digest the connector committed to, or {@code null} when it echoed none
+     * @throws SigningEngineException if the echo is missing, unusable or bound to a different document
+     */
+    public static void verify(DocumentDigest authorized, DocumentDigest echoed) throws SigningEngineException {
+        Objects.requireNonNull(authorized, "authorized");
+        if (echoed == null) {
+            throw brokenEcho("connector echoed no documentDigest");
+        }
+        requireUsableEcho(authorized, echoed);
+        if (!MessageDigest.isEqual(authorized.value(), echoed.value())) {
+            throw SigningEngineException
+                    .stepFailed(SigningEngineFailure.BINDING_VIOLATION, STEP,
+                            "connector committed to %s but %s was authorized".formatted(echoed, authorized), null,
+                            MISMATCH_CLIENT_MESSAGE);
+        }
+    }
+
+    /**
+     * Verifies a multi-document operation, pairing each response with the authorized digest at the same position. Every
+     * document is checked against its own authorized occurrence, so one document's echo can never vouch for another.
+     *
+     * @throws IllegalArgumentException if the two lists differ in size, which means the caller paired them wrong
+     * @throws SigningEngineException if any echo is missing, unusable or bound to a different document
+     */
+    public static void verifyAll(List<DocumentDigest> authorized, List<ComputeDtbsResponseDto> responses)
+            throws SigningEngineException {
+        Objects.requireNonNull(authorized, "authorized");
+        Objects.requireNonNull(responses, "responses");
+        if (authorized.size() != responses.size()) {
+            throw new IllegalArgumentException("Cannot pair %d authorized digests with %d computeDtbs responses"
+                    .formatted(authorized.size(), responses.size()));
+        }
+        for (int document = 0; document < authorized.size(); document++) {
+            verify(authorized.get(document), responses.get(document));
+        }
+    }
+
+    private static DocumentDigest echoOf(ComputeDtbsResponseDto response) {
+        return response.getDocumentDigest() == null || response.getDocumentDigestAlgorithm() == null
+                ? null
+                : new DocumentDigest(response.getDocumentDigestAlgorithm(), response.getDocumentDigest());
+    }
+
+    /**
+     * An echo of the wrong algorithm or of a length its algorithm never produces proves the connector broke the
+     * contract, not that the document differs — so it must not reach the caller as a mismatch.
+     */
+    private static void requireUsableEcho(DocumentDigest authorized, DocumentDigest echoed)
+            throws SigningEngineException {
+        if (echoed.algorithm() != authorized.algorithm()) {
+            throw brokenEcho("connector echoed a %s digest but %s was authorized"
+                    .formatted(echoed.algorithm().getCode(), authorized.algorithm().getCode()));
+        }
+        if (!echoed.hasLengthOfItsAlgorithm()) {
+            throw brokenEcho("connector echoed a %d-byte digest, which %s never produces"
+                    .formatted(echoed.value().length, echoed.algorithm().getCode()));
+        }
+    }
+
+    private static SigningEngineException brokenEcho(String defect) {
+        return SigningEngineException
+                .stepFailed(SigningEngineFailure.CONNECTOR_FAULT, STEP, defect, null, BROKEN_ECHO_CLIENT_MESSAGE);
+    }
+}

--- a/src/main/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifier.java
+++ b/src/main/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifier.java
@@ -8,15 +8,15 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Verifies that the data-to-be-signed a formatting connector produced is bound to the document the caller authorized,
- * by comparing the connector's echoed {@code documentDigest} against the authorized digest. The engine runs this before
- * it releases the signing key, so a connector bug or a document mix-up cannot get an unauthorized document signed.
+ * Verifies that the data-to-be-signed a formatting connector produced is bound to the document the caller authorized.
+ * The engine runs this before it releases the signing key.
  *
  * <p>
- * The rule is family-blind: PAdES, XAdES, CAdES and JAdES all satisfy it the same way. The platform never parses the
- * data-to-be-signed and never re-derives the digest from the document — the connector must echo the digest it actually
- * committed to, and the authorized digest is the one computed once when the operation was accepted. Raw signing needs
- * no echo at all, because there the client submits the digest itself.
+ * The check compares the connector's echoed {@code documentDigest} against the authorized digest. The platform never
+ * parses the data-to-be-signed, and never re-derives the digest from the document. So the connector must echo the
+ * digest it actually committed to. The authorized digest is the one computed when the operation was accepted. The rule
+ * is family-blind: PAdES, XAdES, CAdES and JAdES all satisfy it the same way. Raw signing carries no echo, because
+ * there the client submits the digest itself.
  * </p>
  */
 public final class DtbsBindingVerifier {
@@ -33,22 +33,24 @@ public final class DtbsBindingVerifier {
     /**
      * Verifies the echo a {@code computeDtbs} response carries against the authorized digest.
      *
+     * @throws IllegalArgumentException if the authorized digest is not as long as its algorithm produces
      * @throws SigningEngineException if the echo is missing, unusable or bound to a different document
      */
     public static void verify(DocumentDigest authorized, ComputeDtbsResponseDto response)
             throws SigningEngineException {
         Objects.requireNonNull(response, "response");
-        verify(authorized, echoOf(response));
+        verifyEcho(authorized, echoOf(response));
     }
 
     /**
      * Verifies an echoed digest against the authorized digest.
      *
      * @param echoed the digest the connector committed to, or {@code null} when it echoed none
+     * @throws IllegalArgumentException if the authorized digest is not as long as its algorithm produces
      * @throws SigningEngineException if the echo is missing, unusable or bound to a different document
      */
-    public static void verify(DocumentDigest authorized, DocumentDigest echoed) throws SigningEngineException {
-        Objects.requireNonNull(authorized, "authorized");
+    public static void verifyEcho(DocumentDigest authorized, DocumentDigest echoed) throws SigningEngineException {
+        requireWellFormedAuthorizedDigest(authorized);
         if (echoed == null) {
             throw brokenEcho("connector echoed no documentDigest");
         }
@@ -65,19 +67,35 @@ public final class DtbsBindingVerifier {
      * Verifies a multi-document operation, pairing each response with the authorized digest at the same position. Every
      * document is checked against its own authorized occurrence, so one document's echo can never vouch for another.
      *
-     * @throws IllegalArgumentException if the two lists differ in size, which means the caller paired them wrong
+     * @throws IllegalArgumentException if the two lists differ in size or are empty, which means the caller paired them
+     * wrong
      * @throws SigningEngineException if any echo is missing, unusable or bound to a different document
      */
     public static void verifyAll(List<DocumentDigest> authorized, List<ComputeDtbsResponseDto> responses)
             throws SigningEngineException {
         Objects.requireNonNull(authorized, "authorized");
         Objects.requireNonNull(responses, "responses");
+        if (authorized.isEmpty()) {
+            throw new IllegalArgumentException("Cannot verify a binding with no authorized digest to check against");
+        }
         if (authorized.size() != responses.size()) {
             throw new IllegalArgumentException("Cannot pair %d authorized digests with %d computeDtbs responses"
                     .formatted(authorized.size(), responses.size()));
         }
         for (int document = 0; document < authorized.size(); document++) {
             verify(authorized.get(document), responses.get(document));
+        }
+    }
+
+    /**
+     * A malformed authorized digest is a platform defect, and every echo would mismatch it. Rejecting it here keeps
+     * {@link SigningEngineFailure#BINDING_VIOLATION} for the case where the documents genuinely differ.
+     */
+    private static void requireWellFormedAuthorizedDigest(DocumentDigest authorized) {
+        Objects.requireNonNull(authorized, "authorized");
+        if (!authorized.hasLengthOfItsAlgorithm()) {
+            throw new IllegalArgumentException("Authorized digest is %d bytes, which %s never produces"
+                    .formatted(authorized.length(), authorized.algorithm().getCode()));
         }
     }
 
@@ -99,7 +117,7 @@ public final class DtbsBindingVerifier {
         }
         if (!echoed.hasLengthOfItsAlgorithm()) {
             throw brokenEcho("connector echoed a %d-byte digest, which %s never produces"
-                    .formatted(echoed.value().length, echoed.algorithm().getCode()));
+                    .formatted(echoed.length(), echoed.algorithm().getCode()));
         }
     }
 

--- a/src/main/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifier.java
+++ b/src/main/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifier.java
@@ -1,5 +1,6 @@
 package com.otilm.core.signing.contentsigning;
 
+import com.otilm.api.model.common.enums.cryptography.DigestAlgorithm;
 import com.otilm.api.model.connector.signatures.contentsigning.common.ComputeDtbsResponseDto;
 import com.otilm.core.signing.engine.error.SigningEngineException;
 import com.otilm.core.signing.engine.error.SigningEngineFailure;
@@ -37,11 +38,10 @@ public final class DtbsBindingVerifier {
      */
     public static void verify(DocumentDigest authorized, ComputeDtbsResponseDto response)
             throws SigningEngineException {
-        requireWellFormedAuthorizedDigest(authorized);
         if (response == null) {
             throw brokenEcho("connector returned no computeDtbs response");
         }
-        verifyEcho(authorized, echoOf(response));
+        verifyEcho(authorized, requireCompleteEcho(response));
     }
 
     /**
@@ -101,10 +101,25 @@ public final class DtbsBindingVerifier {
         }
     }
 
-    private static DocumentDigest echoOf(ComputeDtbsResponseDto response) {
-        return response.getDocumentDigest() == null || response.getDocumentDigestAlgorithm() == null
-                ? null
-                : new DocumentDigest(response.getDocumentDigestAlgorithm(), response.getDocumentDigest());
+    /**
+     * An echo is only usable with both halves present. Naming the half that is missing points whoever debugs the
+     * connector at the field actually at fault, rather than at the one that is populated.
+     */
+    private static DocumentDigest requireCompleteEcho(ComputeDtbsResponseDto response) throws SigningEngineException {
+        DigestAlgorithm algorithm = response.getDocumentDigestAlgorithm();
+        byte[] digest = response.getDocumentDigest();
+        if (algorithm == null && digest == null) {
+            throw brokenEcho("connector echoed no documentDigest");
+        }
+        if (digest == null) {
+            throw brokenEcho("connector echoed a %s documentDigestAlgorithm but no documentDigest"
+                    .formatted(algorithm.getCode()));
+        }
+        if (algorithm == null) {
+            throw brokenEcho("connector echoed a %d-byte documentDigest but no documentDigestAlgorithm"
+                    .formatted(digest.length));
+        }
+        return new DocumentDigest(algorithm, digest);
     }
 
     /**

--- a/src/main/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifier.java
+++ b/src/main/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifier.java
@@ -12,11 +12,10 @@ import java.util.Objects;
  * The engine runs this before it releases the signing key.
  *
  * <p>
- * The check compares the connector's echoed {@code documentDigest} against the authorized digest. The platform never
- * parses the data-to-be-signed, and never re-derives the digest from the document. So the connector must echo the
- * digest it actually committed to. The authorized digest is the one computed when the operation was accepted. The rule
- * is family-blind: PAdES, XAdES, CAdES and JAdES all satisfy it the same way. Raw signing carries no echo, because
- * there the client submits the digest itself.
+ * The check compares the connector's echoed {@code documentDigest} against the digest authorized when the operation was
+ * accepted. The platform never parses the data-to-be-signed and never re-derives the digest, so the connector must echo
+ * the digest it committed to. PAdES, XAdES, CAdES and JAdES all satisfy the rule the same way; raw signing carries no
+ * echo, because there the client submits the digest itself.
  * </p>
  */
 public final class DtbsBindingVerifier {

--- a/src/main/java/com/otilm/core/signing/engine/error/SigningEngineFailure.java
+++ b/src/main/java/com/otilm/core/signing/engine/error/SigningEngineFailure.java
@@ -19,8 +19,8 @@ public enum SigningEngineFailure {
     CONNECTOR_FAULT,
 
     /**
-     * The signature would have covered something other than what was authorized. This is the security event the
-     * data-to-be-signed binding check exists to catch, not an ordinary fault, so it stays separately recordable.
+     * The signature would have covered something other than what was authorized. The data-to-be-signed binding check
+     * records this separately so it can be alerted on as a security event.
      */
     BINDING_VIOLATION,
 

--- a/src/main/java/com/otilm/core/signing/engine/error/SigningEngineFailure.java
+++ b/src/main/java/com/otilm/core/signing/engine/error/SigningEngineFailure.java
@@ -18,6 +18,12 @@ public enum SigningEngineFailure {
     /** A connector was reached but did not deliver. */
     CONNECTOR_FAULT,
 
+    /**
+     * The signature would have covered something other than what was authorized. This is the security event the
+     * data-to-be-signed binding check exists to catch, not an ordinary fault, so it stays separately recordable.
+     */
+    BINDING_VIOLATION,
+
     /** The signing key or the cryptography provider failed to produce a signature. */
     SIGNER_FAULT,
 

--- a/src/main/java/com/otilm/core/signing/tsa/TspErrorMapper.java
+++ b/src/main/java/com/otilm/core/signing/tsa/TspErrorMapper.java
@@ -18,7 +18,8 @@ public final class TspErrorMapper {
         return switch (failure) {
             case INVALID_INPUT -> TspFailureInfo.BAD_REQUEST;
             case MALFORMED_INPUT -> TspFailureInfo.BAD_DATA_FORMAT;
-            case MISCONFIGURED, CONNECTOR_FAULT, SIGNER_FAULT, STEP_FAILED -> TspFailureInfo.SYSTEM_FAILURE;
+            case MISCONFIGURED, CONNECTOR_FAULT, BINDING_VIOLATION, SIGNER_FAULT, STEP_FAILED ->
+                TspFailureInfo.SYSTEM_FAILURE;
         };
     }
 

--- a/src/test/java/com/otilm/core/signing/contentsigning/DocumentDigestTest.java
+++ b/src/test/java/com/otilm/core/signing/contentsigning/DocumentDigestTest.java
@@ -24,12 +24,13 @@ class DocumentDigestTest {
     void tellsDigestsApartByValueAndByAlgorithm() {
         // given
         DocumentDigest digest = new DocumentDigest(DigestAlgorithm.SHA_256, VALUE);
+        Object notADigest = "not a digest";
 
         // when / then
         assertThat(digest)
                 .isNotEqualTo(new DocumentDigest(DigestAlgorithm.SHA_256, new byte[]{0x0a, 0x0c}))
                 .isNotEqualTo(new DocumentDigest(DigestAlgorithm.SHA_512, VALUE))
-                .isNotEqualTo("not a digest")
+                .isNotEqualTo(notADigest)
                 .isEqualTo(digest);
     }
 

--- a/src/test/java/com/otilm/core/signing/contentsigning/DocumentDigestTest.java
+++ b/src/test/java/com/otilm/core/signing/contentsigning/DocumentDigestTest.java
@@ -1,0 +1,81 @@
+package com.otilm.core.signing.contentsigning;
+
+import com.otilm.api.model.common.enums.cryptography.DigestAlgorithm;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class DocumentDigestTest {
+
+    private static final byte[] VALUE = new byte[]{0x0a, 0x0b};
+
+    @Test
+    void comparesTheDigestByValueRatherThanByArrayIdentity() {
+        // given
+        DocumentDigest digest = new DocumentDigest(DigestAlgorithm.SHA_256, VALUE);
+        DocumentDigest equalDigest = new DocumentDigest(DigestAlgorithm.SHA_256, VALUE.clone());
+
+        // when / then
+        assertThat(digest).isEqualTo(equalDigest).hasSameHashCodeAs(equalDigest);
+    }
+
+    @Test
+    void tellsDigestsApartByValueAndByAlgorithm() {
+        // given
+        DocumentDigest digest = new DocumentDigest(DigestAlgorithm.SHA_256, VALUE);
+
+        // when / then
+        assertThat(digest)
+                .isNotEqualTo(new DocumentDigest(DigestAlgorithm.SHA_256, new byte[]{0x0a, 0x0c}))
+                .isNotEqualTo(new DocumentDigest(DigestAlgorithm.SHA_512, VALUE))
+                .isNotEqualTo("not a digest")
+                .isEqualTo(digest);
+    }
+
+    @Test
+    void rendersTheDigestLegiblyForALogLine() {
+        // when / then
+        assertThat(new DocumentDigest(DigestAlgorithm.SHA_256, VALUE).toString()).contains("SHA-256", "0a0b");
+    }
+
+    @Test
+    void recognisesADigestOfItsAlgorithmsLength() {
+        // when / then
+        assertThat(new DocumentDigest(DigestAlgorithm.SHA_256, new byte[32]).hasLengthOfItsAlgorithm()).isTrue();
+        assertThat(new DocumentDigest(DigestAlgorithm.SHA_256, VALUE).hasLengthOfItsAlgorithm()).isFalse();
+    }
+
+    @Test
+    void refusesToExistWithoutBothHalves() {
+        // when / then
+        assertThatNullPointerException().isThrownBy(() -> new DocumentDigest(null, VALUE));
+        assertThatNullPointerException().isThrownBy(() -> new DocumentDigest(DigestAlgorithm.SHA_256, null));
+    }
+
+    /** The authorized digest is a security boundary, so a caller reusing its buffer must not be able to move it. */
+    @Test
+    void survivesMutationOfTheArrayItWasBuiltFrom() {
+        // given
+        byte[] source = VALUE.clone();
+        DocumentDigest digest = new DocumentDigest(DigestAlgorithm.SHA_256, source);
+
+        // when
+        source[0] = 0x7f;
+
+        // then
+        assertThat(digest.value()).containsExactly(VALUE);
+    }
+
+    @Test
+    void survivesMutationThroughItsOwnAccessor() {
+        // given
+        DocumentDigest digest = new DocumentDigest(DigestAlgorithm.SHA_256, VALUE);
+
+        // when
+        digest.value()[0] = 0x7f;
+
+        // then
+        assertThat(digest.value()).containsExactly(VALUE);
+    }
+}

--- a/src/test/java/com/otilm/core/signing/contentsigning/DocumentDigestTest.java
+++ b/src/test/java/com/otilm/core/signing/contentsigning/DocumentDigestTest.java
@@ -47,6 +47,12 @@ class DocumentDigestTest {
     }
 
     @Test
+    void reportsItsLengthWithoutCopyingTheDigest() {
+        // when / then
+        assertThat(new DocumentDigest(DigestAlgorithm.SHA_256, VALUE).length()).isEqualTo(VALUE.length);
+    }
+
+    @Test
     void refusesToExistWithoutBothHalves() {
         // when / then
         assertThatNullPointerException().isThrownBy(() -> new DocumentDigest(null, VALUE));

--- a/src/test/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifierTest.java
+++ b/src/test/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifierTest.java
@@ -132,14 +132,28 @@ class DtbsBindingVerifierTest {
     }
 
     @Test
-    void treatsAResponseMissingEitherHalfOfTheEchoAsNoEcho() {
-        // given
-        ComputeDtbsResponseDto noDigest = response(DigestAlgorithm.SHA_256, null);
-        ComputeDtbsResponseDto noAlgorithm = response(null, AUTHORIZED_VALUE);
-
+    void treatsAResponseCarryingNeitherHalfOfTheEchoAsNoEcho() {
         // when / then
-        assertThat(catchVerify(AUTHORIZED, noDigest).operatorMessage()).contains("echoed no documentDigest");
-        assertThat(catchVerify(AUTHORIZED, noAlgorithm).operatorMessage()).contains("echoed no documentDigest");
+        SigningEngineException thrown = catchVerify(AUTHORIZED, response(null, null));
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.CONNECTOR_FAULT);
+        assertThat(thrown.operatorMessage()).contains("echoed no documentDigest");
+    }
+
+    /** Naming the missing half sends whoever debugs the connector to the field that is actually at fault. */
+    @Test
+    void namesTheMissingDigestWhenTheConnectorEchoedOnlyItsAlgorithm() {
+        // when / then
+        SigningEngineException thrown = catchVerify(AUTHORIZED, response(DigestAlgorithm.SHA_256, null));
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.CONNECTOR_FAULT);
+        assertThat(thrown.operatorMessage()).contains("SHA-256 documentDigestAlgorithm but no documentDigest");
+    }
+
+    @Test
+    void namesTheMissingAlgorithmWhenTheConnectorEchoedOnlyTheDigest() {
+        // when / then
+        SigningEngineException thrown = catchVerify(AUTHORIZED, response(null, AUTHORIZED_VALUE));
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.CONNECTOR_FAULT);
+        assertThat(thrown.operatorMessage()).contains("32-byte documentDigest but no documentDigestAlgorithm");
     }
 
     /** A connector that delivered nothing at all is the same fault as one that echoed no digest. */

--- a/src/test/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifierTest.java
+++ b/src/test/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifierTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
@@ -20,22 +19,25 @@ class DtbsBindingVerifierTest {
 
     private static final DocumentDigest AUTHORIZED = new DocumentDigest(DigestAlgorithm.SHA_256, AUTHORIZED_VALUE);
 
+    private static final DocumentDigest DIFFERENT_DOCUMENT = new DocumentDigest(DigestAlgorithm.SHA_256,
+            digestOfLength(32, (byte) 0x22));
+
+    private static final DocumentDigest UNUSABLE_ECHO = new DocumentDigest(DigestAlgorithm.SHA_512,
+            digestOfLength(64, (byte) 0x11));
+
     @Test
     void acceptsAnEchoOfTheAuthorizedDocument() {
         // given a connector echoing an equal array rather than the very same one
         DocumentDigest echoed = new DocumentDigest(DigestAlgorithm.SHA_256, AUTHORIZED_VALUE.clone());
 
         // when / then
-        assertThatCode(() -> DtbsBindingVerifier.verify(AUTHORIZED, echoed)).doesNotThrowAnyException();
+        assertThatCode(() -> DtbsBindingVerifier.verifyEcho(AUTHORIZED, echoed)).doesNotThrowAnyException();
     }
 
     @Test
     void refusesAnEchoOfADifferentDocument() {
-        // given
-        DocumentDigest echoed = new DocumentDigest(DigestAlgorithm.SHA_256, digestOfLength(32, (byte) 0x22));
-
         // when / then
-        SigningEngineException thrown = catchVerify(AUTHORIZED, echoed);
+        SigningEngineException thrown = catchVerifyEcho(AUTHORIZED, DIFFERENT_DOCUMENT);
         assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.BINDING_VIOLATION);
         assertThat(thrown.step()).isEqualTo("computeDtbs");
         assertThat(thrown.operatorMessage()).contains("2222", "1111");
@@ -48,14 +50,14 @@ class DtbsBindingVerifierTest {
         almost[31] ^= 0x01;
 
         // when / then
-        assertThat(catchVerify(AUTHORIZED, new DocumentDigest(DigestAlgorithm.SHA_256, almost)).failure())
+        assertThat(catchVerifyEcho(AUTHORIZED, new DocumentDigest(DigestAlgorithm.SHA_256, almost)).failure())
                 .isEqualTo(SigningEngineFailure.BINDING_VIOLATION);
     }
 
     @Test
     void refusesAMissingEcho() {
         // when / then
-        SigningEngineException thrown = catchVerify(AUTHORIZED, (DocumentDigest) null);
+        SigningEngineException thrown = catchVerifyEcho(AUTHORIZED, null);
         assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.CONNECTOR_FAULT);
         assertThat(thrown.operatorMessage()).contains("echoed no documentDigest");
     }
@@ -63,11 +65,8 @@ class DtbsBindingVerifierTest {
     /** Digests of different algorithms are incomparable, so the platform refuses instead of re-deriving one. */
     @Test
     void refusesAnEchoUnderADifferentAlgorithm() {
-        // given
-        DocumentDigest echoed = new DocumentDigest(DigestAlgorithm.SHA_512, digestOfLength(64, (byte) 0x11));
-
         // when / then
-        assertThat(catchVerify(AUTHORIZED, echoed).operatorMessage()).contains("SHA-512", "SHA-256");
+        assertThat(catchVerifyEcho(AUTHORIZED, UNUSABLE_ECHO).operatorMessage()).contains("SHA-512", "SHA-256");
     }
 
     @Test
@@ -76,50 +75,59 @@ class DtbsBindingVerifierTest {
         DocumentDigest echoed = new DocumentDigest(DigestAlgorithm.SHA_256, digestOfLength(16, (byte) 0x11));
 
         // when / then
-        assertThat(catchVerify(AUTHORIZED, echoed).operatorMessage()).contains("16-byte", "never produces");
+        assertThat(catchVerifyEcho(AUTHORIZED, echoed).operatorMessage()).contains("16-byte", "never produces");
+    }
+
+    /** A platform-side digest no algorithm could have produced would mismatch every echo, so it is not a violation. */
+    @Test
+    void refusesAMalformedAuthorizedDigest() {
+        // given
+        DocumentDigest malformed = new DocumentDigest(DigestAlgorithm.SHA_256, digestOfLength(16, (byte) 0x11));
+
+        // when / then
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> DtbsBindingVerifier
+                        .verifyEcho(malformed, new DocumentDigest(DigestAlgorithm.SHA_256, AUTHORIZED_VALUE)))
+                .withMessageContaining("16 bytes")
+                .withMessageContaining("SHA-256");
     }
 
     /** A broken connector must not be reported to the client as an unauthorized document. */
     @Test
     void tellsABrokenEchoApartFromAMismatchOnTheWire() {
-        // given
-        DocumentDigest different = new DocumentDigest(DigestAlgorithm.SHA_256, digestOfLength(32, (byte) 0x22));
-        DocumentDigest unusable = new DocumentDigest(DigestAlgorithm.SHA_512, digestOfLength(64, (byte) 0x11));
-
         // when / then
-        assertThat(catchVerify(AUTHORIZED, different).clientMessage())
-                .isNotEqualTo(catchVerify(AUTHORIZED, unusable).clientMessage());
+        assertThat(catchVerifyEcho(AUTHORIZED, DIFFERENT_DOCUMENT).clientMessage())
+                .isNotEqualTo(catchVerifyEcho(AUTHORIZED, UNUSABLE_ECHO).clientMessage());
     }
 
     /** Records and alerting key off the failure value, so the security event must not collapse into a fault. */
     @Test
     void classifiesAMismatchApartFromABrokenEcho() {
-        // given
-        DocumentDigest different = new DocumentDigest(DigestAlgorithm.SHA_256, digestOfLength(32, (byte) 0x22));
-        DocumentDigest unusable = new DocumentDigest(DigestAlgorithm.SHA_512, digestOfLength(64, (byte) 0x11));
-
         // when / then
-        assertThat(catchVerify(AUTHORIZED, different).failure()).isEqualTo(SigningEngineFailure.BINDING_VIOLATION);
-        assertThat(catchVerify(AUTHORIZED, unusable).failure()).isEqualTo(SigningEngineFailure.CONNECTOR_FAULT);
+        assertThat(catchVerifyEcho(AUTHORIZED, DIFFERENT_DOCUMENT).failure())
+                .isEqualTo(SigningEngineFailure.BINDING_VIOLATION);
+        assertThat(catchVerifyEcho(AUTHORIZED, UNUSABLE_ECHO).failure())
+                .isEqualTo(SigningEngineFailure.CONNECTOR_FAULT);
     }
 
     @Test
     void keepsDigestsOutOfTheClientMessage() {
-        // given
-        DocumentDigest echoed = new DocumentDigest(DigestAlgorithm.SHA_256, digestOfLength(32, (byte) 0x22));
-
         // when / then
-        assertThat(catchVerify(AUTHORIZED, echoed).clientMessage()).doesNotContain("1111", "2222");
+        assertThat(catchVerifyEcho(AUTHORIZED, DIFFERENT_DOCUMENT).clientMessage()).doesNotContain("1111", "2222");
     }
 
     @Test
-    void readsTheEchoOffAComputeDtbsResponse() {
+    void acceptsAnEchoReadOffAComputeDtbsResponse() {
         // when / then
         assertThatCode(
                 () -> DtbsBindingVerifier.verify(AUTHORIZED, response(DigestAlgorithm.SHA_256, AUTHORIZED_VALUE)))
                 .doesNotThrowAnyException();
-        assertThat(
-                catchVerify(AUTHORIZED, response(DigestAlgorithm.SHA_256, digestOfLength(32, (byte) 0x22))).failure())
+    }
+
+    @Test
+    void refusesAnEchoReadOffAComputeDtbsResponseThatNamesAnotherDocument() {
+        // when / then
+        assertThat(catchVerify(AUTHORIZED, response(DigestAlgorithm.SHA_256, DIFFERENT_DOCUMENT.value())).failure())
                 .isEqualTo(SigningEngineFailure.BINDING_VIOLATION);
     }
 
@@ -158,8 +166,10 @@ class DtbsBindingVerifierTest {
                         response(DigestAlgorithm.SHA_256, AUTHORIZED_VALUE));
 
         // when / then
-        assertThatExceptionOfType(SigningEngineException.class)
-                .isThrownBy(() -> DtbsBindingVerifier.verifyAll(List.of(AUTHORIZED, second), swapped));
+        SigningEngineException thrown = catchThrowableOfType(SigningEngineException.class,
+                () -> DtbsBindingVerifier.verifyAll(List.of(AUTHORIZED, second), swapped));
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.BINDING_VIOLATION);
+        assertThat(thrown.operatorMessage()).contains("3333", "1111");
     }
 
     @Test
@@ -170,13 +180,17 @@ class DtbsBindingVerifierTest {
                         .verifyAll(List.of(AUTHORIZED),
                                 List
                                         .of(response(DigestAlgorithm.SHA_256, AUTHORIZED_VALUE),
-                                                response(DigestAlgorithm.SHA_256, AUTHORIZED_VALUE))));
+                                                response(DigestAlgorithm.SHA_256, AUTHORIZED_VALUE))))
+                .withMessageContaining("Cannot pair 1 authorized digests with 2");
     }
 
+    /** An operation covering no document would satisfy the gate by having nothing to check. */
     @Test
-    void acceptsAnEmptyMultiDocumentOperation() {
+    void refusesAMultiDocumentOperationWithNothingToCheck() {
         // when / then
-        assertThatCode(() -> DtbsBindingVerifier.verifyAll(List.of(), List.of())).doesNotThrowAnyException();
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> DtbsBindingVerifier.verifyAll(List.of(), List.of()))
+                .withMessageContaining("no authorized digest");
     }
 
     /** Whoever computed the authorized digest cannot move it afterwards by reusing the buffer it came in. */
@@ -191,14 +205,15 @@ class DtbsBindingVerifierTest {
 
         // then
         assertThatCode(() -> DtbsBindingVerifier
-                .verify(authorized, new DocumentDigest(DigestAlgorithm.SHA_256, digestOfLength(32, (byte) 0x11))))
+                .verifyEcho(authorized, new DocumentDigest(DigestAlgorithm.SHA_256, digestOfLength(32, (byte) 0x11))))
                 .doesNotThrowAnyException();
-        assertThat(catchVerify(authorized, new DocumentDigest(DigestAlgorithm.SHA_256, source)).failure())
+        assertThat(catchVerifyEcho(authorized, new DocumentDigest(DigestAlgorithm.SHA_256, source)).failure())
                 .isEqualTo(SigningEngineFailure.BINDING_VIOLATION);
     }
 
-    private static SigningEngineException catchVerify(DocumentDigest authorized, DocumentDigest echoed) {
-        return catchThrowableOfType(SigningEngineException.class, () -> DtbsBindingVerifier.verify(authorized, echoed));
+    private static SigningEngineException catchVerifyEcho(DocumentDigest authorized, DocumentDigest echoed) {
+        return catchThrowableOfType(SigningEngineException.class,
+                () -> DtbsBindingVerifier.verifyEcho(authorized, echoed));
     }
 
     private static SigningEngineException catchVerify(DocumentDigest authorized, ComputeDtbsResponseDto response) {

--- a/src/test/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifierTest.java
+++ b/src/test/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifierTest.java
@@ -1,0 +1,221 @@
+package com.otilm.core.signing.contentsigning;
+
+import com.otilm.api.model.common.enums.cryptography.DigestAlgorithm;
+import com.otilm.api.model.connector.signatures.contentsigning.common.ComputeDtbsResponseDto;
+import com.otilm.core.signing.engine.error.SigningEngineException;
+import com.otilm.core.signing.engine.error.SigningEngineFailure;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+class DtbsBindingVerifierTest {
+
+    private static final byte[] AUTHORIZED_VALUE = digestOfLength(32, (byte) 0x11);
+
+    private static final DocumentDigest AUTHORIZED = new DocumentDigest(DigestAlgorithm.SHA_256, AUTHORIZED_VALUE);
+
+    @Test
+    void acceptsAnEchoOfTheAuthorizedDocument() {
+        // given a connector echoing an equal array rather than the very same one
+        DocumentDigest echoed = new DocumentDigest(DigestAlgorithm.SHA_256, AUTHORIZED_VALUE.clone());
+
+        // when / then
+        assertThatCode(() -> DtbsBindingVerifier.verify(AUTHORIZED, echoed)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void refusesAnEchoOfADifferentDocument() {
+        // given
+        DocumentDigest echoed = new DocumentDigest(DigestAlgorithm.SHA_256, digestOfLength(32, (byte) 0x22));
+
+        // when / then
+        SigningEngineException thrown = catchVerify(AUTHORIZED, echoed);
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.BINDING_VIOLATION);
+        assertThat(thrown.step()).isEqualTo("computeDtbs");
+        assertThat(thrown.operatorMessage()).contains("2222", "1111");
+    }
+
+    @Test
+    void refusesAnEchoDifferingInASingleBit() {
+        // given
+        byte[] almost = AUTHORIZED_VALUE.clone();
+        almost[31] ^= 0x01;
+
+        // when / then
+        assertThat(catchVerify(AUTHORIZED, new DocumentDigest(DigestAlgorithm.SHA_256, almost)).failure())
+                .isEqualTo(SigningEngineFailure.BINDING_VIOLATION);
+    }
+
+    @Test
+    void refusesAMissingEcho() {
+        // when / then
+        SigningEngineException thrown = catchVerify(AUTHORIZED, (DocumentDigest) null);
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.CONNECTOR_FAULT);
+        assertThat(thrown.operatorMessage()).contains("echoed no documentDigest");
+    }
+
+    /** Digests of different algorithms are incomparable, so the platform refuses instead of re-deriving one. */
+    @Test
+    void refusesAnEchoUnderADifferentAlgorithm() {
+        // given
+        DocumentDigest echoed = new DocumentDigest(DigestAlgorithm.SHA_512, digestOfLength(64, (byte) 0x11));
+
+        // when / then
+        assertThat(catchVerify(AUTHORIZED, echoed).operatorMessage()).contains("SHA-512", "SHA-256");
+    }
+
+    @Test
+    void refusesAnEchoTooShortForItsAlgorithm() {
+        // given
+        DocumentDigest echoed = new DocumentDigest(DigestAlgorithm.SHA_256, digestOfLength(16, (byte) 0x11));
+
+        // when / then
+        assertThat(catchVerify(AUTHORIZED, echoed).operatorMessage()).contains("16-byte", "never produces");
+    }
+
+    /** A broken connector must not be reported to the client as an unauthorized document. */
+    @Test
+    void tellsABrokenEchoApartFromAMismatchOnTheWire() {
+        // given
+        DocumentDigest different = new DocumentDigest(DigestAlgorithm.SHA_256, digestOfLength(32, (byte) 0x22));
+        DocumentDigest unusable = new DocumentDigest(DigestAlgorithm.SHA_512, digestOfLength(64, (byte) 0x11));
+
+        // when / then
+        assertThat(catchVerify(AUTHORIZED, different).clientMessage())
+                .isNotEqualTo(catchVerify(AUTHORIZED, unusable).clientMessage());
+    }
+
+    /** Records and alerting key off the failure value, so the security event must not collapse into a fault. */
+    @Test
+    void classifiesAMismatchApartFromABrokenEcho() {
+        // given
+        DocumentDigest different = new DocumentDigest(DigestAlgorithm.SHA_256, digestOfLength(32, (byte) 0x22));
+        DocumentDigest unusable = new DocumentDigest(DigestAlgorithm.SHA_512, digestOfLength(64, (byte) 0x11));
+
+        // when / then
+        assertThat(catchVerify(AUTHORIZED, different).failure()).isEqualTo(SigningEngineFailure.BINDING_VIOLATION);
+        assertThat(catchVerify(AUTHORIZED, unusable).failure()).isEqualTo(SigningEngineFailure.CONNECTOR_FAULT);
+    }
+
+    @Test
+    void keepsDigestsOutOfTheClientMessage() {
+        // given
+        DocumentDigest echoed = new DocumentDigest(DigestAlgorithm.SHA_256, digestOfLength(32, (byte) 0x22));
+
+        // when / then
+        assertThat(catchVerify(AUTHORIZED, echoed).clientMessage()).doesNotContain("1111", "2222");
+    }
+
+    @Test
+    void readsTheEchoOffAComputeDtbsResponse() {
+        // when / then
+        assertThatCode(
+                () -> DtbsBindingVerifier.verify(AUTHORIZED, response(DigestAlgorithm.SHA_256, AUTHORIZED_VALUE)))
+                .doesNotThrowAnyException();
+        assertThat(
+                catchVerify(AUTHORIZED, response(DigestAlgorithm.SHA_256, digestOfLength(32, (byte) 0x22))).failure())
+                .isEqualTo(SigningEngineFailure.BINDING_VIOLATION);
+    }
+
+    @Test
+    void treatsAResponseMissingEitherHalfOfTheEchoAsNoEcho() {
+        // given
+        ComputeDtbsResponseDto noDigest = response(DigestAlgorithm.SHA_256, null);
+        ComputeDtbsResponseDto noAlgorithm = response(null, AUTHORIZED_VALUE);
+
+        // when / then
+        assertThat(catchVerify(AUTHORIZED, noDigest).operatorMessage()).contains("echoed no documentDigest");
+        assertThat(catchVerify(AUTHORIZED, noAlgorithm).operatorMessage()).contains("echoed no documentDigest");
+    }
+
+    @Test
+    void verifiesEveryDocumentOfAMultiDocumentOperation() {
+        // given
+        DocumentDigest second = new DocumentDigest(DigestAlgorithm.SHA_256, digestOfLength(32, (byte) 0x33));
+
+        // when / then
+        assertThatCode(() -> DtbsBindingVerifier
+                .verifyAll(List.of(AUTHORIZED, second),
+                        List
+                                .of(response(DigestAlgorithm.SHA_256, AUTHORIZED_VALUE),
+                                        response(DigestAlgorithm.SHA_256, second.value()))))
+                .doesNotThrowAnyException();
+    }
+
+    /** Each document answers for itself: a set of echoes matching as a set is not a binding. */
+    @Test
+    void refusesSwappedEchoesInAMultiDocumentOperation() {
+        // given
+        DocumentDigest second = new DocumentDigest(DigestAlgorithm.SHA_256, digestOfLength(32, (byte) 0x33));
+        List<ComputeDtbsResponseDto> swapped = List
+                .of(response(DigestAlgorithm.SHA_256, second.value()),
+                        response(DigestAlgorithm.SHA_256, AUTHORIZED_VALUE));
+
+        // when / then
+        assertThatExceptionOfType(SigningEngineException.class)
+                .isThrownBy(() -> DtbsBindingVerifier.verifyAll(List.of(AUTHORIZED, second), swapped));
+    }
+
+    @Test
+    void refusesToPairListsOfDifferentLengths() {
+        // when / then
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> DtbsBindingVerifier
+                        .verifyAll(List.of(AUTHORIZED),
+                                List
+                                        .of(response(DigestAlgorithm.SHA_256, AUTHORIZED_VALUE),
+                                                response(DigestAlgorithm.SHA_256, AUTHORIZED_VALUE))));
+    }
+
+    @Test
+    void acceptsAnEmptyMultiDocumentOperation() {
+        // when / then
+        assertThatCode(() -> DtbsBindingVerifier.verifyAll(List.of(), List.of())).doesNotThrowAnyException();
+    }
+
+    /** Whoever computed the authorized digest cannot move it afterwards by reusing the buffer it came in. */
+    @Test
+    void holdsTheAuthorizedDigestAgainstMutationOfItsSourceArray() {
+        // given
+        byte[] source = digestOfLength(32, (byte) 0x11);
+        DocumentDigest authorized = new DocumentDigest(DigestAlgorithm.SHA_256, source);
+
+        // when
+        Arrays.fill(source, (byte) 0x22);
+
+        // then
+        assertThatCode(() -> DtbsBindingVerifier
+                .verify(authorized, new DocumentDigest(DigestAlgorithm.SHA_256, digestOfLength(32, (byte) 0x11))))
+                .doesNotThrowAnyException();
+        assertThat(catchVerify(authorized, new DocumentDigest(DigestAlgorithm.SHA_256, source)).failure())
+                .isEqualTo(SigningEngineFailure.BINDING_VIOLATION);
+    }
+
+    private static SigningEngineException catchVerify(DocumentDigest authorized, DocumentDigest echoed) {
+        return catchThrowableOfType(SigningEngineException.class, () -> DtbsBindingVerifier.verify(authorized, echoed));
+    }
+
+    private static SigningEngineException catchVerify(DocumentDigest authorized, ComputeDtbsResponseDto response) {
+        return catchThrowableOfType(SigningEngineException.class,
+                () -> DtbsBindingVerifier.verify(authorized, response));
+    }
+
+    private static ComputeDtbsResponseDto response(DigestAlgorithm algorithm, byte[] digest) {
+        ComputeDtbsResponseDto response = new ComputeDtbsResponseDto();
+        response.setDocumentDigestAlgorithm(algorithm);
+        response.setDocumentDigest(digest);
+        return response;
+    }
+
+    private static byte[] digestOfLength(int length, byte fill) {
+        byte[] digest = new byte[length];
+        Arrays.fill(digest, fill);
+        return digest;
+    }
+}

--- a/src/test/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifierTest.java
+++ b/src/test/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifierTest.java
@@ -193,7 +193,6 @@ class DtbsBindingVerifierTest {
                 .withMessageContaining("no authorized digest");
     }
 
-    /** Whoever computed the authorized digest cannot move it afterwards by reusing the buffer it came in. */
     @Test
     void holdsTheAuthorizedDigestAgainstMutationOfItsSourceArray() {
         // given

--- a/src/test/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifierTest.java
+++ b/src/test/java/com/otilm/core/signing/contentsigning/DtbsBindingVerifierTest.java
@@ -142,6 +142,15 @@ class DtbsBindingVerifierTest {
         assertThat(catchVerify(AUTHORIZED, noAlgorithm).operatorMessage()).contains("echoed no documentDigest");
     }
 
+    /** A connector that delivered nothing at all is the same fault as one that echoed no digest. */
+    @Test
+    void treatsAMissingResponseAsAConnectorFault() {
+        // when / then
+        SigningEngineException thrown = catchVerify(AUTHORIZED, null);
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.CONNECTOR_FAULT);
+        assertThat(thrown.operatorMessage()).contains("returned no computeDtbs response");
+    }
+
     @Test
     void verifiesEveryDocumentOfAMultiDocumentOperation() {
         // given

--- a/src/test/java/com/otilm/core/signing/tsa/TspErrorMapperTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/TspErrorMapperTest.java
@@ -18,6 +18,7 @@ class TspErrorMapperTest {
             "MALFORMED_INPUT,BAD_DATA_FORMAT",
             "MISCONFIGURED,SYSTEM_FAILURE",
             "CONNECTOR_FAULT,SYSTEM_FAILURE",
+            "BINDING_VIOLATION,SYSTEM_FAILURE",
             "SIGNER_FAULT,SYSTEM_FAILURE",
             "STEP_FAILED,SYSTEM_FAILURE"})
     void mapsEveryFailureToATspFailureInfo(SigningEngineFailure failure, TspFailureInfo expected) {

--- a/src/test/java/com/otilm/core/signing/tsa/TspErrorMapperTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/TspErrorMapperTest.java
@@ -26,7 +26,7 @@ class TspErrorMapperTest {
     @EnumSource(SigningEngineFailure.class)
     void mapsEveryFailureToATspFailureInfo(SigningEngineFailure failure) {
         // when / then
-        assertThat(EXPECTED).containsKey(failure);
+        assertThat(failure).isIn(EXPECTED.keySet());
         assertThat(TspErrorMapper.toFailureInfo(failure)).isEqualTo(EXPECTED.get(failure));
     }
 

--- a/src/test/java/com/otilm/core/signing/tsa/TspErrorMapperTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/TspErrorMapperTest.java
@@ -4,26 +4,30 @@ import com.otilm.api.interfaces.core.tsp.error.TspException;
 import com.otilm.api.interfaces.core.tsp.error.TspFailureInfo;
 import com.otilm.core.signing.engine.error.SigningEngineException;
 import com.otilm.core.signing.engine.error.SigningEngineFailure;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TspErrorMapperTest {
 
+    private static final Map<SigningEngineFailure, TspFailureInfo> EXPECTED = Map
+            .of(SigningEngineFailure.INVALID_INPUT, TspFailureInfo.BAD_REQUEST, SigningEngineFailure.MALFORMED_INPUT,
+                    TspFailureInfo.BAD_DATA_FORMAT, SigningEngineFailure.MISCONFIGURED, TspFailureInfo.SYSTEM_FAILURE,
+                    SigningEngineFailure.CONNECTOR_FAULT, TspFailureInfo.SYSTEM_FAILURE,
+                    SigningEngineFailure.BINDING_VIOLATION, TspFailureInfo.SYSTEM_FAILURE,
+                    SigningEngineFailure.SIGNER_FAULT, TspFailureInfo.SYSTEM_FAILURE, SigningEngineFailure.STEP_FAILED,
+                    TspFailureInfo.SYSTEM_FAILURE);
+
+    /** Driving off the enum makes a new failure value fail here until it is given a TSP meaning. */
     @ParameterizedTest
-    @CsvSource({
-            "INVALID_INPUT,BAD_REQUEST",
-            "MALFORMED_INPUT,BAD_DATA_FORMAT",
-            "MISCONFIGURED,SYSTEM_FAILURE",
-            "CONNECTOR_FAULT,SYSTEM_FAILURE",
-            "BINDING_VIOLATION,SYSTEM_FAILURE",
-            "SIGNER_FAULT,SYSTEM_FAILURE",
-            "STEP_FAILED,SYSTEM_FAILURE"})
-    void mapsEveryFailureToATspFailureInfo(SigningEngineFailure failure, TspFailureInfo expected) {
+    @EnumSource(SigningEngineFailure.class)
+    void mapsEveryFailureToATspFailureInfo(SigningEngineFailure failure) {
         // when / then
-        assertThat(TspErrorMapper.toFailureInfo(failure)).isEqualTo(expected);
+        assertThat(EXPECTED).containsKey(failure);
+        assertThat(TspErrorMapper.toFailureInfo(failure)).isEqualTo(EXPECTED.get(failure));
     }
 
     @Test


### PR DESCRIPTION
## What this adds

The Core-side half of DP-7. The formatting contract (interfaces#818) specifies the mandatory `documentDigest` echo on the `computeDtbs` response; nothing owned the code that checks it. #1974 runs the gate between steps 1 and 2 of the level state machine, #1982 runs the same check inside the SAD reservation transaction — this is the one implementation both consume.

`DtbsBindingVerifier` compares the echoed digest against the digest the operation authorized, before the signing key is released. Pure and stateless: no I/O, no persistence, no Spring bean.

`DocumentDigest` carries a digest together with the algorithm that produced it, because a digest cannot be interpreted without one.

## Decisions worth a look

**A broken echo is not a mismatch.** An echo that is absent, of another algorithm, or of a length its algorithm never produces proves the connector broke the contract — it does not prove the document differs. Those get the neutral "internal error" client text; only a genuine digest inequality tells the client its document was not the authorized one. Operator detail (both digests, hex) stays in `operatorMessage()` and never reaches the wire.

**Algorithm disagreement is refused, not resolved.** Core never re-derives a digest from the document, so two digests under different algorithms are simply incomparable and the step fails.

**`DocumentDigest` copies in and copies out.** The authorized digest is a security boundary, so the record clones the array on construction and returns a clone from `value()`. A caller that reuses its buffer cannot move what was authorized after the fact, and `equals`/`hashCode` stay stable. This follows `CertificateChain`, which snapshots its chain in the same way.

**Multi-document pairs positionally.** `verifyAll` checks each response against the authorized digest at the same position and refuses lists of different lengths. A set of echoes that matches as a *set* is not a binding — the swapped-echo test pins this. The size-mismatch refusal is an `IllegalArgumentException` on purpose: mis-pairing the lists is a Core caller bug, and a generic 500 is the right answer for a bug.

**Failure classification.** A genuine digest mismatch is its own failure value, `BINDING_VIOLATION` — it is the security event DP-7 exists for and must stay distinguishable from an ordinary fault for records and alerting, and the exhaustive `TspErrorMapper` switch forces every protocol edge to map it consciously (the TSP edge never calls the verifier, so it maps to the same server-fault answer). The broken-echo cases stay `CONNECTOR_FAULT`: those really are a connector not delivering. All are named to step `computeDtbs`.

## No caller yet

Like `TransitionGuard` in #2036, this ships ahead of its consumers (#1974, #1982) — that is the epic's build order, not dead code. Please don't file it as unused. #2037's DoD is being re-scoped so the enforcement proof lands with #1974/#1982, which already carry the gate acceptance criteria.

## Verification

- 23 unit vectors, positive and negative; 100 % line and branch coverage on both new classes (JaCoCo).
- `spotless:check` clean.

## Out of scope

Raw signing needs no echo — the client submits the digest itself — so `signHash` never reaches this verifier.
