### PR TITLE
Wire discovery v2 clients and capability gate

### DIFF
--- a/src/main/java/com/otilm/core/client/ConnectorApiFactory.java
+++ b/src/main/java/com/otilm/core/client/ConnectorApiFactory.java
@@ -304,7 +304,7 @@ public class ConnectorApiFactory {
         return getClient(connector, restAuthorityApiClientV3, mqAuthorityApiClientV3);
     }
 
-    public com.otilm.api.interfaces.client.v2.DiscoverySyncApiClient getDiscoveryV2ApiClient(
+    public com.otilm.api.interfaces.client.v2.DiscoverySyncApiClient getDiscoveryApiClientV2(
             ApiClientConnectorInfo connector) {
         return getClient(connector, restDiscoveryApiClientV2, mqDiscoveryApiClientV2);
     }

--- a/src/main/java/com/otilm/core/client/ConnectorApiFactory.java
+++ b/src/main/java/com/otilm/core/client/ConnectorApiFactory.java
@@ -100,6 +100,7 @@ public class ConnectorApiFactory {
     private final com.otilm.api.clients.v2.MetricsApiClient restMetricsApiClientV2;
     private final com.otilm.api.clients.v3.CertificateApiClient restCertificateApiClientV3;
     private final com.otilm.api.clients.v3.AuthorityApiClient restAuthorityApiClientV3;
+    private final com.otilm.api.clients.discovery.v2.DiscoveryApiClient restDiscoveryApiClientV2;
 
     // MQ clients (optional - Spring injects Optional.empty() if bean is missing)
     private final Optional<com.otilm.api.clients.mq.AttributeApiClient> mqAttributeApiClient;
@@ -125,6 +126,7 @@ public class ConnectorApiFactory {
     private final Optional<com.otilm.api.clients.mq.v2.MetricsApiClient> mqMetricsApiClientV2;
     private final Optional<com.otilm.api.clients.mq.v3.CertificateApiClient> mqCertificateApiClientV3;
     private final Optional<com.otilm.api.clients.mq.v3.AuthorityApiClient> mqAuthorityApiClientV3;
+    private final Optional<com.otilm.api.clients.mq.discovery.v2.DiscoveryApiClient> mqDiscoveryApiClientV2;
 
     // Signing clients
     private final SignatureFormattingApiClient restSignatureFormattingApiClient;
@@ -147,20 +149,20 @@ public class ConnectorApiFactory {
     @PostConstruct
     void logInitialization() {
         log
-                .info("ConnectorApiFactory initialized. MQ clients available: attribute={}, attributesV2={}, authorityInstance={}, certificate={}, certificateV2={}, certificateV3={}, authorityV3={}, compliance={}, complianceV2={}, connector={}, discovery={}, endEntity={}, endEntityProfile={}, entityInstance={}, health={}, healthV2={}, infoV2={}, location={}, metricsV2={}, notificationInstance={}, tokenInstance={}, keyManagement={}, cryptographicOperations={}, signatureFormatting={}, contentSigningFormatting={}, vault={}, secret(REST-only)={}",
+                .info("ConnectorApiFactory initialized. MQ clients available: attribute={}, attributesV2={}, authorityInstance={}, certificate={}, certificateV2={}, certificateV3={}, authorityV3={}, compliance={}, complianceV2={}, connector={}, discovery={}, discoveryV2={}, endEntity={}, endEntityProfile={}, entityInstance={}, health={}, healthV2={}, infoV2={}, location={}, metricsV2={}, notificationInstance={}, tokenInstance={}, keyManagement={}, cryptographicOperations={}, signatureFormatting={}, contentSigningFormatting={}, vault={}, secret(REST-only)={}",
                         mqAttributeApiClient.isPresent(), mqAttributesApiClientV2.isPresent(),
                         mqAuthorityInstanceApiClient.isPresent(), mqCertificateApiClient.isPresent(),
                         mqCertificateApiClientV2.isPresent(), mqCertificateApiClientV3.isPresent(),
                         mqAuthorityApiClientV3.isPresent(), mqComplianceApiClient.isPresent(),
                         mqComplianceApiClientV2.isPresent(), mqConnectorApiClient.isPresent(),
-                        mqDiscoveryApiClient.isPresent(), mqEndEntityApiClient.isPresent(),
-                        mqEndEntityProfileApiClient.isPresent(), mqEntityInstanceApiClient.isPresent(),
-                        mqHealthApiClient.isPresent(), mqHealthApiClientV2.isPresent(), mqInfoApiClientV2.isPresent(),
-                        mqLocationApiClient.isPresent(), mqMetricsApiClientV2.isPresent(),
-                        mqNotificationInstanceApiClient.isPresent(), mqTokenInstanceApiClient.isPresent(),
-                        mqKeyManagementApiClient.isPresent(), mqCryptographicOperationsApiClient.isPresent(),
-                        mqSignatureFormattingApiClient.isPresent(), mqContentSigningFormattingApiClient.isPresent(),
-                        mqVaultApiClient.isPresent(), true);
+                        mqDiscoveryApiClient.isPresent(), mqDiscoveryApiClientV2.isPresent(),
+                        mqEndEntityApiClient.isPresent(), mqEndEntityProfileApiClient.isPresent(),
+                        mqEntityInstanceApiClient.isPresent(), mqHealthApiClient.isPresent(),
+                        mqHealthApiClientV2.isPresent(), mqInfoApiClientV2.isPresent(), mqLocationApiClient.isPresent(),
+                        mqMetricsApiClientV2.isPresent(), mqNotificationInstanceApiClient.isPresent(),
+                        mqTokenInstanceApiClient.isPresent(), mqKeyManagementApiClient.isPresent(),
+                        mqCryptographicOperationsApiClient.isPresent(), mqSignatureFormattingApiClient.isPresent(),
+                        mqContentSigningFormattingApiClient.isPresent(), mqVaultApiClient.isPresent(), true);
     }
 
     /**
@@ -300,6 +302,11 @@ public class ConnectorApiFactory {
 
     public AuthoritySyncApiClient getAuthorityInstanceApiClientV3(ApiClientConnectorInfo connector) {
         return getClient(connector, restAuthorityApiClientV3, mqAuthorityApiClientV3);
+    }
+
+    public com.otilm.api.interfaces.client.v2.DiscoverySyncApiClient getDiscoveryV2ApiClient(
+            ApiClientConnectorInfo connector) {
+        return getClient(connector, restDiscoveryApiClientV2, mqDiscoveryApiClientV2);
     }
 
     /**

--- a/src/main/java/com/otilm/core/config/ApplicationConfig.java
+++ b/src/main/java/com/otilm/core/config/ApplicationConfig.java
@@ -78,7 +78,8 @@ public class ApplicationConfig {
         return BaseApiClient
                 .prepareWebClient(new ClientTuning(connectorApiClientProperties.connectTimeout(),
                         connectorApiClientProperties.responseTimeout(), connectorApiClientProperties.maxConnections(),
-                        connectorApiClientProperties.pendingAcquireTimeout()));
+                        connectorApiClientProperties.pendingAcquireTimeout(),
+                        (int) connectorApiClientProperties.maxInMemorySize().toBytes()));
     }
 
     @Bean
@@ -226,6 +227,12 @@ public class ApplicationConfig {
     public com.otilm.api.clients.v3.AuthorityApiClient authorityApiClientV3(WebClient webClient,
             TrustManager[] defaultTrustManagers) {
         return new com.otilm.api.clients.v3.AuthorityApiClient(webClient, defaultTrustManagers);
+    }
+
+    @Bean
+    public com.otilm.api.clients.discovery.v2.DiscoveryApiClient discoveryApiClientV2(WebClient webClient,
+            TrustManager[] defaultTrustManagers) {
+        return new com.otilm.api.clients.discovery.v2.DiscoveryApiClient(webClient, defaultTrustManagers);
     }
 
     @Bean

--- a/src/main/java/com/otilm/core/config/ConnectorApiClientProperties.java
+++ b/src/main/java/com/otilm/core/config/ConnectorApiClientProperties.java
@@ -3,21 +3,27 @@ package com.otilm.core.config;
 import jakarta.validation.constraints.Positive;
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.unit.DataSize;
 import org.springframework.validation.annotation.Validated;
 
 /**
- * Tuning for the shared WebClient — response/connect timeouts and the connection pool — used for all outbound
- * API-client calls. Bound from {@code connector.api-client.*}; validated at startup so misconfiguration fails fast with
- * a clear error rather than a runtime NPE or an invalid pool.
+ * Tuning for the shared WebClient — response/connect timeouts, the connection pool, and the in-memory response cap —
+ * used for all outbound API-client calls. Bound from {@code connector.api-client.*}; validated at startup so
+ * misconfiguration fails fast with a clear error rather than a runtime NPE or an invalid pool.
  *
  * <p>
  * The {@code application.yml} defaults mirror {@code ClientTuning.defaults()} in interfaces (tests and untuned callers
  * use those; deployments use these). Keep the two in sync.
+ *
+ * <p>
+ * {@code maxInMemorySize} caps every client on the shared WebClient, never a single one: the mTLS client cache in
+ * {@code BaseApiClient} is keyed by connector uuid alone, so a per-client cap would apply or vanish depending on which
+ * interface's client warmed the cache first.
  */
 @ConfigurationProperties(prefix = "connector.api-client")
 @Validated
 public record ConnectorApiClientProperties(Duration connectTimeout, Duration responseTimeout,
-        @Positive int maxConnections, Duration pendingAcquireTimeout) {
+        @Positive int maxConnections, Duration pendingAcquireTimeout, DataSize maxInMemorySize) {
 
     public ConnectorApiClientProperties {
         // Strictly positive, not merely non-null: 0s/negative would disable timeouts or fail deeper
@@ -25,6 +31,12 @@ public record ConnectorApiClientProperties(Duration connectTimeout, Duration res
         requirePositive(connectTimeout, "connect-timeout");
         requirePositive(responseTimeout, "response-timeout");
         requirePositive(pendingAcquireTimeout, "pending-acquire-timeout");
+        if (maxInMemorySize == null || maxInMemorySize.toBytes() <= 0
+                || maxInMemorySize.toBytes() > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException(
+                    "connector.api-client.max-in-memory-size must be a positive size below 2GB, was "
+                            + maxInMemorySize);
+        }
     }
 
     private static void requirePositive(Duration value, String name) {

--- a/src/main/java/com/otilm/core/dao/entity/Discovery.java
+++ b/src/main/java/com/otilm/core/dao/entity/Discovery.java
@@ -165,12 +165,12 @@ public class Discovery extends UniquelyIdentifiedAndAudited implements Serializa
         dto.setTriggers(triggers.stream().map(Trigger::mapToDto).toList());
         dto.setConnectorStatus(connectorStatus);
         dto.setConnectorTotalCertificatesDiscovered(connectorTotalCertificatesDiscovered);
-        // The contract publishes both lists as always present. Every run this Core can hold ran against a
-        // v1 discovery connector, so the v1 synthesis is exact: certificates only, no lifecycle capabilities.
-        // The discovery v2 implementation replaces these constants with the run's stored targets and the
-        // capabilities synced from its connector.
+        // The contract publishes both fields as always present. Every run this Core can hold ran against a
+        // v1 discovery connector, so the v1 synthesis is exact: certificates only, never stoppable.
+        // The discovery v2 implementation replaces these constants with the run's stored targets and its
+        // stoppable snapshot from the initiate response.
         dto.setResources(List.of(Resource.CERTIFICATE));
-        dto.setEffectiveCapabilities(List.of());
+        dto.setStoppable(false);
         return dto;
     }
 

--- a/src/main/java/com/otilm/core/dao/entity/Discovery.java
+++ b/src/main/java/com/otilm/core/dao/entity/Discovery.java
@@ -167,8 +167,6 @@ public class Discovery extends UniquelyIdentifiedAndAudited implements Serializa
         dto.setConnectorTotalCertificatesDiscovered(connectorTotalCertificatesDiscovered);
         // The contract publishes both fields as always present. Every run this Core can hold ran against a
         // v1 discovery connector, so the v1 synthesis is exact: certificates only, never stoppable.
-        // The discovery v2 implementation replaces these constants with the run's stored targets and its
-        // stoppable snapshot from the initiate response.
         dto.setResources(List.of(Resource.CERTIFICATE));
         dto.setStoppable(false);
         return dto;

--- a/src/main/java/com/otilm/core/messaging/proxy/DiscoveryMqTimeoutsProperties.java
+++ b/src/main/java/com/otilm/core/messaging/proxy/DiscoveryMqTimeoutsProperties.java
@@ -1,0 +1,15 @@
+package com.otilm.core.messaging.proxy;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Per-operation timeout budgets for the discovery v2 MQ client — bound from {@code discovery.mq-timeouts.*} so a
+ * deployment whose connectors return large drain batches can raise the drain budget without touching the proxy-wide
+ * request timeout. Positivity is enforced by {@code DiscoveryMqTimeouts} itself at bean construction.
+ */
+@ConfigurationProperties(prefix = "discovery.mq-timeouts")
+@Validated
+public record DiscoveryMqTimeoutsProperties(Duration status, Duration drain, Duration control) {
+}

--- a/src/main/java/com/otilm/core/messaging/proxy/DiscoveryMqTimeoutsProperties.java
+++ b/src/main/java/com/otilm/core/messaging/proxy/DiscoveryMqTimeoutsProperties.java
@@ -1,5 +1,6 @@
 package com.otilm.core.messaging.proxy;
 
+import jakarta.validation.constraints.NotNull;
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
@@ -7,9 +8,11 @@ import org.springframework.validation.annotation.Validated;
 /**
  * Per-operation timeout budgets for the discovery v2 MQ client — bound from {@code discovery.mq-timeouts.*} so a
  * deployment whose connectors return large drain batches can raise the drain budget without touching the proxy-wide
- * request timeout. Positivity is enforced by {@code DiscoveryMqTimeouts} itself at bean construction.
+ * request timeout. A missing key fails at binding with the full property path; positivity is enforced by
+ * {@code DiscoveryMqTimeouts} itself at bean construction.
  */
 @ConfigurationProperties(prefix = "discovery.mq-timeouts")
 @Validated
-public record DiscoveryMqTimeoutsProperties(Duration status, Duration drain, Duration control) {
+public record DiscoveryMqTimeoutsProperties(@NotNull Duration status, @NotNull Duration drain,
+        @NotNull Duration control) {
 }

--- a/src/main/java/com/otilm/core/messaging/proxy/DiscoveryMqTimeoutsProperties.java
+++ b/src/main/java/com/otilm/core/messaging/proxy/DiscoveryMqTimeoutsProperties.java
@@ -6,9 +6,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 /**
- * Per-operation timeout budgets for the discovery v2 MQ client — bound from {@code discovery.mq-timeouts.*} so a
- * deployment whose connectors return large drain batches can raise the drain budget without touching the proxy-wide
- * request timeout. A missing key fails at binding with the full property path; positivity is enforced by
+ * Per-operation timeout budgets for the discovery v2 MQ client, bound from {@code discovery.mq-timeouts.*}.
+ *
+ * <p>
+ * <b>Customization:</b> a deployment whose connectors return large drain batches raises the drain budget here, without
+ * touching the proxy-wide request timeout.
+ *
+ * <p>
+ * <b>Validation:</b> a missing key fails at binding, naming the full property path. Positivity is enforced by
  * {@code DiscoveryMqTimeouts} itself at bean construction.
  */
 @ConfigurationProperties(prefix = "discovery.mq-timeouts")

--- a/src/main/java/com/otilm/core/messaging/proxy/ProxyClientConfig.java
+++ b/src/main/java/com/otilm/core/messaging/proxy/ProxyClientConfig.java
@@ -15,6 +15,7 @@ import com.otilm.api.clients.mq.LocationApiClient;
 import com.otilm.api.clients.mq.NotificationInstanceApiClient;
 import com.otilm.api.clients.mq.ProxyClient;
 import com.otilm.api.clients.mq.TokenInstanceApiClient;
+import com.otilm.api.clients.mq.discovery.v2.DiscoveryMqTimeouts;
 import com.otilm.api.clients.mq.signing.SignatureFormattingApiClient;
 import com.otilm.api.clients.mq.signing.contentsigning.ContentSigningFormattingApiClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -27,7 +28,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @ConditionalOnProperty(name = "proxy.enabled", havingValue = "true")
-@EnableConfigurationProperties(ProxyProperties.class)
+@EnableConfigurationProperties({ProxyProperties.class, DiscoveryMqTimeoutsProperties.class})
 public class ProxyClientConfig {
 
     /**
@@ -204,6 +205,17 @@ public class ProxyClientConfig {
     @Bean
     public com.otilm.api.clients.mq.v3.AuthorityApiClient mqAuthorityApiClientV3(ProxyClient proxyClient) {
         return new com.otilm.api.clients.mq.v3.AuthorityApiClient(proxyClient);
+    }
+
+    /**
+     * Create MQ-based discovery v2 client bean. Unlike its siblings it carries per-operation timeout budgets, because a
+     * drain response can legitimately take far longer than a status probe.
+     */
+    @Bean
+    public com.otilm.api.clients.mq.discovery.v2.DiscoveryApiClient mqDiscoveryApiClientV2(ProxyClient proxyClient,
+            DiscoveryMqTimeoutsProperties timeouts) {
+        return new com.otilm.api.clients.mq.discovery.v2.DiscoveryApiClient(proxyClient,
+                new DiscoveryMqTimeouts(timeouts.status(), timeouts.drain(), timeouts.control()));
     }
 
     /**

--- a/src/main/java/com/otilm/core/messaging/proxy/ProxyClientConfig.java
+++ b/src/main/java/com/otilm/core/messaging/proxy/ProxyClientConfig.java
@@ -208,8 +208,8 @@ public class ProxyClientConfig {
     }
 
     /**
-     * Create MQ-based discovery v2 client bean. Unlike its siblings it carries per-operation timeout budgets, because a
-     * drain response can legitimately take far longer than a status probe.
+     * Unlike its sibling beans this one carries per-operation timeout budgets, because a drain response can
+     * legitimately take far longer than a status probe.
      */
     @Bean
     public com.otilm.api.clients.mq.discovery.v2.DiscoveryApiClient mqDiscoveryApiClientV2(ProxyClient proxyClient,

--- a/src/main/java/com/otilm/core/messaging/proxy/ProxyClientImpl.java
+++ b/src/main/java/com/otilm/core/messaging/proxy/ProxyClientImpl.java
@@ -88,7 +88,14 @@ public class ProxyClientImpl implements ProxyClient {
     @Override
     public <T> ResponseEntity<T> sendRequestForEntity(ApiClientConnectorInfo connector, String path, String method,
             Object body, Class<T> responseType) throws ConnectorException {
-        Duration timeout = proxyProperties.requestTimeout();
+        return sendRequestForEntity(connector, path, method, body, responseType, proxyProperties.requestTimeout());
+    }
+
+    // Overridden so an explicit timeout keeps the status-preserving path: the interface default wraps the bare
+    // body in ResponseEntity.ok, which would turn MQ cancel's 204 into a 200.
+    @Override
+    public <T> ResponseEntity<T> sendRequestForEntity(ApiClientConnectorInfo connector, String path, String method,
+            Object body, Class<T> responseType, Duration timeout) throws ConnectorException {
         try {
             CompletableFuture<ResponseEntity<T>> future = sendRequestForEntityAsync(connector, path, method, body,
                     responseType, timeout);

--- a/src/main/java/com/otilm/core/service/handler/ConnectorCapabilityService.java
+++ b/src/main/java/com/otilm/core/service/handler/ConnectorCapabilityService.java
@@ -20,21 +20,29 @@ import org.springframework.stereotype.Service;
  * </ul>
  *
  * <p>
- * The ENFORCED/INFORMATIONAL gate is generic over any {@link FeatureFlag}; the current entry point resolves per
- * authority instance.
+ * The ENFORCED/INFORMATIONAL gate is generic over any {@link FeatureFlag}; entry points resolve per bound interface
+ * row, or per authority instance for the authority-typed convenience overload.
  */
 @Service
 public class ConnectorCapabilityService {
 
     /**
-     * Per-authority check — reads the authority's own bound interface entity directly, so it is correct even when the
-     * connector exposes multiple versions of the AUTHORITY interface.
+     * Per-interface-row check — keyed on the bound {@link ConnectorInterfaceEntity} rather than (connector, code), so
+     * it is correct even when the connector exposes multiple versions of the same interface. Callers holding a bound
+     * row (an authority's interface, a discovery run's {@code connector_interface_uuid} target) pass it directly.
      */
-    public boolean supports(AuthorityInstanceReference authority, FeatureFlag flag) {
+    public boolean supports(ConnectorInterfaceEntity iface, FeatureFlag flag) {
         if (flag.getBehavior() == FeatureFlagBehavior.INFORMATIONAL) {
             return true;
         }
-        return authority != null && advertises(authority.getConnectorInterface(), flag);
+        return advertises(iface, flag);
+    }
+
+    /**
+     * Per-authority check — reads the authority's own bound interface entity directly.
+     */
+    public boolean supports(AuthorityInstanceReference authority, FeatureFlag flag) {
+        return supports(authority != null ? authority.getConnectorInterface() : null, flag);
     }
 
     private static boolean advertises(ConnectorInterfaceEntity iface, FeatureFlag flag) {

--- a/src/main/java/com/otilm/core/service/handler/ConnectorCapabilityService.java
+++ b/src/main/java/com/otilm/core/service/handler/ConnectorCapabilityService.java
@@ -28,8 +28,7 @@ public class ConnectorCapabilityService {
 
     /**
      * Per-interface-row check — keyed on the bound {@link ConnectorInterfaceEntity} rather than (connector, code), so
-     * it is correct even when the connector exposes multiple versions of the same interface. Callers holding a bound
-     * row (an authority's interface, a discovery run's {@code connector_interface_uuid} target) pass it directly.
+     * it is correct even when the connector exposes multiple versions of the same interface.
      */
     public boolean supports(ConnectorInterfaceEntity iface, FeatureFlag flag) {
         if (flag.getBehavior() == FeatureFlagBehavior.INFORMATIONAL) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -327,6 +327,12 @@ validation:
     connect-timeout: 1000
 
 # Shared WebClient tuning applied to every outbound API-client call (any provider implementation)
+discovery:
+  mq-timeouts:
+    status: ${DISCOVERY_MQ_TIMEOUT_STATUS:30s}
+    drain: ${DISCOVERY_MQ_TIMEOUT_DRAIN:30s}
+    control: ${DISCOVERY_MQ_TIMEOUT_CONTROL:30s}
+
 connector:
   api-client:
     # Fail fast on unresponsive endpoints; keep connect + response timeouts below the 120s transaction timeout.
@@ -336,6 +342,7 @@ connector:
     max-connections: ${CONNECTOR_API_CLIENT_MAX_CONNECTIONS:20}
     # Shed load quickly under pool saturation rather than queueing behind the response timeout
     pending-acquire-timeout: ${CONNECTOR_API_CLIENT_PENDING_ACQUIRE_TIMEOUT:10s}
+    max-in-memory-size: ${CONNECTOR_API_CLIENT_MAX_IN_MEMORY_SIZE:16MB}
 
 cbom:
   client:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,6 +63,11 @@ discovery:
     max-parallelism: ${DISCOVERY_PROVIDER_MAX_PARALLELISM:5}
     sleep-time-ms: ${DISCOVERY_PROVIDER_SLEEP_TIME_MS:5000}
     max-wait-time-seconds: ${DISCOVERY_PROVIDER_MAX_WAIT_TIME_SECONDS:21600}
+  # Per-operation timeout budgets for the discovery v2 MQ client (proxy.enabled deployments only)
+  mq-timeouts:
+    status: ${DISCOVERY_MQ_TIMEOUT_STATUS:30s}
+    drain: ${DISCOVERY_MQ_TIMEOUT_DRAIN:30s}
+    control: ${DISCOVERY_MQ_TIMEOUT_CONTROL:30s}
 
 # Authority-provider async (HTTP 202) operation status polling
 provider:
@@ -327,12 +332,6 @@ validation:
     connect-timeout: 1000
 
 # Shared WebClient tuning applied to every outbound API-client call (any provider implementation)
-discovery:
-  mq-timeouts:
-    status: ${DISCOVERY_MQ_TIMEOUT_STATUS:30s}
-    drain: ${DISCOVERY_MQ_TIMEOUT_DRAIN:30s}
-    control: ${DISCOVERY_MQ_TIMEOUT_CONTROL:30s}
-
 connector:
   api-client:
     # Fail fast on unresponsive endpoints; keep connect + response timeouts below the 120s transaction timeout.

--- a/src/test/java/com/otilm/core/architecture/ContextSignatureGuardTest.java
+++ b/src/test/java/com/otilm/core/architecture/ContextSignatureGuardTest.java
@@ -13,7 +13,7 @@ class ContextSignatureGuardTest {
     /**
      * Committed baseline: the exact current distinct count. Update in lock-step with any change.
      */
-    static final int BASELINE = 57;
+    static final int BASELINE = 58;
 
     private static final Path TEST_ROOT = Path.of("src/test/java");
 

--- a/src/test/java/com/otilm/core/config/ConnectorApiClientPropertiesTest.java
+++ b/src/test/java/com/otilm/core/config/ConnectorApiClientPropertiesTest.java
@@ -1,0 +1,35 @@
+package com.otilm.core.config;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.unit.DataSize;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class ConnectorApiClientPropertiesTest {
+
+    private static ConnectorApiClientProperties withMaxInMemorySize(DataSize size) {
+        return new ConnectorApiClientProperties(Duration.ofSeconds(3), Duration.ofSeconds(35), 20,
+                Duration.ofSeconds(10), size);
+    }
+
+    @Test
+    void acceptsAPositiveInMemoryCap() {
+        assertThatNoException().isThrownBy(() -> withMaxInMemorySize(DataSize.ofMegabytes(16)));
+    }
+
+    @Test
+    void rejectsAMissingZeroOrOversizedInMemoryCap() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> withMaxInMemorySize(null))
+                .withMessageContaining("max-in-memory-size");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> withMaxInMemorySize(DataSize.ofBytes(0)))
+                .withMessageContaining("max-in-memory-size");
+        // ClientTuning takes an int of bytes, so anything above Integer.MAX_VALUE cannot be represented.
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> withMaxInMemorySize(DataSize.ofGigabytes(3)))
+                .withMessageContaining("max-in-memory-size");
+    }
+}

--- a/src/test/java/com/otilm/core/integration/client/ConnectorApiFactoryDiscoveryV2ITest.java
+++ b/src/test/java/com/otilm/core/integration/client/ConnectorApiFactoryDiscoveryV2ITest.java
@@ -23,21 +23,21 @@ class ConnectorApiFactoryDiscoveryV2ITest extends BaseSpringBootTest {
 
     @Test
     void directConnectorGetsTheRestClient() {
-        DiscoverySyncApiClient client = connectorApiFactory.getDiscoveryV2ApiClient(savedConnectorDto(null));
+        DiscoverySyncApiClient client = connectorApiFactory.getDiscoveryApiClientV2(savedConnectorDto(null));
 
         Assertions.assertInstanceOf(com.otilm.api.clients.discovery.v2.DiscoveryApiClient.class, client);
     }
 
     @Test
     void proxiedConnectorGetsTheMqClient() {
-        DiscoverySyncApiClient client = connectorApiFactory.getDiscoveryV2ApiClient(savedConnectorDto("proxy-1"));
+        DiscoverySyncApiClient client = connectorApiFactory.getDiscoveryApiClientV2(savedConnectorDto("proxy-1"));
 
         Assertions.assertInstanceOf(com.otilm.api.clients.mq.discovery.v2.DiscoveryApiClient.class, client);
     }
 
     private ConnectorDetailDto savedConnectorDto(String proxyCode) {
         Connector connector = new Connector();
-        connector.setName("discovery-v2-factory-" + proxyCode);
+        connector.setName("discovery-v2-factory-" + (proxyCode != null ? proxyCode : "direct"));
         connector.setUrl("http://localhost");
         connector.setVersion(ConnectorVersion.V2);
         connector.setStatus(ConnectorStatus.CONNECTED);

--- a/src/test/java/com/otilm/core/integration/client/ConnectorApiFactoryDiscoveryV2ITest.java
+++ b/src/test/java/com/otilm/core/integration/client/ConnectorApiFactoryDiscoveryV2ITest.java
@@ -1,0 +1,54 @@
+package com.otilm.core.integration.client;
+
+import com.otilm.api.interfaces.client.v2.DiscoverySyncApiClient;
+import com.otilm.api.model.client.connector.v2.ConnectorVersion;
+import com.otilm.api.model.core.connector.ConnectorStatus;
+import com.otilm.api.model.core.connector.v2.ConnectorDetailDto;
+import com.otilm.api.model.core.proxy.ProxyDto;
+import com.otilm.core.client.ConnectorApiFactory;
+import com.otilm.core.dao.entity.Connector;
+import com.otilm.core.dao.repository.ConnectorRepository;
+import com.otilm.core.util.BaseSpringBootTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/** The test context runs with {@code proxy.enabled=true}, so the MQ bean exists here. */
+class ConnectorApiFactoryDiscoveryV2ITest extends BaseSpringBootTest {
+
+    @Autowired
+    private ConnectorApiFactory connectorApiFactory;
+    @Autowired
+    private ConnectorRepository connectorRepository;
+
+    @Test
+    void directConnectorGetsTheRestClient() {
+        DiscoverySyncApiClient client = connectorApiFactory.getDiscoveryV2ApiClient(savedConnectorDto(null));
+
+        Assertions.assertInstanceOf(com.otilm.api.clients.discovery.v2.DiscoveryApiClient.class, client);
+    }
+
+    @Test
+    void proxiedConnectorGetsTheMqClient() {
+        DiscoverySyncApiClient client = connectorApiFactory.getDiscoveryV2ApiClient(savedConnectorDto("proxy-1"));
+
+        Assertions.assertInstanceOf(com.otilm.api.clients.mq.discovery.v2.DiscoveryApiClient.class, client);
+    }
+
+    private ConnectorDetailDto savedConnectorDto(String proxyCode) {
+        Connector connector = new Connector();
+        connector.setName("discovery-v2-factory-" + proxyCode);
+        connector.setUrl("http://localhost");
+        connector.setVersion(ConnectorVersion.V2);
+        connector.setStatus(ConnectorStatus.CONNECTED);
+        connectorRepository.save(connector);
+
+        ConnectorDetailDto dto = connector.mapToDetailDto();
+        if (proxyCode != null) {
+            ProxyDto proxy = new ProxyDto();
+            proxy.setCode(proxyCode);
+            dto.setProxy(proxy);
+        }
+        return dto;
+    }
+}

--- a/src/test/java/com/otilm/core/integration/client/ConnectorApiFactoryDiscoveryV2ITest.java
+++ b/src/test/java/com/otilm/core/integration/client/ConnectorApiFactoryDiscoveryV2ITest.java
@@ -9,9 +9,10 @@ import com.otilm.core.client.ConnectorApiFactory;
 import com.otilm.core.dao.entity.Connector;
 import com.otilm.core.dao.repository.ConnectorRepository;
 import com.otilm.core.util.BaseSpringBootTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** The test context runs with {@code proxy.enabled=true}, so the MQ bean exists here. */
 class ConnectorApiFactoryDiscoveryV2ITest extends BaseSpringBootTest {
@@ -25,14 +26,14 @@ class ConnectorApiFactoryDiscoveryV2ITest extends BaseSpringBootTest {
     void directConnectorGetsTheRestClient() {
         DiscoverySyncApiClient client = connectorApiFactory.getDiscoveryApiClientV2(savedConnectorDto(null));
 
-        Assertions.assertInstanceOf(com.otilm.api.clients.discovery.v2.DiscoveryApiClient.class, client);
+        assertThat(client).isInstanceOf(com.otilm.api.clients.discovery.v2.DiscoveryApiClient.class);
     }
 
     @Test
     void proxiedConnectorGetsTheMqClient() {
         DiscoverySyncApiClient client = connectorApiFactory.getDiscoveryApiClientV2(savedConnectorDto("proxy-1"));
 
-        Assertions.assertInstanceOf(com.otilm.api.clients.mq.discovery.v2.DiscoveryApiClient.class, client);
+        assertThat(client).isInstanceOf(com.otilm.api.clients.mq.discovery.v2.DiscoveryApiClient.class);
     }
 
     private ConnectorDetailDto savedConnectorDto(String proxyCode) {

--- a/src/test/java/com/otilm/core/integration/client/ConnectorApiFactoryDiscoveryV2NoProxyITest.java
+++ b/src/test/java/com/otilm/core/integration/client/ConnectorApiFactoryDiscoveryV2NoProxyITest.java
@@ -36,7 +36,7 @@ class ConnectorApiFactoryDiscoveryV2NoProxyITest extends BaseSpringBootTest {
         proxy.setCode("proxy-1");
         dto.setProxy(proxy);
 
-        DiscoverySyncApiClient client = connectorApiFactory.getDiscoveryV2ApiClient(dto);
+        DiscoverySyncApiClient client = connectorApiFactory.getDiscoveryApiClientV2(dto);
 
         Assertions.assertInstanceOf(com.otilm.api.clients.discovery.v2.DiscoveryApiClient.class, client);
     }

--- a/src/test/java/com/otilm/core/integration/client/ConnectorApiFactoryDiscoveryV2NoProxyITest.java
+++ b/src/test/java/com/otilm/core/integration/client/ConnectorApiFactoryDiscoveryV2NoProxyITest.java
@@ -1,0 +1,43 @@
+package com.otilm.core.integration.client;
+
+import com.otilm.api.interfaces.client.v2.DiscoverySyncApiClient;
+import com.otilm.api.model.client.connector.v2.ConnectorVersion;
+import com.otilm.api.model.core.connector.ConnectorStatus;
+import com.otilm.api.model.core.connector.v2.ConnectorDetailDto;
+import com.otilm.api.model.core.proxy.ProxyDto;
+import com.otilm.core.client.ConnectorApiFactory;
+import com.otilm.core.dao.entity.Connector;
+import com.otilm.core.dao.repository.ConnectorRepository;
+import com.otilm.core.util.BaseSpringBootTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = "proxy.enabled=false")
+class ConnectorApiFactoryDiscoveryV2NoProxyITest extends BaseSpringBootTest {
+
+    @Autowired
+    private ConnectorApiFactory connectorApiFactory;
+    @Autowired
+    private ConnectorRepository connectorRepository;
+
+    @Test
+    void proxiedConnectorFallsBackToRestWhenTheMqBeanIsAbsent() {
+        Connector connector = new Connector();
+        connector.setName("discovery-v2-factory-fallback");
+        connector.setUrl("http://localhost");
+        connector.setVersion(ConnectorVersion.V2);
+        connector.setStatus(ConnectorStatus.CONNECTED);
+        connectorRepository.save(connector);
+
+        ConnectorDetailDto dto = connector.mapToDetailDto();
+        ProxyDto proxy = new ProxyDto();
+        proxy.setCode("proxy-1");
+        dto.setProxy(proxy);
+
+        DiscoverySyncApiClient client = connectorApiFactory.getDiscoveryV2ApiClient(dto);
+
+        Assertions.assertInstanceOf(com.otilm.api.clients.discovery.v2.DiscoveryApiClient.class, client);
+    }
+}

--- a/src/test/java/com/otilm/core/integration/client/ConnectorApiFactoryDiscoveryV2NoProxyITest.java
+++ b/src/test/java/com/otilm/core/integration/client/ConnectorApiFactoryDiscoveryV2NoProxyITest.java
@@ -9,10 +9,11 @@ import com.otilm.core.client.ConnectorApiFactory;
 import com.otilm.core.dao.entity.Connector;
 import com.otilm.core.dao.repository.ConnectorRepository;
 import com.otilm.core.util.BaseSpringBootTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @TestPropertySource(properties = "proxy.enabled=false")
 class ConnectorApiFactoryDiscoveryV2NoProxyITest extends BaseSpringBootTest {
@@ -38,6 +39,6 @@ class ConnectorApiFactoryDiscoveryV2NoProxyITest extends BaseSpringBootTest {
 
         DiscoverySyncApiClient client = connectorApiFactory.getDiscoveryApiClientV2(dto);
 
-        Assertions.assertInstanceOf(com.otilm.api.clients.discovery.v2.DiscoveryApiClient.class, client);
+        assertThat(client).isInstanceOf(com.otilm.api.clients.discovery.v2.DiscoveryApiClient.class);
     }
 }

--- a/src/test/java/com/otilm/core/messaging/proxy/ProxyClientImplTest.java
+++ b/src/test/java/com/otilm/core/messaging/proxy/ProxyClientImplTest.java
@@ -36,7 +36,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;

--- a/src/test/java/com/otilm/core/messaging/proxy/ProxyClientImplTest.java
+++ b/src/test/java/com/otilm/core/messaging/proxy/ProxyClientImplTest.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
@@ -953,6 +954,31 @@ class ProxyClientImplTest {
                         .build());
 
         ResponseEntity<Map> result = proxyClient.sendRequestForEntity(connector, "/v1/test", "POST", null, Map.class);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(result.getBody()).isNull();
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void sendRequestForEntity_withExplicitTimeout_preservesStatusAndUsesTheTimeout() throws Exception {
+        // Without the six-argument override, an explicit timeout would fall through to the interface default,
+        // which wraps the bare body in ResponseEntity.ok — turning MQ cancel's 204 into a 200.
+        ConnectorDto connector = createConnector("proxy-001");
+        CompletableFuture<ProxyMessage> future = new CompletableFuture<>();
+        when(correlator.registerRequest(anyString(), eq(Duration.ofSeconds(90)))).thenReturn(future);
+
+        future
+                .complete(ProxyMessage
+                        .builder()
+                        .correlationId("test-corr")
+                        .proxyId("proxy-001")
+                        .timestamp(Instant.now())
+                        .connectorResponse(ConnectorResponse.builder().statusCode(204).body(null).build())
+                        .build());
+
+        ResponseEntity<Map> result = proxyClient
+                .sendRequestForEntity(connector, "/v1/test", "DELETE", null, Map.class, Duration.ofSeconds(90));
 
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
         assertThat(result.getBody()).isNull();

--- a/src/test/java/com/otilm/core/service/handler/ConnectorCapabilityServiceTest.java
+++ b/src/test/java/com/otilm/core/service/handler/ConnectorCapabilityServiceTest.java
@@ -50,4 +50,31 @@ class ConnectorCapabilityServiceTest {
         assertFalse(
                 service.supports(authorityWith(authorityInterface("v3", null)), FeatureFlag.CERTIFICATE_REGISTRATION));
     }
+
+    private ConnectorInterfaceEntity discoveryInterface(List<FeatureFlag> features) {
+        ConnectorInterfaceEntity iface = new ConnectorInterfaceEntity();
+        iface.setInterfaceCode(ConnectorInterface.DISCOVERY);
+        iface.setVersion("v2");
+        iface.setFeatures(features);
+        return iface;
+    }
+
+    @Test
+    void interfaceRowKeyedEnforcedFlagSupportedOnlyWhenAdvertised() {
+        assertTrue(service
+                .supports(discoveryInterface(List.of(FeatureFlag.DISCOVERY_STOP_RESUME)),
+                        FeatureFlag.DISCOVERY_STOP_RESUME));
+        assertFalse(service.supports(discoveryInterface(List.of()), FeatureFlag.DISCOVERY_STOP_RESUME));
+    }
+
+    @Test
+    void interfaceRowKeyedInformationalFlagAlwaysPassesThrough() {
+        assertTrue(service.supports(discoveryInterface(List.of()), FeatureFlag.STATELESS));
+    }
+
+    @Test
+    void interfaceRowKeyedEnforcedFlagUnsupportedWhenRowOrFeaturesMissing() {
+        assertFalse(service.supports((ConnectorInterfaceEntity) null, FeatureFlag.DISCOVERY_STOP_RESUME));
+        assertFalse(service.supports(discoveryInterface(null), FeatureFlag.DISCOVERY_STOP_RESUME));
+    }
 }

--- a/src/test/java/com/otilm/core/service/v2/impl/ClientOperationServiceImplIssueDispatchTest.java
+++ b/src/test/java/com/otilm/core/service/v2/impl/ClientOperationServiceImplIssueDispatchTest.java
@@ -158,7 +158,8 @@ class ClientOperationServiceImplIssueDispatchTest {
         // Poll scheduling reloads the cert with the polling graph and re-checks pollability against the adapter.
         when(certificateRepository.findForPollingByUuid(certUuid)).thenReturn(Optional.of(certificate));
         when(capabilityService
-                .supports(ArgumentMatchers.any(), ArgumentMatchers.eq(FeatureFlag.CERTIFICATE_STATUS_POLLING)))
+                .supports(ArgumentMatchers.any(AuthorityInstanceReference.class),
+                        ArgumentMatchers.eq(FeatureFlag.CERTIFICATE_STATUS_POLLING)))
                 .thenReturn(true);
 
         // when

--- a/src/test/java/com/otilm/core/service/v2/impl/ClientOperationServiceImplRegisterBoundIssueTest.java
+++ b/src/test/java/com/otilm/core/service/v2/impl/ClientOperationServiceImplRegisterBoundIssueTest.java
@@ -179,9 +179,11 @@ class ClientOperationServiceImplRegisterBoundIssueTest {
         // binding by certificate UUID — a pre-registered placeholder has one.
         when(certificateRegistrationRepository.findByCertificateUuid(certUuid)).thenReturn(Optional.of(binding));
         when(certificateRegistrationRepository.findAndLockByCertificateUuid(certUuid)).thenReturn(Optional.of(binding));
-        when(capabilityService.supports(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(false);
+        when(capabilityService.supports(ArgumentMatchers.any(AuthorityInstanceReference.class), ArgumentMatchers.any()))
+                .thenReturn(false);
         when(capabilityService
-                .supports(ArgumentMatchers.any(), ArgumentMatchers.eq(FeatureFlag.CERTIFICATE_REGISTRATION)))
+                .supports(ArgumentMatchers.any(AuthorityInstanceReference.class),
+                        ArgumentMatchers.eq(FeatureFlag.CERTIFICATE_REGISTRATION)))
                 .thenReturn(true);
     }
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -33,6 +33,13 @@ connector:
     connect-timeout: 3s
     max-connections: 20
     pending-acquire-timeout: 10s
+    max-in-memory-size: 16MB
+
+discovery:
+  mq-timeouts:
+    status: 30s
+    drain: 30s
+    control: 30s
 
 # Points at the port com.otilm.core.util.WireMockPorts.AUTH_SERVICE names.
 auth-service:


### PR DESCRIPTION
Closes #1961 (epic OmniTrustILM/ilm#267, core plan Tasks 4–5).

> **Merge order: OmniTrustILM/interfaces#883 first.** The last commit adopts its contract (`DiscoveryDetailDto.stoppable` replaces `effectiveCapabilities`), so this branch compiles only against the snapshot carrying that change. Conversely, once #883 merges, core main stops compiling until this lands — the two should merge back-to-back.

## Client wiring (Task 4)

- REST and MQ discovery v2 clients become beans and route through `getDiscoveryApiClientV2` via the existing `shouldUseMq` chokepoint, with REST fallback when the MQ bean is absent.
- The drain response size bound lands as `ClientTuning.maxInMemorySize` on the single shared WebClient, surfaced as `connector.api-client.max-in-memory-size` (DataSize, validated < 2 GB) — deliberately never a per-client cap, which would collide with `BaseApiClient`'s connector-keyed mTLS client cache.
- The MQ client carries per-operation timeout budgets from `discovery.mq-timeouts.*` (status/drain/control, 30s defaults), and `ProxyClientImpl` overrides the six-argument `sendRequestForEntity` so an explicit timeout keeps the status-preserving path — without it, MQ `cancel`'s 204 arrives as the interface default's `ResponseEntity.ok`.

## Capability gate (Task 5, slimmed)

`ConnectorCapabilityService.supports(ConnectorInterfaceEntity, FeatureFlag)` is the new primary entry point, keyed on the bound interface row so it stays correct across multiple versions of one interface; the authority-typed overload delegates to it.

**Plan deviation:** the plan's supported-resources persistence (column, migration, reconcile sync) is deliberately absent. An independent adversarial review of the per-resource capability model led to replacing it with per-run stoppability declared at initiate (interfaces#883); the resource listing relays live in core#1964. Decision record: `docs/superpowers/2026-08-04-discovery-provider-api-v2/per-run-stoppability-decision.md` in the planning workspace.

## Review already folded in

A four-source multi-review ran pre-opening; its round is the last commit and includes two finds worth a reviewer's eye: a duplicate top-level `discovery:` YAML key that SnakeYAML 2 rejects at boot but no test could see (the test-classpath yml shadows the main one), and the context-signature baseline bump recording the deliberately forked proxy-disabled test context.

Deployment note: the four new env vars need chart enumeration — folded into OmniTrustILM/helm-charts#321.
