### PR TITLE
Issue the timestamps an AdES signature needs in-process

### DIFF
--- a/src/main/java/com/otilm/core/service/SigningProfileInternalService.java
+++ b/src/main/java/com/otilm/core/service/SigningProfileInternalService.java
@@ -47,6 +47,7 @@ public interface SigningProfileInternalService extends ResourceExtensionService 
      * @throws IllegalArgumentException if the profile's workflow type has no model mapper, or the version declares a
      * scheme the mapper does not support
      */
+    @SuppressWarnings("java:S1452") // wildcards for the same reason as SigningRecordInputSource#signingProfile
     SigningProfileModel<?, ?> loadSigningProfileModel(String name) throws NotFoundException;
 
     /**

--- a/src/main/java/com/otilm/core/service/SigningProfileInternalService.java
+++ b/src/main/java/com/otilm/core/service/SigningProfileInternalService.java
@@ -36,6 +36,20 @@ public interface SigningProfileInternalService extends ResourceExtensionService 
             throws NotFoundException;
 
     /**
+     * Returns the same cached model as {@link #getSigningProfileModel}, without the {@code DETAIL} authorization check.
+     *
+     * <p>
+     * Intended for digital signing the platform initiates on its own, such as timestamping a signed document.
+     *
+     * @throws NotFoundException if no signing profile with the given name exists
+     * @throws IllegalStateException if the profile has no version row matching its {@code latestVersion}, or the
+     * version declares a managed scheme but its {@code managedSigningType} is {@code null}
+     * @throws IllegalArgumentException if the profile's workflow type has no model mapper, or the version declares a
+     * scheme the mapper does not support
+     */
+    SigningProfileModel<?, ?> loadSigningProfileModel(String name) throws NotFoundException;
+
+    /**
      * Resolves the governing TSP profile for a request targeting the indirect signing profile-based route, without any
      * authorization check.
      *

--- a/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
@@ -123,7 +123,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class SigningProfileServiceImpl implements SigningProfileExternalService, SigningProfileInternalService {
 
     /**
-     * Defines which signing protocols are allowed for each workflow type.
+     * Defines which signing protocols an operator may enable per workflow type. Only protocols a client can actually
+     * reach belong here; {@code SigningProfileSupportedProtocolsTest} holds that line.
      */
     private static final Map<SigningWorkflowType, Set<SigningProtocol>> SUPPORTED_PROTOCOLS = Map
             .of(SigningWorkflowType.TIMESTAMPING, EnumSet.of(SigningProtocol.TSP));

--- a/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
@@ -300,7 +300,7 @@ public class SigningProfileServiceImpl implements SigningProfileExternalService,
     /** Cache loader. No authorization annotation by design. */
     @Override
     @Cacheable(value = CacheConfig.SIGNING_PROFILE_CACHE, key = "#name", sync = true)
-    @Transactional(readOnly = true)
+    @Transactional(readOnly = true, noRollbackFor = NotFoundException.class)
     public SigningProfileModel<?, ?> loadSigningProfileModel(String name) throws NotFoundException {
         SigningProfile profile = signingProfileRepository
                 .findByName(name)

--- a/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
@@ -124,7 +124,7 @@ public class SigningProfileServiceImpl implements SigningProfileExternalService,
 
     /**
      * Defines which signing protocols an operator may enable per workflow type. Only protocols a client can actually
-     * reach belong here; {@code SigningProfileSupportedProtocolsTest} holds that line.
+     * reach belong here.
      */
     private static final Map<SigningWorkflowType, Set<SigningProtocol>> SUPPORTED_PROTOCOLS = Map
             .of(SigningWorkflowType.TIMESTAMPING, EnumSet.of(SigningProtocol.TSP));
@@ -297,17 +297,11 @@ public class SigningProfileServiceImpl implements SigningProfileExternalService,
         return self.loadSigningProfileModel(name);
     }
 
-    /**
-     * Package-private internal cache loader, self-invoked.
-     *
-     * @throws IllegalStateException if the profile has no version row matching its {@code latestVersion}, or the
-     * version declares a managed scheme but its {@code managedSigningType} is {@code null} (DB integrity violations)
-     * @throws IllegalArgumentException if the profile's workflow type has no model mapper, or the version declares a
-     * scheme the mapper does not support
-     */
+    /** Cache loader. No authorization annotation by design. */
+    @Override
     @Cacheable(value = CacheConfig.SIGNING_PROFILE_CACHE, key = "#name", sync = true)
     @Transactional(readOnly = true)
