### PR TITLE
Backport httpcore5 CVE fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,20 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.5.1</version>
+            <version>5.6.1</version>
+        </dependency>
+        <!-- Explicit httpcore5 pins: CVE-2026-54399 is fixed in core5 5.4.3, but every released httpclient5,
+             5.6.1 included, still pulls in an httpcore5 below 5.4.3. Drop both once a httpclient5 release
+             manages httpcore5 >= 5.4.3. -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+            <version>5.4.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5-h2</artifactId>
+            <version>5.4.3</version>
         </dependency>
 
         <!-- this dependency is included to avoid warning -->

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>core</artifactId>
-    <version>2.19.0</version>
+    <version>2.19.1-SNAPSHOT</version>
     <name>core</name>
 
     <properties>


### PR DESCRIPTION
Backport of the mainline httpcore5 security pins **and** the hotfix dev-version bump for **2.19.1**. Merges first into `hotfix/2.19.1` (unblocks the Trivy gate for #2106).

## Why

The Trivy image scan on the 2.19.1 build fails on two HIGH findings the `2.19.0` base carries but `main` already fixed:

| CVE | Package | Installed | Fixed |
|---|---|---|---|
| CVE-2026-54399 | `org.apache.httpcomponents.core5:httpcore5` | 5.3.6 | 5.4.3 |
| CVE-2026-54428 | `org.apache.httpcomponents.core5:httpcore5-h2` | 5.3.6 | 5.4.3 |

## What

- Backports `main`'s fix verbatim: bump `httpclient5` `5.5.1 → 5.6.1` and add explicit `httpcore5` / `httpcore5-h2` `5.4.3` pins.
- Sets the hotfix development version `2.19.0 → 2.19.1-SNAPSHOT`. Per repo convention (main is on `2.20.0-SNAPSHOT`), development runs on `-SNAPSHOT`; the `2.19.1-SNAPSHOT → 2.19.1` release commit is a separate final step at tag time. This PR merges first, so it establishes the dev version for the branch.

## Verification

`mvn dependency:tree -Dincludes=org.apache.httpcomponents.core5` resolves both to `5.4.3` (was `5.3.6`). CI's Trivy scan is the authoritative gate.

Core-only; `interfaces` untouched. Both this and #2106 must merge into `hotfix/2.19.1` before tagging `2.19.1`.