### PR TITLE
Fix newly created secrets being left inactive and unusable

### DIFF
--- a/src/main/java/com/otilm/core/service/impl/SecretServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SecretServiceImpl.java
@@ -62,6 +62,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.concurrent.DelegatingSecurityContextExecutorService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
@@ -370,7 +372,14 @@ public class SecretServiceImpl implements SecretExternalService, SecretInternalS
         actionMessage.setResource(Resource.SECRET);
         actionMessage.setResourceAction(resourceAction);
         actionMessage.setResourceUuid(secret.getUuid());
-        actionProducer.produceMessage(actionMessage);
+        // actionsListener consumes this on another thread in its own transaction; publishing before the creating
+        // transaction commits leaves that transaction unable to load the secret, so defer the send until after commit.
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                actionProducer.produceMessage(actionMessage);
+            }
+        });
     }
 
     @ExternalAuthorization(resource = Resource.SECRET, action = ResourceAction.UPDATE)

--- a/src/test/java/com/otilm/core/integration/service/SecretServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/SecretServiceITest.java
@@ -65,6 +65,9 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
 import com.otilm.core.events.SecretContentUpdatedEvent;
 
 import java.io.Serializable;
@@ -73,6 +76,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -115,6 +119,8 @@ class SecretServiceITest extends BaseSpringBootTest {
     private ConnectorRepository connectorRepository;
     @Autowired
     private ActionsListener actionListener;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
     @MockitoBean
     private ActionProducer actionProducer;
     @MockitoBean
@@ -129,12 +135,21 @@ class SecretServiceITest extends BaseSpringBootTest {
     @BeforeEach
     void setUp() throws AlreadyExistException, AttributeException, NoSuchAlgorithmException, JsonProcessingException {
 
-        // Process message instead of sending it to the queue and set approval status to approved to bypass approval in tests
+        // REQUIRES_NEW so the handler runs in its own transaction like the real broker: at afterCommit the producing
+        // transaction has already committed, so an inline handler would join it and its writes would be discarded.
+        final TransactionTemplate listenerTransaction = new TransactionTemplate(transactionManager);
+        listenerTransaction.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
         Mockito.doAnswer(invocation -> {
                     ActionMessage msg = invocation.getArgument(0);
                     msg.setApprovalStatus(ApprovalStatusEnum.APPROVED);
                     msg.setApprovalUuid(UUID.randomUUID());
-                    actionListener.processMessage(msg);
+                    listenerTransaction.executeWithoutResult(status -> {
+                        try {
+                            actionListener.processMessage(msg);
+                        } catch (MessageHandlingException e) {
+                            throw new IllegalStateException(e);
+                        }
+                    });
                     return null; // because produceMessage returns void
                 }
         ).when(actionProducer).produceMessage(any());
@@ -772,6 +787,31 @@ class SecretServiceITest extends BaseSpringBootTest {
         } finally {
             authServiceMock.stop();
         }
+    }
+
+    @Test
+    void createSecretPublishesActionMessageOnlyAfterCommit() throws NotFoundException, AttributeException, AlreadyExistException, ConnectorException {
+        // Read from a separate REQUIRES_NEW transaction: a publish before commit leaves the secret invisible there,
+        // exactly as it is to the real listener's own transaction.
+        final AtomicBoolean secretVisibleFromSeparateTransaction = new AtomicBoolean();
+        final TransactionTemplate separateTransaction = new TransactionTemplate(transactionManager);
+        separateTransaction.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
+        Mockito.doAnswer(invocation -> {
+            ActionMessage msg = invocation.getArgument(0);
+            secretVisibleFromSeparateTransaction.set(separateTransaction.execute(status -> secretRepository.findByUuid(msg.getResourceUuid()).isPresent()));
+            return null;
+        }).when(actionProducer).produceMessage(any());
+
+        SecretRequestDto request = new SecretRequestDto();
+        request.setName("afterCommitSecret");
+        request.setSecret(new BasicAuthSecretContent());
+
+        secretService.createSecret(request, vaultProfile.getSecuredParentUuid(), vaultInstance.getSecuredUuid());
+
+        assertThat(secretVisibleFromSeparateTransaction.get())
+                .as("action message must be published only after the creating transaction commits")
+                .isTrue();
     }
 
 }

--- a/src/test/java/com/otilm/core/integration/service/SecretServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/SecretServiceITest.java
@@ -65,10 +65,8 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionDefinition;
-import org.springframework.transaction.support.TransactionTemplate;
 import com.otilm.core.events.SecretContentUpdatedEvent;
+import com.otilm.core.events.transaction.TransactionHandler;
 
 import java.io.Serializable;
 import java.security.NoSuchAlgorithmException;
@@ -120,7 +118,7 @@ class SecretServiceITest extends BaseSpringBootTest {
     @Autowired
     private ActionsListener actionListener;
     @Autowired
-    private PlatformTransactionManager transactionManager;
+    private TransactionHandler transactionHandler;
     @MockitoBean
     private ActionProducer actionProducer;
     @MockitoBean
@@ -135,15 +133,14 @@ class SecretServiceITest extends BaseSpringBootTest {
     @BeforeEach
     void setUp() throws AlreadyExistException, AttributeException, NoSuchAlgorithmException, JsonProcessingException {
 
-        // REQUIRES_NEW so the handler runs in its own transaction like the real broker: at afterCommit the producing
-        // transaction has already committed, so an inline handler would join it and its writes would be discarded.
-        final TransactionTemplate listenerTransaction = new TransactionTemplate(transactionManager);
-        listenerTransaction.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        // Stand in for the broker: pre-approve, since ActionsListener creates an Approval and stops when approvalUuid
+        // is null; and run the handler in its own transaction, because at afterCommit the producing transaction has
+        // already committed and an inline handler would join it and have its writes discarded.
         Mockito.doAnswer(invocation -> {
                     ActionMessage msg = invocation.getArgument(0);
                     msg.setApprovalStatus(ApprovalStatusEnum.APPROVED);
                     msg.setApprovalUuid(UUID.randomUUID());
-                    listenerTransaction.executeWithoutResult(status -> {
+                    transactionHandler.runInNewTransaction(() -> {
                         try {
                             actionListener.processMessage(msg);
                         } catch (MessageHandlingException e) {
@@ -794,12 +791,11 @@ class SecretServiceITest extends BaseSpringBootTest {
         // Read from a separate REQUIRES_NEW transaction: a publish before commit leaves the secret invisible there,
         // exactly as it is to the real listener's own transaction.
         final AtomicBoolean secretVisibleFromSeparateTransaction = new AtomicBoolean();
-        final TransactionTemplate separateTransaction = new TransactionTemplate(transactionManager);
-        separateTransaction.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
 
         Mockito.doAnswer(invocation -> {
             ActionMessage msg = invocation.getArgument(0);
-            secretVisibleFromSeparateTransaction.set(separateTransaction.execute(status -> secretRepository.findByUuid(msg.getResourceUuid()).isPresent()));
+            secretVisibleFromSeparateTransaction.set(
+                    transactionHandler.runInNewTransaction(() -> secretRepository.findByUuid(msg.getResourceUuid()).isPresent()));
             return null;
         }).when(actionProducer).produceMessage(any());
 
@@ -809,6 +805,7 @@ class SecretServiceITest extends BaseSpringBootTest {
 
         secretService.createSecret(request, vaultProfile.getSecuredParentUuid(), vaultInstance.getSecuredUuid());
 
+        Mockito.verify(actionProducer, Mockito.times(1)).produceMessage(any());
         assertThat(secretVisibleFromSeparateTransaction.get())
                 .as("action message must be published only after the creating transaction commits")
                 .isTrue();


### PR DESCRIPTION
Backport of #2099 onto the `2.19.0` tag for the **2.19.1 hotfix**, for a customer hit by #2098 (secrets stuck `INACTIVE`).

## What

`SecretServiceImpl.produceActionMessage` published the JMS action message inside the class-level `@Transactional`, before commit, so `actionsListener` (separate thread, own transaction) could not load the secret and failed — leaving it `INACTIVE`. The fix defers the publish to a `TransactionSynchronizationManager.registerSynchronization(...afterCommit())` callback, mirroring `ApprovalServiceImpl`. Covers all four Secret action sites via the shared helper.

## Backport notes

- **Re-applied by hand**, not cherry-picked: the `2.19.0` base predates the mainline Spotless/Checkstyle reformatting (48 commits), so the merged commit `488ea840f` conflicts on the reformatted `SecretServiceITest` import block.
- The production change is byte-for-byte equivalent to what merged on `main`.
- The test broker shim is adapted to the `2.19.0` structure and now runs the listener in a `REQUIRES_NEW` transaction (the old inline shim only passed by riding the bug). Added the focused regression test `createSecretPublishesActionMessageOnlyAfterCommit`.

## Merge order

Pure code fix — **no version bump here**. Depends on #2108 (httpcore5 CVE pins + `2.19.1-SNAPSHOT` dev version), which must merge first: this branch's image build fails Trivy until the pins land. After #2108 merges, this branch rebases onto `hotfix/2.19.1` (picking up the pins) and goes green. The `2.19.1-SNAPSHOT → 2.19.1` release commit happens at tag time.

## Verification

`SecretServiceITest` — 22/22 green (`REQUIRES_NEW` shim + new regression test).

## Scope

Defect 1 (the pre-commit race) only, matching #2099. Durability (#2100) and log-leak (#2101) are not backported — not customer-blocking for 2.19.1.

Refs #2098, #2099