-    SigningProfileModel<?, ?> loadSigningProfileModel(String name) throws NotFoundException {
+    public SigningProfileModel<?, ?> loadSigningProfileModel(String name) throws NotFoundException {
         SigningProfile profile = signingProfileRepository
                 .findByName(name)
                 .orElseThrow(() -> new NotFoundException(SigningProfile.class, name));

--- a/src/main/java/com/otilm/core/signing/engine/error/SigningEngineFailure.java
+++ b/src/main/java/com/otilm/core/signing/engine/error/SigningEngineFailure.java
@@ -15,6 +15,11 @@ public enum SigningEngineFailure {
     /** The platform's own configuration is wrong. */
     MISCONFIGURED,
 
+    /**
+     * The platform's time reference is not trustworthy enough to stamp with, so the operation refuses rather than lies.
+     */
+    TIME_UNAVAILABLE,
+
     /** A connector was reached but did not deliver. */
     CONNECTOR_FAULT,
 

--- a/src/main/java/com/otilm/core/signing/record/SigningRecordInputSource.java
+++ b/src/main/java/com/otilm/core/signing/record/SigningRecordInputSource.java
@@ -11,7 +11,7 @@ import com.otilm.core.model.signing.workflow.SigningWorkflow;
  * {@code requestMetadataJson} serialization, which on the TSA hot path would otherwise be built and discarded for
  * profiles that have recording disabled.
  *
- * @see com.otilm.core.signing.tsa.TspSigningRecordFactory#source
+ * @see com.otilm.core.signing.tsa.TimestampSigningRecordFactory#source
  */
 public interface SigningRecordInputSource {
 

--- a/src/main/java/com/otilm/core/signing/tsa/InternalTimestampSource.java
+++ b/src/main/java/com/otilm/core/signing/tsa/InternalTimestampSource.java
@@ -1,0 +1,127 @@
+package com.otilm.core.signing.tsa;
+
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.model.common.enums.cryptography.DigestAlgorithm;
+import com.otilm.api.model.core.signing.SigningProtocol;
+import com.otilm.core.model.signing.SigningProfileModel;
+import com.otilm.core.model.signing.resolved.ResolvedManagedTimestampingProfile;
+import com.otilm.core.model.signing.resolved.ResolvedSigningProfile;
+import com.otilm.core.service.SigningProfileInternalService;
+import com.otilm.core.signing.engine.error.SigningEngineException;
+import com.otilm.core.signing.engine.error.SigningEngineFailure;
+import com.otilm.core.signing.engine.resolver.SigningProfileResolverFactory;
+import com.otilm.core.signing.tsa.messages.IssuedTimestamp;
+import com.otilm.core.signing.tsa.messages.TimestampImprint;
+import com.otilm.core.signing.tsa.messages.TspRequest;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/**
+ * Issues the timestamps an AdES signature needs from an ILM-managed TIMESTAMPING Signing Profile, in-process.
+ *
+ * <p>
+ * The call goes below the TSP protocol edge: no HTTP, no TSP profile, no protocol authentication. Being referenced by a
+ * content-signing profile is the authorization, so the referenced profile's {@code enabledProtocols} are not consulted
+ * — an in-process protocol can never be listed there anyway.
+ * </p>
+ */
+@Component
+public class InternalTimestampSource {
+
+    private static final String CLIENT_MESSAGE = "Internal error while timestamping the signature";
+
+    private final SigningProfileInternalService signingProfileService;
+    private final SigningProfileResolverFactory signingProfileResolverFactory;
+    private final ManagedTimestampEngine engine;
+
+    public InternalTimestampSource(SigningProfileInternalService signingProfileService,
+            SigningProfileResolverFactory signingProfileResolverFactory, ManagedTimestampEngine engine) {
+        this.signingProfileService = signingProfileService;
+        this.signingProfileResolverFactory = signingProfileResolverFactory;
+        this.engine = engine;
+    }
+
+    /**
+     * Issues a timestamp over {@code imprint} from the named TIMESTAMPING Signing Profile.
+     *
+     * @param timestampingProfileName the profile's name, which the caller resolves from the {@code signingProfileUuid}
+     * its workflow configuration stores — the name is this bridge's key because the profile-model cache is name-keyed
+     * @param step the calling workflow step, which names the failure when issuance does not succeed
+     * @throws SigningEngineException if the profile cannot be used or the timestamp cannot be issued
+     */
+    public IssuedTimestamp timestamp(TimestampImprint imprint, String timestampingProfileName, String step)
+            throws SigningEngineException {
+        try {
+            SigningProfileModel<?, ?> profile = loadProfile(timestampingProfileName);
+            ResolvedManagedTimestampingProfile resolved = resolveTimestampingProfile(profile);
+            requireUsableImprint(imprint, resolved);
+            return engine.issue(requestFor(imprint), profile, resolved, SigningProtocol.INTERNAL_TSA);
+        } catch (SigningEngineException e) {
+            throw SigningEngineException.stepFailed(e.failure(), step, e.operatorMessage(), e, e.clientMessage());
+        }
+    }
+
+    private SigningProfileModel<?, ?> loadProfile(String timestampingProfileName) throws SigningEngineException {
+        SigningProfileModel<?, ?> profile;
+        try {
+            profile = signingProfileService.getSigningProfileModel(timestampingProfileName);
+        } catch (NotFoundException e) {
+            throw misconfigured("timestamping Signing Profile '%s' does not exist".formatted(timestampingProfileName),
+                    e);
+        }
+        if (!profile.enabled()) {
+            throw misconfigured("timestamping Signing Profile '%s' is disabled".formatted(timestampingProfileName),
+                    null);
+        }
+        return profile;
+    }
+
+    private ResolvedManagedTimestampingProfile resolveTimestampingProfile(SigningProfileModel<?, ?> profile)
+            throws SigningEngineException {
+        ResolvedSigningProfile resolved = signingProfileResolverFactory.resolve(profile);
+        if (resolved instanceof ResolvedManagedTimestampingProfile timestampingProfile) {
+            return timestampingProfile;
+        }
+        throw misconfigured(
+                "Signing Profile '%s' resolved to %s, not a managed timestamping profile"
+                        .formatted(profile.name(), resolved == null ? "null" : resolved.getClass().getSimpleName()),
+                null);
+    }
+
+    /**
+     * The imprint comes from a formatting connector rather than from a client, so the two refusals here have different
+     * culprits: an algorithm the profile does not list means the content-signing and timestamping profiles disagree,
+     * while a digest of the wrong length for its own algorithm came from no document and so is the connector's fault.
+     * The RFC 3161 edge rejects both in {@code TspRequestParser} and {@code TspRequestValidator}; in-process issuance
+     * has no parser in front of it.
+     */
+    private static void requireUsableImprint(TimestampImprint imprint, ResolvedManagedTimestampingProfile resolved)
+            throws SigningEngineException {
+        List<DigestAlgorithm> allowed = resolved.allowedDigestAlgorithms();
+        if (!allowed.isEmpty() && !allowed.contains(imprint.algorithm())) {
+            throw new SigningEngineException(SigningEngineFailure.MISCONFIGURED,
+                    "timestamping Signing Profile '%s' does not accept %s imprints"
+                            .formatted(resolved.name(), imprint.algorithm().getCode()),
+                    CLIENT_MESSAGE);
+        }
+        if (!imprint.hasLengthOfItsAlgorithm()) {
+            throw new SigningEngineException(SigningEngineFailure.CONNECTOR_FAULT,
+                    "imprint is %d bytes, which %s never produces"
+                            .formatted(imprint.length(), imprint.algorithm().getCode()),
+                    CLIENT_MESSAGE);
+        }
+    }
+
+    /**
+     * A nonce would only prove freshness to a remote caller, and the signer certificate is always embedded because the
+     * token travels inside the signature that a validator checks on its own.
+     */
+    private static TspRequest requestFor(TimestampImprint imprint) {
+        return new TspRequest(imprint.algorithm(), imprint.value(), Optional.empty(), Optional.empty(), true, null);
+    }
+
+    private static SigningEngineException misconfigured(String operatorMessage, Throwable cause) {
+        return new SigningEngineException(SigningEngineFailure.MISCONFIGURED, operatorMessage, cause, CLIENT_MESSAGE);
+    }
+}

--- a/src/main/java/com/otilm/core/signing/tsa/InternalTimestampSource.java
+++ b/src/main/java/com/otilm/core/signing/tsa/InternalTimestampSource.java
@@ -21,9 +21,9 @@ import org.springframework.stereotype.Component;
  * Issues the timestamps an AdES signature needs from an ILM-managed TIMESTAMPING Signing Profile, in-process.
  *
  * <p>
- * The call goes below the TSP protocol edge: no HTTP, no TSP profile, no protocol authentication. Being referenced by a
- * content-signing profile is the authorization, so the referenced profile's {@code enabledProtocols} are not consulted
- * — an in-process protocol can never be listed there anyway.
+ * The call goes below the TSP protocol layer, so being referenced by a content-signing profile is the authorization and
+ * the referenced profile's {@code enabledProtocols} are not consulted — an in-process protocol can never be listed
+ * there anyway.
  * </p>
  */
 @Component
@@ -62,13 +62,19 @@ public class InternalTimestampSource {
         }
     }
 
+    /**
+     * Uses the authorization-free loader, per the class-level invariant.
+     */
     private SigningProfileModel<?, ?> loadProfile(String timestampingProfileName) throws SigningEngineException {
         SigningProfileModel<?, ?> profile;
         try {
-            profile = signingProfileService.getSigningProfileModel(timestampingProfileName);
+            profile = signingProfileService.loadSigningProfileModel(timestampingProfileName);
         } catch (NotFoundException e) {
             throw misconfigured("timestamping Signing Profile '%s' does not exist".formatted(timestampingProfileName),
                     e);
+        } catch (IllegalStateException | IllegalArgumentException e) {
+            throw misconfigured("timestamping Signing Profile '%s' cannot be loaded: %s"
+                    .formatted(timestampingProfileName, e.getMessage()), e);
         }
         if (!profile.enabled()) {
             throw misconfigured("timestamping Signing Profile '%s' is disabled".formatted(timestampingProfileName),

--- a/src/main/java/com/otilm/core/signing/tsa/ManagedTimestampEngine.java
+++ b/src/main/java/com/otilm/core/signing/tsa/ManagedTimestampEngine.java
@@ -204,10 +204,6 @@ public class ManagedTimestampEngine {
         return new SigningEngineException(SigningEngineFailure.CONNECTOR_FAULT, defect, INTERNAL_ERROR_CLIENT_MESSAGE);
     }
 
-    /**
-     * A fault in the platform's own signing path is an operational alert; a rejection the requester or the operator
-     * caused is not. Both entry points log here, because {@link #issue} is the one place every failure passes through.
-     */
     private static void logFailure(ResolvedManagedTimestampingProfile timestampingProfile, SigningProtocol protocol,
             SigningEngineException e) {
         if (isPlatformFault(e.failure())) {
@@ -217,7 +213,7 @@ public class ManagedTimestampEngine {
         } else {
             logger
                     .warn("Refusing to issue a timestamp for signing profile '{}' via {}: {}",
-                            timestampingProfile.name(), protocol, e.operatorMessage(), e);
+                            timestampingProfile.name(), protocol, e.operatorMessage());
         }
     }
 

--- a/src/main/java/com/otilm/core/signing/tsa/ManagedTimestampEngine.java
+++ b/src/main/java/com/otilm/core/signing/tsa/ManagedTimestampEngine.java
@@ -24,6 +24,7 @@ import com.otilm.core.util.serialnumber.SerialNumberGenerator;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.time.Instant;
+import java.util.Objects;
 import org.bouncycastle.cms.jcajce.JcaSimpleSignerInfoVerifierBuilder;
 import org.bouncycastle.tsp.TSPValidationException;
 import org.bouncycastle.tsp.TimeStampToken;
@@ -91,10 +92,11 @@ public class ManagedTimestampEngine {
     public IssuedTimestamp issue(TspRequest request, SigningProfileModel<?, ?> signingProfile,
             ResolvedManagedTimestampingProfile timestampingProfile, SigningProtocol protocol)
             throws SigningEngineException {
+        Objects.requireNonNull(protocol, "protocol");
         try {
             return issueToken(request, signingProfile, timestampingProfile, protocol);
         } catch (SigningEngineException e) {
-            logFailure(timestampingProfile, e);
+            logFailure(timestampingProfile, protocol, e);
             throw e;
         }
     }
@@ -124,7 +126,7 @@ public class ManagedTimestampEngine {
             return new IssuedTimestamp(encodedToken, serialNumber, genTime);
 
         } catch (SigningEngineException e) {
-            // keeps engine failures out of catch (Exception) below, which would collapse their classification
+            // keeps engine failures out of the catch-all below, which would collapse their classification
             throw e;
         } catch (TSPValidationException e) {
             throw new SigningEngineException(SigningEngineFailure.SIGNER_FAULT, "timestamp signature validation failed",
@@ -206,15 +208,16 @@ public class ManagedTimestampEngine {
      * A fault in the platform's own signing path is an operational alert; a rejection the requester or the operator
      * caused is not. Both entry points log here, because {@link #issue} is the one place every failure passes through.
      */
-    private static void logFailure(ResolvedManagedTimestampingProfile timestampingProfile, SigningEngineException e) {
+    private static void logFailure(ResolvedManagedTimestampingProfile timestampingProfile, SigningProtocol protocol,
+            SigningEngineException e) {
         if (isPlatformFault(e.failure())) {
             logger
-                    .error("Timestamp issuance failed for signing profile '{}': {}", timestampingProfile.name(),
-                            e.operatorMessage(), e);
+                    .error("Timestamp issuance failed for signing profile '{}' via {}: {}", timestampingProfile.name(),
+                            protocol, e.operatorMessage(), e);
         } else {
             logger
-                    .warn("Rejecting timestamp request for signing profile '{}': {}", timestampingProfile.name(),
-                            e.operatorMessage(), e);
+                    .warn("Refusing to issue a timestamp for signing profile '{}' via {}: {}",
+                            timestampingProfile.name(), protocol, e.operatorMessage(), e);
         }
     }
 

--- a/src/main/java/com/otilm/core/signing/tsa/ManagedTimestampEngine.java
+++ b/src/main/java/com/otilm/core/signing/tsa/ManagedTimestampEngine.java
@@ -1,8 +1,7 @@
 package com.otilm.core.signing.tsa;
 
-import com.otilm.api.interfaces.core.tsp.error.TspException;
-import com.otilm.api.interfaces.core.tsp.error.TspFailureInfo;
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
+import com.otilm.api.model.core.signing.SigningProtocol;
 import com.otilm.api.model.messaging.timequality.TimeQualityStatus;
 import com.otilm.core.model.signing.SigningProfileModel;
 import com.otilm.core.model.signing.resolved.ResolvedManagedScheme;
@@ -14,6 +13,7 @@ import com.otilm.core.signing.engine.error.SigningEngineException;
 import com.otilm.core.signing.engine.error.SigningEngineFailure;
 import com.otilm.core.signing.record.SigningRecordInputSource;
 import com.otilm.core.signing.record.SigningRecordStrategyFactory;
+import com.otilm.core.signing.tsa.messages.IssuedTimestamp;
 import com.otilm.core.signing.tsa.messages.TspRequest;
 import com.otilm.core.signing.tsa.messages.TspResponse;
 import com.otilm.core.signing.tsa.timequality.TimeQualityRegister;
@@ -22,25 +22,28 @@ import com.otilm.core.util.serialnumber.ClockDriftException;
 import com.otilm.core.util.serialnumber.SerialNumberGenerationException;
 import com.otilm.core.util.serialnumber.SerialNumberGenerator;
 import java.math.BigInteger;
+import java.security.MessageDigest;
 import java.time.Instant;
 import org.bouncycastle.cms.jcajce.JcaSimpleSignerInfoVerifierBuilder;
 import org.bouncycastle.tsp.TSPValidationException;
+import org.bouncycastle.tsp.TimeStampToken;
+import org.bouncycastle.tsp.TimeStampTokenInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /**
- * Core engine that processes RFC 3161 timestamp requests.
+ * Core engine that issues RFC 3161 timestamp tokens.
  *
  * <p>
- * Validates time quality, generates a serial number, delegates token creation to
- * {@link ManagedTimestampTokenGenerator}, verifies the signer certificate, and optionally validates the token signature
- * before returning the response.
+ * {@link #issue} is the protocol-neutral entry point; {@link #process} wraps it for RFC 3161.
  */
 @Component
 public class ManagedTimestampEngine {
 
     private static final Logger logger = LoggerFactory.getLogger(ManagedTimestampEngine.class);
+
+    private static final String INTERNAL_ERROR_CLIENT_MESSAGE = "Internal error";
 
     private final TimeQualityRegister timeQualityRegister;
     private final SerialNumberGenerator serialNumberGenerator;
@@ -48,115 +51,199 @@ public class ManagedTimestampEngine {
     private final SigningCertificateValidatorFactory signingCertificateValidatorFactory;
     private final ClockSource clockSource;
     private final SigningRecordStrategyFactory signingRecordStrategyFactory;
-    private final TspSigningRecordFactory tspSigningRecordFactory;
+    private final TimestampSigningRecordFactory timestampSigningRecordFactory;
 
     public ManagedTimestampEngine(TimeQualityRegister timeQualityRegister, SerialNumberGenerator serialNumberGenerator,
             ManagedTimestampTokenGenerator tokenGenerator,
             SigningCertificateValidatorFactory signingCertificateValidatorFactory, ClockSource clockSource,
             SigningRecordStrategyFactory signingRecordStrategyFactory,
-            TspSigningRecordFactory tspSigningRecordFactory) {
+            TimestampSigningRecordFactory timestampSigningRecordFactory) {
         this.timeQualityRegister = timeQualityRegister;
         this.serialNumberGenerator = serialNumberGenerator;
         this.tokenGenerator = tokenGenerator;
         this.signingCertificateValidatorFactory = signingCertificateValidatorFactory;
         this.clockSource = clockSource;
         this.signingRecordStrategyFactory = signingRecordStrategyFactory;
-        this.tspSigningRecordFactory = tspSigningRecordFactory;
+        this.timestampSigningRecordFactory = timestampSigningRecordFactory;
     }
 
+    /**
+     * Renders an {@link #issue} run as an RFC 3161 response. A failure becomes a rejection carrying the same failure
+     * info and client text the protocol edge would have produced from the thrown exception.
+     */
     public TspResponse process(TspRequest request, SigningProfileModel<?, ?> signingProfile,
-            ResolvedManagedTimestampingProfile timestampingProfile) throws TspException {
+            ResolvedManagedTimestampingProfile timestampingProfile) {
         try {
-            return processInternal(request, signingProfile, timestampingProfile);
+            return TspResponse
+                    .granted(issue(request, signingProfile, timestampingProfile, SigningProtocol.TSP).encoded());
         } catch (SigningEngineException e) {
-            throw TspErrorMapper.toTspException(e); // TspController maps this to a proper rejection response
+            return TspResponse.rejected(TspErrorMapper.toFailureInfo(e.failure()), e.clientMessage());
         }
     }
 
-    private TspResponse processInternal(TspRequest request, SigningProfileModel<?, ?> signingProfile,
-            ResolvedManagedTimestampingProfile timestampingProfile) throws SigningEngineException {
+    /**
+     * Issues a timestamp token below any protocol edge, reporting failures in the Signing Engine's own currency.
+     *
+     * @param protocol how the issuance was initiated, which is what its signing record will carry
+     * @throws SigningEngineException if the time reference, the signing certificate, or token assembly does not permit
+     * issuing
+     */
+    public IssuedTimestamp issue(TspRequest request, SigningProfileModel<?, ?> signingProfile,
+            ResolvedManagedTimestampingProfile timestampingProfile, SigningProtocol protocol)
+            throws SigningEngineException {
+        try {
+            return issueToken(request, signingProfile, timestampingProfile, protocol);
+        } catch (SigningEngineException e) {
+            logFailure(timestampingProfile, e);
+            throw e;
+        }
+    }
 
+    private IssuedTimestamp issueToken(TspRequest request, SigningProfileModel<?, ?> signingProfile,
+            ResolvedManagedTimestampingProfile timestampingProfile, SigningProtocol protocol)
+            throws SigningEngineException {
         ResolvedManagedScheme signingScheme = timestampingProfile.resolvedScheme();
-        var signerCertificateValidator = signingCertificateValidatorFactory.getValidator(signingScheme);
-        TimeQualityConfigurationModel timeQualityConfiguration = timestampingProfile.timeQualityConfiguration();
+        requireTrustworthyTime(timestampingProfile);
+        requireAcceptableSigningCertificate(timestampingProfile, signingScheme);
 
-        var timeStatus = timeQualityRegister.getStatus(timeQualityConfiguration);
+        try {
+            BigInteger serialNumber = serialNumberGenerator.generate();
+            Instant genTime = clockSource.wallTimeInstant();
+            var certificateChain = signingScheme.chain();
+
+            TimeStampToken token = tokenGenerator
+                    .generate(request, timestampingProfile, certificateChain, serialNumber, genTime);
+            if (Boolean.TRUE.equals(timestampingProfile.validateTokenSignature())) {
+                token.validate(new JcaSimpleSignerInfoVerifierBuilder().build(certificateChain.signingCertificate()));
+            }
+
+            requireTokenBoundToRequest(token, request, serialNumber);
+
+            byte[] encodedToken = token.getEncoded();
+            recordSigning(signingProfile, request, serialNumber, genTime, encodedToken, protocol);
+            return new IssuedTimestamp(encodedToken, serialNumber, genTime);
+
+        } catch (SigningEngineException e) {
+            // keeps engine failures out of catch (Exception) below, which would collapse their classification
+            throw e;
+        } catch (TSPValidationException e) {
+            throw new SigningEngineException(SigningEngineFailure.SIGNER_FAULT, "timestamp signature validation failed",
+                    e, "Timestamp signature validation failed");
+        } catch (ClockDriftException e) {
+            throw new SigningEngineException(SigningEngineFailure.TIME_UNAVAILABLE,
+                    "clock drift detected during timestamp generation", e, "Clock drift detected");
+        } catch (SerialNumberGenerationException e) {
+            throw new SigningEngineException(SigningEngineFailure.STEP_FAILED, "timestamp generation interrupted", e,
+                    INTERNAL_ERROR_CLIENT_MESSAGE);
+        } catch (Exception e) {
+            throw new SigningEngineException(SigningEngineFailure.STEP_FAILED,
+                    "unexpected error during timestamp generation", e, INTERNAL_ERROR_CLIENT_MESSAGE);
+        }
+    }
+
+    /**
+     * A timestamp asserts that a document existed at a stated moment, so an untrustworthy time reference must stop
+     * issuance rather than produce a token nobody can rely on.
+     */
+    private void requireTrustworthyTime(ResolvedManagedTimestampingProfile timestampingProfile)
+            throws SigningEngineException {
+        TimeQualityConfigurationModel timeQualityConfiguration = timestampingProfile.timeQualityConfiguration();
+        TimeQualityStatus timeStatus = timeQualityRegister.getStatus(timeQualityConfiguration);
         if (timeStatus != TimeQualityStatus.OK) {
-            logger
-                    .warn("Rejecting timestamp request for timestampingProfile '{}' using timeQualityProfile '{}': time quality status is {}",
-                            timestampingProfile.name(), timeQualityConfiguration.getName(), timeStatus);
-            return TspResponse
-                    .rejected(TspFailureInfo.TIME_NOT_AVAILABLE,
-                            "Time quality is not sufficient for timestampingProfile '%s'"
-                                    .formatted(timestampingProfile.name()));
+            throw new SigningEngineException(SigningEngineFailure.TIME_UNAVAILABLE,
+                    "time quality status is %s for timestampingProfile '%s' using timeQualityProfile '%s'"
+                            .formatted(timeStatus, timestampingProfile.name(), timeQualityConfiguration.getName()),
+                    "Time quality is not sufficient for timestampingProfile '%s'"
+                            .formatted(timestampingProfile.name()));
         }
         logger
                 .info("Time quality status for time quality configuration '{}': {}", timeQualityConfiguration.getName(),
                         timeStatus);
+    }
 
-        var validationResult = signerCertificateValidator
+    private void requireAcceptableSigningCertificate(ResolvedManagedTimestampingProfile timestampingProfile,
+            ResolvedManagedScheme signingScheme) throws SigningEngineException {
+        ValidationResult result = signingCertificateValidatorFactory
+                .getValidator(signingScheme)
                 .validate(signingScheme, SigningWorkflowType.TIMESTAMPING, timestampingProfile.isQualifiedTimestamp());
-        if (validationResult instanceof ValidationResult.Nok(SigningEngineFailure failure, String logMessage, String clientMessage)) {
-            logger
-                    .warn("Rejecting timestamp request for signing profile '{}': {}", timestampingProfile.name(),
-                            logMessage);
-            return TspResponse.rejected(TspErrorMapper.toFailureInfo(failure), clientMessage);
+        if (result instanceof ValidationResult.Nok(SigningEngineFailure failure, String logMessage, String clientMessage)) {
+            throw new SigningEngineException(failure,
+                    "signing certificate of timestampingProfile '%s' is not acceptable: %s"
+                            .formatted(timestampingProfile.name(), logMessage),
+                    clientMessage);
         }
-
-        try {
-            var serialNumber = serialNumberGenerator.generate();
-            var genTime = clockSource.wallTimeInstant();
-            var certificateChain = signingScheme.chain();
-
-            var token = tokenGenerator.generate(request, timestampingProfile, certificateChain, serialNumber, genTime);
-
-            if (Boolean.TRUE.equals(timestampingProfile.validateTokenSignature())) {
-                var verifier = new JcaSimpleSignerInfoVerifierBuilder().build(certificateChain.signingCertificate());
-                token.validate(verifier);
-            }
-
-            byte[] encodedToken = token.getEncoded();
-            recordSigning(signingProfile, request, serialNumber, genTime, encodedToken);
-
-            return TspResponse.granted(encodedToken);
-
-        } catch (SigningEngineException e) {
-            // keeps engine failures out of catch (Exception) below, which would collapse them into SYSTEM_FAILURE
-            throw e;
-        } catch (TSPValidationException e) {
-            logger.error("Timestamp signature validation failed", e);
-            return TspResponse.rejected(TspFailureInfo.SYSTEM_FAILURE, "Timestamp signature validation failed");
-        } catch (ClockDriftException e) {
-            logger.error("Clock drift detected during timestamp generation", e);
-            return TspResponse.rejected(TspFailureInfo.TIME_NOT_AVAILABLE, "Clock drift detected");
-        } catch (SerialNumberGenerationException e) {
-            logger.error("Timestamp generation interrupted", e);
-            return TspResponse.rejected(TspFailureInfo.SYSTEM_FAILURE, "Internal error");
-        } catch (Exception e) {
-            logger.error("Unexpected error during timestamp generation", e);
-            return TspResponse.rejected(TspFailureInfo.SYSTEM_FAILURE, "Internal error");
-        }
-
     }
 
     /**
-     * Records the granted timestamp. The signature has already been produced by the managed key, so a recording failure
-     * must never downgrade the response: it is logged and swallowed, leaving the granted token intact. The engine hands
-     * the strategy a deferred {@link SigningRecordInputSource} so the strategy's {@code recordingEnabled} gate
+     * The connector assembles the {@code TSTInfo}, so the token it returns is only as trustworthy as its echo of what
+     * was asked for. On the RFC 3161 path the client checks this itself against its own request; in-process issuance
+     * has no such counterparty, and the token goes straight into a signature. The generation time is deliberately not
+     * compared: its encoded precision is the connector's choice, so an exact match would be brittle without adding
+     * assurance the imprint and serial do not already give.
+     */
+    private static void requireTokenBoundToRequest(TimeStampToken token, TspRequest request, BigInteger serialNumber)
+            throws SigningEngineException {
+        TimeStampTokenInfo info = token.getTimeStampInfo();
+        String stampedAlgorithm = info.getMessageImprintAlgOID().getId();
+        if (!request.hashAlgorithm().getOid().equals(stampedAlgorithm)) {
+            throw brokenEcho("connector stamped a %s imprint but %s was requested"
+                    .formatted(stampedAlgorithm, request.hashAlgorithm().getCode()));
+        }
+        if (!MessageDigest.isEqual(request.hashedMessage(), info.getMessageImprintDigest())) {
+            throw brokenEcho("connector stamped an imprint other than the one requested");
+        }
+        if (!serialNumber.equals(info.getSerialNumber())) {
+            throw brokenEcho("connector stamped serial number %s but %s was issued"
+                    .formatted(info.getSerialNumber().toString(16), serialNumber.toString(16)));
+        }
+    }
+
+    private static SigningEngineException brokenEcho(String defect) {
+        return new SigningEngineException(SigningEngineFailure.CONNECTOR_FAULT, defect, INTERNAL_ERROR_CLIENT_MESSAGE);
+    }
+
+    /**
+     * A fault in the platform's own signing path is an operational alert; a rejection the requester or the operator
+     * caused is not. Both entry points log here, because {@link #issue} is the one place every failure passes through.
+     */
+    private static void logFailure(ResolvedManagedTimestampingProfile timestampingProfile, SigningEngineException e) {
+        if (isPlatformFault(e.failure())) {
+            logger
+                    .error("Timestamp issuance failed for signing profile '{}': {}", timestampingProfile.name(),
+                            e.operatorMessage(), e);
+        } else {
+            logger
+                    .warn("Rejecting timestamp request for signing profile '{}': {}", timestampingProfile.name(),
+                            e.operatorMessage(), e);
+        }
+    }
+
+    /** Exhaustive so that a new failure class has to choose its log level rather than inherit one. */
+    private static boolean isPlatformFault(SigningEngineFailure failure) {
+        return switch (failure) {
+            case SIGNER_FAULT, STEP_FAILED, CONNECTOR_FAULT -> true;
+            case INVALID_INPUT, MALFORMED_INPUT, MISCONFIGURED, TIME_UNAVAILABLE, BINDING_VIOLATION -> false;
+        };
+    }
+
+    /**
+     * Records the issued timestamp. The signature has already been produced by the managed key, so a recording failure
+     * must never withdraw it: it is logged and swallowed, leaving the issued token intact. The engine hands the
+     * strategy a deferred {@link SigningRecordInputSource} so the strategy's {@code recordingEnabled} gate
      * short-circuits disabled profiles before the input — and its request-metadata serialization — is assembled on the
-     * TSA hot path.
+     * hot path.
      */
     private void recordSigning(SigningProfileModel<?, ?> signingProfile, TspRequest request, BigInteger serialNumber,
-            Instant genTime, byte[] encodedToken) {
+            Instant genTime, byte[] encodedToken, SigningProtocol protocol) {
         try {
-            SigningRecordInputSource source = tspSigningRecordFactory
-                    .source(signingProfile, request, serialNumber, genTime, encodedToken);
+            SigningRecordInputSource source = timestampSigningRecordFactory
+                    .source(signingProfile, request, serialNumber, genTime, encodedToken, protocol);
             signingRecordStrategyFactory
                     .strategyFor(signingProfile.recordPolicy().persistenceMode())
                     .recordSigning(source);
         } catch (Exception e) {
             logger
-                    .error("Failed to record signing for signing profile '{}'; the timestamp was granted regardless",
+                    .error("Failed to record signing for signing profile '{}'; the timestamp was issued regardless",
                             signingProfile.name(), e);
         }
     }

--- a/src/main/java/com/otilm/core/signing/tsa/TimestampSigningRecordFactory.java
+++ b/src/main/java/com/otilm/core/signing/tsa/TimestampSigningRecordFactory.java
@@ -15,8 +15,9 @@ import java.util.Map;
 import org.springframework.stereotype.Component;
 
 /**
- * Builds the {@link SigningRecordInput} for a granted RFC 3161 timestamp from the signing profile, the request, and the
- * artifacts produced during token assembly.
+ * Builds the {@link SigningRecordInput} for an issued timestamp from the signing profile, the request, and the
+ * artifacts produced during token assembly. The caller supplies the {@link SigningProtocol} so the record distinguishes
+ * a client's RFC 3161 request from issuance the platform made on its own.
  *
  * <p>
  * The per-field {@code record*} content toggles are applied downstream by the signing-record mapper, which is the
@@ -25,14 +26,14 @@ import org.springframework.stereotype.Component;
  *
  * <p>
  * {@code requestedBy} is left {@code null}: the TSP caller identity is resolved in the protocol layer and is not
- * currently threaded down to the TSA engine.
+ * currently threaded down to the TSA engine, and in-process issuance has no caller identity of its own.
  */
 @Component
-public class TspSigningRecordFactory {
+public class TimestampSigningRecordFactory {
 
     private final ObjectMapper objectMapper;
 
-    public TspSigningRecordFactory(ObjectMapper objectMapper) {
+    public TimestampSigningRecordFactory(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
@@ -43,22 +44,22 @@ public class TspSigningRecordFactory {
      * called, so disabled profiles never pay for it.
      */
     public SigningRecordInputSource source(SigningProfileModel<?, ?> signingProfile, TspRequest request,
-            BigInteger serialNumber, Instant genTime, byte[] encodedToken) {
+            BigInteger serialNumber, Instant genTime, byte[] encodedToken, SigningProtocol protocol) {
         return new DeferredSigningRecordInputSource(signingProfile,
-                () -> build(signingProfile, request, serialNumber, genTime, encodedToken));
+                () -> build(signingProfile, request, serialNumber, genTime, encodedToken, protocol));
     }
 
     private SigningRecordInput build(SigningProfileModel<?, ?> signingProfile, TspRequest request,
-            BigInteger serialNumber, Instant genTime, byte[] encodedToken) {
+            BigInteger serialNumber, Instant genTime, byte[] encodedToken, SigningProtocol protocol) {
         String serialHex = serialNumber.toString(16);
 
         // The timestamp token is the self-contained signed artifact: it already embeds the signature value and the
         // signed attributes (DTBS), so both are recoverable from it. Storing them again under signature/dtbs would
-        // duplicate substrings of the token, so only signedDocument is populated for the TSP path.
+        // duplicate substrings of the token, so only signedDocument is populated.
         return SigningRecordInput
                 .builder()
                 .signingProfile(signingProfile)
-                .protocol(SigningProtocol.TSP)
+                .protocol(protocol)
                 .signingTime(genTime)
                 .requestedBy(null)
                 .displayName(signingProfile.name() + " #" + serialHex)

--- a/src/main/java/com/otilm/core/signing/tsa/TspErrorMapper.java
+++ b/src/main/java/com/otilm/core/signing/tsa/TspErrorMapper.java
@@ -7,7 +7,8 @@ import com.otilm.core.signing.engine.error.SigningEngineFailure;
 
 /**
  * Maps the Signing Engine's error currency onto RFC 3161's. Only {@code INVALID_INPUT} and {@code MALFORMED_INPUT} are
- * attributable to the requester, so everything else collapses onto {@code SYSTEM_FAILURE}.
+ * attributable to the requester, and only {@code TIME_UNAVAILABLE} has a failure info of its own, so everything else
+ * collapses onto {@code SYSTEM_FAILURE}.
  */
 public final class TspErrorMapper {
 
@@ -18,6 +19,7 @@ public final class TspErrorMapper {
         return switch (failure) {
             case INVALID_INPUT -> TspFailureInfo.BAD_REQUEST;
             case MALFORMED_INPUT -> TspFailureInfo.BAD_DATA_FORMAT;
+            case TIME_UNAVAILABLE -> TspFailureInfo.TIME_NOT_AVAILABLE;
             case MISCONFIGURED, CONNECTOR_FAULT, BINDING_VIOLATION, SIGNER_FAULT, STEP_FAILED ->
                 TspFailureInfo.SYSTEM_FAILURE;
         };

--- a/src/main/java/com/otilm/core/signing/tsa/messages/IssuedTimestamp.java
+++ b/src/main/java/com/otilm/core/signing/tsa/messages/IssuedTimestamp.java
@@ -1,0 +1,50 @@
+package com.otilm.core.signing.tsa.messages;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Objects;
+import org.springframework.lang.NonNull;
+
+/**
+ * A timestamp token the engine has issued, with the artifacts a caller needs to trace it back to its signing record.
+ *
+ * @param encoded the DER-encoded token (CMS {@code ContentInfo})
+ * @param serialNumber the token's serial number, which its signing record carries in the display name and the request
+ * metadata
+ * @param genTime the generation time embedded in the token
+ */
+public record IssuedTimestamp(byte[] encoded, BigInteger serialNumber, Instant genTime) {
+
+    public IssuedTimestamp {
+        Objects.requireNonNull(encoded, "encoded");
+        Objects.requireNonNull(serialNumber, "serialNumber");
+        Objects.requireNonNull(genTime, "genTime");
+        encoded = encoded.clone();
+    }
+
+    @Override
+    public byte[] encoded() {
+        return encoded.clone();
+    }
+
+    /** Compares the token by value, which a record's generated {@code equals} would not do for its array. */
+    @Override
+    public boolean equals(Object other) {
+        return this == other || other instanceof IssuedTimestamp issued && serialNumber.equals(issued.serialNumber)
+                && genTime.equals(issued.genTime) && Arrays.equals(encoded, issued.encoded);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * Objects.hash(serialNumber, genTime) + Arrays.hashCode(encoded);
+    }
+
+    /** Renders the serial and generation time; the token itself is too long to be useful in a log line. */
+    @Override
+    @NonNull
+    public String toString() {
+        return "IssuedTimestamp[serialNumber=%s, genTime=%s, encoded=%d bytes]"
+                .formatted(serialNumber.toString(16), genTime, encoded.length);
+    }
+}

--- a/src/main/java/com/otilm/core/signing/tsa/messages/TimestampImprint.java
+++ b/src/main/java/com/otilm/core/signing/tsa/messages/TimestampImprint.java
@@ -1,0 +1,58 @@
+package com.otilm.core.signing.tsa.messages;
+
+import com.otilm.api.model.common.enums.cryptography.DigestAlgorithm;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.Objects;
+import org.springframework.lang.NonNull;
+
+/**
+ * What a timestamp is to be taken over: a digest and the algorithm that produced it.
+ *
+ * @param algorithm the algorithm that produced {@code value}
+ * @param value the digest itself
+ */
+public record TimestampImprint(DigestAlgorithm algorithm, byte[] value) {
+
+    /** Copies the digest in, so a caller that reuses its buffer cannot change what is stamped after the fact. */
+    public TimestampImprint {
+        Objects.requireNonNull(algorithm, "algorithm");
+        Objects.requireNonNull(value, "value");
+        value = value.clone();
+    }
+
+    /** Copies the digest out, so a consumer cannot reach back through the accessor and alter it. */
+    @Override
+    public byte[] value() {
+        return value.clone();
+    }
+
+    /** The digest length, free of the copy {@link #value()} has to make. */
+    public int length() {
+        return value.length;
+    }
+
+    /** Whether the digest is as long as its algorithm produces; a shorter or longer one came from no document. */
+    public boolean hasLengthOfItsAlgorithm() {
+        return value.length == algorithm.getDigestSizeBytes();
+    }
+
+    /** Compares the imprint by value in constant time, which a record's generated {@code equals} would not do. */
+    @Override
+    public boolean equals(Object other) {
+        return this == other || other instanceof TimestampImprint imprint && algorithm == imprint.algorithm
+                && MessageDigest.isEqual(value, imprint.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * algorithm.hashCode() + Arrays.hashCode(value);
+    }
+
+    @Override
+    @NonNull
+    public String toString() {
+        return "TimestampImprint[%s:%s]".formatted(algorithm.getCode(), HexFormat.of().formatHex(value));
+    }
+}

--- a/src/main/java/com/otilm/core/signing/tsa/messages/TspRequest.java
+++ b/src/main/java/com/otilm/core/signing/tsa/messages/TspRequest.java
@@ -10,13 +10,15 @@ import org.bouncycastle.asn1.x509.Extensions;
 import org.springframework.lang.NonNull;
 
 /**
- * Parsed RFC 3161 Timestamp Request.
+ * The TSA engine's input: a parsed RFC 3161 Timestamp Request on the protocol path, or one the platform synthesizes for
+ * in-process issuance.
  *
  * <p>
- * Before this record reaches the TSA engine, {@link TspRequestValidator} has already checked:
+ * Before this record reaches the engine, these have already been checked — by {@link TspRequestValidator} on the
+ * protocol path, and by {@link com.otilm.core.signing.tsa.InternalTimestampSource} in-process:
  * <ul>
  * <li>Hash algorithm — on the profile's allowed-digest-algorithm list.</li>
- * <li>Policy OID — if present, on the profile's allowed-policy-id list.</li>
+ * <li>Policy OID — if present, on the profile's allowed-policy-id list (in-process issuance requests none).</li>
  * </ul>
  * Client request extensions are accepted as-is (any well-formed extension is allowed) and carried through in
  * {@code requestExtensions}; the validator does not filter them. The engine is responsible for effective-policy

--- a/src/test/java/com/otilm/core/integration/signing/tsa/TsaServiceImplITest.java
+++ b/src/test/java/com/otilm/core/integration/signing/tsa/TsaServiceImplITest.java
@@ -74,6 +74,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class TsaServiceImplITest extends BaseSpringBootTest {
 
+    private static final String DEFAULT_POLICY_ID = "1.2.3";
+
     @Autowired
     private TsaExternalService tsaService;
 
@@ -111,7 +113,6 @@ class TsaServiceImplITest extends BaseSpringBootTest {
     private TimestampingFormattingConnectorMock timestampingFormattingMock;
     private ConnectorDetailDto timestampingFormattingConnector;
     private Certificate signingCertificate;
-    private byte[] timestampTokenBytes;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -155,10 +156,10 @@ class TsaServiceImplITest extends BaseSpringBootTest {
                 .createTrustedCa("CN=Test Root CA")
                 .issueTimestampingCertificate(keyPair, "CN=Test TSA");
 
-        // The connector signs the DTBS and assembles the token; the assembled token is a real RFC 3161 token.
-        timestampTokenBytes = TimestampTokenTestUtil.createTimestampToken().getEncoded();
+        // The connector assembles the token from the request it is given, so what comes back echoes the imprint and
+        // the serial the engine asked for. The engine verifies that echo before recording.
         cryptographyProviderMock.stubSignData("connector-signature".getBytes(StandardCharsets.UTF_8));
-        timestampingFormattingMock.stubFormattingAttributes().stubTokenAssembly(timestampTokenBytes);
+        timestampingFormattingMock.stubFormattingAttributes().stubFormatDtbs().stubFormatResponse();
     }
 
     @AfterEach
@@ -190,6 +191,7 @@ class TsaServiceImplITest extends BaseSpringBootTest {
                         .withTimestamping(aTimestampingWorkflow()
                                 .withSignatureFormattingConnector(
                                         UUID.fromString(timestampingFormattingConnector.getUuid()))
+                                .withDefaultPolicyId(DEFAULT_POLICY_ID)
                                 .withValidateTokenSignature(false)
                                 .withQualifiedTimestamp(false)
                                 .withAllowedDigestAlgorithms(allowedDigestAlgorithms)
@@ -381,6 +383,30 @@ class TsaServiceImplITest extends BaseSpringBootTest {
                 assertThat(rejected.failureInfo()).isEqualTo(TspFailureInfo.SYSTEM_FAILURE);
                 assertThat(rejected.statusString()).isEqualTo("Internal error during DTBS formatting");
             });
+        }
+
+        /**
+         * The connector assembles the {@code TSTInfo}, so a token that does not echo the request must not be recorded
+         * or returned. {@code stubTokenAssembly} answers with a pre-built token whose serial number is unrelated to the
+         * one the engine generated, which is exactly the defect the echo check exists to catch.
+         */
+        @Test
+        void rejectsWithSystemFailure_whenTheConnectorStampsAnotherSerialNumber() throws Exception {
+            // given
+            SigningProfileDto profile = createTimestampingSigningProfile("sp-unbound-token");
+            timestampingFormattingMock.stubTokenAssembly(TimestampTokenTestUtil.createTimestampToken().getEncoded());
+
+            // when
+            TspResponse response = tsaService
+                    .processTspRequestForSigningProfile(profile.getName(), aTspRequest().build());
+
+            // then
+            assertThat(response)
+                    .isInstanceOfSatisfying(TspResponse.Rejected.class,
+                            rejected -> assertThat(rejected.failureInfo()).isEqualTo(TspFailureInfo.SYSTEM_FAILURE));
+            assertThat(signingRecordService
+                    .listSigningRecords(aSearchRequest().build(), SecurityFilter.create())
+                    .getItems()).isEmpty();
         }
     }
 }

--- a/src/test/java/com/otilm/core/integration/signing/tsa/TsaServiceImplITest.java
+++ b/src/test/java/com/otilm/core/integration/signing/tsa/TsaServiceImplITest.java
@@ -1,6 +1,5 @@
 package com.otilm.core.integration.signing.tsa;
 
-import com.otilm.api.exception.ConnectorServerException;
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.interfaces.core.tsp.error.TspException;
 import com.otilm.api.interfaces.core.tsp.error.TspFailureInfo;
@@ -28,7 +27,6 @@ import com.otilm.core.service.TokenInstanceExternalService;
 import com.otilm.core.service.TokenProfileExternalService;
 import com.otilm.core.service.TspProfileExternalService;
 import com.otilm.core.service.v2.ConnectorExternalService;
-import com.otilm.core.signing.engine.error.SigningEngineException;
 import com.otilm.core.signing.tsa.ManagedTimestampEngine;
 import com.otilm.core.signing.tsa.TimestampTokenTestUtil;
 import com.otilm.core.signing.tsa.TsaExternalService;
@@ -369,20 +367,20 @@ class TsaServiceImplITest extends BaseSpringBootTest {
         }
 
         @Test
-        void throwsSystemFailure_whenFormattingConnectorFails() throws Exception {
+        void rejectsWithSystemFailure_whenFormattingConnectorFails() throws Exception {
             // given — the signature formatting is unavailable during token assembly
             SigningProfileDto profile = createTimestampingSigningProfile("sp-formatting-down");
             timestampingFormattingMock.stubTokenAssemblyFailure();
 
-            // when / then — the controller renders this service exception as a TSP rejection
-            assertThatThrownBy(
-                    () -> tsaService.processTspRequestForSigningProfile(profile.getName(), aTspRequest().build()))
-                    .isInstanceOf(TspException.class)
-                    .satisfies(ex -> assertThat(((TspException) ex).getFailureInfo())
-                            .isEqualTo(TspFailureInfo.SYSTEM_FAILURE))
-                    .hasMessageContaining("Signature formatting connector communication failed during DTBS phase")
-                    .hasCauseInstanceOf(SigningEngineException.class)
-                    .hasRootCauseInstanceOf(ConnectorServerException.class);
+            // when
+            TspResponse response = tsaService
+                    .processTspRequestForSigningProfile(profile.getName(), aTspRequest().build());
+
+            // then — the connector's own detail stays in the log; only the wire-safe text reaches the caller
+            assertThat(response).isInstanceOfSatisfying(TspResponse.Rejected.class, rejected -> {
+                assertThat(rejected.failureInfo()).isEqualTo(TspFailureInfo.SYSTEM_FAILURE);
+                assertThat(rejected.statusString()).isEqualTo("Internal error during DTBS formatting");
+            });
         }
     }
 }

--- a/src/test/java/com/otilm/core/integration/signing/tsa/TsaServiceImplITest.java
+++ b/src/test/java/com/otilm/core/integration/signing/tsa/TsaServiceImplITest.java
@@ -387,8 +387,7 @@ class TsaServiceImplITest extends BaseSpringBootTest {
 
         /**
          * The connector assembles the {@code TSTInfo}, so a token that does not echo the request must not be recorded
-         * or returned. {@code stubTokenAssembly} answers with a pre-built token whose serial number is unrelated to the
-         * one the engine generated, which is exactly the defect the echo check exists to catch.
+         * or returned — which is what {@link TimestampingFormattingConnectorMock#stubTokenAssembly} produces.
          */
         @Test
         void rejectsWithSystemFailure_whenTheConnectorStampsAnotherSerialNumber() throws Exception {

--- a/src/test/java/com/otilm/core/serialization/golden/JsonColumnGoldenTest.java
+++ b/src/test/java/com/otilm/core/serialization/golden/JsonColumnGoldenTest.java
@@ -33,7 +33,7 @@ import com.otilm.core.model.compliance.ComplianceResultDto;
 import com.otilm.core.model.signing.SigningProfileModel;
 import com.otilm.core.model.signing.scheme.SigningSchemeModel;
 import com.otilm.core.model.signing.workflow.SigningWorkflow;
-import com.otilm.core.signing.tsa.TspSigningRecordFactory;
+import com.otilm.core.signing.tsa.TimestampSigningRecordFactory;
 import com.otilm.core.signing.tsa.messages.TspRequest;
 import java.lang.reflect.Type;
 import java.math.BigInteger;
@@ -290,7 +290,8 @@ class JsonColumnGoldenTest {
 
     /**
      * Backs {@code SigningRecord.requestMetadataJson} and {@code SigningRecordOutbox.requestMetadataJson}. Both are
-     * declared {@code String}, so Hibernate stores what {@link TspSigningRecordFactory} built with the wire mapper.
+     * declared {@code String}, so Hibernate stores what {@link TimestampSigningRecordFactory} built with the wire
+     * mapper.
      */
     @Test
     void signingRecordMetadataColumnKeepsTheShapeTheWireMapperGivesItAndIsStoredVerbatim() {
@@ -333,8 +334,9 @@ class JsonColumnGoldenTest {
                 List.of(SigningProtocol.TSP), null, null, null, null);
         TspRequest request = new TspRequest(DigestAlgorithm.SHA_256, new byte[]{1, 2, 3}, policy, nonce, false, null);
 
-        return new TspSigningRecordFactory(webMapper)
-                .source(profile, request, new BigInteger("48879"), FIXED_TIMESTAMP.toInstant(), new byte[]{4, 5})
+        return new TimestampSigningRecordFactory(webMapper)
+                .source(profile, request, new BigInteger("48879"), FIXED_TIMESTAMP.toInstant(), new byte[]{4, 5},
+                        SigningProtocol.TSP)
                 .build()
                 .getRequestMetadataJson();
     }

--- a/src/test/java/com/otilm/core/service/impl/SigningProfileSupportedProtocolsTest.java
+++ b/src/test/java/com/otilm/core/service/impl/SigningProfileSupportedProtocolsTest.java
@@ -2,6 +2,8 @@ package com.otilm.core.service.impl;
 
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
 import com.otilm.api.model.core.signing.SigningProtocol;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -16,19 +18,21 @@ class SigningProfileSupportedProtocolsTest {
 
     private final SigningProfileServiceImpl service = new SigningProfileServiceImpl();
 
-    @ParameterizedTest
-    @EnumSource(SigningWorkflowType.class)
-    void offersOnlyProtocolsAnOperatorCanEnable(SigningWorkflowType workflowType) {
+    @Test
+    void offersOnlyProtocolsAnOperatorCanEnable() {
         // when
-        var supported = service.listSupportedProtocols(workflowType);
+        var offered = Arrays
+                .stream(SigningWorkflowType.values())
+                .flatMap(workflowType -> service.listSupportedProtocols(workflowType).stream())
+                .toList();
 
         // then
-        assertThat(supported)
+        assertThat(offered)
+                .isNotEmpty()
                 .allMatch(SigningProtocol::isEnableableOnProfile)
                 .doesNotContain(SigningProtocol.INTERNAL_TSA);
     }
 
-    /** Keeps the guard above from passing merely because nothing is offered at all. */
     @ParameterizedTest
     @EnumSource(value = SigningWorkflowType.class, names = "TIMESTAMPING")
     void offersTheTimestampingProtocolForTimestampingProfiles(SigningWorkflowType workflowType) {

--- a/src/test/java/com/otilm/core/service/impl/SigningProfileSupportedProtocolsTest.java
+++ b/src/test/java/com/otilm/core/service/impl/SigningProfileSupportedProtocolsTest.java
@@ -1,0 +1,37 @@
+package com.otilm.core.service.impl;
+
+import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
+import com.otilm.api.model.core.signing.SigningProtocol;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the protocol list an operator may enable on a Signing Profile. Some {@link SigningProtocol} values record an
+ * invocation the platform makes on its own and have no client edge to authenticate, so offering one as enableable would
+ * advertise a route no caller can take.
+ */
+class SigningProfileSupportedProtocolsTest {
+
+    private final SigningProfileServiceImpl service = new SigningProfileServiceImpl();
+
+    @ParameterizedTest
+    @EnumSource(SigningWorkflowType.class)
+    void offersOnlyProtocolsAnOperatorCanEnable(SigningWorkflowType workflowType) {
+        // when
+        var supported = service.listSupportedProtocols(workflowType);
+
+        // then
+        assertThat(supported).allMatch(SigningProtocol::isEnableableOnProfile);
+        assertThat(supported).doesNotContain(SigningProtocol.INTERNAL_TSA);
+    }
+
+    /** Keeps the guard above from passing merely because nothing is offered at all. */
+    @ParameterizedTest
+    @EnumSource(value = SigningWorkflowType.class, names = "TIMESTAMPING")
+    void offersTheTimestampingProtocolForTimestampingProfiles(SigningWorkflowType workflowType) {
+        // when / then
+        assertThat(service.listSupportedProtocols(workflowType)).containsExactly(SigningProtocol.TSP);
+    }
+}

--- a/src/test/java/com/otilm/core/service/impl/SigningProfileSupportedProtocolsTest.java
+++ b/src/test/java/com/otilm/core/service/impl/SigningProfileSupportedProtocolsTest.java
@@ -23,8 +23,9 @@ class SigningProfileSupportedProtocolsTest {
         var supported = service.listSupportedProtocols(workflowType);
 
         // then
-        assertThat(supported).allMatch(SigningProtocol::isEnableableOnProfile);
-        assertThat(supported).doesNotContain(SigningProtocol.INTERNAL_TSA);
+        assertThat(supported)
+                .allMatch(SigningProtocol::isEnableableOnProfile)
+                .doesNotContain(SigningProtocol.INTERNAL_TSA);
     }
 
     /** Keeps the guard above from passing merely because nothing is offered at all. */

--- a/src/test/java/com/otilm/core/signing/record/SigningRecordInputSources.java
+++ b/src/test/java/com/otilm/core/signing/record/SigningRecordInputSources.java
@@ -3,8 +3,8 @@ package com.otilm.core.signing.record;
 /**
  * Test-only adapter from a materialized {@link SigningRecordInput} to a {@link SigningRecordInputSource}. Production
  * code always supplies a genuinely deferred source (see
- * {@code com.otilm.core.signing.tsa.TspSigningRecordFactory#source}); tests that already hold a built input use this to
- * feed a strategy without redundantly deferring the build.
+ * {@code com.otilm.core.signing.tsa.TimestampSigningRecordFactory#source}); tests that already hold a built input use
+ * this to feed a strategy without redundantly deferring the build.
  */
 public final class SigningRecordInputSources {
 

--- a/src/test/java/com/otilm/core/signing/tsa/InternalTimestampSourceTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/InternalTimestampSourceTest.java
@@ -153,7 +153,7 @@ class InternalTimestampSourceTest {
         // given
         doReturn(aSigningProfile().withEnabled(false).build())
                 .when(signingProfileService)
-                .getSigningProfileModel(PROFILE_NAME);
+                .loadSigningProfileModel(PROFILE_NAME);
 
         // when / then
         assertThat(catchTimestamp().failure()).isEqualTo(SigningEngineFailure.MISCONFIGURED);
@@ -163,7 +163,7 @@ class InternalTimestampSourceTest {
     @Test
     void refusesAProfileThatDoesNotExist() throws Exception {
         // given
-        when(signingProfileService.getSigningProfileModel(PROFILE_NAME))
+        when(signingProfileService.loadSigningProfileModel(PROFILE_NAME))
                 .thenThrow(new NotFoundException("Signing Profile not found: " + PROFILE_NAME));
 
         // when / then
@@ -173,9 +173,34 @@ class InternalTimestampSourceTest {
     }
 
     @Test
+    void refusesAProfileWhoseStoredVersionIsInconsistent() throws Exception {
+        // given
+        when(signingProfileService.loadSigningProfileModel(PROFILE_NAME))
+                .thenThrow(new IllegalStateException(
+                        "Signing Profile '%s' has no row for latestVersion 3".formatted(PROFILE_NAME)));
+
+        // when / then
+        SigningEngineException thrown = catchTimestamp();
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.MISCONFIGURED);
+        assertThat(thrown.operatorMessage()).contains("cannot be loaded", "latestVersion 3");
+    }
+
+    @Test
+    void refusesAProfileTheLoaderCannotMap() throws Exception {
+        // given
+        when(signingProfileService.loadSigningProfileModel(PROFILE_NAME))
+                .thenThrow(new IllegalArgumentException("Unsupported signing scheme for workflow type TIMESTAMPING"));
+
+        // when / then
+        SigningEngineException thrown = catchTimestamp();
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.MISCONFIGURED);
+        assertThat(thrown.operatorMessage()).contains("cannot be loaded", "Unsupported signing scheme");
+    }
+
+    @Test
     void refusesAProfileThatIsNotATimestampingOne() throws Exception {
         // given a content-signing profile, which cannot issue timestamps
-        doReturn(aSigningProfile().build()).when(signingProfileService).getSigningProfileModel(PROFILE_NAME);
+        doReturn(aSigningProfile().build()).when(signingProfileService).loadSigningProfileModel(PROFILE_NAME);
         when(signingProfileResolverFactory.resolve(any()))
                 .thenReturn(new ResolvedManagedContentSigningProfile(UUID.randomUUID(), PROFILE_NAME, null, 1, true,
                         List.of(), List.of(), null, null));
@@ -189,7 +214,7 @@ class InternalTimestampSourceTest {
     @Test
     void refusesAProfileNoResolverCouldResolve() throws Exception {
         // given a resolver that answered with nothing rather than refusing outright
-        doReturn(aSigningProfile().build()).when(signingProfileService).getSigningProfileModel(PROFILE_NAME);
+        doReturn(aSigningProfile().build()).when(signingProfileService).loadSigningProfileModel(PROFILE_NAME);
         when(signingProfileResolverFactory.resolve(any())).thenReturn(null);
 
         // when / then
@@ -235,7 +260,7 @@ class InternalTimestampSourceTest {
 
     private SigningProfileModel<?, ?> givenProfileResolvesTo(ResolvedManagedTimestampingProfile resolved,
             SigningProfileModel<?, ?> profile) throws Exception {
-        doReturn(profile).when(signingProfileService).getSigningProfileModel(PROFILE_NAME);
+        doReturn(profile).when(signingProfileService).loadSigningProfileModel(PROFILE_NAME);
         when(signingProfileResolverFactory.resolve(profile)).thenReturn(resolved);
         return profile;
     }

--- a/src/test/java/com/otilm/core/signing/tsa/InternalTimestampSourceTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/InternalTimestampSourceTest.java
@@ -1,0 +1,259 @@
+package com.otilm.core.signing.tsa;
+
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.model.common.enums.cryptography.DigestAlgorithm;
+import com.otilm.api.model.core.signing.SigningProtocol;
+import com.otilm.core.model.signing.SigningCertificateBuilder;
+import com.otilm.core.model.signing.SigningProfileModel;
+import com.otilm.core.model.signing.resolved.ResolvedManagedContentSigningProfile;
+import com.otilm.core.model.signing.resolved.ResolvedManagedTimestampingProfile;
+import com.otilm.core.model.signing.resolved.ResolvedStaticKeyManagedSigning;
+import com.otilm.core.model.signing.timequality.LocalClockTimeQualityConfiguration;
+import com.otilm.core.service.SigningProfileInternalService;
+import com.otilm.core.signing.engine.error.SigningEngineException;
+import com.otilm.core.signing.engine.error.SigningEngineFailure;
+import com.otilm.core.signing.engine.resolver.SigningProfileResolverFactory;
+import com.otilm.core.signing.tsa.messages.IssuedTimestamp;
+import com.otilm.core.signing.tsa.messages.TimestampImprint;
+import com.otilm.core.signing.tsa.messages.TspRequest;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.otilm.core.util.builders.SigningProfileModelBuilder.aSigningProfile;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InternalTimestampSourceTest {
+
+    private static final String PROFILE_NAME = "ades-timestamps";
+
+    private static final String STEP = "signatureTimestamp";
+
+    private static final TimestampImprint IMPRINT = new TimestampImprint(DigestAlgorithm.SHA_256, imprintOfLength(32));
+
+    private static final IssuedTimestamp ISSUED = new IssuedTimestamp(new byte[]{7, 8}, BigInteger.TEN, Instant.EPOCH);
+
+    @Mock
+    SigningProfileInternalService signingProfileService;
+    @Mock
+    SigningProfileResolverFactory signingProfileResolverFactory;
+    @Mock
+    ManagedTimestampEngine engine;
+
+    private InternalTimestampSource source;
+
+    @BeforeEach
+    void createSource() {
+        source = new InternalTimestampSource(signingProfileService, signingProfileResolverFactory, engine);
+    }
+
+    @Test
+    void issuesATokenUnderTheInProcessProtocol() throws Exception {
+        // given
+        SigningProfileModel<?, ?> profile = givenProfileResolvesTo(aResolvedProfile(List.of()));
+        when(engine.issue(any(), any(), any(), any())).thenReturn(ISSUED);
+
+        // when
+        IssuedTimestamp issued = source.timestamp(IMPRINT, PROFILE_NAME, STEP);
+
+        // then
+        assertThat(issued).isSameAs(ISSUED);
+        verify(engine).issue(any(), eq(profile), any(), eq(SigningProtocol.INTERNAL_TSA));
+    }
+
+    /** The imprint is the whole request: the profile's default policy is applied downstream, so none is requested. */
+    @Test
+    void synthesizesTheRequestFromTheImprintAloneAndLeavesThePolicyToTheProfile() throws Exception {
+        // given
+        givenProfileResolvesTo(aResolvedProfile(List.of()));
+        when(engine.issue(any(), any(), any(), any())).thenReturn(ISSUED);
+
+        // when
+        source.timestamp(IMPRINT, PROFILE_NAME, STEP);
+
+        // then
+        ArgumentCaptor<TspRequest> request = ArgumentCaptor.forClass(TspRequest.class);
+        verify(engine).issue(request.capture(), any(), any(), any());
+        assertThat(request.getValue().hashAlgorithm()).isEqualTo(DigestAlgorithm.SHA_256);
+        assertThat(request.getValue().hashedMessage()).isEqualTo(IMPRINT.value());
+        assertThat(request.getValue().policy()).isEmpty();
+        assertThat(request.getValue().nonce()).isEmpty();
+        assertThat(request.getValue().includeSignerCertificate()).isTrue();
+    }
+
+    /** Being referenced by a content-signing profile is the authorization; the client-protocol gate does not apply. */
+    @Test
+    void issuesEvenThoughTheProfileEnablesNoClientProtocol() throws Exception {
+        // given
+        givenProfileResolvesTo(aResolvedProfile(List.of()), aSigningProfile().withEnabledProtocols(List.of()).build());
+        when(engine.issue(any(), any(), any(), any())).thenReturn(ISSUED);
+
+        // when / then
+        assertThat(source.timestamp(IMPRINT, PROFILE_NAME, STEP)).isSameAs(ISSUED);
+    }
+
+    @Test
+    void issuesForAnImprintUnderAnAlgorithmTheProfileLists() throws Exception {
+        // given
+        givenProfileResolvesTo(aResolvedProfile(List.of(DigestAlgorithm.SHA_256, DigestAlgorithm.SHA_512)));
+        when(engine.issue(any(), any(), any(), any())).thenReturn(ISSUED);
+
+        // when / then
+        assertThat(source.timestamp(IMPRINT, PROFILE_NAME, STEP)).isSameAs(ISSUED);
+    }
+
+    /** The imprint comes from a connector, not a client, so a profile pair that disagrees is an operator fault. */
+    @Test
+    void refusesAnImprintUnderAnAlgorithmTheProfileDoesNotAccept() throws Exception {
+        // given
+        givenProfileResolvesTo(aResolvedProfile(List.of(DigestAlgorithm.SHA_512)));
+
+        // when / then
+        SigningEngineException thrown = catchTimestamp();
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.MISCONFIGURED);
+        assertThat(thrown.operatorMessage()).contains("SHA-256");
+        verify(engine, never()).issue(any(), any(), any(), any());
+    }
+
+    /**
+     * A digest of the wrong length for its own algorithm came from no document, so the connector broke its contract.
+     */
+    @Test
+    void refusesAnImprintThatIsNotAsLongAsItsAlgorithmProduces() throws Exception {
+        // given
+        givenProfileResolvesTo(aResolvedProfile(List.of(DigestAlgorithm.SHA_256)));
+        TimestampImprint tooShort = new TimestampImprint(DigestAlgorithm.SHA_256, imprintOfLength(16));
+
+        // when / then
+        SigningEngineException thrown = catchThrowableOfType(SigningEngineException.class,
+                () -> source.timestamp(tooShort, PROFILE_NAME, STEP));
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.CONNECTOR_FAULT);
+        assertThat(thrown.operatorMessage()).contains("16 bytes", "SHA-256");
+        verify(engine, never()).issue(any(), any(), any(), any());
+    }
+
+    @Test
+    void refusesAProfileAnOperatorHasDisabled() throws Exception {
+        // given
+        doReturn(aSigningProfile().withEnabled(false).build())
+                .when(signingProfileService)
+                .getSigningProfileModel(PROFILE_NAME);
+
+        // when / then
+        assertThat(catchTimestamp().failure()).isEqualTo(SigningEngineFailure.MISCONFIGURED);
+        verify(engine, never()).issue(any(), any(), any(), any());
+    }
+
+    @Test
+    void refusesAProfileThatDoesNotExist() throws Exception {
+        // given
+        when(signingProfileService.getSigningProfileModel(PROFILE_NAME))
+                .thenThrow(new NotFoundException("Signing Profile not found: " + PROFILE_NAME));
+
+        // when / then
+        SigningEngineException thrown = catchTimestamp();
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.MISCONFIGURED);
+        assertThat(thrown.operatorMessage()).contains(PROFILE_NAME);
+    }
+
+    @Test
+    void refusesAProfileThatIsNotATimestampingOne() throws Exception {
+        // given a content-signing profile, which cannot issue timestamps
+        doReturn(aSigningProfile().build()).when(signingProfileService).getSigningProfileModel(PROFILE_NAME);
+        when(signingProfileResolverFactory.resolve(any()))
+                .thenReturn(new ResolvedManagedContentSigningProfile(UUID.randomUUID(), PROFILE_NAME, null, 1, true,
+                        List.of(), List.of(), null, null));
+
+        // when / then
+        SigningEngineException thrown = catchTimestamp();
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.MISCONFIGURED);
+        assertThat(thrown.operatorMessage()).contains("not a managed timestamping profile");
+    }
+
+    @Test
+    void refusesAProfileNoResolverCouldResolve() throws Exception {
+        // given a resolver that answered with nothing rather than refusing outright
+        doReturn(aSigningProfile().build()).when(signingProfileService).getSigningProfileModel(PROFILE_NAME);
+        when(signingProfileResolverFactory.resolve(any())).thenReturn(null);
+
+        // when / then
+        SigningEngineException thrown = catchTimestamp();
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.MISCONFIGURED);
+        assertThat(thrown.operatorMessage()).contains("resolved to null");
+    }
+
+    /** The caller owns the step name, so a failure points at the AdES step rather than at the bridge. */
+    @Test
+    void namesTheCallersStepOnEveryFailure() throws Exception {
+        // given
+        givenProfileResolvesTo(aResolvedProfile(List.of(DigestAlgorithm.SHA_512)));
+
+        // when / then
+        SigningEngineException thrown = catchTimestamp();
+        assertThat(thrown.step()).isEqualTo(STEP);
+        assertThat(thrown.operatorMessage()).contains(STEP);
+    }
+
+    /** A degraded time source must stop the step, not silently produce a token stamped with untrusted time. */
+    @Test
+    void surfacesADegradedTimeSourceAsAFailureOfTheStep() throws Exception {
+        // given
+        givenProfileResolvesTo(aResolvedProfile(List.of()));
+        when(engine.issue(any(), any(), any(), any()))
+                .thenThrow(new SigningEngineException(SigningEngineFailure.TIME_UNAVAILABLE, "time quality is DEGRADED",
+                        "Time quality is not sufficient"));
+
+        // when / then
+        SigningEngineException thrown = catchTimestamp();
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.TIME_UNAVAILABLE);
+        assertThat(thrown.step()).isEqualTo(STEP);
+        assertThat(thrown.clientMessage()).isEqualTo("Time quality is not sufficient");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private SigningProfileModel<?, ?> givenProfileResolvesTo(ResolvedManagedTimestampingProfile resolved)
+            throws Exception {
+        return givenProfileResolvesTo(resolved, aSigningProfile().build());
+    }
+
+    private SigningProfileModel<?, ?> givenProfileResolvesTo(ResolvedManagedTimestampingProfile resolved,
+            SigningProfileModel<?, ?> profile) throws Exception {
+        doReturn(profile).when(signingProfileService).getSigningProfileModel(PROFILE_NAME);
+        when(signingProfileResolverFactory.resolve(profile)).thenReturn(resolved);
+        return profile;
+    }
+
+    private SigningEngineException catchTimestamp() {
+        return catchThrowableOfType(SigningEngineException.class, () -> source.timestamp(IMPRINT, PROFILE_NAME, STEP));
+    }
+
+    private static ResolvedManagedTimestampingProfile aResolvedProfile(List<DigestAlgorithm> allowedDigestAlgorithms) {
+        return new ResolvedManagedTimestampingProfile(UUID.randomUUID(), PROFILE_NAME, null, 1, true, List.of(),
+                Boolean.FALSE, "1.2.3.4.5", List.of(), allowedDigestAlgorithms, false, List.of(),
+                LocalClockTimeQualityConfiguration.INSTANCE, null,
+                new ResolvedStaticKeyManagedSigning(SigningCertificateBuilder.valid(), List.of(), null, List.of()));
+    }
+
+    private static byte[] imprintOfLength(int length) {
+        byte[] imprint = new byte[length];
+        Arrays.fill(imprint, (byte) 0x5a);
+        return imprint;
+    }
+}

--- a/src/test/java/com/otilm/core/signing/tsa/ManagedTimestampEngineTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/ManagedTimestampEngineTest.java
@@ -169,7 +169,7 @@ class ManagedTimestampEngineTest {
     }
 
     @Test
-    void failsIssuanceWithTimeUnavailable_whenTheClockDriftedDuringSerialNumberGeneration() throws Exception {
+    void failsIssuanceWithTimeUnavailable_whenTheClockDriftedDuringSerialNumberGeneration() {
         // given
         when(timeQualityRegister.getStatus(any())).thenReturn(TimeQualityStatus.OK);
         when(signingCertificateValidator.validate(any(), any(), anyBoolean())).thenReturn(ValidationResult.ok());
@@ -183,7 +183,7 @@ class ManagedTimestampEngineTest {
 
     /** The validator already speaks engine currency, so issuance must surface its verdict rather than restate it. */
     @Test
-    void failsIssuanceWithTheValidatorsVerdict_whenCertificateValidationFails() throws Exception {
+    void failsIssuanceWithTheValidatorsVerdict_whenCertificateValidationFails() {
         // given
         when(timeQualityRegister.getStatus(any())).thenReturn(TimeQualityStatus.OK);
         when(signingCertificateValidator.validate(any(), any(), anyBoolean()))

--- a/src/test/java/com/otilm/core/signing/tsa/ManagedTimestampEngineTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/ManagedTimestampEngineTest.java
@@ -1,8 +1,8 @@
 package com.otilm.core.signing.tsa;
 
-import com.otilm.api.interfaces.core.tsp.error.TspException;
 import com.otilm.api.interfaces.core.tsp.error.TspFailureInfo;
 import com.otilm.api.model.client.signing.profile.record.SigningRecordPersistenceMode;
+import com.otilm.api.model.common.enums.cryptography.DigestAlgorithm;
 import com.otilm.api.model.core.signing.SigningProtocol;
 import com.otilm.api.model.messaging.timequality.TimeQualityStatus;
 import com.otilm.core.model.signing.SigningCertificateBuilder;
@@ -32,7 +32,9 @@ import com.otilm.core.util.serialnumber.SerialNumberGenerator;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.UUID;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.tsp.TimeStampToken;
+import org.bouncycastle.tsp.TimeStampTokenInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,11 +45,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static com.otilm.core.signing.tsa.messages.TspRequestBuilder.aTspRequest;
 import static com.otilm.core.util.builders.SigningProfileModelBuilder.aSigningProfile;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -67,7 +71,7 @@ class ManagedTimestampEngineTest {
     @Mock
     SigningRecordStrategyFactory signingRecordStrategyFactory;
     @Mock
-    TspSigningRecordFactory tspSigningRecordFactory;
+    TimestampSigningRecordFactory timestampSigningRecordFactory;
     @Mock
     SigningRecordStrategy signingRecordStrategy;
 
@@ -78,13 +82,14 @@ class ManagedTimestampEngineTest {
     @BeforeEach
     void createEngine() {
         engine = new ManagedTimestampEngine(timeQualityRegister, serialNumberGenerator, tokenGenerator,
-                signingCertificateValidatorFactory, clock, signingRecordStrategyFactory, tspSigningRecordFactory);
+                signingCertificateValidatorFactory, clock, signingRecordStrategyFactory, timestampSigningRecordFactory);
     }
 
     @BeforeEach
     void wireProvider() throws Exception {
-        // always route signing scheme lookups to the shared signingCertificateValidator mock
-        when(signingCertificateValidatorFactory.getValidator(any())).thenReturn(signingCertificateValidator);
+        // always route signing scheme lookups to the shared signingCertificateValidator mock; lenient because the
+        // time-quality gate short-circuits before any certificate is looked up
+        lenient().when(signingCertificateValidatorFactory.getValidator(any())).thenReturn(signingCertificateValidator);
         // recording is best-effort and only reached on a granted token; lenient so reject paths don't trip strict
         // stubbing
         lenient()
@@ -92,13 +97,37 @@ class ManagedTimestampEngineTest {
                 .thenReturn(signingRecordStrategy);
     }
 
-    private static TimeStampToken aTokenEncodingTo(byte[] encoded) throws Exception {
+    /** A token from a sound connector: it echoes the request's imprint and the serial the engine issued. */
+    private static TimeStampToken aTokenEncodingTo(byte[] encoded, BigInteger serialNumber) throws Exception {
+        return aTokenStamping(encoded, DigestAlgorithm.SHA_256, new byte[32], serialNumber);
+    }
+
+    private static TimeStampToken aTokenStamping(byte[] encoded, DigestAlgorithm imprintAlgorithm, byte[] imprint,
+            BigInteger serialNumber) throws Exception {
+        TimeStampTokenInfo info = mock(TimeStampTokenInfo.class);
+        lenient().when(info.getMessageImprintAlgOID()).thenReturn(new ASN1ObjectIdentifier(imprintAlgorithm.getOid()));
+        lenient().when(info.getMessageImprintDigest()).thenReturn(imprint);
+        lenient().when(info.getSerialNumber()).thenReturn(serialNumber);
+
         TimeStampToken token = mock(TimeStampToken.class);
-        when(token.getEncoded()).thenReturn(encoded);
+        lenient().when(token.getEncoded()).thenReturn(encoded);
+        lenient().when(token.getTimeStampInfo()).thenReturn(info);
         return token;
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private void givenIssuanceReaches(TimeStampToken token) throws Exception {
+        when(timeQualityRegister.getStatus(any())).thenReturn(TimeQualityStatus.OK);
+        when(signingCertificateValidator.validate(any(), any(), anyBoolean())).thenReturn(ValidationResult.ok());
+        when(serialNumberGenerator.generate()).thenReturn(BigInteger.ONE);
+        when(tokenGenerator.generate(any(), any(), any(), any(), any())).thenReturn(token);
+    }
+
+    private SigningEngineException catchIssue() {
+        return catchThrowableOfType(SigningEngineException.class, () -> engine
+                .issue(aTspRequest().build(), signingProfile, aResolvedProfile(false, null), SigningProtocol.TSP));
+    }
 
     private static ResolvedManagedTimestampingProfile aResolvedProfile(boolean validateTokenSignature,
             CertificateChain chain) {
@@ -109,9 +138,132 @@ class ManagedTimestampEngineTest {
     }
 
     @Test
+    void issuesTokenWithItsSerialAndGenerationTime_whenAllDependenciesSucceed() throws Exception {
+        // given
+        var timestampToken = aTokenEncodingTo(new byte[]{1, 2, 3}, BigInteger.TEN);
+
+        when(timeQualityRegister.getStatus(any())).thenReturn(TimeQualityStatus.OK);
+        when(signingCertificateValidator.validate(any(), any(), anyBoolean())).thenReturn(ValidationResult.ok());
+        when(serialNumberGenerator.generate()).thenReturn(BigInteger.TEN);
+        when(tokenGenerator.generate(any(), any(), any(), any(), any())).thenReturn(timestampToken);
+
+        // when
+        var issued = engine
+                .issue(aTspRequest().build(), signingProfile, aResolvedProfile(false, null), SigningProtocol.TSP);
+
+        // then
+        assertThat(issued.encoded()).isEqualTo(new byte[]{1, 2, 3});
+        assertThat(issued.serialNumber()).isEqualTo(BigInteger.TEN);
+        assertThat(issued.genTime()).isEqualTo(clock.wallTimeInstant());
+    }
+
+    @Test
+    void failsIssuanceWithTimeUnavailable_whenTimeQualityIsDegraded() {
+        // given
+        when(timeQualityRegister.getStatus(any())).thenReturn(TimeQualityStatus.DEGRADED);
+
+        // when / then
+        assertThat(catchIssue())
+                .extracting(SigningEngineException::failure)
+                .isEqualTo(SigningEngineFailure.TIME_UNAVAILABLE);
+    }
+
+    @Test
+    void failsIssuanceWithTimeUnavailable_whenTheClockDriftedDuringSerialNumberGeneration() throws Exception {
+        // given
+        when(timeQualityRegister.getStatus(any())).thenReturn(TimeQualityStatus.OK);
+        when(signingCertificateValidator.validate(any(), any(), anyBoolean())).thenReturn(ValidationResult.ok());
+        when(serialNumberGenerator.generate()).thenThrow(new ClockDriftException("monotonic clock drifted"));
+
+        // when / then
+        assertThat(catchIssue())
+                .extracting(SigningEngineException::failure)
+                .isEqualTo(SigningEngineFailure.TIME_UNAVAILABLE);
+    }
+
+    /** The validator already speaks engine currency, so issuance must surface its verdict rather than restate it. */
+    @Test
+    void failsIssuanceWithTheValidatorsVerdict_whenCertificateValidationFails() throws Exception {
+        // given
+        when(timeQualityRegister.getStatus(any())).thenReturn(TimeQualityStatus.OK);
+        when(signingCertificateValidator.validate(any(), any(), anyBoolean()))
+                .thenReturn(ValidationResult
+                        .nok(SigningEngineFailure.MISCONFIGURED, "certificate not acceptable",
+                                "contact your administrator"));
+
+        // when / then
+        SigningEngineException thrown = catchIssue();
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.MISCONFIGURED);
+        assertThat(thrown.clientMessage()).isEqualTo("contact your administrator");
+        assertThat(thrown.operatorMessage()).contains("certificate not acceptable");
+    }
+
+    /**
+     * The connector assembles the TSTInfo, and in-process issuance has no client to check it, so a token stamped over
+     * another document must not reach the caller.
+     */
+    @Test
+    void refusesATokenStampedOverAnotherImprint() throws Exception {
+        // given
+        byte[] otherDocument = new byte[32];
+        otherDocument[0] = 0x7f;
+        givenIssuanceReaches(aTokenStamping(new byte[]{1}, DigestAlgorithm.SHA_256, otherDocument, BigInteger.ONE));
+
+        // when / then
+        SigningEngineException thrown = catchIssue();
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.CONNECTOR_FAULT);
+        assertThat(thrown.operatorMessage()).contains("imprint other than the one requested");
+        verify(signingRecordStrategy, never()).recordSigning(any());
+    }
+
+    @Test
+    void refusesATokenStampedUnderAnotherDigestAlgorithm() throws Exception {
+        // given
+        givenIssuanceReaches(aTokenStamping(new byte[]{1}, DigestAlgorithm.SHA_512, new byte[32], BigInteger.ONE));
+
+        // when / then
+        SigningEngineException thrown = catchIssue();
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.CONNECTOR_FAULT);
+        assertThat(thrown.operatorMessage()).contains("SHA-256 was requested");
+        verify(signingRecordStrategy, never()).recordSigning(any());
+    }
+
+    /** The serial keys the signing record, so a token carrying a different one would be recorded under the wrong id. */
+    @Test
+    void refusesATokenCarryingAnotherSerialNumber() throws Exception {
+        // given
+        givenIssuanceReaches(aTokenEncodingTo(new byte[]{1}, BigInteger.TWO));
+
+        // when / then
+        SigningEngineException thrown = catchIssue();
+        assertThat(thrown.failure()).isEqualTo(SigningEngineFailure.CONNECTOR_FAULT);
+        assertThat(thrown.operatorMessage()).contains("serial number");
+        verify(signingRecordStrategy, never()).recordSigning(any());
+    }
+
+    @Test
+    void recordsIssuanceUnderTheProtocolItWasInvokedWith() throws Exception {
+        // given
+        when(timeQualityRegister.getStatus(any())).thenReturn(TimeQualityStatus.OK);
+        when(signingCertificateValidator.validate(any(), any(), anyBoolean())).thenReturn(ValidationResult.ok());
+        when(serialNumberGenerator.generate()).thenReturn(BigInteger.ONE);
+        var timestampToken = aTokenEncodingTo(new byte[]{1}, BigInteger.ONE);
+        when(tokenGenerator.generate(any(), any(), any(), any(), any())).thenReturn(timestampToken);
+
+        // when
+        engine
+                .issue(aTspRequest().build(), signingProfile, aResolvedProfile(false, null),
+                        SigningProtocol.INTERNAL_TSA);
+
+        // then
+        verify(timestampSigningRecordFactory)
+                .source(any(), any(), any(), any(), any(), eq(SigningProtocol.INTERNAL_TSA));
+    }
+
+    @Test
     void returnsGrantedToken_whenAllDependenciesSucceed() throws Exception {
         // given
-        var timestampToken = aTokenEncodingTo(new byte[]{1, 2, 3});
+        var timestampToken = aTokenEncodingTo(new byte[]{1, 2, 3}, BigInteger.ONE);
 
         when(timeQualityRegister.getStatus(any())).thenReturn(TimeQualityStatus.OK);
         when(signingCertificateValidator.validate(any(), any(), anyBoolean())).thenReturn(ValidationResult.ok());
@@ -129,7 +281,7 @@ class ManagedTimestampEngineTest {
     @Test
     void recordsSigning_whenTokenIsGranted() throws Exception {
         // given — a token is produced; the engine must record the granted signing exactly once
-        var timestampToken = aTokenEncodingTo(new byte[]{1, 2, 3});
+        var timestampToken = aTokenEncodingTo(new byte[]{1, 2, 3}, BigInteger.ONE);
         var recordInput = mock(SigningRecordInput.class);
         var recordInputSource = SigningRecordInputSources.of(recordInput);
 
@@ -137,7 +289,8 @@ class ManagedTimestampEngineTest {
         when(signingCertificateValidator.validate(any(), any(), anyBoolean())).thenReturn(ValidationResult.ok());
         when(serialNumberGenerator.generate()).thenReturn(BigInteger.ONE);
         when(tokenGenerator.generate(any(), any(), any(), any(), any())).thenReturn(timestampToken);
-        when(tspSigningRecordFactory.source(any(), any(), any(), any(), any())).thenReturn(recordInputSource);
+        when(timestampSigningRecordFactory.source(any(), any(), any(), any(), any(), any()))
+                .thenReturn(recordInputSource);
 
         // when
         engine.process(aTspRequest().build(), signingProfile, aResolvedProfile(false, null));
@@ -152,7 +305,7 @@ class ManagedTimestampEngineTest {
     void routesRecordingToStrategyForProfilePersistenceMode() throws Exception {
         // given — the profile pins an explicit persistence mode; the engine must route recording to that mode's
         // strategy
-        var timestampToken = aTokenEncodingTo(new byte[]{1, 2, 3});
+        var timestampToken = aTokenEncodingTo(new byte[]{1, 2, 3}, BigInteger.ONE);
         var profileWithImmediateMode = aSigningProfile()
                 .withRecordPolicy(new SigningRecordPolicyModel(true, false, false, false, false, null, false,
                         SigningRecordPersistenceMode.IMMEDIATE))
@@ -249,8 +402,12 @@ class ManagedTimestampEngineTest {
         assertThat(((TspResponse.Rejected) response).failureInfo()).isEqualTo(TspFailureInfo.SYSTEM_FAILURE);
     }
 
+    /**
+     * An engine failure escaping token generation renders as a rejection like any other failure; the wire bytes are the
+     * same either way, because {@code TspControllerImpl} builds a rejection from a thrown {@code TspException} too.
+     */
     @Test
-    void mapsToTspException_whenTokenGenerationThrowsSigningEngineException() throws Exception {
+    void rejectsWithTheMappedFailure_whenTokenGenerationThrowsSigningEngineException() throws Exception {
         // given — the token generator fails with an engine-currency error (e.g. no signer found for the scheme)
         var cause = new SigningEngineException(SigningEngineFailure.MISCONFIGURED, "no signer found",
                 "The system is misconfigured.");
@@ -259,14 +416,13 @@ class ManagedTimestampEngineTest {
         when(serialNumberGenerator.generate()).thenReturn(BigInteger.ONE);
         when(tokenGenerator.generate(any(), any(), any(), any(), any())).thenThrow(cause);
 
-        // when / then — the escaping SigningEngineException is mapped, not collapsed into a rejected TspResponse
-        assertThatThrownBy(() -> engine.process(aTspRequest().build(), signingProfile, aResolvedProfile(false, null)))
-                .isInstanceOf(TspException.class)
-                .satisfies(ex -> {
-                    assertThat(((TspException) ex).getFailureInfo()).isEqualTo(TspFailureInfo.SYSTEM_FAILURE);
-                    assertThat(((TspException) ex).getClientMessage()).isEqualTo(cause.clientMessage());
-                    assertThat(ex.getCause()).isSameAs(cause);
-                });
+        // when
+        var response = engine.process(aTspRequest().build(), signingProfile, aResolvedProfile(false, null));
+
+        // then
+        assertThat(response).isInstanceOf(TspResponse.Rejected.class);
+        assertThat(((TspResponse.Rejected) response).failureInfo()).isEqualTo(TspFailureInfo.SYSTEM_FAILURE);
+        assertThat(((TspResponse.Rejected) response).statusString()).isEqualTo(cause.clientMessage());
     }
 
     @Test
@@ -310,7 +466,7 @@ class ManagedTimestampEngineTest {
     @Test
     void stillReturnsGrantedToken_whenSigningRecordPersistenceFails() throws Exception {
         // given — the token is produced, but recording it blows up; the granted token must survive
-        var timestampToken = aTokenEncodingTo(new byte[]{1, 2, 3});
+        var timestampToken = aTokenEncodingTo(new byte[]{1, 2, 3}, BigInteger.ONE);
 
         when(timeQualityRegister.getStatus(any())).thenReturn(TimeQualityStatus.OK);
         when(signingCertificateValidator.validate(any(), any(), anyBoolean())).thenReturn(ValidationResult.ok());

--- a/src/test/java/com/otilm/core/signing/tsa/TimestampSigningRecordFactoryTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/TimestampSigningRecordFactoryTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.otilm.api.model.common.enums.cryptography.DigestAlgorithm;
+import com.otilm.api.model.core.signing.SigningProtocol;
 import com.otilm.core.signing.record.SigningRecordInput;
 import com.otilm.core.util.builders.SigningProfileModelBuilder;
 import java.math.BigInteger;
@@ -12,6 +13,8 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import static com.otilm.core.model.signing.SigningRecordPolicyModelBuilder.aSigningRecordPolicy;
 import static com.otilm.core.signing.tsa.messages.TspRequestBuilder.aTspRequest;
@@ -25,24 +28,37 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Pure unit test for {@link TspSigningRecordFactory}: the assembly of a {@link SigningRecordInput} from a signing
+ * Pure unit test for {@link TimestampSigningRecordFactory}: the assembly of a {@link SigningRecordInput} from a signing
  * profile, TSP request, and the already-encoded granted timestamp token. Uses a real {@link ObjectMapper} (fast and
  * deterministic); the token DER-encoding now happens upstream in the engine, so the factory takes the encoded bytes
  * directly and no token mocking is needed.
  */
-class TspSigningRecordFactoryTest {
+class TimestampSigningRecordFactoryTest {
 
     private static final BigInteger SERIAL = BigInteger.ONE;
     private static final Instant GEN_TIME = Instant.parse("2026-06-16T00:00:00Z");
     private static final byte[] ENCODED_TOKEN = {10, 20, 30};
 
     private ObjectMapper objectMapper;
-    private TspSigningRecordFactory factory;
+    private TimestampSigningRecordFactory factory;
 
     @BeforeEach
     void setUp() {
         objectMapper = new ObjectMapper();
-        factory = new TspSigningRecordFactory(objectMapper);
+        factory = new TimestampSigningRecordFactory(objectMapper);
+    }
+
+    /** The record must tell an auditor whether a client asked for the token or the platform issued it itself. */
+    @ParameterizedTest
+    @EnumSource(value = SigningProtocol.class, names = {"TSP", "INTERNAL_TSA"})
+    void build_recordsTheProtocolTheCallerIssuedUnder(SigningProtocol protocol) {
+        // when
+        SigningRecordInput input = factory
+                .source(aRecordingProfile().build(), aTspRequest().build(), SERIAL, GEN_TIME, ENCODED_TOKEN, protocol)
+                .build();
+
+        // then
+        assertEquals(protocol, input.getProtocol());
     }
 
     @Test
@@ -58,7 +74,9 @@ class TspSigningRecordFactoryTest {
         var request = aTspRequest().hashAlgorithm(hashAlgorithm).policy(policyOid).nonce(nonce).build();
 
         // when
-        SigningRecordInput input = factory.source(profile, request, serialNumber, GEN_TIME, ENCODED_TOKEN).build();
+        SigningRecordInput input = factory
+                .source(profile, request, serialNumber, GEN_TIME, ENCODED_TOKEN, SigningProtocol.TSP)
+                .build();
 
         // then
         Map<String, Object> metadata = parseMetadata(input.getRequestMetadataJson());
@@ -77,7 +95,7 @@ class TspSigningRecordFactoryTest {
 
         // when
         SigningRecordInput input = factory
-                .source(aRecordingProfile().build(), request, SERIAL, GEN_TIME, ENCODED_TOKEN)
+                .source(aRecordingProfile().build(), request, SERIAL, GEN_TIME, ENCODED_TOKEN, SigningProtocol.TSP)
                 .build();
 
         // then
@@ -91,7 +109,7 @@ class TspSigningRecordFactoryTest {
 
         // when
         SigningRecordInput input = factory
-                .source(aRecordingProfile().build(), request, SERIAL, GEN_TIME, ENCODED_TOKEN)
+                .source(aRecordingProfile().build(), request, SERIAL, GEN_TIME, ENCODED_TOKEN, SigningProtocol.TSP)
                 .build();
 
         // then
@@ -105,7 +123,7 @@ class TspSigningRecordFactoryTest {
 
         // when
         SigningRecordInput input = factory
-                .source(aRecordingProfile().build(), request, SERIAL, GEN_TIME, ENCODED_TOKEN)
+                .source(aRecordingProfile().build(), request, SERIAL, GEN_TIME, ENCODED_TOKEN, SigningProtocol.TSP)
                 .build();
 
         // then
@@ -121,7 +139,7 @@ class TspSigningRecordFactoryTest {
 
         // when
         SigningRecordInput input = factory
-                .source(profile, aTspRequest().build(), serialNumber, GEN_TIME, ENCODED_TOKEN)
+                .source(profile, aTspRequest().build(), serialNumber, GEN_TIME, ENCODED_TOKEN, SigningProtocol.TSP)
                 .build();
 
         // then
@@ -135,7 +153,8 @@ class TspSigningRecordFactoryTest {
 
         // when
         SigningRecordInput input = factory
-                .source(aSigningProfile().build(), aTspRequest().build(), SERIAL, GEN_TIME, encodedToken)
+                .source(aSigningProfile().build(), aTspRequest().build(), SERIAL, GEN_TIME, encodedToken,
+                        SigningProtocol.TSP)
                 .build();
 
         // then
@@ -148,7 +167,8 @@ class TspSigningRecordFactoryTest {
 
         // when
         SigningRecordInput input = factory
-                .source(aSigningProfile().build(), aTspRequest().build(), SERIAL, GEN_TIME, ENCODED_TOKEN)
+                .source(aSigningProfile().build(), aTspRequest().build(), SERIAL, GEN_TIME, ENCODED_TOKEN,
+                        SigningProtocol.TSP)
                 .build();
 
         // then
@@ -161,11 +181,12 @@ class TspSigningRecordFactoryTest {
         // given a mapper that fails to serialize the request metadata
         ObjectMapper failingMapper = mock(ObjectMapper.class);
         when(failingMapper.writeValueAsString(any())).thenThrow(mock(JsonProcessingException.class));
-        var factoryWithFailingMapper = new TspSigningRecordFactory(failingMapper);
+        var factoryWithFailingMapper = new TimestampSigningRecordFactory(failingMapper);
 
         // when
         Executable build = () -> factoryWithFailingMapper
-                .source(aRecordingProfile().build(), aTspRequest().build(), SERIAL, GEN_TIME, ENCODED_TOKEN)
+                .source(aRecordingProfile().build(), aTspRequest().build(), SERIAL, GEN_TIME, ENCODED_TOKEN,
+                        SigningProtocol.TSP)
                 .build();
 
         // then

--- a/src/test/java/com/otilm/core/signing/tsa/TspErrorMapperTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/TspErrorMapperTest.java
@@ -16,6 +16,7 @@ class TspErrorMapperTest {
     private static final Map<SigningEngineFailure, TspFailureInfo> EXPECTED = Map
             .of(SigningEngineFailure.INVALID_INPUT, TspFailureInfo.BAD_REQUEST, SigningEngineFailure.MALFORMED_INPUT,
                     TspFailureInfo.BAD_DATA_FORMAT, SigningEngineFailure.MISCONFIGURED, TspFailureInfo.SYSTEM_FAILURE,
+                    SigningEngineFailure.TIME_UNAVAILABLE, TspFailureInfo.TIME_NOT_AVAILABLE,
                     SigningEngineFailure.CONNECTOR_FAULT, TspFailureInfo.SYSTEM_FAILURE,
                     SigningEngineFailure.BINDING_VIOLATION, TspFailureInfo.SYSTEM_FAILURE,
                     SigningEngineFailure.SIGNER_FAULT, TspFailureInfo.SYSTEM_FAILURE, SigningEngineFailure.STEP_FAILED,

--- a/src/test/java/com/otilm/core/signing/tsa/messages/IssuedTimestampTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/messages/IssuedTimestampTest.java
@@ -1,0 +1,83 @@
+package com.otilm.core.signing.tsa.messages;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class IssuedTimestampTest {
+
+    private static final byte[] TOKEN = new byte[]{0x0a, 0x0b};
+
+    private static final BigInteger SERIAL = BigInteger.valueOf(255);
+
+    private static final Instant GEN_TIME = Instant.parse("2026-08-19T10:15:30Z");
+
+    @Test
+    void comparesTheTokenByValueRatherThanByArrayIdentity() {
+        // given
+        IssuedTimestamp issued = new IssuedTimestamp(TOKEN, SERIAL, GEN_TIME);
+        IssuedTimestamp equalIssued = new IssuedTimestamp(TOKEN.clone(), SERIAL, GEN_TIME);
+
+        // when / then
+        assertThat(issued).isEqualTo(equalIssued).hasSameHashCodeAs(equalIssued);
+    }
+
+    @Test
+    void tellsIssuedTimestampsApartByEveryComponent() {
+        // given
+        IssuedTimestamp issued = new IssuedTimestamp(TOKEN, SERIAL, GEN_TIME);
+        Object notAnIssuedTimestamp = "not an issued timestamp";
+
+        // when / then
+        assertThat(issued)
+                .isNotEqualTo(new IssuedTimestamp(new byte[]{0x0a, 0x0c}, SERIAL, GEN_TIME))
+                .isNotEqualTo(new IssuedTimestamp(TOKEN, BigInteger.ONE, GEN_TIME))
+                .isNotEqualTo(new IssuedTimestamp(TOKEN, SERIAL, GEN_TIME.plusSeconds(1)))
+                .isNotEqualTo(notAnIssuedTimestamp)
+                .isEqualTo(issued);
+    }
+
+    /** The token is far too long to belong in a log line, so only its length is rendered. */
+    @Test
+    void rendersTheSerialAndGenerationTimeButNotTheToken() {
+        // when / then
+        assertThat(new IssuedTimestamp(TOKEN, SERIAL, GEN_TIME))
+                .hasToString("IssuedTimestamp[serialNumber=ff, genTime=2026-08-19T10:15:30Z, encoded=2 bytes]");
+    }
+
+    @Test
+    void refusesToExistWithoutAllThreeComponents() {
+        // when / then
+        assertThatNullPointerException().isThrownBy(() -> new IssuedTimestamp(null, SERIAL, GEN_TIME));
+        assertThatNullPointerException().isThrownBy(() -> new IssuedTimestamp(TOKEN, null, GEN_TIME));
+        assertThatNullPointerException().isThrownBy(() -> new IssuedTimestamp(TOKEN, SERIAL, null));
+    }
+
+    @Test
+    void survivesMutationOfTheArrayItWasBuiltFrom() {
+        // given
+        byte[] source = TOKEN.clone();
+        IssuedTimestamp issued = new IssuedTimestamp(source, SERIAL, GEN_TIME);
+
+        // when
+        source[0] = 0x7f;
+
+        // then
+        assertThat(issued.encoded()).containsExactly(TOKEN);
+    }
+
+    @Test
+    void survivesMutationThroughItsOwnAccessor() {
+        // given
+        IssuedTimestamp issued = new IssuedTimestamp(TOKEN, SERIAL, GEN_TIME);
+
+        // when
+        issued.encoded()[0] = 0x7f;
+
+        // then
+        assertThat(issued.encoded()).containsExactly(TOKEN);
+    }
+}

--- a/src/test/java/com/otilm/core/signing/tsa/messages/TimestampImprintTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/messages/TimestampImprintTest.java
@@ -1,0 +1,94 @@
+package com.otilm.core.signing.tsa.messages;
+
+import com.otilm.api.model.common.enums.cryptography.DigestAlgorithm;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class TimestampImprintTest {
+
+    private static final byte[] VALUE = new byte[]{0x0a, 0x0b};
+
+    /** A record's generated equality would compare the array by identity, so two equal digests would differ. */
+    @Test
+    void comparesTheImprintByValueRatherThanByArrayIdentity() {
+        // given
+        TimestampImprint imprint = new TimestampImprint(DigestAlgorithm.SHA_256, VALUE);
+        TimestampImprint equalImprint = new TimestampImprint(DigestAlgorithm.SHA_256, VALUE.clone());
+
+        // when / then
+        assertThat(imprint).isEqualTo(equalImprint).hasSameHashCodeAs(equalImprint);
+    }
+
+    @Test
+    void tellsImprintsApartByValueAndByAlgorithm() {
+        // given
+        TimestampImprint imprint = new TimestampImprint(DigestAlgorithm.SHA_256, VALUE);
+        Object notAnImprint = "not an imprint";
+
+        // when / then
+        assertThat(imprint)
+                .isNotEqualTo(new TimestampImprint(DigestAlgorithm.SHA_256, new byte[]{0x0a, 0x0c}))
+                .isNotEqualTo(new TimestampImprint(DigestAlgorithm.SHA_512, VALUE))
+                .isNotEqualTo(notAnImprint)
+                .isEqualTo(imprint);
+    }
+
+    @Test
+    void rendersTheImprintLegiblyForALogLine() {
+        // when / then
+        assertThat(new TimestampImprint(DigestAlgorithm.SHA_256, VALUE)).hasToString("TimestampImprint[SHA-256:0a0b]");
+    }
+
+    @Test
+    void refusesToExistWithoutBothHalves() {
+        // when / then
+        assertThatNullPointerException().isThrownBy(() -> new TimestampImprint(null, VALUE));
+        assertThatNullPointerException().isThrownBy(() -> new TimestampImprint(DigestAlgorithm.SHA_256, null));
+    }
+
+    /** A digest that is not as long as its algorithm produces came from no document. */
+    @Test
+    void knowsWhetherItIsAsLongAsItsAlgorithmProduces() {
+        // given
+        byte[] full = new byte[32];
+        TimestampImprint wellFormed = new TimestampImprint(DigestAlgorithm.SHA_256, full);
+        TimestampImprint tooShort = new TimestampImprint(DigestAlgorithm.SHA_256, VALUE);
+
+        // when / then
+        assertThat(wellFormed.hasLengthOfItsAlgorithm()).isTrue();
+        assertThat(tooShort.hasLengthOfItsAlgorithm()).isFalse();
+    }
+
+    @Test
+    void reportsItsLengthWithoutCopyingTheDigest() {
+        // when / then
+        assertThat(new TimestampImprint(DigestAlgorithm.SHA_256, VALUE).length()).isEqualTo(2);
+    }
+
+    @Test
+    void survivesMutationOfTheArrayItWasBuiltFrom() {
+        // given
+        byte[] source = VALUE.clone();
+        TimestampImprint imprint = new TimestampImprint(DigestAlgorithm.SHA_256, source);
+
+        // when
+        source[0] = 0x7f;
+
+        // then
+        assertThat(imprint.value()).containsExactly(VALUE);
+    }
+
+    @Test
+    void survivesMutationThroughItsOwnAccessor() {
+        // given
+        TimestampImprint imprint = new TimestampImprint(DigestAlgorithm.SHA_256, VALUE);
+
+        // when
+        imprint.value()[0] = 0x7f;
+
+        // then
+        assertThat(imprint.value()).containsExactly(VALUE);
+    }
+}

--- a/src/test/java/com/otilm/core/util/mocks/TimestampingFormattingConnectorMock.java
+++ b/src/test/java/com/otilm/core/util/mocks/TimestampingFormattingConnectorMock.java
@@ -110,6 +110,11 @@ public class TimestampingFormattingConnectorMock extends BaseConnectorMock {
      * regardless of request content — suited to minimal-request unit tests. The token must be structurally parseable as
      * a CMS {@code TimeStampToken}; it need not cryptographically verify unless the profile enables token-signature
      * validation.
+     *
+     * <p>
+     * The engine checks that a token echoes the imprint and serial number it asked for, so a token built independently
+     * of the request is refused as a {@code CONNECTOR_FAULT}. Use this to exercise that refusal; use
+     * {@link #stubFormatDtbs()}/{@link #stubFormatResponse()} whenever a test needs issuance to succeed.
      */
     public TimestampingFormattingConnectorMock stubTokenAssembly(byte[] timestampTokenBytes) {
         String dtbs = Base64.getEncoder().encodeToString("placeholder-dtbs".getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
**Adds a protocol-neutral way for the platform to issue itself an RFC 3161 timestamp, so an AdES signature can get the tokens it needs without going out over the wire.** Closes #1976.

## Why

An AdES signature needs timestamps. The TIMESTAMPED step needs one over the signature; the ARCHIVAL step needs another.

Today the only way to get a token out of the TSA engine is `ManagedTimestampEngine.process(...)`. That returns a wire-shaped `TspResponse`, which is the wrong currency for an in-process caller. A time-quality failure came back as `TspResponse.rejected(...)`, so a calling workflow step had nothing to throw and no token-shaped success to unwrap.

## What this adds

**`ManagedTimestampEngine.issue(...)` is the new protocol-neutral entry point.** It returns an `IssuedTimestamp` — the encoded token, its serial number, its generation time. Failures come back as `SigningEngineException` in the engine's own vocabulary. `process(...)` is now a thin wrapper over it.

**`InternalTimestampSource` is the bridge.** It takes an imprint and the name of a TIMESTAMPING Signing Profile. It resolves that profile through the same resolver factory the protocol path uses, synthesizes a `TspRequest`, and calls `issue(...)` directly. No HTTP, no TSP profile, no protocol authentication.

**`SigningProtocol.INTERNAL_TSA` records the difference.** Issuance is recorded under the TIMESTAMPING profile's own record policy, exactly as it is for TSP. The protocol value on the record says whether a client asked over RFC 3161 or the platform issued the token to itself.

The pipeline is otherwise unchanged: time-quality gate, serial generation, token generation, recording.

## Three deliberate consequences

**A degraded time source stops the step.** The `TimeQualityRegister` gate runs for in-process issuance exactly as it does for TSP. An AdES timestamp carrying untrustworthy time is worse than a failed operation. The failure names the calling step, so an operator sees which step stopped and why.

**`enabledProtocols` is not consulted in-process.** Being referenced by a content-signing profile *is* the authorization, and that reference is admin-controlled.

**`INTERNAL_TSA` can never be offered as enableable.** `SUPPORTED_PROTOCOLS` is the list an operator may switch on per workflow type. Offering a protocol with no client edge would advertise a route no caller can take. `SigningProfileSupportedProtocolsTest` asserts that everything offered is gate-eligible and that `INTERNAL_TSA` is not among it.

## The engine now checks the connector's echo

The connector assembles the `TSTInfo`. The token it hands back is only as trustworthy as its echo of what was asked for.

On the RFC 3161 path the client checks that itself, against its own request. **In-process there is no such counterparty, and the token goes straight into a signature.** So `issue(...)` verifies three things before anything is recorded or returned:

- the stamped message imprint, compared in constant time;
- its digest algorithm;
- the serial number the platform generated.

A mismatch is a `CONNECTOR_FAULT` and nothing is recorded.

`genTime` is deliberately **not** compared. Its encoded precision is the connector's choice, so an exact match would be brittle without adding assurance the imprint and the serial do not already give. The reason is in the method's Javadoc so the next reader does not "fix" the omission.

## Wire behaviour

**The failure info a client sees is unchanged.** The engine used to build `TspResponse.rejected(...)` inline at each failure site; it now throws in its own vocabulary and `TspErrorMapper` maps that back. `TIME_UNAVAILABLE` is a new `SigningEngineFailure` value that exists so the protocol-neutral path does not lose the distinction, and it maps to RFC 3161's `timeNotAvailable` — the same answer the inline code gave.

**One observable change.** `process(...)` no longer declares `throws TspException`; it renders engine failures as rejections itself. A formatting-connector failure therefore comes back as a rejection carrying the wire-safe `clientMessage` ("Internal error during DTBS formatting") instead of a thrown `TspException` whose message carried the connector's own text. The `failureInfo` is the same `SYSTEM_FAILURE` as before, and the connector's detail is still in the operator log. `TspErrorMapper.toTspException` stays for failures `TsaServiceImpl` raises outside the engine.

## No caller yet

Like #2089, this ships ahead of its consumers. The two workflow steps that call `InternalTimestampSource` land with #1974, which also owns putting the token serial on the AdES operation's record. That is the epic's build order, not dead code — please don't file it as unused.

