### PR TITLE
Fix newly created secrets being left inactive and unusable

### DIFF
--- a/src/main/java/com/otilm/core/service/impl/SecretServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SecretServiceImpl.java
@@ -116,6 +116,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.concurrent.DelegatingSecurityContextExecutorService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service(value = Resource.Codes.SECRET)
 @Transactional
@@ -492,7 +494,14 @@ public class SecretServiceImpl implements SecretExternalService, SecretInternalS
         actionMessage.setResource(Resource.SECRET);
         actionMessage.setResourceAction(resourceAction);
         actionMessage.setResourceUuid(secret.getUuid());
-        actionProducer.produceMessage(actionMessage);
+        // actionsListener consumes this on another thread in its own transaction; publishing before the creating
+        // transaction commits leaves that transaction unable to load the secret, so defer the send until after commit.
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                actionProducer.produceMessage(actionMessage);
+            }
+        });
     }
 
     @ExternalAuthorization(resource = Resource.SECRET, action = ResourceAction.UPDATE)

--- a/src/test/java/com/otilm/core/integration/service/SecretServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/SecretServiceITest.java
@@ -151,12 +151,8 @@ class SecretServiceITest extends BaseSpringBootTest {
     @BeforeEach
     void setUp() throws AlreadyExistException, AttributeException, NoSuchAlgorithmException, JsonProcessingException {
 
-        // Stand in for the broker so the listener runs the way it does in production.
-        // Broker model: process the action message inline instead of queueing it, approved to bypass approval.
-        // Transaction boundary: the real listener runs on another thread in its own transaction, only after the
-        // producing transaction has committed — so run the handler in a fresh REQUIRES_NEW transaction.
-        // Why not inline: at afterCommit the producing transaction has already committed; an inline handler would
-        // join that committed transaction, so its writes would never commit and would be discarded at cleanup.
+        // REQUIRES_NEW so the handler runs in its own transaction like the real broker: at afterCommit the producing
+        // transaction has already committed, so an inline handler would join it and its writes would be discarded.
         final TransactionTemplate listenerTransaction = new TransactionTemplate(transactionManager);
         listenerTransaction.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
         Mockito.doAnswer(invocation -> {
@@ -949,11 +945,8 @@ class SecretServiceITest extends BaseSpringBootTest {
     @Test
     void createSecretPublishesActionMessageOnlyAfterCommit()
             throws NotFoundException, AttributeException, AlreadyExistException, ConnectorException {
-        // Assert the action message is published only after the creating transaction commits.
-        // Broker model: the real listener loads the secret on another thread in its own READ COMMITTED transaction.
-        // Failure guarded: publishing while the creating transaction is still open leaves the row invisible to that
-        // separate transaction, so the listener throws NotFoundException and the secret stays INACTIVE.
-        // Check: read the secret from a REQUIRES_NEW transaction at the moment the message is published.
+        // Read from a separate REQUIRES_NEW transaction: a publish before commit leaves the secret invisible there,
+        // exactly as it is to the real listener's own transaction.
         final AtomicBoolean secretVisibleFromSeparateTransaction = new AtomicBoolean();
         final TransactionTemplate separateTransaction = new TransactionTemplate(transactionManager);
         separateTransaction.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);

--- a/src/test/java/com/otilm/core/integration/service/SecretServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/SecretServiceITest.java
@@ -151,10 +151,12 @@ class SecretServiceITest extends BaseSpringBootTest {
     @BeforeEach
     void setUp() throws AlreadyExistException, AttributeException, NoSuchAlgorithmException, JsonProcessingException {
 
-        // Stand in for the broker: process the action message instead of queueing it, and approve it to bypass
-        // approval. The real listener consumes on another thread in its own transaction after the producing
-        // transaction has committed, so run the handler in a fresh REQUIRES_NEW transaction rather than inline in the
-        // producer's — inline would run in the producer's already-committed transaction and its writes would be lost.
+        // Stand in for the broker so the listener runs the way it does in production.
+        // Broker model: process the action message inline instead of queueing it, approved to bypass approval.
+        // Transaction boundary: the real listener runs on another thread in its own transaction, only after the
+        // producing transaction has committed — so run the handler in a fresh REQUIRES_NEW transaction.
+        // Why not inline: at afterCommit the producing transaction has already committed; an inline handler would
+        // join that committed transaction, so its writes would never commit and would be discarded at cleanup.
         final TransactionTemplate listenerTransaction = new TransactionTemplate(transactionManager);
         listenerTransaction.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
         Mockito.doAnswer(invocation -> {
@@ -947,10 +949,11 @@ class SecretServiceITest extends BaseSpringBootTest {
     @Test
     void createSecretPublishesActionMessageOnlyAfterCommit()
             throws NotFoundException, AttributeException, AlreadyExistException, ConnectorException {
-        // The listener consumes the action message on another thread in its own READ COMMITTED transaction, so it can
-        // only load the secret once the creating transaction has committed. Reproduce that constraint by reading the
-        // secret from a separate transaction at the moment the message is published: if the publish still happens
-        // inside the open creating transaction, the row is invisible and the listener would throw NotFoundException.
+        // Assert the action message is published only after the creating transaction commits.
+        // Broker model: the real listener loads the secret on another thread in its own READ COMMITTED transaction.
+        // Failure guarded: publishing while the creating transaction is still open leaves the row invisible to that
+        // separate transaction, so the listener throws NotFoundException and the secret stays INACTIVE.
+        // Check: read the secret from a REQUIRES_NEW transaction at the moment the message is published.
         final AtomicBoolean secretVisibleFromSeparateTransaction = new AtomicBoolean();
         final TransactionTemplate separateTransaction = new TransactionTemplate(transactionManager);
         separateTransaction.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);

--- a/src/test/java/com/otilm/core/integration/service/SecretServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/SecretServiceITest.java
@@ -7,6 +7,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.otilm.api.exception.AlreadyExistException;
 import com.otilm.api.exception.AttributeException;
 import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.exception.MessageHandlingException;
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.exception.SecretOperationException;
 import com.otilm.api.exception.ValidationException;
@@ -81,6 +82,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -94,6 +96,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -130,6 +135,8 @@ class SecretServiceITest extends BaseSpringBootTest {
     private ConnectorRepository connectorRepository;
     @Autowired
     private ActionsListener actionListener;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
     @MockitoBean
     private ActionProducer actionProducer;
     @MockitoBean
@@ -144,13 +151,23 @@ class SecretServiceITest extends BaseSpringBootTest {
     @BeforeEach
     void setUp() throws AlreadyExistException, AttributeException, NoSuchAlgorithmException, JsonProcessingException {
 
-        // Process message instead of sending it to the queue and set approval status to approved to bypass approval in
-        // tests
+        // Stand in for the broker: process the action message instead of queueing it, and approve it to bypass
+        // approval. The real listener consumes on another thread in its own transaction after the producing
+        // transaction has committed, so run the handler in a fresh REQUIRES_NEW transaction rather than inline in the
+        // producer's — inline would run in the producer's already-committed transaction and its writes would be lost.
+        final TransactionTemplate listenerTransaction = new TransactionTemplate(transactionManager);
+        listenerTransaction.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
         Mockito.doAnswer(invocation -> {
             ActionMessage msg = invocation.getArgument(0);
             msg.setApprovalStatus(ApprovalStatusEnum.APPROVED);
             msg.setApprovalUuid(UUID.randomUUID());
-            actionListener.processMessage(msg);
+            listenerTransaction.executeWithoutResult(status -> {
+                try {
+                    actionListener.processMessage(msg);
+                } catch (MessageHandlingException e) {
+                    throw new IllegalStateException(e);
+                }
+            });
             return null; // because produceMessage returns void
         }).when(actionProducer).produceMessage(any());
         Mockito.doNothing().when(authHelper).authenticateAsUser(any());
@@ -925,6 +942,36 @@ class SecretServiceITest extends BaseSpringBootTest {
         } finally {
             authServiceMock.stop();
         }
+    }
+
+    @Test
+    void createSecretPublishesActionMessageOnlyAfterCommit()
+            throws NotFoundException, AttributeException, AlreadyExistException, ConnectorException {
+        // The listener consumes the action message on another thread in its own READ COMMITTED transaction, so it can
+        // only load the secret once the creating transaction has committed. Reproduce that constraint by reading the
+        // secret from a separate transaction at the moment the message is published: if the publish still happens
+        // inside the open creating transaction, the row is invisible and the listener would throw NotFoundException.
+        final AtomicBoolean secretVisibleFromSeparateTransaction = new AtomicBoolean();
+        final TransactionTemplate separateTransaction = new TransactionTemplate(transactionManager);
+        separateTransaction.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
+        Mockito.doAnswer(invocation -> {
+            ActionMessage msg = invocation.getArgument(0);
+            secretVisibleFromSeparateTransaction
+                    .set(separateTransaction
+                            .execute(status -> secretRepository.findByUuid(msg.getResourceUuid()).isPresent()));
+            return null;
+        }).when(actionProducer).produceMessage(any());
+
+        SecretRequestDto request = new SecretRequestDto();
+        request.setName("afterCommitSecret");
+        request.setSecret(new BasicAuthSecretContent());
+
+        secretService.createSecret(request, vaultProfile.getSecuredParentUuid(), vaultInstance.getSecuredUuid());
+
+        assertThat(secretVisibleFromSeparateTransaction.get())
+                .as("action message must be published only after the creating transaction commits")
+                .isTrue();
     }
 
 }


### PR DESCRIPTION
## Problem

Creating a secret through Core left it permanently `INACTIVE` (#2098). `SecretServiceImpl` carries a class-level `@Transactional`, and `produceActionMessage` published the JMS action message via `actionProducer.produceMessage` **while that transaction was still open**. `actionsListener` consumed it on another thread in its own READ COMMITTED transaction, could not see the uncommitted `Secret` row, and threw `NotFoundException`. The secret committed `INACTIVE`, the connector was never invoked, and the caller still got a success response.

All four Secret action sites — CREATE, UPDATE, DELETE, UPDATE_SOURCE_VAULT_PROFILE — route through the same `produceActionMessage` helper and shared the defect.

## Fix

Defer the publish to an `afterCommit` synchronization via `TransactionSynchronizationManager.registerSynchronization(...)`, so the message reaches the broker only once the creating transaction has committed and the listener's transaction can load the row. One change covers all four action sites.

This mirrors the pattern already used in `ApprovalServiceImpl` (afterCommit `actionProducer.produceMessage`) and `NotificationProducer` (`@TransactionalEventListener(AFTER_COMMIT)`).

## Tests

- New `SecretServiceITest#createSecretPublishesActionMessageOnlyAfterCommit` reads the secret from a separate `REQUIRES_NEW` transaction at publish time; fails before the fix (row invisible), passes after.
- The existing broker shim in `SecretServiceITest` previously ran the listener **inline in the producer's transaction** and so only passed by riding this bug. It now runs the handler in a `REQUIRES_NEW` transaction, faithfully modelling the real separate-transaction consumer. Full class: 22/22 green.

## Scope

This PR fixes only the **pre-commit publish race** (defect 1 of #2098). Deliberately deferred to follow-ups:

- **Durable dispatch / redelivery / DLQ** — an `afterCommit` send that exhausts retries (e.g. broker down) commits the DB but loses the message. This is the same tradeoff the platform already accepts in `ApprovalServiceImpl` / `NotificationProducer`; closing it needs a transactional outbox or redelivery, tracked separately.
- **Handler-failure swallow** in `AbstractJmsEndpointConfig` and the **action-payload leak** into ERROR logs — separate follow-ups.

An independent `copilot` review pass confirmed no no-transaction path (all producers enter through the class-level `@Transactional`) and raised only the durability gap above, which is out of scope by design.

Refs #2098