### PR TITLE
Handle comment events and deliver notifications

### DIFF
--- a/src/main/java/com/otilm/core/dao/entity/notifications/Notification.java
+++ b/src/main/java/com/otilm/core/dao/entity/notifications/Notification.java
@@ -28,10 +28,10 @@ import lombok.ToString;
 @Table(name = "notification")
 public class Notification extends UniquelyIdentified {
 
-    @Column(name = "message", nullable = false)
+    @Column(name = "message", nullable = false, columnDefinition = "TEXT")
     private String message;
 
-    @Column(name = "detail")
+    @Column(name = "detail", columnDefinition = "TEXT")
     private String detail;
 
     @Column(name = "sent_at", nullable = false, columnDefinition = "TIMESTAMP default CURRENT_TIMESTAMP")

--- a/src/main/java/com/otilm/core/dao/repository/CommentRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CommentRepository.java
@@ -38,15 +38,17 @@ public interface CommentRepository extends SecurityFilterRepository<Comment, UUI
     @Query("SELECT DISTINCT c.authorUuid FROM Comment c WHERE c.uuid = :rootUuid OR c.parentUuid = :rootUuid")
     List<UUID> findThreadParticipantUuids(@Param("rootUuid") UUID rootUuid);
 
+    // The state predicate makes the transition atomic: a repeated request updates no rows, so the caller can
+    // tell a real transition from a no-op without reading the row first.
     @Modifying
     @Query("UPDATE Comment c SET c.resolvedAt = :resolvedAt, c.resolvedByUuid = :actorUuid, "
-            + "c.resolvedByUsername = :actorUsername WHERE c.uuid = :uuid")
+            + "c.resolvedByUsername = :actorUsername WHERE c.uuid = :uuid AND c.resolvedAt IS NULL")
     int resolve(@Param("uuid") UUID uuid, @Param("resolvedAt") OffsetDateTime resolvedAt,
             @Param("actorUuid") UUID actorUuid, @Param("actorUsername") String actorUsername);
 
     @Modifying
     @Query("UPDATE Comment c SET c.resolvedAt = NULL, c.resolvedByUuid = NULL, c.resolvedByUsername = NULL "
-            + "WHERE c.uuid = :uuid")
+            + "WHERE c.uuid = :uuid AND c.resolvedAt IS NOT NULL")
     int unresolve(@Param("uuid") UUID uuid);
 
     @Modifying

--- a/src/main/java/com/otilm/core/dao/repository/CommentRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CommentRepository.java
@@ -35,6 +35,9 @@ public interface CommentRepository extends SecurityFilterRepository<Comment, UUI
     @Query("SELECT c FROM Comment c WHERE c.uuid = :uuid")
     Optional<Comment> findWithLockByUuid(@Param("uuid") UUID uuid);
 
+    @Query("SELECT DISTINCT c.authorUuid FROM Comment c WHERE c.uuid = :rootUuid OR c.parentUuid = :rootUuid")
+    List<UUID> findThreadParticipantUuids(@Param("rootUuid") UUID rootUuid);
+
     @Modifying
     @Query("UPDATE Comment c SET c.resolvedAt = :resolvedAt, c.resolvedByUuid = :actorUuid, "
             + "c.resolvedByUsername = :actorUsername WHERE c.uuid = :uuid")

--- a/src/main/java/com/otilm/core/enums/FilterField.java
+++ b/src/main/java/com/otilm/core/enums/FilterField.java
@@ -57,6 +57,7 @@ import com.otilm.core.dao.entity.Group_;
 import com.otilm.core.dao.entity.Location_;
 import com.otilm.core.dao.entity.OwnerAssociation_;
 import com.otilm.core.dao.entity.RaProfile_;
+import com.otilm.core.dao.entity.ResourceObjectAssociation_;
 import com.otilm.core.dao.entity.ScheduledJob_;
 import com.otilm.core.dao.entity.Secret2SyncVaultProfile_;
 import com.otilm.core.dao.entity.Secret_;
@@ -310,17 +311,19 @@ public enum FilterField {
             ResourceAction.class),
     APPROVAL_STATUS(Resource.APPROVAL, null, null, Approval_.status, Constants.STATUS, SearchFieldTypeEnum.LIST,
             ApprovalStatusEnum.class),
-    APPROVAL_CREATED_AT(Resource.APPROVAL, null, null, Approval_.createdAt, "Created At", SearchFieldTypeEnum.DATETIME),
+    APPROVAL_CREATED_AT(Resource.APPROVAL, null, null, Approval_.createdAt, Constants.CREATED_AT,
+            SearchFieldTypeEnum.DATETIME),
     APPROVAL_EXPIRY_AT(Resource.APPROVAL, null, null, Approval_.expiryAt, "Expiry At", SearchFieldTypeEnum.DATETIME),
     APPROVAL_CLOSED_AT(Resource.APPROVAL, null, null, Approval_.closedAt, "Closed At", SearchFieldTypeEnum.DATETIME),
 
     // Comment
-    COMMENT_HOST_RESOURCE(Resource.COMMENT, null, null, Comment_.resource, "Host Resource", SearchFieldTypeEnum.LIST,
-            Resource.class),
+    COMMENT_HOST_RESOURCE(Resource.COMMENT, null, null, ResourceObjectAssociation_.resource, "Host Resource",
+            SearchFieldTypeEnum.LIST, Resource.class),
     COMMENT_PARENT(Resource.COMMENT, null, null, Comment_.parentUuid, "Parent Comment", SearchFieldTypeEnum.PRESENCE),
     COMMENT_AUTHOR(Resource.COMMENT, Resource.USER, null, Comment_.authorUsername, "Author", SearchFieldTypeEnum.LIST),
     COMMENT_BODY(Resource.COMMENT, null, null, Comment_.body, "Body", SearchFieldTypeEnum.STRING),
-    COMMENT_CREATED_AT(Resource.COMMENT, null, null, Comment_.createdAt, "Created At", SearchFieldTypeEnum.DATETIME),
+    COMMENT_CREATED_AT(Resource.COMMENT, null, null, Comment_.createdAt, Constants.CREATED_AT,
+            SearchFieldTypeEnum.DATETIME),
     COMMENT_RESOLVED_AT(Resource.COMMENT, null, null, Comment_.resolvedAt, "Resolved At", SearchFieldTypeEnum.DATETIME),
 
     // OID Entry
@@ -424,7 +427,7 @@ public enum FilterField {
             SearchFieldTypeEnum.DATETIME),
     SIGNING_RECORD_SIGNED_DOCUMENT_RETRIEVED_AT(Resource.SIGNING_RECORD, null, null,
             SigningRecord_.signedDocumentRetrievedAt, "Signed Document Retrieved At", SearchFieldTypeEnum.DATETIME),
-    SIGNING_RECORD_CREATED(Resource.SIGNING_RECORD, null, null, Audited_.created, "Created At",
+    SIGNING_RECORD_CREATED(Resource.SIGNING_RECORD, null, null, Audited_.created, Constants.CREATED_AT,
             SearchFieldTypeEnum.DATETIME);
 
     private static final FilterField[] VALUES;
@@ -489,6 +492,7 @@ public enum FilterField {
         public static final String STATE = "State";
         public static final String ENABLED = "Enabled";
         public static final String STATUS = "Status";
+        public static final String CREATED_AT = "Created At";
     }
 
 }

--- a/src/main/java/com/otilm/core/enums/FilterField.java
+++ b/src/main/java/com/otilm/core/enums/FilterField.java
@@ -44,6 +44,7 @@ import com.otilm.core.dao.entity.CertificateProtocolAssociation_;
 import com.otilm.core.dao.entity.CertificateRelation_;
 import com.otilm.core.dao.entity.CertificateRequestEntity_;
 import com.otilm.core.dao.entity.Certificate_;
+import com.otilm.core.dao.entity.Comment_;
 import com.otilm.core.dao.entity.Connector2FunctionGroup_;
 import com.otilm.core.dao.entity.ConnectorInterfaceEntity_;
 import com.otilm.core.dao.entity.Connector_;
@@ -312,6 +313,15 @@ public enum FilterField {
     APPROVAL_CREATED_AT(Resource.APPROVAL, null, null, Approval_.createdAt, "Created At", SearchFieldTypeEnum.DATETIME),
     APPROVAL_EXPIRY_AT(Resource.APPROVAL, null, null, Approval_.expiryAt, "Expiry At", SearchFieldTypeEnum.DATETIME),
     APPROVAL_CLOSED_AT(Resource.APPROVAL, null, null, Approval_.closedAt, "Closed At", SearchFieldTypeEnum.DATETIME),
+
+    // Comment
+    COMMENT_HOST_RESOURCE(Resource.COMMENT, null, null, Comment_.resource, "Host Resource", SearchFieldTypeEnum.LIST,
+            Resource.class),
+    COMMENT_PARENT(Resource.COMMENT, null, null, Comment_.parentUuid, "Parent Comment", SearchFieldTypeEnum.PRESENCE),
+    COMMENT_AUTHOR(Resource.COMMENT, Resource.USER, null, Comment_.authorUsername, "Author", SearchFieldTypeEnum.LIST),
+    COMMENT_BODY(Resource.COMMENT, null, null, Comment_.body, "Body", SearchFieldTypeEnum.STRING),
+    COMMENT_CREATED_AT(Resource.COMMENT, null, null, Comment_.createdAt, "Created At", SearchFieldTypeEnum.DATETIME),
+    COMMENT_RESOLVED_AT(Resource.COMMENT, null, null, Comment_.resolvedAt, "Resolved At", SearchFieldTypeEnum.DATETIME),
 
     // OID Entry
     OID_ENTRY_OID(Resource.OID, null, null, CustomOidEntry_.oid, "OID", SearchFieldTypeEnum.STRING),

--- a/src/main/java/com/otilm/core/enums/ResourceToClass.java
+++ b/src/main/java/com/otilm/core/enums/ResourceToClass.java
@@ -10,6 +10,7 @@ import com.otilm.core.dao.entity.AuditLog;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.CertificateRequestEntity;
+import com.otilm.core.dao.entity.Comment;
 import com.otilm.core.dao.entity.ComplianceProfile;
 import com.otilm.core.dao.entity.Connector;
 import com.otilm.core.dao.entity.Credential;
@@ -78,6 +79,9 @@ public enum ResourceToClass {
     // APPROVALS
     APPROVAL_PROFILE(Resource.APPROVAL_PROFILE, ApprovalProfile.class),
     APPROVAL(Resource.APPROVAL, Approval.class),
+
+    // COMMENTS
+    COMMENT(Resource.COMMENT, Comment.class),
 
     // SIGNING
     SIGNING_PROFILE(Resource.SIGNING_PROFILE, SigningProfile.class),

--- a/src/main/java/com/otilm/core/enums/SearchFieldTypeEnum.java
+++ b/src/main/java/com/otilm/core/enums/SearchFieldTypeEnum.java
@@ -53,6 +53,10 @@ public enum SearchFieldTypeEnum {
                             FilterConditionOperator.EQUALS, FilterConditionOperator.NOT_EQUALS,
                             FilterConditionOperator.EMPTY, FilterConditionOperator.NOT_EMPTY),
             true, null),
+    // For fields whose value is not meaningful to the user (for example an internal UUID reference):
+    // only the presence of a value can be tested, never the value itself.
+    PRESENCE(FilterFieldType.STRING, List.of(FilterConditionOperator.EMPTY, FilterConditionOperator.NOT_EMPTY), false,
+            null),
     BOOLEAN(FilterFieldType.BOOLEAN,
             List
                     .of(FilterConditionOperator.EQUALS, FilterConditionOperator.NOT_EQUALS,

--- a/src/main/java/com/otilm/core/events/handlers/CommentCreatedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CommentCreatedEventHandler.java
@@ -12,9 +12,10 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
 @Component(ResourceEvent.Codes.COMMENT_CREATED)
 public class CommentCreatedEventHandler extends CommentEventsHandler {
 

--- a/src/main/java/com/otilm/core/events/handlers/CommentCreatedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CommentCreatedEventHandler.java
@@ -7,7 +7,6 @@ import com.otilm.core.dao.repository.CommentRepository;
 import com.otilm.core.evaluator.TriggerEvaluator;
 import com.otilm.core.events.EventContext;
 import com.otilm.core.messaging.model.NotificationRecipient;
-import com.otilm.core.service.ResourceObjectAssociationService;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,16 +17,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Component(ResourceEvent.Codes.COMMENT_CREATED)
 public class CommentCreatedEventHandler extends CommentEventsHandler {
 
-    private ResourceObjectAssociationService resourceObjectAssociationService;
-
     @Autowired
     protected CommentCreatedEventHandler(CommentRepository repository, TriggerEvaluator<Comment> triggerEvaluator) {
         super(repository, triggerEvaluator);
-    }
-
-    @Autowired
-    public void setResourceObjectAssociationService(ResourceObjectAssociationService resourceObjectAssociationService) {
-        this.resourceObjectAssociationService = resourceObjectAssociationService;
     }
 
     @Override

--- a/src/main/java/com/otilm/core/events/handlers/CommentCreatedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CommentCreatedEventHandler.java
@@ -1,7 +1,6 @@
 package com.otilm.core.events.handlers;
 
 import com.otilm.api.model.common.NameAndUuidDto;
-import com.otilm.api.model.core.notification.RecipientType;
 import com.otilm.api.model.core.other.ResourceEvent;
 import com.otilm.core.dao.entity.Comment;
 import com.otilm.core.dao.repository.CommentRepository;
@@ -43,7 +42,7 @@ public class CommentCreatedEventHandler extends CommentEventsHandler {
             if (owner == null || owner.getUuid().equals(String.valueOf(actingUser))) {
                 return;
             }
-            recipients = List.of(new NotificationRecipient(RecipientType.OWNER, null));
+            recipients = NotificationRecipient.buildUserNotificationRecipient(UUID.fromString(owner.getUuid()));
         } else {
             recipients = threadParticipantsExcept(comment.getParentUuid(), actingUser);
         }

--- a/src/main/java/com/otilm/core/events/handlers/CommentCreatedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CommentCreatedEventHandler.java
@@ -37,7 +37,7 @@ public class CommentCreatedEventHandler extends CommentEventsHandler {
             }
             recipients = List.of(new NotificationRecipient(RecipientType.USER, UUID.fromString(owner.getUuid())));
         } else {
-            recipients = threadParticipantsExcept(comment.getParentUuid(), actingUser);
+            recipients = threadParticipantsExcept(comment, comment.getParentUuid(), actingUser);
         }
         publishFollowUpNotification(eventContext, comment, recipients);
     }

--- a/src/main/java/com/otilm/core/events/handlers/CommentCreatedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CommentCreatedEventHandler.java
@@ -1,0 +1,52 @@
+package com.otilm.core.events.handlers;
+
+import com.otilm.api.model.common.NameAndUuidDto;
+import com.otilm.api.model.core.notification.RecipientType;
+import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.core.dao.entity.Comment;
+import com.otilm.core.dao.repository.CommentRepository;
+import com.otilm.core.evaluator.TriggerEvaluator;
+import com.otilm.core.events.EventContext;
+import com.otilm.core.messaging.model.NotificationRecipient;
+import com.otilm.core.service.ResourceObjectAssociationService;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Component(ResourceEvent.Codes.COMMENT_CREATED)
+public class CommentCreatedEventHandler extends CommentEventsHandler {
+
+    private ResourceObjectAssociationService resourceObjectAssociationService;
+
+    @Autowired
+    protected CommentCreatedEventHandler(CommentRepository repository, TriggerEvaluator<Comment> triggerEvaluator) {
+        super(repository, triggerEvaluator);
+    }
+
+    @Autowired
+    public void setResourceObjectAssociationService(ResourceObjectAssociationService resourceObjectAssociationService) {
+        this.resourceObjectAssociationService = resourceObjectAssociationService;
+    }
+
+    @Override
+    protected void sendFollowUpEventsNotifications(EventContext<Comment> eventContext) {
+        Comment comment = eventContext.getResourceObjects().getFirst();
+        UUID actingUser = eventContext.getUserUuid();
+
+        List<NotificationRecipient> recipients;
+        if (comment.getParentUuid() == null) {
+            NameAndUuidDto owner = resourceObjectAssociationService
+                    .getOwner(comment.getResource(), comment.getObjectUuid());
+            if (owner == null || owner.getUuid().equals(String.valueOf(actingUser))) {
+                return;
+            }
+            recipients = List.of(new NotificationRecipient(RecipientType.OWNER, null));
+        } else {
+            recipients = threadParticipantsExcept(comment.getParentUuid(), actingUser);
+        }
+        publishFollowUpNotification(eventContext, comment, recipients);
+    }
+}

--- a/src/main/java/com/otilm/core/events/handlers/CommentCreatedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CommentCreatedEventHandler.java
@@ -1,6 +1,7 @@
 package com.otilm.core.events.handlers;
 
 import com.otilm.api.model.common.NameAndUuidDto;
+import com.otilm.api.model.core.notification.RecipientType;
 import com.otilm.api.model.core.other.ResourceEvent;
 import com.otilm.core.dao.entity.Comment;
 import com.otilm.core.dao.repository.CommentRepository;
@@ -34,7 +35,7 @@ public class CommentCreatedEventHandler extends CommentEventsHandler {
             if (owner == null || owner.getUuid().equals(String.valueOf(actingUser))) {
                 return;
             }
-            recipients = NotificationRecipient.buildUserNotificationRecipient(UUID.fromString(owner.getUuid()));
+            recipients = List.of(new NotificationRecipient(RecipientType.USER, UUID.fromString(owner.getUuid())));
         } else {
             recipients = threadParticipantsExcept(comment.getParentUuid(), actingUser);
         }

--- a/src/main/java/com/otilm/core/events/handlers/CommentEventsHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CommentEventsHandler.java
@@ -12,6 +12,9 @@ import com.otilm.core.events.EventContextTriggers;
 import com.otilm.core.events.EventHandler;
 import com.otilm.core.messaging.model.NotificationMessage;
 import com.otilm.core.messaging.model.NotificationRecipient;
+import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.security.authz.AuthorizationEnforcer;
+import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.service.ResourceObjectAssociationService;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +31,8 @@ public abstract class CommentEventsHandler extends EventHandler<Comment> {
 
     protected ResourceObjectAssociationService resourceObjectAssociationService;
 
+    private AuthorizationEnforcer authorizationEnforcer;
+
     protected CommentEventsHandler(CommentRepository repository, TriggerEvaluator<Comment> triggerEvaluator) {
         super(repository, triggerEvaluator);
         this.commentRepository = repository;
@@ -36,6 +41,11 @@ public abstract class CommentEventsHandler extends EventHandler<Comment> {
     @Autowired
     public void setResourceObjectAssociationService(ResourceObjectAssociationService resourceObjectAssociationService) {
         this.resourceObjectAssociationService = resourceObjectAssociationService;
+    }
+
+    @Autowired
+    public void setAuthorizationEnforcer(AuthorizationEnforcer authorizationEnforcer) {
+        this.authorizationEnforcer = authorizationEnforcer;
     }
 
     @Override
@@ -54,11 +64,19 @@ public abstract class CommentEventsHandler extends EventHandler<Comment> {
         return eventContextTriggers;
     }
 
-    protected List<NotificationRecipient> threadParticipantsExcept(UUID rootUuid, UUID actingUser) {
+    /**
+     * Participants are historical: somebody who commented while they could read the host object may have lost that
+     * access since. Each one is therefore re-authorized against the host before being notified, so a revoked user stops
+     * learning who acts on the object and what it is called.
+     */
+    protected List<NotificationRecipient> threadParticipantsExcept(Comment comment, UUID rootUuid, UUID actingUser) {
+        SecuredUUID hostUuid = SecuredUUID.fromUUID(comment.getObjectUuid());
         return commentRepository
                 .findThreadParticipantUuids(rootUuid)
                 .stream()
                 .filter(participant -> !participant.equals(actingUser))
+                .filter(participant -> authorizationEnforcer
+                        .isAuthorizedAs(participant, comment.getResource(), ResourceAction.DETAIL, hostUuid))
                 .map(participant -> new NotificationRecipient(RecipientType.USER, participant))
                 .toList();
     }

--- a/src/main/java/com/otilm/core/events/handlers/CommentEventsHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CommentEventsHandler.java
@@ -71,10 +71,6 @@ public abstract class CommentEventsHandler extends EventHandler<Comment> {
     }
 
     /**
-     * Delegated to a bean of its own so the authorization calls it makes run with this handler's transaction suspended;
-     * see {@link CommentParticipantResolver}.
-     */
-    /**
      * Participants are historical: somebody who commented while they could read the host object may have lost that
      * access since. Each one is therefore re-authorized against the host before being notified, so a revoked user stops
      * learning who acts on the object and what it is called.

--- a/src/main/java/com/otilm/core/events/handlers/CommentEventsHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CommentEventsHandler.java
@@ -1,0 +1,79 @@
+package com.otilm.core.events.handlers;
+
+import com.otilm.api.exception.EventException;
+import com.otilm.api.model.common.events.data.CommentEventData;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.notification.RecipientType;
+import com.otilm.core.dao.entity.Comment;
+import com.otilm.core.dao.entity.GroupAssociation;
+import com.otilm.core.dao.repository.CommentRepository;
+import com.otilm.core.dao.repository.GroupAssociationRepository;
+import com.otilm.core.evaluator.TriggerEvaluator;
+import com.otilm.core.events.EventContext;
+import com.otilm.core.events.EventContextTriggers;
+import com.otilm.core.events.EventHandler;
+import com.otilm.core.messaging.model.NotificationMessage;
+import com.otilm.core.messaging.model.NotificationRecipient;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional
+public abstract class CommentEventsHandler extends EventHandler<Comment> {
+
+    protected final CommentRepository commentRepository;
+
+    private GroupAssociationRepository groupAssociationRepository;
+
+    protected CommentEventsHandler(CommentRepository repository, TriggerEvaluator<Comment> triggerEvaluator) {
+        super(repository, triggerEvaluator);
+        this.commentRepository = repository;
+    }
+
+    @Autowired
+    public void setGroupAssociationRepository(GroupAssociationRepository groupAssociationRepository) {
+        this.groupAssociationRepository = groupAssociationRepository;
+    }
+
+    @Override
+    protected Object getEventData(Comment comment, Object eventMessageData) {
+        return objectMapper.convertValue(eventMessageData, CommentEventData.class);
+    }
+
+    @Override
+    protected List<EventContextTriggers> getOverridingTriggers(EventContext<Comment> eventContext, Comment comment)
+            throws EventException {
+        List<EventContextTriggers> eventContextTriggers = new ArrayList<>();
+        for (GroupAssociation groupAssociation : groupAssociationRepository
+                .findByResourceAndObjectUuid(comment.getResource(), comment.getObjectUuid())) {
+            eventContextTriggers.add(fetchEventTriggers(eventContext, Resource.GROUP, groupAssociation.getGroupUuid()));
+        }
+        return eventContextTriggers;
+    }
+
+    protected List<NotificationRecipient> threadParticipantsExcept(UUID rootUuid, UUID actingUser) {
+        return commentRepository
+                .findThreadParticipantUuids(rootUuid)
+                .stream()
+                .filter(participant -> !participant.equals(actingUser))
+                .map(participant -> new NotificationRecipient(RecipientType.USER, participant))
+                .toList();
+    }
+
+    // The message carries the HOST object, not the comment: owner resolution and the notification's deep link
+    // both key on the message's resource and object UUID.
+    protected void publishFollowUpNotification(EventContext<Comment> eventContext, Comment comment,
+            List<NotificationRecipient> recipients) {
+        if (recipients.isEmpty()) {
+            return;
+        }
+        CommentEventData eventData = (CommentEventData) eventContext.getResourceObjectsEventData().getFirst();
+        applicationEventPublisher
+                .publishEvent(new NotificationMessage(eventContext.getEvent(), comment.getResource(),
+                        comment.getObjectUuid(), null, recipients, eventData));
+    }
+}

--- a/src/main/java/com/otilm/core/events/handlers/CommentEventsHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CommentEventsHandler.java
@@ -5,15 +5,14 @@ import com.otilm.api.model.common.events.data.CommentEventData;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.notification.RecipientType;
 import com.otilm.core.dao.entity.Comment;
-import com.otilm.core.dao.entity.GroupAssociation;
 import com.otilm.core.dao.repository.CommentRepository;
-import com.otilm.core.dao.repository.GroupAssociationRepository;
 import com.otilm.core.evaluator.TriggerEvaluator;
 import com.otilm.core.events.EventContext;
 import com.otilm.core.events.EventContextTriggers;
 import com.otilm.core.events.EventHandler;
 import com.otilm.core.messaging.model.NotificationMessage;
 import com.otilm.core.messaging.model.NotificationRecipient;
+import com.otilm.core.service.ResourceObjectAssociationService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -27,7 +26,7 @@ public abstract class CommentEventsHandler extends EventHandler<Comment> {
 
     protected final CommentRepository commentRepository;
 
-    private GroupAssociationRepository groupAssociationRepository;
+    protected ResourceObjectAssociationService resourceObjectAssociationService;
 
     protected CommentEventsHandler(CommentRepository repository, TriggerEvaluator<Comment> triggerEvaluator) {
         super(repository, triggerEvaluator);
@@ -35,8 +34,8 @@ public abstract class CommentEventsHandler extends EventHandler<Comment> {
     }
 
     @Autowired
-    public void setGroupAssociationRepository(GroupAssociationRepository groupAssociationRepository) {
-        this.groupAssociationRepository = groupAssociationRepository;
+    public void setResourceObjectAssociationService(ResourceObjectAssociationService resourceObjectAssociationService) {
+        this.resourceObjectAssociationService = resourceObjectAssociationService;
     }
 
     @Override
@@ -48,9 +47,9 @@ public abstract class CommentEventsHandler extends EventHandler<Comment> {
     protected List<EventContextTriggers> getOverridingTriggers(EventContext<Comment> eventContext, Comment comment)
             throws EventException {
         List<EventContextTriggers> eventContextTriggers = new ArrayList<>();
-        for (GroupAssociation groupAssociation : groupAssociationRepository
-                .findByResourceAndObjectUuid(comment.getResource(), comment.getObjectUuid())) {
-            eventContextTriggers.add(fetchEventTriggers(eventContext, Resource.GROUP, groupAssociation.getGroupUuid()));
+        for (UUID groupUuid : resourceObjectAssociationService
+                .getGroupUuids(comment.getResource(), comment.getObjectUuid())) {
+            eventContextTriggers.add(fetchEventTriggers(eventContext, Resource.GROUP, groupUuid));
         }
         return eventContextTriggers;
     }

--- a/src/main/java/com/otilm/core/events/handlers/CommentEventsHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CommentEventsHandler.java
@@ -21,10 +21,16 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Unlike the other event handlers, comment handling carries no ambient transaction: deciding who to notify authorizes
+ * every thread participant, which makes blocking OPA calls, and a database connection must not be held across them.
+ * Nothing here writes -- the event-history rows the base class keeps are written through their own short transactions.
+ */
 @Component
-@Transactional
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
 public abstract class CommentEventsHandler extends EventHandler<Comment> {
 
     protected final CommentRepository commentRepository;
@@ -64,6 +70,10 @@ public abstract class CommentEventsHandler extends EventHandler<Comment> {
         return eventContextTriggers;
     }
 
+    /**
+     * Delegated to a bean of its own so the authorization calls it makes run with this handler's transaction suspended;
+     * see {@link CommentParticipantResolver}.
+     */
     /**
      * Participants are historical: somebody who commented while they could read the host object may have lost that
      * access since. Each one is therefore re-authorized against the host before being notified, so a revoked user stops

--- a/src/main/java/com/otilm/core/events/handlers/CommentResolvedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CommentResolvedEventHandler.java
@@ -22,6 +22,6 @@ public class CommentResolvedEventHandler extends CommentEventsHandler {
     protected void sendFollowUpEventsNotifications(EventContext<Comment> eventContext) {
         Comment comment = eventContext.getResourceObjects().getFirst();
         publishFollowUpNotification(eventContext, comment,
-                threadParticipantsExcept(comment.getUuid(), eventContext.getUserUuid()));
+                threadParticipantsExcept(comment, comment.getUuid(), eventContext.getUserUuid()));
     }
 }

--- a/src/main/java/com/otilm/core/events/handlers/CommentResolvedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CommentResolvedEventHandler.java
@@ -7,9 +7,10 @@ import com.otilm.core.evaluator.TriggerEvaluator;
 import com.otilm.core.events.EventContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
 @Component(ResourceEvent.Codes.COMMENT_RESOLVED)
 public class CommentResolvedEventHandler extends CommentEventsHandler {
 

--- a/src/main/java/com/otilm/core/events/handlers/CommentResolvedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CommentResolvedEventHandler.java
@@ -1,0 +1,27 @@
+package com.otilm.core.events.handlers;
+
+import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.core.dao.entity.Comment;
+import com.otilm.core.dao.repository.CommentRepository;
+import com.otilm.core.evaluator.TriggerEvaluator;
+import com.otilm.core.events.EventContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Component(ResourceEvent.Codes.COMMENT_RESOLVED)
+public class CommentResolvedEventHandler extends CommentEventsHandler {
+
+    @Autowired
+    protected CommentResolvedEventHandler(CommentRepository repository, TriggerEvaluator<Comment> triggerEvaluator) {
+        super(repository, triggerEvaluator);
+    }
+
+    @Override
+    protected void sendFollowUpEventsNotifications(EventContext<Comment> eventContext) {
+        Comment comment = eventContext.getResourceObjects().getFirst();
+        publishFollowUpNotification(eventContext, comment,
+                threadParticipantsExcept(comment.getUuid(), eventContext.getUserUuid()));
+    }
+}

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
@@ -761,10 +761,9 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
         logger
                 .debug("Sending internal notification. Message: {}. Detail: {}", notificationData.getText(),
                         notificationData.getDetail());
-        List<NotificationRecipient> resolvedRecipients = resolveOwnerRecipients(recipients, resource, objectUuid);
         int notified = 0;
         int failed = 0;
-        for (NotificationRecipient recipient : resolvedRecipients) {
+        for (NotificationRecipient recipient : recipients) {
             try {
                 // Each recipient commits on its own: the listener runs without an ambient transaction, so
                 // every notification-service call opens and commits its own short transaction.
@@ -779,28 +778,7 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
                                 recipient.getRecipientType().getLabel(), recipient.getRecipientUuid(), e.getMessage());
             }
         }
-        return new InternalNotificationOutcome(notified, failed, resolvedRecipients.size());
-    }
-
-    /**
-     * OWNER is an indirection over the subject object, resolved on the profile-driven path by {@link #getRecipients};
-     * handler-driven messages carry the subject themselves, so the same owner-association lookup applies here. An
-     * owner-less subject drops the recipient — configuration, not a failure.
-     */
-    private List<NotificationRecipient> resolveOwnerRecipients(List<NotificationRecipient> recipients,
-            Resource resource, UUID objectUuid) {
-        List<NotificationRecipient> resolved = new ArrayList<>();
-        for (NotificationRecipient recipient : recipients) {
-            if (recipient.getRecipientType() != RecipientType.OWNER) {
-                resolved.add(recipient);
-                continue;
-            }
-            NameAndUuidDto owner = resourceObjectAssociationService.getOwner(resource, objectUuid);
-            if (owner != null) {
-                resolved.add(new NotificationRecipient(RecipientType.USER, UUID.fromString(owner.getUuid())));
-            }
-        }
-        return resolved;
+        return new InternalNotificationOutcome(notified, failed, recipients.size());
     }
 
     /**

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
@@ -761,9 +761,10 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
         logger
                 .debug("Sending internal notification. Message: {}. Detail: {}", notificationData.getText(),
                         notificationData.getDetail());
+        List<NotificationRecipient> resolvedRecipients = resolveOwnerRecipients(recipients, resource, objectUuid);
         int notified = 0;
         int failed = 0;
-        for (NotificationRecipient recipient : recipients) {
+        for (NotificationRecipient recipient : resolvedRecipients) {
             try {
                 // Each recipient commits on its own: the listener runs without an ambient transaction, so
                 // every notification-service call opens and commits its own short transaction.
@@ -778,7 +779,28 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
                                 recipient.getRecipientType().getLabel(), recipient.getRecipientUuid(), e.getMessage());
             }
         }
-        return new InternalNotificationOutcome(notified, failed, recipients.size());
+        return new InternalNotificationOutcome(notified, failed, resolvedRecipients.size());
+    }
+
+    /**
+     * OWNER is an indirection over the subject object, resolved on the profile-driven path by {@link #getRecipients};
+     * handler-driven messages carry the subject themselves, so the same owner-association lookup applies here. An
+     * owner-less subject drops the recipient — configuration, not a failure.
+     */
+    private List<NotificationRecipient> resolveOwnerRecipients(List<NotificationRecipient> recipients,
+            Resource resource, UUID objectUuid) {
+        List<NotificationRecipient> resolved = new ArrayList<>();
+        for (NotificationRecipient recipient : recipients) {
+            if (recipient.getRecipientType() != RecipientType.OWNER) {
+                resolved.add(recipient);
+                continue;
+            }
+            NameAndUuidDto owner = resourceObjectAssociationService.getOwner(resource, objectUuid);
+            if (owner != null) {
+                resolved.add(new NotificationRecipient(RecipientType.USER, UUID.fromString(owner.getUuid())));
+            }
+        }
+        return resolved;
     }
 
     /**

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
@@ -85,6 +85,8 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
     private static final Logger logger = LoggerFactory.getLogger(NotificationListener.class);
     private static final String EMAIL_NOTIFICATION_PROVIDER_KIND = "EMAIL";
     private static final Set<Resource> OBJECT_RECIPIENT_SUBJECT_RESOURCES = Set.of(Resource.CERTIFICATE);
+    private static final Set<ResourceEvent> SUBJECT_LINKED_EVENTS = EnumSet
+            .of(ResourceEvent.COMMENT_CREATED, ResourceEvent.COMMENT_RESOLVED);
 
     private ObjectMapper mapper;
     private AttributeEngine attributeEngine;
@@ -203,10 +205,10 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
         // sent in corresponding event handlers
         if (sendInternalNotifications) {
             try {
-                // The persisted notification targets the resolved subject, not the event record: for comment
-                // events the deep link has to point at the host object, matching handler-driven follow-ups.
+                NotificationSubjectResolver.SubjectRef target = internalNotificationTarget(message.getEvent(),
+                        message.getResource(), message.getObjectUuid(), subject);
                 InternalNotificationOutcome outcome = sendInternalNotifications(recipients,
-                        getInternalNotificationData(message), subject.resource(), subject.objectUuid());
+                        getInternalNotificationData(message), target.resource(), target.objectUuid());
                 notificationSent = notificationSent || outcome.notified() > 0;
                 reportInternalNotificationGap(outcome, "Notification profile %s in event %s"
                         .formatted(notificationProfileVersion.getNotificationProfile().getName(), message.getEvent()),
@@ -490,6 +492,19 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
             return List.of();
         }
         return recipientUuids.stream().map(uuid -> new NotificationRecipient(recipientType, uuid)).toList();
+    }
+
+    /**
+     * Which object the persisted notification points the reader at. Almost every event names the record the reader acts
+     * on -- an approval notification must open the approval, not the object awaiting it -- so the message's own
+     * coordinates win. A comment has no page of its own, so its notification points at the host object instead,
+     * matching what the comment handlers publish for their follow-ups.
+     */
+    static NotificationSubjectResolver.SubjectRef internalNotificationTarget(ResourceEvent event,
+            Resource messageResource, UUID messageObjectUuid, NotificationSubjectResolver.SubjectRef subject) {
+        return SUBJECT_LINKED_EVENTS.contains(event)
+                ? subject
+                : new NotificationSubjectResolver.SubjectRef(messageResource, messageObjectUuid);
     }
 
     List<NotificationRecipient> getDefaultRecipients(ResourceEvent event, Object data, Resource resource,

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
@@ -203,8 +203,10 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
         // sent in corresponding event handlers
         if (sendInternalNotifications) {
             try {
+                // The persisted notification targets the resolved subject, not the event record: for comment
+                // events the deep link has to point at the host object, matching handler-driven follow-ups.
                 InternalNotificationOutcome outcome = sendInternalNotifications(recipients,
-                        getInternalNotificationData(message), message.getResource(), message.getObjectUuid());
+                        getInternalNotificationData(message), subject.resource(), subject.objectUuid());
                 notificationSent = notificationSent || outcome.notified() > 0;
                 reportInternalNotificationGap(outcome, "Notification profile %s in event %s"
                         .formatted(notificationProfileVersion.getNotificationProfile().getName(), message.getEvent()),
@@ -452,8 +454,9 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
             return List.of(new NotificationRecipient(RecipientType.USER, UUID.fromString(ownerInfo.getUuid())));
         }
 
-        return getDefaultRecipients(message.getEvent(), message.getData(), message.getResource(),
-                message.getObjectUuid());
+        // Defaults resolve against the subject for the same reason OWNER does: comment events carry the comment,
+        // but their natural audience belongs to the host object.
+        return getDefaultRecipients(message.getEvent(), message.getData(), subject.resource(), subject.objectUuid());
     }
 
     /**
@@ -489,12 +492,12 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
         return recipientUuids.stream().map(uuid -> new NotificationRecipient(recipientType, uuid)).toList();
     }
 
-    private List<NotificationRecipient> getDefaultRecipients(ResourceEvent event, Object data, Resource resource,
+    List<NotificationRecipient> getDefaultRecipients(ResourceEvent event, Object data, Resource resource,
             UUID objectUuid) {
         List<NotificationRecipient> recipients = new ArrayList<>();
         switch (event) {
             case CERTIFICATE_STATUS_CHANGED, CERTIFICATE_ACTION_PERFORMED, CERTIFICATE_EXPIRING,
-                    CERTIFICATE_NOT_COMPLIANT, CERTIFICATE_UPLOADED -> {
+                    CERTIFICATE_NOT_COMPLIANT, CERTIFICATE_UPLOADED, COMMENT_CREATED, COMMENT_RESOLVED -> {
                 NameAndUuidDto ownerInfo = resourceObjectAssociationService.getOwner(resource, objectUuid);
                 if (ownerInfo != null) {
                     recipients.add(new NotificationRecipient(RecipientType.USER, UUID.fromString(ownerInfo.getUuid())));

--- a/src/main/java/com/otilm/core/security/authz/AuthorizationEnforcer.java
+++ b/src/main/java/com/otilm/core/security/authz/AuthorizationEnforcer.java
@@ -3,6 +3,7 @@ package com.otilm.core.security.authz;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.core.model.auth.ResourceAction;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.security.access.AccessDeniedException;
 
 /**
@@ -31,4 +32,15 @@ public interface AuthorizationEnforcer {
      * check fails.
      */
     void enforce(Resource resource, ResourceAction action, List<SecuredUUID> objectUuids) throws AccessDeniedException;
+
+    /**
+     * Whether {@code userUuid} -- somebody other than the current principal -- may perform {@code action} on the
+     * object. A user the auth service can no longer resolve is denied.
+     *
+     * <p>
+     * The decision is made against a principal resolved for that user, leaving the current security context and the
+     * actor MDC untouched, so this is safe to call while acting as somebody else. On top of the cost noted above, each
+     * call resolves the user against the auth service (cached).
+     */
+    boolean isAuthorizedAs(UUID userUuid, Resource resource, ResourceAction action, SecuredUUID objectUuid);
 }

--- a/src/main/java/com/otilm/core/security/authz/AuthorizationEnforcerImpl.java
+++ b/src/main/java/com/otilm/core/security/authz/AuthorizationEnforcerImpl.java
@@ -1,9 +1,19 @@
 package com.otilm.core.security.authz;
 
 import com.otilm.api.model.core.auth.Resource;
+import com.otilm.core.logging.LoggingHelper;
 import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.security.authn.PlatformAuthenticationToken;
+import com.otilm.core.security.authn.PlatformUserDetails;
+import com.otilm.core.security.authn.client.AuthenticationInfo;
+import com.otilm.core.security.authn.client.PlatformAuthenticationClient;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.core.Authentication;
@@ -13,10 +23,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class AuthorizationEnforcerImpl implements AuthorizationEnforcer {
 
-    private final ExternalAuthorizationCore core;
+    private static final Logger logger = LoggerFactory.getLogger(AuthorizationEnforcerImpl.class);
 
-    public AuthorizationEnforcerImpl(ExternalAuthorizationCore core) {
+    private final ExternalAuthorizationCore core;
+    private final PlatformAuthenticationClient authenticationClient;
+
+    public AuthorizationEnforcerImpl(ExternalAuthorizationCore core,
+            @Lazy PlatformAuthenticationClient authenticationClient) {
         this.core = core;
+        this.authenticationClient = authenticationClient;
     }
 
     @Override
@@ -31,6 +46,34 @@ public class AuthorizationEnforcerImpl implements AuthorizationEnforcer {
         AuthorizationDecision decision = core.decide(authentication, request);
         if (!decision.isGranted()) {
             throw new AccessDeniedException("Access denied to %s:%s".formatted(resource.getCode(), action.getCode()));
+        }
+    }
+
+    @Override
+    public boolean isAuthorizedAs(UUID userUuid, Resource resource, ResourceAction action, SecuredUUID objectUuid) {
+        Authentication authentication = resolvePrincipal(userUuid);
+        if (authentication == null) {
+            return false;
+        }
+        AuthorizationRequest request = AuthorizationRequest.forDirectCheck(resource, action, List.of(objectUuid));
+        return core.decide(authentication, request).isGranted();
+    }
+
+    /**
+     * Resolving somebody replays their actor MDC, which would otherwise attribute the caller's own audited records to
+     * the user being checked, so the caller's actor info is restored afterwards. A user the auth service answers for
+     * anonymously no longer exists as a principal and gets no decision of their own.
+     */
+    private Authentication resolvePrincipal(UUID userUuid) {
+        Map<String, String> callerActor = LoggingHelper.snapshotActorInfo();
+        try {
+            AuthenticationInfo info = authenticationClient.authenticateByUserUuid(userUuid);
+            return info.isAnonymous() ? null : new PlatformAuthenticationToken(new PlatformUserDetails(info));
+        } catch (Exception e) {
+            logger.warn("Could not resolve user {} to authorize them: {}", userUuid, e.getMessage());
+            return null;
+        } finally {
+            LoggingHelper.restoreActorInfo(callerActor);
         }
     }
 }

--- a/src/main/java/com/otilm/core/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CommentServiceImpl.java
@@ -263,8 +263,10 @@ public class CommentServiceImpl implements CommentExternalService, CommentIntern
         int updated = resolved
                 ? commentWriter.resolve(uuid, changedAt, UUID.fromString(actor.getUuid()), actor.getName())
                 : commentWriter.unresolve(uuid);
+        // The thread is already in the requested state, or vanished between the read and the update: the
+        // request succeeds, but there is no transition to announce.
         if (updated == 0) {
-            throw new NotFoundException(Comment.class, uuid);
+            return;
         }
 
         CommentEventData eventData = baseEventData(comment, hostObject.getName());

--- a/src/main/java/com/otilm/core/service/notifications/NotificationSubjectResolver.java
+++ b/src/main/java/com/otilm/core/service/notifications/NotificationSubjectResolver.java
@@ -1,15 +1,16 @@
 package com.otilm.core.service.notifications;
 
 import com.otilm.api.model.common.events.data.ApprovalEventData;
+import com.otilm.api.model.common.events.data.CommentEventData;
 import com.otilm.api.model.common.events.data.EventData;
 import com.otilm.api.model.core.auth.Resource;
 
 import java.util.UUID;
 
 /**
- * Resolves which object a notification's enrichment and subject-scoped recipients describe. Approval events reference a
- * target object in their payload; the approval record itself carries no attributes, owner, or groups, so the target is
- * the meaningful subject. Every other event's subject is the event object itself.
+ * Resolves which object a notification's enrichment and subject-scoped recipients describe. Approval and comment events
+ * reference a target object in their payload; the approval or comment record itself carries no attributes, owner, or
+ * groups, so the target is the meaningful subject. Every other event's subject is the event object itself.
  */
 public final class NotificationSubjectResolver {
 
@@ -23,6 +24,10 @@ public final class NotificationSubjectResolver {
         if (eventData instanceof ApprovalEventData approval && approval.getResource() != null
                 && approval.getObjectUuid() != null) {
             return new SubjectRef(approval.getResource(), approval.getObjectUuid());
+        }
+        if (eventData instanceof CommentEventData comment && comment.getResource() != null
+                && comment.getObjectUuid() != null) {
+            return new SubjectRef(comment.getResource(), comment.getObjectUuid());
         }
         return new SubjectRef(resource, objectUuid);
     }

--- a/src/test/java/com/otilm/core/events/handlers/CommentCreatedEventHandlerTest.java
+++ b/src/test/java/com/otilm/core/events/handlers/CommentCreatedEventHandlerTest.java
@@ -12,6 +12,7 @@ import com.otilm.core.events.EventContext;
 import com.otilm.core.messaging.model.EventMessage;
 import com.otilm.core.messaging.model.NotificationMessage;
 import com.otilm.core.messaging.model.NotificationRecipient;
+import com.otilm.core.security.authz.AuthorizationEnforcer;
 import com.otilm.core.service.ResourceObjectAssociationService;
 import java.util.List;
 import java.util.UUID;
@@ -22,6 +23,8 @@ import org.springframework.context.ApplicationEventPublisher;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -33,6 +36,7 @@ class CommentCreatedEventHandlerTest {
     private static final UUID ACTOR_UUID = UUID.randomUUID();
 
     private CommentRepository commentRepository;
+    private AuthorizationEnforcer authorizationEnforcer;
     private ResourceObjectAssociationService associationService;
     private ApplicationEventPublisher publisher;
     private CommentCreatedEventHandler handler;
@@ -44,9 +48,13 @@ class CommentCreatedEventHandlerTest {
         associationService = mock(ResourceObjectAssociationService.class);
         publisher = mock(ApplicationEventPublisher.class);
 
+        authorizationEnforcer = mock(AuthorizationEnforcer.class);
+        when(authorizationEnforcer.isAuthorizedAs(any(), any(), any(), any())).thenReturn(true);
+
         handler = new CommentCreatedEventHandler(commentRepository, mock(TriggerEvaluator.class));
         handler.setResourceObjectAssociationService(associationService);
         handler.setApplicationEventPublisher(publisher);
+        handler.setAuthorizationEnforcer(authorizationEnforcer);
     }
 
     private Comment comment(UUID parentUuid) {
@@ -126,6 +134,23 @@ class CommentCreatedEventHandlerTest {
         assertEquals(List.of(participantB, participantC),
                 captor.getValue().getRecipients().stream().map(NotificationRecipient::getRecipientUuid).toList());
         assertEquals(RecipientType.USER, captor.getValue().getRecipients().getFirst().getRecipientType());
+    }
+
+    @Test
+    void replyDoesNotNotifyParticipantsWhoCanNoLongerReadTheHost() {
+        UUID rootUuid = UUID.randomUUID();
+        UUID stillAllowed = UUID.randomUUID();
+        UUID revoked = UUID.randomUUID();
+        when(commentRepository.findThreadParticipantUuids(rootUuid))
+                .thenReturn(List.of(ACTOR_UUID, stillAllowed, revoked));
+        when(authorizationEnforcer.isAuthorizedAs(eq(revoked), any(), any(), any())).thenReturn(false);
+
+        handler.sendFollowUpEventsNotifications(context(comment(rootUuid)));
+
+        ArgumentCaptor<NotificationMessage> captor = ArgumentCaptor.forClass(NotificationMessage.class);
+        verify(publisher).publishEvent(captor.capture());
+        assertEquals(List.of(stillAllowed),
+                captor.getValue().getRecipients().stream().map(NotificationRecipient::getRecipientUuid).toList());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/events/handlers/CommentCreatedEventHandlerTest.java
+++ b/src/test/java/com/otilm/core/events/handlers/CommentCreatedEventHandlerTest.java
@@ -1,0 +1,138 @@
+package com.otilm.core.events.handlers;
+
+import com.otilm.api.model.common.NameAndUuidDto;
+import com.otilm.api.model.common.events.data.CommentEventData;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.notification.RecipientType;
+import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.core.dao.entity.Comment;
+import com.otilm.core.dao.repository.CommentRepository;
+import com.otilm.core.evaluator.TriggerEvaluator;
+import com.otilm.core.events.EventContext;
+import com.otilm.core.messaging.model.EventMessage;
+import com.otilm.core.messaging.model.NotificationMessage;
+import com.otilm.core.messaging.model.NotificationRecipient;
+import com.otilm.core.service.ResourceObjectAssociationService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class CommentCreatedEventHandlerTest {
+
+    private static final UUID HOST_UUID = UUID.randomUUID();
+    private static final UUID ACTOR_UUID = UUID.randomUUID();
+
+    private CommentRepository commentRepository;
+    private ResourceObjectAssociationService associationService;
+    private ApplicationEventPublisher publisher;
+    private CommentCreatedEventHandler handler;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        commentRepository = mock(CommentRepository.class);
+        associationService = mock(ResourceObjectAssociationService.class);
+        publisher = mock(ApplicationEventPublisher.class);
+
+        handler = new CommentCreatedEventHandler(commentRepository, mock(TriggerEvaluator.class));
+        handler.setResourceObjectAssociationService(associationService);
+        handler.setApplicationEventPublisher(publisher);
+    }
+
+    private Comment comment(UUID parentUuid) {
+        Comment comment = new Comment();
+        comment.setUuid(UUID.randomUUID());
+        comment.setResource(Resource.RA_PROFILE);
+        comment.setObjectUuid(HOST_UUID);
+        comment.setParentUuid(parentUuid);
+        comment.setAuthorUuid(ACTOR_UUID);
+        comment.setAuthorUsername("tst-author");
+        comment.setBody("a request");
+        return comment;
+    }
+
+    private EventContext<Comment> context(Comment comment) {
+        CommentEventData eventData = new CommentEventData();
+        eventData.setCommentUuid(comment.getUuid());
+        eventData.setParentUuid(comment.getParentUuid());
+        eventData.setResource(comment.getResource());
+        eventData.setObjectUuid(comment.getObjectUuid());
+        eventData.setBody(comment.getBody());
+        EventMessage eventMessage = new EventMessage(ResourceEvent.COMMENT_CREATED, Resource.COMMENT, comment.getUuid(),
+                null, null, eventData, ACTOR_UUID, null);
+        return new EventContext<>(eventMessage, null, comment, eventData);
+    }
+
+    @Test
+    void rootNotifiesTheHostObjectOwner() {
+        when(associationService.getOwner(Resource.RA_PROFILE, HOST_UUID))
+                .thenReturn(new NameAndUuidDto(UUID.randomUUID().toString(), "tst-owner"));
+
+        handler.sendFollowUpEventsNotifications(context(comment(null)));
+
+        ArgumentCaptor<NotificationMessage> captor = ArgumentCaptor.forClass(NotificationMessage.class);
+        verify(publisher).publishEvent(captor.capture());
+        NotificationMessage message = captor.getValue();
+        assertNull(message.getNotificationProfileUuids());
+        assertEquals(Resource.RA_PROFILE, message.getResource());
+        assertEquals(HOST_UUID, message.getObjectUuid());
+        assertEquals(1, message.getRecipients().size());
+        assertEquals(RecipientType.OWNER, message.getRecipients().getFirst().getRecipientType());
+    }
+
+    @Test
+    void rootWithoutHostOwnerPublishesNothing() {
+        when(associationService.getOwner(Resource.RA_PROFILE, HOST_UUID)).thenReturn(null);
+
+        handler.sendFollowUpEventsNotifications(context(comment(null)));
+
+        verifyNoInteractions(publisher);
+    }
+
+    @Test
+    void rootPostedByTheOwnerIsNotSelfNotified() {
+        when(associationService.getOwner(Resource.RA_PROFILE, HOST_UUID))
+                .thenReturn(new NameAndUuidDto(ACTOR_UUID.toString(), "tst-author"));
+
+        handler.sendFollowUpEventsNotifications(context(comment(null)));
+
+        verifyNoInteractions(publisher);
+    }
+
+    @Test
+    void replyNotifiesThreadParticipantsExceptTheActor() {
+        UUID rootUuid = UUID.randomUUID();
+        UUID participantB = UUID.randomUUID();
+        UUID participantC = UUID.randomUUID();
+        when(commentRepository.findThreadParticipantUuids(rootUuid))
+                .thenReturn(List.of(ACTOR_UUID, participantB, participantC));
+
+        handler.sendFollowUpEventsNotifications(context(comment(rootUuid)));
+
+        ArgumentCaptor<NotificationMessage> captor = ArgumentCaptor.forClass(NotificationMessage.class);
+        verify(publisher).publishEvent(captor.capture());
+        assertEquals(List.of(participantB, participantC),
+                captor.getValue().getRecipients().stream().map(NotificationRecipient::getRecipientUuid).toList());
+        assertEquals(RecipientType.USER, captor.getValue().getRecipients().getFirst().getRecipientType());
+    }
+
+    @Test
+    void replyWithNoOtherParticipantsPublishesNothing() {
+        UUID rootUuid = UUID.randomUUID();
+        when(commentRepository.findThreadParticipantUuids(rootUuid)).thenReturn(List.of(ACTOR_UUID));
+
+        handler.sendFollowUpEventsNotifications(context(comment(rootUuid)));
+
+        verifyNoInteractions(publisher);
+    }
+}

--- a/src/test/java/com/otilm/core/events/handlers/CommentCreatedEventHandlerTest.java
+++ b/src/test/java/com/otilm/core/events/handlers/CommentCreatedEventHandlerTest.java
@@ -75,8 +75,9 @@ class CommentCreatedEventHandlerTest {
 
     @Test
     void rootNotifiesTheHostObjectOwner() {
+        UUID ownerUuid = UUID.randomUUID();
         when(associationService.getOwner(Resource.RA_PROFILE, HOST_UUID))
-                .thenReturn(new NameAndUuidDto(UUID.randomUUID().toString(), "tst-owner"));
+                .thenReturn(new NameAndUuidDto(ownerUuid.toString(), "tst-owner"));
 
         handler.sendFollowUpEventsNotifications(context(comment(null)));
 
@@ -87,7 +88,8 @@ class CommentCreatedEventHandlerTest {
         assertEquals(Resource.RA_PROFILE, message.getResource());
         assertEquals(HOST_UUID, message.getObjectUuid());
         assertEquals(1, message.getRecipients().size());
-        assertEquals(RecipientType.OWNER, message.getRecipients().getFirst().getRecipientType());
+        assertEquals(RecipientType.USER, message.getRecipients().getFirst().getRecipientType());
+        assertEquals(ownerUuid, message.getRecipients().getFirst().getRecipientUuid());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/events/handlers/CommentCreatedEventHandlerTest.java
+++ b/src/test/java/com/otilm/core/events/handlers/CommentCreatedEventHandlerTest.java
@@ -12,6 +12,7 @@ import com.otilm.core.events.EventContext;
 import com.otilm.core.messaging.model.EventMessage;
 import com.otilm.core.messaging.model.NotificationMessage;
 import com.otilm.core.messaging.model.NotificationRecipient;
+import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authz.AuthorizationEnforcer;
 import com.otilm.core.service.ResourceObjectAssociationService;
 import java.util.List;
@@ -24,6 +25,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -151,6 +153,9 @@ class CommentCreatedEventHandlerTest {
         verify(publisher).publishEvent(captor.capture());
         assertEquals(List.of(stillAllowed),
                 captor.getValue().getRecipients().stream().map(NotificationRecipient::getRecipientUuid).toList());
+        verify(authorizationEnforcer)
+                .isAuthorizedAs(eq(stillAllowed), eq(Resource.RA_PROFILE), eq(ResourceAction.DETAIL),
+                        argThat(uuid -> HOST_UUID.equals(uuid.getValue())));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/events/handlers/CommentResolvedEventHandlerTest.java
+++ b/src/test/java/com/otilm/core/events/handlers/CommentResolvedEventHandlerTest.java
@@ -1,0 +1,98 @@
+package com.otilm.core.events.handlers;
+
+import com.otilm.api.model.common.events.data.CommentEventData;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.notification.RecipientType;
+import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.core.dao.entity.Comment;
+import com.otilm.core.dao.repository.CommentRepository;
+import com.otilm.core.evaluator.TriggerEvaluator;
+import com.otilm.core.events.EventContext;
+import com.otilm.core.messaging.model.EventMessage;
+import com.otilm.core.messaging.model.NotificationMessage;
+import com.otilm.core.messaging.model.NotificationRecipient;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class CommentResolvedEventHandlerTest {
+
+    private static final UUID HOST_UUID = UUID.randomUUID();
+    private static final UUID ACTOR_UUID = UUID.randomUUID();
+
+    private CommentRepository commentRepository;
+    private ApplicationEventPublisher publisher;
+    private CommentResolvedEventHandler handler;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        commentRepository = mock(CommentRepository.class);
+        publisher = mock(ApplicationEventPublisher.class);
+
+        handler = new CommentResolvedEventHandler(commentRepository, mock(TriggerEvaluator.class));
+        handler.setApplicationEventPublisher(publisher);
+    }
+
+    private EventContext<Comment> context(Comment root) {
+        CommentEventData eventData = new CommentEventData();
+        eventData.setCommentUuid(root.getUuid());
+        eventData.setResource(root.getResource());
+        eventData.setObjectUuid(root.getObjectUuid());
+        eventData.setBody(root.getBody());
+        eventData.setResolved(true);
+        eventData.setResolvedByUuid(ACTOR_UUID);
+        EventMessage eventMessage = new EventMessage(ResourceEvent.COMMENT_RESOLVED, Resource.COMMENT, root.getUuid(),
+                null, null, eventData, ACTOR_UUID, null);
+        return new EventContext<>(eventMessage, null, root, eventData);
+    }
+
+    private Comment root() {
+        Comment root = new Comment();
+        root.setUuid(UUID.randomUUID());
+        root.setResource(Resource.RA_PROFILE);
+        root.setObjectUuid(HOST_UUID);
+        root.setAuthorUuid(UUID.randomUUID());
+        root.setAuthorUsername("tst-author");
+        root.setBody("resolve me");
+        return root;
+    }
+
+    @Test
+    void resolutionNotifiesThreadParticipantsExceptTheActor() {
+        Comment root = root();
+        UUID participant = UUID.randomUUID();
+        when(commentRepository.findThreadParticipantUuids(root.getUuid()))
+                .thenReturn(List.of(root.getAuthorUuid(), participant, ACTOR_UUID));
+
+        handler.sendFollowUpEventsNotifications(context(root));
+
+        ArgumentCaptor<NotificationMessage> captor = ArgumentCaptor.forClass(NotificationMessage.class);
+        verify(publisher).publishEvent(captor.capture());
+        NotificationMessage message = captor.getValue();
+        assertEquals(Resource.RA_PROFILE, message.getResource());
+        assertEquals(HOST_UUID, message.getObjectUuid());
+        assertEquals(List.of(root.getAuthorUuid(), participant),
+                message.getRecipients().stream().map(NotificationRecipient::getRecipientUuid).toList());
+        assertEquals(RecipientType.USER, message.getRecipients().getFirst().getRecipientType());
+    }
+
+    @Test
+    void resolutionByTheOnlyParticipantPublishesNothing() {
+        Comment root = root();
+        when(commentRepository.findThreadParticipantUuids(root.getUuid())).thenReturn(List.of(ACTOR_UUID));
+
+        handler.sendFollowUpEventsNotifications(context(root));
+
+        verifyNoInteractions(publisher);
+    }
+}

--- a/src/test/java/com/otilm/core/events/handlers/CommentResolvedEventHandlerTest.java
+++ b/src/test/java/com/otilm/core/events/handlers/CommentResolvedEventHandlerTest.java
@@ -11,6 +11,7 @@ import com.otilm.core.events.EventContext;
 import com.otilm.core.messaging.model.EventMessage;
 import com.otilm.core.messaging.model.NotificationMessage;
 import com.otilm.core.messaging.model.NotificationRecipient;
+import com.otilm.core.security.authz.AuthorizationEnforcer;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +20,7 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.context.ApplicationEventPublisher;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -31,6 +33,7 @@ class CommentResolvedEventHandlerTest {
 
     private CommentRepository commentRepository;
     private ApplicationEventPublisher publisher;
+    private AuthorizationEnforcer authorizationEnforcer;
     private CommentResolvedEventHandler handler;
 
     @BeforeEach
@@ -38,9 +41,12 @@ class CommentResolvedEventHandlerTest {
     void setUp() {
         commentRepository = mock(CommentRepository.class);
         publisher = mock(ApplicationEventPublisher.class);
+        authorizationEnforcer = mock(AuthorizationEnforcer.class);
+        when(authorizationEnforcer.isAuthorizedAs(any(), any(), any(), any())).thenReturn(true);
 
         handler = new CommentResolvedEventHandler(commentRepository, mock(TriggerEvaluator.class));
         handler.setApplicationEventPublisher(publisher);
+        handler.setAuthorizationEnforcer(authorizationEnforcer);
     }
 
     private EventContext<Comment> context(Comment root) {

--- a/src/test/java/com/otilm/core/integration/dao/repository/CommentRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/dao/repository/CommentRepositoryITest.java
@@ -103,6 +103,22 @@ class CommentRepositoryITest extends BaseSpringBootTest {
     }
 
     @Test
+    void collectsDistinctThreadParticipants() {
+        UUID objectUuid = UUID.randomUUID();
+        Comment root = commentRepository.saveAndFlush(newComment(objectUuid, null));
+        Comment replyB = newComment(objectUuid, root.getUuid());
+        UUID authorB = replyB.getAuthorUuid();
+        commentRepository.saveAndFlush(replyB);
+        Comment replyB2 = newComment(objectUuid, root.getUuid());
+        replyB2.setAuthorUuid(authorB);
+        commentRepository.saveAndFlush(replyB2);
+        Comment replyC = commentRepository.saveAndFlush(newComment(objectUuid, root.getUuid()));
+
+        assertThat(commentRepository.findThreadParticipantUuids(root.getUuid()))
+                .containsExactlyInAnyOrder(root.getAuthorUuid(), authorB, replyC.getAuthorUuid());
+    }
+
+    @Test
     void deletingRootCascadesToReplies() {
         UUID objectUuid = UUID.randomUUID();
         Comment root = commentRepository.saveAndFlush(newComment(objectUuid, null));

--- a/src/test/java/com/otilm/core/integration/evaluator/TriggerEvaluatorITest.java
+++ b/src/test/java/com/otilm/core/integration/evaluator/TriggerEvaluatorITest.java
@@ -48,6 +48,7 @@ import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.CertificateContent;
 import com.otilm.core.dao.entity.CertificateLocation;
 import com.otilm.core.dao.entity.CertificateProtocolAssociation;
+import com.otilm.core.dao.entity.Comment;
 import com.otilm.core.dao.entity.Connector;
 import com.otilm.core.dao.entity.CryptographicKey;
 import com.otilm.core.dao.entity.CryptographicKeyItem;
@@ -117,6 +118,9 @@ class TriggerEvaluatorITest extends BaseSpringBootTest {
 
     @Autowired
     private TriggerEvaluator<Discovery> discoveryTriggerEvaluator;
+
+    @Autowired
+    private TriggerEvaluator<Comment> commentTriggerEvaluator;
 
     @Autowired
     private CertificateRepository certificateRepository;
@@ -357,6 +361,50 @@ class TriggerEvaluatorITest extends BaseSpringBootTest {
         Assertions
                 .assertFalse(certificateTriggerEvaluator
                         .evaluateConditionItem(condition, certificate, Resource.CERTIFICATE));
+    }
+
+    @Test
+    void testCommentRuleEvaluatorOnProperties() throws RuleException {
+        Comment comment = new Comment();
+        comment.setResource(Resource.RA_PROFILE);
+        comment.setObjectUuid(UUID.randomUUID());
+        comment.setAuthorUuid(UUID.randomUUID());
+        comment.setAuthorUsername("tst-author");
+        comment.setBody("please review the profile");
+        condition.setFieldSource(FilterFieldSource.PROPERTY);
+
+        condition.setFieldIdentifier(FilterField.COMMENT_HOST_RESOURCE.name());
+        condition.setOperator(FilterConditionOperator.EQUALS);
+        condition.setValue(List.of(Resource.RA_PROFILE.getCode()));
+        Assertions.assertTrue(commentTriggerEvaluator.evaluateConditionItem(condition, comment, Resource.COMMENT));
+        condition.setValue(List.of(Resource.CERTIFICATE.getCode()));
+        Assertions.assertFalse(commentTriggerEvaluator.evaluateConditionItem(condition, comment, Resource.COMMENT));
+
+        condition.setFieldIdentifier(FilterField.COMMENT_AUTHOR.name());
+        condition.setValue(List.of("tst-author", "another-user"));
+        Assertions.assertTrue(commentTriggerEvaluator.evaluateConditionItem(condition, comment, Resource.COMMENT));
+
+        condition.setFieldIdentifier(FilterField.COMMENT_BODY.name());
+        condition.setOperator(FilterConditionOperator.CONTAINS);
+        condition.setValue("review");
+        Assertions.assertTrue(commentTriggerEvaluator.evaluateConditionItem(condition, comment, Resource.COMMENT));
+
+        // The presence-only parent field separates roots from replies
+        condition.setFieldIdentifier(FilterField.COMMENT_PARENT.name());
+        condition.setValue(null);
+        condition.setOperator(FilterConditionOperator.EMPTY);
+        Assertions.assertTrue(commentTriggerEvaluator.evaluateConditionItem(condition, comment, Resource.COMMENT));
+        comment.setParentUuid(UUID.randomUUID());
+        Assertions.assertFalse(commentTriggerEvaluator.evaluateConditionItem(condition, comment, Resource.COMMENT));
+        condition.setOperator(FilterConditionOperator.NOT_EMPTY);
+        Assertions.assertTrue(commentTriggerEvaluator.evaluateConditionItem(condition, comment, Resource.COMMENT));
+
+        // Resolution timestamp presence separates open threads from resolved ones
+        condition.setFieldIdentifier(FilterField.COMMENT_RESOLVED_AT.name());
+        condition.setOperator(FilterConditionOperator.EMPTY);
+        Assertions.assertTrue(commentTriggerEvaluator.evaluateConditionItem(condition, comment, Resource.COMMENT));
+        comment.setResolvedAt(OffsetDateTime.now());
+        Assertions.assertFalse(commentTriggerEvaluator.evaluateConditionItem(condition, comment, Resource.COMMENT));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/events/CommentEventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/CommentEventHandlersITest.java
@@ -1,0 +1,387 @@
+package com.otilm.core.integration.events;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.otilm.api.exception.AlreadyExistException;
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.model.client.notification.NotificationProfileRequestDto;
+import com.otilm.api.model.common.events.data.CommentEventData;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.notification.RecipientType;
+import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.api.model.core.workflows.ActionRequestDto;
+import com.otilm.api.model.core.workflows.ExecutionItemRequestDto;
+import com.otilm.api.model.core.workflows.ExecutionRequestDto;
+import com.otilm.api.model.core.workflows.ExecutionType;
+import com.otilm.api.model.core.workflows.TriggerRequestDto;
+import com.otilm.api.model.core.workflows.TriggerType;
+import com.otilm.core.dao.entity.Comment;
+import com.otilm.core.dao.entity.Group;
+import com.otilm.core.dao.entity.GroupAssociation;
+import com.otilm.core.dao.entity.OwnerAssociation;
+import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.dao.entity.notifications.Notification;
+import com.otilm.core.dao.repository.CommentRepository;
+import com.otilm.core.dao.repository.GroupAssociationRepository;
+import com.otilm.core.dao.repository.GroupRepository;
+import com.otilm.core.dao.repository.OwnerAssociationRepository;
+import com.otilm.core.dao.repository.RaProfileRepository;
+import com.otilm.core.dao.repository.notifications.NotificationRepository;
+import com.otilm.core.dao.repository.workflows.EventHistoryRepository;
+import com.otilm.core.events.handlers.CommentCreatedEventHandler;
+import com.otilm.core.events.handlers.CommentResolvedEventHandler;
+import com.otilm.core.messaging.jms.listeners.NotificationListener;
+import com.otilm.core.messaging.model.EventMessage;
+import com.otilm.core.messaging.model.NotificationMessage;
+import com.otilm.core.service.ActionExternalService;
+import com.otilm.core.service.NotificationProfileExternalService;
+import com.otilm.core.service.TriggerExternalService;
+import com.otilm.core.util.BaseSpringBootTest;
+import com.otilm.core.util.WireMockPorts;
+import com.otilm.core.util.mockbeans.ProducerMocks;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(ProducerMocks.class)
+@TypeExcludeFilters(ProducerMocks.MockedProducersTypeExcludeFilter.class)
+class CommentEventHandlersITest extends BaseSpringBootTest {
+
+    @Autowired
+    private CommentCreatedEventHandler commentCreatedEventHandler;
+    @Autowired
+    private CommentResolvedEventHandler commentResolvedEventHandler;
+    @Autowired
+    private NotificationListener notificationListener;
+    @Autowired
+    private ProducerMocks.RecordedNotificationMessages recordedMessages;
+
+    @Autowired
+    private CommentRepository commentRepository;
+    @Autowired
+    private RaProfileRepository raProfileRepository;
+    @Autowired
+    private GroupRepository groupRepository;
+    @Autowired
+    private GroupAssociationRepository groupAssociationRepository;
+    @Autowired
+    private OwnerAssociationRepository ownerAssociationRepository;
+    @Autowired
+    private NotificationRepository notificationRepository;
+    @Autowired
+    private EventHistoryRepository eventHistoryRepository;
+
+    @Autowired
+    private NotificationProfileExternalService notificationProfileService;
+    @Autowired
+    private ActionExternalService actionService;
+    @Autowired
+    private TriggerExternalService triggerService;
+
+    private WireMockServer mockServer;
+
+    private UUID hostUuid;
+    private UUID actorUuid;
+
+    @BeforeEach
+    void setUp() {
+        recordedMessages.clear();
+        actorUuid = UUID.randomUUID();
+
+        RaProfile raProfile = new RaProfile();
+        raProfile.setName("tst-ra-profile");
+        hostUuid = raProfileRepository.save(raProfile).getUuid();
+
+        mockServer = new WireMockServer(WireMockPorts.AUTH_SERVICE);
+        mockServer.start();
+        WireMock.configureFor("localhost", WireMockPorts.AUTH_SERVICE);
+        mockAuthResponses();
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockServer.stop();
+    }
+
+    /** Impersonation of the trigger-association owner authenticates against the auth service. */
+    private void mockAuthResponses() {
+        UUID anyUserUuid = UUID.randomUUID();
+        mockServer.stubFor(WireMock.get(WireMock.urlPathMatching("/auth/users/[^/]+")).willReturn(WireMock.okJson("""
+                {
+                    "uuid": "%s",
+                    "username": "tst-association-owner",
+                    "email": "owner@example.com",
+                    "groups": [],
+                    "roles": []
+                }
+                """.formatted(anyUserUuid))));
+        mockServer.stubFor(WireMock.post(WireMock.urlPathMatching("/auth")).willReturn(WireMock.okJson("""
+                {
+                    "authenticated": true,
+                    "data": {
+                        "user": {
+                            "uuid": "%s",
+                            "username": "tst-association-owner"
+                        },
+                        "roles": [
+                            {
+                                "name": "superadmin"
+                            }
+                        ],
+                        "permissions": {
+                            "allowAllResources": true,
+                            "resources": []
+                        }
+                    }
+                }
+                """.formatted(anyUserUuid))));
+    }
+
+    private Comment saveComment(UUID objectUuid, UUID parentUuid, UUID authorUuid, String body) {
+        Comment comment = new Comment();
+        comment.setResource(Resource.RA_PROFILE);
+        comment.setObjectUuid(objectUuid);
+        comment.setParentUuid(parentUuid);
+        comment.setAuthorUuid(authorUuid);
+        comment.setAuthorUsername("tst-user");
+        comment.setBody(body);
+        return commentRepository.saveAndFlush(comment);
+    }
+
+    private EventMessage eventMessage(ResourceEvent event, Comment comment, Boolean resolved) {
+        CommentEventData data = new CommentEventData();
+        data.setCommentUuid(comment.getUuid());
+        data.setParentUuid(comment.getParentUuid());
+        data.setResource(comment.getResource());
+        data.setObjectUuid(comment.getObjectUuid());
+        data.setObjectName("tst-ra-profile");
+        data.setAuthorUuid(comment.getAuthorUuid());
+        data.setAuthorUsername(comment.getAuthorUsername());
+        data.setCreatedAt(OffsetDateTime.now());
+        data.setBody(comment.getBody());
+        if (resolved != null) {
+            data.setResolved(resolved);
+            data.setResolvedByUuid(actorUuid);
+            data.setResolvedByUsername("tst-actor");
+            data.setResolvedAt(OffsetDateTime.now());
+        }
+        return new EventMessage(event, Resource.COMMENT, comment.getUuid(), null, null, data, actorUuid, null);
+    }
+
+    private UUID groupWithHostMembership(UUID objectUuid) {
+        Group group = new Group();
+        group.setName("tst-group-" + UUID.randomUUID());
+        groupRepository.save(group);
+
+        GroupAssociation association = new GroupAssociation();
+        association.setResource(Resource.RA_PROFILE);
+        association.setObjectUuid(objectUuid);
+        association.setGroupUuid(group.getUuid());
+        groupAssociationRepository.save(association);
+        return group.getUuid();
+    }
+
+    private UUID bindProfileTrigger(ResourceEvent event, Resource associationResource, UUID associationObjectUuid)
+            throws AlreadyExistException, NotFoundException {
+        NotificationProfileRequestDto profileRequest = new NotificationProfileRequestDto();
+        profileRequest.setName("tst-profile-" + UUID.randomUUID().toString().substring(0, 8));
+        profileRequest.setRecipientType(RecipientType.USER);
+        profileRequest.setRecipientUuids(List.of(UUID.randomUUID()));
+        profileRequest.setRepetitions(1);
+        profileRequest.setInternalNotification(true);
+        UUID profileUuid = UUID
+                .fromString(notificationProfileService.createNotificationProfile(profileRequest).getUuid());
+
+        ExecutionItemRequestDto executionItemRequest = new ExecutionItemRequestDto();
+        executionItemRequest.setNotificationProfileUuid(profileUuid.toString());
+        ExecutionRequestDto executionRequest = new ExecutionRequestDto();
+        executionRequest.setName("tst-execution-" + UUID.randomUUID().toString().substring(0, 8));
+        executionRequest.setResource(Resource.COMMENT);
+        executionRequest.setType(ExecutionType.SEND_NOTIFICATION);
+        executionRequest.setItems(List.of(executionItemRequest));
+        String executionUuid = actionService.createExecution(executionRequest).getUuid();
+
+        ActionRequestDto actionRequest = new ActionRequestDto();
+        actionRequest.setName("tst-action-" + UUID.randomUUID().toString().substring(0, 8));
+        actionRequest.setResource(Resource.COMMENT);
+        actionRequest.setExecutionsUuids(List.of(executionUuid));
+        String actionUuid = actionService.createAction(actionRequest).getUuid();
+
+        TriggerRequestDto triggerRequest = new TriggerRequestDto();
+        triggerRequest.setName("tst-trigger-" + UUID.randomUUID().toString().substring(0, 8));
+        triggerRequest.setResource(Resource.COMMENT);
+        triggerRequest.setType(TriggerType.EVENT);
+        triggerRequest.setEvent(event);
+        triggerRequest.setActionsUuids(List.of(actionUuid));
+        UUID triggerUuid = UUID.fromString(triggerService.createTrigger(triggerRequest).getUuid());
+
+        triggerService
+                .createTriggerAssociations(event, associationResource, associationObjectUuid, List.of(triggerUuid),
+                        false);
+        return profileUuid;
+    }
+
+    private List<NotificationMessage> profileDrivenMessages() {
+        return recordedMessages.messages().stream().filter(m -> m.getNotificationProfileUuids() != null).toList();
+    }
+
+    private List<NotificationMessage> followUpMessages() {
+        return recordedMessages.messages().stream().filter(m -> m.getNotificationProfileUuids() == null).toList();
+    }
+
+    @Test
+    void groupScopedProfileFiresOnlyForObjectsInTheGroup() throws Exception {
+        UUID groupUuid = groupWithHostMembership(hostUuid);
+        UUID profileUuid = bindProfileTrigger(ResourceEvent.COMMENT_CREATED, Resource.GROUP, groupUuid);
+
+        Comment inGroup = saveComment(hostUuid, null, actorUuid, "comment in group");
+        commentCreatedEventHandler.handleEvent(eventMessage(ResourceEvent.COMMENT_CREATED, inGroup, null));
+
+        assertThat(profileDrivenMessages())
+                .anySatisfy(message -> assertThat(message.getNotificationProfileUuids()).contains(profileUuid));
+        assertThat(eventHistoryRepository.findAll()).anySatisfy(history -> {
+            assertThat(history.getResource()).isEqualTo(Resource.GROUP);
+            assertThat(history.getResourceUuid()).isEqualTo(groupUuid);
+        });
+
+        recordedMessages.clear();
+        RaProfile outside = new RaProfile();
+        outside.setName("tst-ra-profile-outside");
+        UUID outsideUuid = raProfileRepository.save(outside).getUuid();
+        Comment outsideComment = saveComment(outsideUuid, null, actorUuid, "comment outside group");
+        commentCreatedEventHandler.handleEvent(eventMessage(ResourceEvent.COMMENT_CREATED, outsideComment, null));
+
+        assertThat(profileDrivenMessages()).isEmpty();
+    }
+
+    @Test
+    void globallyBoundProfileDeliversOnResolve() throws Exception {
+        UUID profileUuid = bindProfileTrigger(ResourceEvent.COMMENT_RESOLVED, null, null);
+
+        Comment root = saveComment(hostUuid, null, UUID.randomUUID(), "resolve me");
+        commentResolvedEventHandler.handleEvent(eventMessage(ResourceEvent.COMMENT_RESOLVED, root, true));
+
+        List<NotificationMessage> profileMessages = profileDrivenMessages();
+        assertThat(profileMessages)
+                .anySatisfy(message -> assertThat(message.getNotificationProfileUuids()).contains(profileUuid));
+
+        notificationListener.processMessage(profileMessages.getFirst());
+        assertThat(notificationRepository.findAll()).isNotEmpty();
+    }
+
+    @Test
+    void unboundEventsPublishNoProfileDrivenMessages() throws Exception {
+        Comment root = saveComment(hostUuid, null, actorUuid, "nobody listens");
+        commentCreatedEventHandler.handleEvent(eventMessage(ResourceEvent.COMMENT_CREATED, root, null));
+        commentResolvedEventHandler.handleEvent(eventMessage(ResourceEvent.COMMENT_RESOLVED, root, true));
+
+        assertThat(profileDrivenMessages()).isEmpty();
+        // the actor is the only thread participant and the host has no owner, so no follow-ups either
+        assertThat(followUpMessages()).isEmpty();
+        assertThat(notificationRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    void replyDeliversInternalNotificationsToParticipantsExceptTheActor() throws Exception {
+        UUID rootAuthor = UUID.randomUUID();
+        UUID earlierReplier = UUID.randomUUID();
+        Comment root = saveComment(hostUuid, null, rootAuthor, "root");
+        saveComment(hostUuid, root.getUuid(), earlierReplier, "earlier reply");
+        Comment reply = saveComment(hostUuid, root.getUuid(), actorUuid, "acting reply");
+
+        commentCreatedEventHandler.handleEvent(eventMessage(ResourceEvent.COMMENT_CREATED, reply, null));
+
+        List<NotificationMessage> followUps = followUpMessages();
+        assertThat(followUps).hasSize(1);
+        assertThat(followUps.getFirst().getRecipients())
+                .extracting(recipient -> recipient.getRecipientUuid())
+                .containsExactlyInAnyOrder(rootAuthor, earlierReplier);
+
+        notificationListener.processMessage(followUps.getFirst());
+        assertThat(notificationRepository.findAll())
+                .hasSize(2)
+                .allSatisfy(notification -> assertThat(notification.getTargetObjectIdentification())
+                        .isEqualTo(hostUuid.toString()));
+    }
+
+    @Test
+    void resolvingDeliversToParticipantsWithTheActorInTheEventData() throws Exception {
+        UUID rootAuthor = UUID.randomUUID();
+        Comment root = saveComment(hostUuid, null, rootAuthor, "resolve me");
+        saveComment(hostUuid, root.getUuid(), actorUuid, "participant resolves");
+
+        commentResolvedEventHandler.handleEvent(eventMessage(ResourceEvent.COMMENT_RESOLVED, root, true));
+
+        List<NotificationMessage> followUps = followUpMessages();
+        assertThat(followUps).hasSize(1);
+        assertThat(followUps.getFirst().getRecipients())
+                .extracting(recipient -> recipient.getRecipientUuid())
+                .containsExactly(rootAuthor);
+        CommentEventData data = (CommentEventData) followUps.getFirst().getData();
+        assertThat(data.getResolvedByUuid()).isEqualTo(actorUuid);
+        assertThat(data.getResolved()).isTrue();
+    }
+
+    @Test
+    void rootCommentNotifiesTheHostOwnerOnlyWhereAnAssociationExists() throws Exception {
+        UUID ownerUuid = UUID.randomUUID();
+        OwnerAssociation association = new OwnerAssociation();
+        association.setResource(Resource.RA_PROFILE);
+        association.setObjectUuid(hostUuid);
+        association.setOwnerUuid(ownerUuid);
+        association.setOwnerUsername("tst-owner");
+        ownerAssociationRepository.save(association);
+
+        Comment root = saveComment(hostUuid, null, actorUuid, "for the owner");
+        commentCreatedEventHandler.handleEvent(eventMessage(ResourceEvent.COMMENT_CREATED, root, null));
+
+        List<NotificationMessage> followUps = followUpMessages();
+        assertThat(followUps).hasSize(1);
+        notificationListener.processMessage(followUps.getFirst());
+        assertThat(notificationRepository.findAll()).hasSize(1);
+
+        recordedMessages.clear();
+        RaProfile ownerless = new RaProfile();
+        ownerless.setName("tst-ra-profile-ownerless");
+        UUID ownerlessUuid = raProfileRepository.save(ownerless).getUuid();
+        Comment ownerlessRoot = saveComment(ownerlessUuid, null, actorUuid, "for nobody");
+        commentCreatedEventHandler.handleEvent(eventMessage(ResourceEvent.COMMENT_CREATED, ownerlessRoot, null));
+
+        assertThat(followUpMessages()).isEmpty();
+    }
+
+    @Test
+    void notificationsCarryTheRawMarkdownTruncatedForDisplayOnly() throws Exception {
+        String hostile = "<script>alert('x')</script> **bold** [link](javascript:alert(1)) ";
+        String body = hostile + "a".repeat(600);
+        UUID ownerUuid = UUID.randomUUID();
+        OwnerAssociation association = new OwnerAssociation();
+        association.setResource(Resource.RA_PROFILE);
+        association.setObjectUuid(hostUuid);
+        association.setOwnerUuid(ownerUuid);
+        association.setOwnerUsername("tst-owner");
+        ownerAssociationRepository.save(association);
+
+        Comment root = saveComment(hostUuid, null, actorUuid, body);
+        commentCreatedEventHandler.handleEvent(eventMessage(ResourceEvent.COMMENT_CREATED, root, null));
+
+        notificationListener.processMessage(followUpMessages().getFirst());
+
+        List<Notification> notifications = notificationRepository.findAll();
+        assertThat(notifications).hasSize(1);
+        Notification notification = notifications.getFirst();
+        // The raw Markdown source, never rendered or sanitized into HTML entities, truncated for display
+        assertThat(notification.getDetail()).startsWith(hostile);
+        assertThat(notification.getDetail()).hasSize(501).endsWith("…");
+        // The stored comment itself is never truncated
+        assertThat(commentRepository.findByUuid(root.getSecuredUuid()).orElseThrow().getBody()).hasSize(body.length());
+    }
+}

--- a/src/test/java/com/otilm/core/integration/events/CommentEventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/CommentEventHandlersITest.java
@@ -359,7 +359,7 @@ class CommentEventHandlersITest extends BaseSpringBootTest {
     }
 
     @Test
-    void notificationsCarryTheRawMarkdownTruncatedForDisplayOnly() throws Exception {
+    void notificationsCarryNoCommentBodyWhileTheEventPayloadKeepsItVerbatim() throws Exception {
         String hostile = "<script>alert('x')</script> **bold** [link](javascript:alert(1)) ";
         String body = hostile + "a".repeat(600);
         UUID ownerUuid = UUID.randomUUID();
@@ -373,14 +373,18 @@ class CommentEventHandlersITest extends BaseSpringBootTest {
         Comment root = saveComment(hostUuid, null, actorUuid, body);
         commentCreatedEventHandler.handleEvent(eventMessage(ResourceEvent.COMMENT_CREATED, root, null));
 
-        notificationListener.processMessage(followUpMessages().getFirst());
+        NotificationMessage followUp = followUpMessages().getFirst();
+        // The event payload keeps the raw Markdown source verbatim for operator-bound templates
+        assertThat(((CommentEventData) followUp.getData()).getBody()).isEqualTo(body);
+
+        notificationListener.processMessage(followUp);
 
         List<Notification> notifications = notificationRepository.findAll();
         assertThat(notifications).hasSize(1);
         Notification notification = notifications.getFirst();
-        // Raw Markdown source — never rendered or sanitized into HTML entities
-        assertThat(notification.getDetail()).startsWith(hostile);
-        assertThat(notification.getDetail()).hasSize(501).endsWith("…");
+        // The persisted notification points at the thread and never mirrors user-authored text
+        assertThat(notification.getDetail()).isNull();
+        assertThat(notification.getMessage()).doesNotContain("<script>");
         assertThat(commentRepository.findByUuid(root.getSecuredUuid()).orElseThrow().getBody()).hasSize(body.length());
     }
 }

--- a/src/test/java/com/otilm/core/integration/events/CommentEventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/CommentEventHandlersITest.java
@@ -40,6 +40,7 @@ import com.otilm.core.events.handlers.CommentResolvedEventHandler;
 import com.otilm.core.messaging.jms.listeners.NotificationListener;
 import com.otilm.core.messaging.model.EventMessage;
 import com.otilm.core.messaging.model.NotificationMessage;
+import com.otilm.core.messaging.model.NotificationRecipient;
 import com.otilm.core.service.ActionExternalService;
 import com.otilm.core.service.NotificationProfileExternalService;
 import com.otilm.core.service.RuleExternalService;
@@ -384,6 +385,10 @@ class CommentEventHandlersITest extends BaseSpringBootTest {
 
         List<NotificationMessage> followUps = followUpMessages();
         assertThat(followUps).hasSize(1);
+        // The owner is resolved at publish time, so the message already carries them as a plain user
+        assertThat(followUps.getFirst().getRecipients())
+                .extracting(NotificationRecipient::getRecipientUuid)
+                .containsExactly(ownerUuid);
         notificationListener.processMessage(followUps.getFirst());
         assertThat(notificationRepository.findAll()).hasSize(1);
 

--- a/src/test/java/com/otilm/core/integration/events/CommentEventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/CommentEventHandlersITest.java
@@ -9,10 +9,16 @@ import com.otilm.api.model.common.events.data.CommentEventData;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.notification.RecipientType;
 import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.api.model.core.search.FilterConditionOperator;
+import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.api.model.core.workflows.ActionRequestDto;
+import com.otilm.api.model.core.workflows.ConditionItemRequestDto;
+import com.otilm.api.model.core.workflows.ConditionRequestDto;
+import com.otilm.api.model.core.workflows.ConditionType;
 import com.otilm.api.model.core.workflows.ExecutionItemRequestDto;
 import com.otilm.api.model.core.workflows.ExecutionRequestDto;
 import com.otilm.api.model.core.workflows.ExecutionType;
+import com.otilm.api.model.core.workflows.RuleRequestDto;
 import com.otilm.api.model.core.workflows.TriggerRequestDto;
 import com.otilm.api.model.core.workflows.TriggerType;
 import com.otilm.core.dao.entity.Comment;
@@ -28,6 +34,7 @@ import com.otilm.core.dao.repository.OwnerAssociationRepository;
 import com.otilm.core.dao.repository.RaProfileRepository;
 import com.otilm.core.dao.repository.notifications.NotificationRepository;
 import com.otilm.core.dao.repository.workflows.EventHistoryRepository;
+import com.otilm.core.enums.FilterField;
 import com.otilm.core.events.handlers.CommentCreatedEventHandler;
 import com.otilm.core.events.handlers.CommentResolvedEventHandler;
 import com.otilm.core.messaging.jms.listeners.NotificationListener;
@@ -35,6 +42,7 @@ import com.otilm.core.messaging.model.EventMessage;
 import com.otilm.core.messaging.model.NotificationMessage;
 import com.otilm.core.service.ActionExternalService;
 import com.otilm.core.service.NotificationProfileExternalService;
+import com.otilm.core.service.RuleExternalService;
 import com.otilm.core.service.TriggerExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.WireMockPorts;
@@ -85,6 +93,8 @@ class CommentEventHandlersITest extends BaseSpringBootTest {
     private ActionExternalService actionService;
     @Autowired
     private TriggerExternalService triggerService;
+    @Autowired
+    private RuleExternalService ruleService;
 
     private WireMockServer mockServer;
 
@@ -191,6 +201,11 @@ class CommentEventHandlersITest extends BaseSpringBootTest {
 
     private UUID bindProfileTrigger(ResourceEvent event, Resource associationResource, UUID associationObjectUuid)
             throws AlreadyExistException, NotFoundException {
+        return bindProfileTrigger(event, associationResource, associationObjectUuid, null);
+    }
+
+    private UUID bindProfileTrigger(ResourceEvent event, Resource associationResource, UUID associationObjectUuid,
+            String ruleUuid) throws AlreadyExistException, NotFoundException {
         NotificationProfileRequestDto profileRequest = new NotificationProfileRequestDto();
         profileRequest.setName("tst-profile-" + UUID.randomUUID().toString().substring(0, 8));
         profileRequest.setRecipientType(RecipientType.USER);
@@ -221,12 +236,36 @@ class CommentEventHandlersITest extends BaseSpringBootTest {
         triggerRequest.setType(TriggerType.EVENT);
         triggerRequest.setEvent(event);
         triggerRequest.setActionsUuids(List.of(actionUuid));
+        if (ruleUuid != null) {
+            triggerRequest.setRulesUuids(List.of(ruleUuid));
+        }
         UUID triggerUuid = UUID.fromString(triggerService.createTrigger(triggerRequest).getUuid());
 
         triggerService
                 .createTriggerAssociations(event, associationResource, associationObjectUuid, List.of(triggerUuid),
                         false);
         return profileUuid;
+    }
+
+    /** Roots carry no parent, so a "Parent Comment is empty" condition scopes the trigger to thread roots. */
+    private String rootsOnlyRule() throws AlreadyExistException, NotFoundException {
+        ConditionItemRequestDto conditionItemRequest = new ConditionItemRequestDto();
+        conditionItemRequest.setFieldSource(FilterFieldSource.PROPERTY);
+        conditionItemRequest.setFieldIdentifier(FilterField.COMMENT_PARENT.name());
+        conditionItemRequest.setOperator(FilterConditionOperator.EMPTY);
+
+        ConditionRequestDto conditionRequest = new ConditionRequestDto();
+        conditionRequest.setName("tst-condition-" + UUID.randomUUID().toString().substring(0, 8));
+        conditionRequest.setResource(Resource.COMMENT);
+        conditionRequest.setType(ConditionType.CHECK_FIELD);
+        conditionRequest.setItems(List.of(conditionItemRequest));
+        String conditionUuid = ruleService.createCondition(conditionRequest).getUuid();
+
+        RuleRequestDto ruleRequest = new RuleRequestDto();
+        ruleRequest.setName("tst-rule-" + UUID.randomUUID().toString().substring(0, 8));
+        ruleRequest.setResource(Resource.COMMENT);
+        ruleRequest.setConditionsUuids(List.of(conditionUuid));
+        return ruleService.createRule(ruleRequest).getUuid();
     }
 
     private List<NotificationMessage> profileDrivenMessages() {
@@ -356,6 +395,23 @@ class CommentEventHandlersITest extends BaseSpringBootTest {
         commentCreatedEventHandler.handleEvent(eventMessage(ResourceEvent.COMMENT_CREATED, ownerlessRoot, null));
 
         assertThat(followUpMessages()).isEmpty();
+    }
+
+    @Test
+    void conditionScopedTriggerFiresForRootsAndSkipsReplies() throws Exception {
+        UUID profileUuid = bindProfileTrigger(ResourceEvent.COMMENT_CREATED, null, null, rootsOnlyRule());
+
+        Comment root = saveComment(hostUuid, null, actorUuid, "a root comment");
+        commentCreatedEventHandler.handleEvent(eventMessage(ResourceEvent.COMMENT_CREATED, root, null));
+
+        assertThat(profileDrivenMessages())
+                .anySatisfy(message -> assertThat(message.getNotificationProfileUuids()).contains(profileUuid));
+
+        recordedMessages.clear();
+        Comment reply = saveComment(hostUuid, root.getUuid(), UUID.randomUUID(), "a reply");
+        commentCreatedEventHandler.handleEvent(eventMessage(ResourceEvent.COMMENT_CREATED, reply, null));
+
+        assertThat(profileDrivenMessages()).isEmpty();
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/events/CommentEventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/CommentEventHandlersITest.java
@@ -45,6 +45,7 @@ import com.otilm.core.service.ActionExternalService;
 import com.otilm.core.service.NotificationProfileExternalService;
 import com.otilm.core.service.RuleExternalService;
 import com.otilm.core.service.TriggerExternalService;
+import com.otilm.core.util.AuthServiceWireMockStubs;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.WireMockPorts;
 import com.otilm.core.util.mockbeans.ProducerMocks;
@@ -124,36 +125,7 @@ class CommentEventHandlersITest extends BaseSpringBootTest {
 
     /** Impersonation of the trigger-association owner authenticates against the auth service. */
     private void mockAuthResponses() {
-        UUID anyUserUuid = UUID.randomUUID();
-        mockServer.stubFor(WireMock.get(WireMock.urlPathMatching("/auth/users/[^/]+")).willReturn(WireMock.okJson("""
-                {
-                    "uuid": "%s",
-                    "username": "tst-association-owner",
-                    "email": "owner@example.com",
-                    "groups": [],
-                    "roles": []
-                }
-                """.formatted(anyUserUuid))));
-        mockServer.stubFor(WireMock.post(WireMock.urlPathMatching("/auth")).willReturn(WireMock.okJson("""
-                {
-                    "authenticated": true,
-                    "data": {
-                        "user": {
-                            "uuid": "%s",
-                            "username": "tst-association-owner"
-                        },
-                        "roles": [
-                            {
-                                "name": "superadmin"
-                            }
-                        ],
-                        "permissions": {
-                            "allowAllResources": true,
-                            "resources": []
-                        }
-                    }
-                }
-                """.formatted(anyUserUuid))));
+        AuthServiceWireMockStubs.stubImpersonation(mockServer, UUID.randomUUID(), "tst-association-owner");
     }
 
     private Comment saveComment(UUID objectUuid, UUID parentUuid, UUID authorUuid, String body) {
@@ -314,7 +286,11 @@ class CommentEventHandlersITest extends BaseSpringBootTest {
                 .anySatisfy(message -> assertThat(message.getNotificationProfileUuids()).contains(profileUuid));
 
         notificationListener.processMessage(profileMessages.getFirst());
-        assertThat(notificationRepository.findAll()).isNotEmpty();
+        // The persisted notification deep-links to the host object, not the comment the trigger evaluated
+        assertThat(notificationRepository.findAll()).isNotEmpty().allSatisfy(notification -> {
+            assertThat(notification.getTargetObjectType()).isEqualTo(Resource.RA_PROFILE);
+            assertThat(notification.getTargetObjectIdentification()).isEqualTo(hostUuid.toString());
+        });
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/events/CommentEventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/CommentEventHandlersITest.java
@@ -378,10 +378,9 @@ class CommentEventHandlersITest extends BaseSpringBootTest {
         List<Notification> notifications = notificationRepository.findAll();
         assertThat(notifications).hasSize(1);
         Notification notification = notifications.getFirst();
-        // The raw Markdown source, never rendered or sanitized into HTML entities, truncated for display
+        // Raw Markdown source — never rendered or sanitized into HTML entities
         assertThat(notification.getDetail()).startsWith(hostile);
         assertThat(notification.getDetail()).hasSize(501).endsWith("…");
-        // The stored comment itself is never truncated
         assertThat(commentRepository.findByUuid(root.getSecuredUuid()).orElseThrow().getBody()).hasSize(body.length());
     }
 }

--- a/src/test/java/com/otilm/core/integration/events/CommentEventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/CommentEventHandlersITest.java
@@ -318,7 +318,7 @@ class CommentEventHandlersITest extends BaseSpringBootTest {
         List<NotificationMessage> followUps = followUpMessages();
         assertThat(followUps).hasSize(1);
         assertThat(followUps.getFirst().getRecipients())
-                .extracting(recipient -> recipient.getRecipientUuid())
+                .extracting(NotificationRecipient::getRecipientUuid)
                 .containsExactlyInAnyOrder(rootAuthor, earlierReplier);
 
         notificationListener.processMessage(followUps.getFirst());
@@ -339,7 +339,7 @@ class CommentEventHandlersITest extends BaseSpringBootTest {
         List<NotificationMessage> followUps = followUpMessages();
         assertThat(followUps).hasSize(1);
         assertThat(followUps.getFirst().getRecipients())
-                .extracting(recipient -> recipient.getRecipientUuid())
+                .extracting(NotificationRecipient::getRecipientUuid)
                 .containsExactly(rootAuthor);
         CommentEventData data = (CommentEventData) followUps.getFirst().getData();
         assertThat(data.getResolvedByUuid()).isEqualTo(actorUuid);

--- a/src/test/java/com/otilm/core/integration/events/CommentEventITest.java
+++ b/src/test/java/com/otilm/core/integration/events/CommentEventITest.java
@@ -133,6 +133,17 @@ class CommentEventITest extends BaseSpringBootTest {
     }
 
     @Test
+    void repeatedResolutionRequestPublishesNoSecondEvent() throws NotFoundException {
+        CommentDto root = post("resolve me twice", null);
+        commentService.resolveComment(root.getUuid());
+        reset(eventProducer);
+
+        commentService.resolveComment(root.getUuid());
+
+        assertThat(capturedMessages()).isEmpty();
+    }
+
+    @Test
     void deletePublishesNothing() throws NotFoundException {
         CommentDto root = post("silent delete", null);
         reset(eventProducer);

--- a/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
@@ -121,6 +121,7 @@ import com.otilm.core.service.handler.CertificateHandler;
 import com.otilm.core.service.impl.CertificateServiceImpl;
 import com.otilm.core.tasks.DiscoveryCertificateTask;
 import com.otilm.core.util.AuthHelper;
+import com.otilm.core.util.AuthServiceWireMockStubs;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.CertificateUtil;
 import com.otilm.core.util.WireMockPorts;
@@ -1330,36 +1331,7 @@ class EventHandlersITest extends BaseSpringBootTest {
     }
 
     private void mockAuthResponse(NameAndUuidDto userInfo) {
-        mockServer.stubFor(WireMock.get(WireMock.urlPathMatching("/auth/users/[^/]+")).willReturn(WireMock.okJson("""
-                {
-                    "uuid": "%s",
-                    "username": "%s",
-                    "email": "testuser1@example.com",
-                    "groups": [],
-                    "roles": []
-                }
-                """.formatted(userInfo.getUuid(), userInfo.getName()))));
-
-        mockServer.stubFor(WireMock.post(WireMock.urlPathMatching("/auth")).willReturn(WireMock.okJson("""
-                {
-                                  "authenticated": true,
-                                  "data": {
-                                    "user": {
-                                      "uuid": "%s",
-                                      "username": "%s"
-                                    },
-                                    "roles": [
-                                      {
-                                        "name": "superadmin"
-                                      }
-                                    ],
-                                    "permissions": {
-                                      "allowAllResources": true,
-                                      "resources": []
-                                    }
-                                  }
-                                }
-                """.formatted(userInfo.getUuid(), userInfo.getName()))));
+        AuthServiceWireMockStubs.stubImpersonation(mockServer, UUID.fromString(userInfo.getUuid()), userInfo.getName());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/events/NotificationInternalNotificationITest.java
+++ b/src/test/java/com/otilm/core/integration/events/NotificationInternalNotificationITest.java
@@ -3,16 +3,20 @@ package com.otilm.core.integration.events;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.otilm.api.model.common.events.data.CertificateStatusChangedEventData;
+import com.otilm.api.model.common.events.data.CommentEventData;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.notification.RecipientType;
 import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.core.dao.entity.OwnerAssociation;
 import com.otilm.core.dao.entity.notifications.Notification;
+import com.otilm.core.dao.repository.OwnerAssociationRepository;
 import com.otilm.core.dao.repository.notifications.NotificationRepository;
 import com.otilm.core.messaging.jms.listeners.NotificationListener;
 import com.otilm.core.messaging.model.NotificationMessage;
 import com.otilm.core.messaging.model.NotificationRecipient;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.WireMockPorts;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -36,6 +40,8 @@ class NotificationInternalNotificationITest extends BaseSpringBootTest {
     private NotificationListener notificationListener;
     @Autowired
     private NotificationRepository notificationRepository;
+    @Autowired
+    private OwnerAssociationRepository ownerAssociationRepository;
 
     private WireMockServer mockServer;
 
@@ -78,6 +84,50 @@ class NotificationInternalNotificationITest extends BaseSpringBootTest {
     @AfterEach
     void stopAuthServiceMock() {
         mockServer.stop();
+    }
+
+    @Test
+    void ownerRecipientResolvesToTheSubjectObjectsOwner() {
+        UUID objectUuid = UUID.randomUUID();
+        UUID ownerUuid = UUID.randomUUID();
+        OwnerAssociation association = new OwnerAssociation();
+        association.setResource(Resource.RA_PROFILE);
+        association.setObjectUuid(objectUuid);
+        association.setOwnerUuid(ownerUuid);
+        association.setOwnerUsername("tst-owner");
+        ownerAssociationRepository.save(association);
+
+        notificationListener
+                .processMessage(commentCreatedMessage(objectUuid,
+                        List.of(new NotificationRecipient(RecipientType.OWNER, null))));
+
+        List<Notification> notifications = notificationRepository.findAll();
+        Assertions.assertEquals(1, notifications.size());
+        Assertions.assertEquals(objectUuid.toString(), notifications.getFirst().getTargetObjectIdentification());
+    }
+
+    @Test
+    void ownerRecipientWithoutAssociationResolvesToNobody() {
+        notificationListener
+                .processMessage(commentCreatedMessage(UUID.randomUUID(),
+                        List.of(new NotificationRecipient(RecipientType.OWNER, null))));
+
+        Assertions.assertEquals(0, notificationRepository.findAll().size());
+    }
+
+    private static NotificationMessage commentCreatedMessage(UUID objectUuid, List<NotificationRecipient> recipients) {
+        CommentEventData data = new CommentEventData();
+        data.setCommentUuid(UUID.randomUUID());
+        data.setResource(Resource.RA_PROFILE);
+        data.setObjectUuid(objectUuid);
+        data.setObjectName("tst-ra-profile");
+        data.setAuthorUuid(UUID.randomUUID());
+        data.setAuthorUsername("tst-author");
+        data.setCreatedAt(OffsetDateTime.now());
+        data.setBody("A **markdown** request");
+
+        return new NotificationMessage(ResourceEvent.COMMENT_CREATED, Resource.RA_PROFILE, objectUuid, null, recipients,
+                data);
     }
 
     /**

--- a/src/test/java/com/otilm/core/integration/events/NotificationInternalNotificationITest.java
+++ b/src/test/java/com/otilm/core/integration/events/NotificationInternalNotificationITest.java
@@ -3,20 +3,16 @@ package com.otilm.core.integration.events;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.otilm.api.model.common.events.data.CertificateStatusChangedEventData;
-import com.otilm.api.model.common.events.data.CommentEventData;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.notification.RecipientType;
 import com.otilm.api.model.core.other.ResourceEvent;
-import com.otilm.core.dao.entity.OwnerAssociation;
 import com.otilm.core.dao.entity.notifications.Notification;
-import com.otilm.core.dao.repository.OwnerAssociationRepository;
 import com.otilm.core.dao.repository.notifications.NotificationRepository;
 import com.otilm.core.messaging.jms.listeners.NotificationListener;
 import com.otilm.core.messaging.model.NotificationMessage;
 import com.otilm.core.messaging.model.NotificationRecipient;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.WireMockPorts;
-import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -40,8 +36,6 @@ class NotificationInternalNotificationITest extends BaseSpringBootTest {
     private NotificationListener notificationListener;
     @Autowired
     private NotificationRepository notificationRepository;
-    @Autowired
-    private OwnerAssociationRepository ownerAssociationRepository;
 
     private WireMockServer mockServer;
 
@@ -84,50 +78,6 @@ class NotificationInternalNotificationITest extends BaseSpringBootTest {
     @AfterEach
     void stopAuthServiceMock() {
         mockServer.stop();
-    }
-
-    @Test
-    void ownerRecipientResolvesToTheSubjectObjectsOwner() {
-        UUID objectUuid = UUID.randomUUID();
-        UUID ownerUuid = UUID.randomUUID();
-        OwnerAssociation association = new OwnerAssociation();
-        association.setResource(Resource.RA_PROFILE);
-        association.setObjectUuid(objectUuid);
-        association.setOwnerUuid(ownerUuid);
-        association.setOwnerUsername("tst-owner");
-        ownerAssociationRepository.save(association);
-
-        notificationListener
-                .processMessage(commentCreatedMessage(objectUuid,
-                        List.of(new NotificationRecipient(RecipientType.OWNER, null))));
-
-        List<Notification> notifications = notificationRepository.findAll();
-        Assertions.assertEquals(1, notifications.size());
-        Assertions.assertEquals(objectUuid.toString(), notifications.getFirst().getTargetObjectIdentification());
-    }
-
-    @Test
-    void ownerRecipientWithoutAssociationResolvesToNobody() {
-        notificationListener
-                .processMessage(commentCreatedMessage(UUID.randomUUID(),
-                        List.of(new NotificationRecipient(RecipientType.OWNER, null))));
-
-        Assertions.assertEquals(0, notificationRepository.findAll().size());
-    }
-
-    private static NotificationMessage commentCreatedMessage(UUID objectUuid, List<NotificationRecipient> recipients) {
-        CommentEventData data = new CommentEventData();
-        data.setCommentUuid(UUID.randomUUID());
-        data.setResource(Resource.RA_PROFILE);
-        data.setObjectUuid(objectUuid);
-        data.setObjectName("tst-ra-profile");
-        data.setAuthorUuid(UUID.randomUUID());
-        data.setAuthorUsername("tst-author");
-        data.setCreatedAt(OffsetDateTime.now());
-        data.setBody("A **markdown** request");
-
-        return new NotificationMessage(ResourceEvent.COMMENT_CREATED, Resource.RA_PROFILE, objectUuid, null, recipients,
-                data);
     }
 
     /**

--- a/src/test/java/com/otilm/core/integration/service/CommentServiceValidationITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CommentServiceValidationITest.java
@@ -13,6 +13,7 @@ import com.otilm.core.security.authz.SecuredResource;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.service.CommentExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -145,6 +146,27 @@ class CommentServiceValidationITest extends BaseSpringBootTest {
         CommentDto reopened = list(raProfileUuid).getComments().getFirst();
         assertThat(reopened.getResolved()).isFalse();
         assertThat(reopened.getResolvedBy()).isNull();
+    }
+
+    @Test
+    void repeatedResolutionRequestIsANoOpAndAMissingCommentIsStillNotFound() throws NotFoundException {
+        CommentDto root = post(raProfileUuid, "root", null);
+        commentService.resolveComment(root.getUuid());
+        OffsetDateTime firstResolvedAt = list(raProfileUuid).getComments().getFirst().getResolvedAt();
+
+        commentService.resolveComment(root.getUuid());
+
+        CommentDto stillResolved = list(raProfileUuid).getComments().getFirst();
+        assertThat(stillResolved.getResolved()).isTrue();
+        assertThat(stillResolved.getResolvedAt()).isEqualTo(firstResolvedAt);
+
+        commentService.unresolveComment(root.getUuid());
+        commentService.unresolveComment(root.getUuid());
+        assertThat(list(raProfileUuid).getComments().getFirst().getResolved()).isFalse();
+
+        UUID missingUuid = UUID.randomUUID();
+        assertThatThrownBy(() -> commentService.resolveComment(missingUuid)).isInstanceOf(NotFoundException.class);
+        assertThatThrownBy(() -> commentService.unresolveComment(missingUuid)).isInstanceOf(NotFoundException.class);
     }
 
     @Test

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/NotificationListenerTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/NotificationListenerTest.java
@@ -3,6 +3,7 @@ package com.otilm.core.messaging.jms.listeners;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.otilm.api.interfaces.client.v1.NotificationInstanceSyncApiClient;
+import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.common.events.data.CertificateRegisteredEventData;
 import com.otilm.api.model.common.events.data.CommentEventData;
 import com.otilm.api.model.core.auth.Resource;
@@ -53,6 +54,8 @@ class NotificationListenerTest {
 
     private final NotificationInternalService notificationService = mock(NotificationInternalService.class);
 
+    private final ResourceObjectAssociationService associationService = mock(ResourceObjectAssociationService.class);
+
     private NotificationListener listener() {
         ObjectMapper realMapper = JsonMapper.builder().findAndAddModules().build();
         return new NotificationListener(realMapper, mock(AttributeEngine.class), notificationService,
@@ -60,7 +63,7 @@ class NotificationListenerTest {
                 mock(ConnectorInternalService.class), mock(PendingNotificationRepository.class),
                 mock(NotificationProfileVersionRepository.class), mock(NotificationInstanceReferenceRepository.class),
                 mock(GroupRepository.class), mock(UserManagementApiClient.class), mock(RoleManagementApiClient.class),
-                mock(ResourceObjectAssociationService.class),
+                associationService,
                 // The real handler, invoked directly rather than through its proxy, runs the work without a
                 // transaction -- which is what this unencumbered unit context wants.
                 new TransactionHandler(), mock(PendingNotificationWriter.class),
@@ -155,6 +158,25 @@ class NotificationListenerTest {
                         eq(1));
         // The failed suppression write is not a delivery failure: trigger history stays untouched.
         verifyNoInteractions(triggerService);
+    }
+
+    @Test
+    void defaultRecipientsForCommentEventsResolveToTheHostOwnerAndGroups() {
+        UUID hostUuid = UUID.randomUUID();
+        UUID ownerUuid = UUID.randomUUID();
+        UUID groupUuid = UUID.randomUUID();
+        when(associationService.getOwner(Resource.RA_PROFILE, hostUuid))
+                .thenReturn(new NameAndUuidDto(ownerUuid.toString(), "tst-owner"));
+        when(associationService.getGroupUuids(Resource.RA_PROFILE, hostUuid)).thenReturn(List.of(groupUuid));
+
+        List<NotificationRecipient> recipients = listener()
+                .getDefaultRecipients(ResourceEvent.COMMENT_CREATED, null, Resource.RA_PROFILE, hostUuid);
+
+        assertEquals(2, recipients.size());
+        assertEquals(RecipientType.USER, recipients.get(0).getRecipientType());
+        assertEquals(ownerUuid, recipients.get(0).getRecipientUuid());
+        assertEquals(RecipientType.GROUP, recipients.get(1).getRecipientType());
+        assertEquals(groupUuid, recipients.get(1).getRecipientUuid());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/NotificationListenerTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/NotificationListenerTest.java
@@ -26,6 +26,7 @@ import com.otilm.core.service.NotificationInternalService;
 import com.otilm.core.service.ResourceObjectAssociationService;
 import com.otilm.core.service.TriggerInternalService;
 import com.otilm.core.service.notifications.NotificationObjectDataService;
+import com.otilm.core.service.notifications.NotificationSubjectResolver.SubjectRef;
 import com.otilm.core.service.v2.ConnectorInternalService;
 import com.otilm.core.service.writer.PendingNotificationWriter;
 import java.time.OffsetDateTime;
@@ -177,6 +178,29 @@ class NotificationListenerTest {
         assertEquals(ownerUuid, recipients.get(0).getRecipientUuid());
         assertEquals(RecipientType.GROUP, recipients.get(1).getRecipientType());
         assertEquals(groupUuid, recipients.get(1).getRecipientUuid());
+    }
+
+    @Test
+    void commentNotificationsPointAtTheHostWhileEveryOtherEventKeepsItsOwnRecord() {
+        UUID approvalUuid = UUID.randomUUID();
+        UUID hostUuid = UUID.randomUUID();
+        SubjectRef approvalTarget = new SubjectRef(Resource.CERTIFICATE, UUID.randomUUID());
+        SubjectRef commentHost = new SubjectRef(Resource.RA_PROFILE, hostUuid);
+
+        // An approval notification has to open the approval, not the object awaiting it
+        assertEquals(new SubjectRef(Resource.APPROVAL, approvalUuid),
+                NotificationListener
+                        .internalNotificationTarget(ResourceEvent.APPROVAL_REQUESTED, Resource.APPROVAL, approvalUuid,
+                                approvalTarget));
+        // A comment has no page of its own, so its notification opens the host thread
+        assertEquals(commentHost,
+                NotificationListener
+                        .internalNotificationTarget(ResourceEvent.COMMENT_CREATED, Resource.COMMENT, UUID.randomUUID(),
+                                commentHost));
+        assertEquals(commentHost,
+                NotificationListener
+                        .internalNotificationTarget(ResourceEvent.COMMENT_RESOLVED, Resource.COMMENT, UUID.randomUUID(),
+                                commentHost));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/security/authz/AuthorizationEnforcerImplTest.java
+++ b/src/test/java/com/otilm/core/security/authz/AuthorizationEnforcerImplTest.java
@@ -1,11 +1,14 @@
 package com.otilm.core.security.authz;
 
 import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.logging.enums.ActorType;
 import com.otilm.api.model.core.logging.enums.AuthMethod;
+import com.otilm.core.logging.LoggingHelper;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authn.PlatformAuthenticationToken;
 import com.otilm.core.security.authn.PlatformUserDetails;
 import com.otilm.core.security.authn.client.AuthenticationInfo;
+import com.otilm.core.security.authn.client.PlatformAuthenticationClient;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -18,6 +21,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,6 +29,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,17 +38,21 @@ class AuthorizationEnforcerImplTest {
     @Mock
     ExternalAuthorizationCore core;
 
+    @Mock
+    PlatformAuthenticationClient authenticationClient;
+
     AuthorizationEnforcerImpl enforcer;
 
     @BeforeEach
     void setUp() {
-        enforcer = new AuthorizationEnforcerImpl(core);
+        enforcer = new AuthorizationEnforcerImpl(core, authenticationClient);
         SecurityContextHolder.getContext().setAuthentication(platformAuth());
     }
 
     @AfterEach
     void tearDown() {
         SecurityContextHolder.clearContext();
+        LoggingHelper.clearActorInfo();
     }
 
     @Test
@@ -128,6 +137,73 @@ class AuthorizationEnforcerImplTest {
         assertThatThrownBy(() -> enforcer.enforce(Resource.CERTIFICATE, ResourceAction.DETAIL, uuid))
                 .isInstanceOf(AccessDeniedException.class);
         verify(core).decide(isNull(), any());
+    }
+
+    @Test
+    void authorizesAnotherUserAgainstAPrincipalResolvedForThem() {
+        UUID otherUser = UUID.randomUUID();
+        when(authenticationClient.authenticateByUserUuid(otherUser)).thenReturn(resolvableUser());
+        when(core.decide(any(), any())).thenReturn(new AuthorizationDecision(true));
+
+        boolean authorized = enforcer
+                .isAuthorizedAs(otherUser, Resource.RA_PROFILE, ResourceAction.DETAIL,
+                        SecuredUUID.fromUUID(UUID.randomUUID()));
+
+        assertThat(authorized).isTrue();
+        verify(core)
+                .decide(argThat(auth -> auth instanceof PlatformAuthenticationToken token
+                        && "other-user".equals(token.getPrincipal().getUsername())),
+                        argThat(req -> req.properties().get("action").equals(ResourceAction.DETAIL.getCode())));
+    }
+
+    @Test
+    void deniesAUserTheAuthServiceNoLongerResolves() {
+        UUID deletedUser = UUID.randomUUID();
+        when(authenticationClient.authenticateByUserUuid(deletedUser))
+                .thenReturn(AuthenticationInfo.getAnonymousAuthenticationInfo());
+
+        boolean authorized = enforcer
+                .isAuthorizedAs(deletedUser, Resource.RA_PROFILE, ResourceAction.DETAIL,
+                        SecuredUUID.fromUUID(UUID.randomUUID()));
+
+        assertThat(authorized).isFalse();
+        verifyNoInteractions(core);
+    }
+
+    @Test
+    void deniesWhenTheUserCannotBeResolvedAtAll() {
+        UUID unreachable = UUID.randomUUID();
+        when(authenticationClient.authenticateByUserUuid(unreachable))
+                .thenThrow(new IllegalStateException("auth service is down"));
+
+        assertThat(enforcer
+                .isAuthorizedAs(unreachable, Resource.RA_PROFILE, ResourceAction.DETAIL,
+                        SecuredUUID.fromUUID(UUID.randomUUID())))
+                .isFalse();
+        verifyNoInteractions(core);
+    }
+
+    @Test
+    void leavesTheCallersActorAttributionUntouched() {
+        UUID otherUser = UUID.randomUUID();
+        // Resolving somebody replays their actor MDC, which must not become the caller's audited identity
+        when(authenticationClient.authenticateByUserUuid(otherUser)).thenAnswer(invocation -> {
+            LoggingHelper.putActorInfoWhenNull(ActorType.USER, otherUser.toString(), "other-user");
+            return resolvableUser();
+        });
+        when(core.decide(any(), any())).thenReturn(new AuthorizationDecision(true));
+        LoggingHelper.putActorInfoWhenNull(ActorType.USER, UUID.randomUUID().toString(), "caller");
+
+        enforcer
+                .isAuthorizedAs(otherUser, Resource.RA_PROFILE, ResourceAction.DETAIL,
+                        SecuredUUID.fromUUID(UUID.randomUUID()));
+
+        assertThat(LoggingHelper.getActorInfo().name()).isEqualTo("caller");
+    }
+
+    private AuthenticationInfo resolvableUser() {
+        return new AuthenticationInfo(AuthMethod.USER_PROXY, UUID.randomUUID().toString(), "other-user", List.of(),
+                "{\"user\":{\"username\":\"other-user\"}}");
     }
 
     private PlatformAuthenticationToken platformAuth() {

--- a/src/test/java/com/otilm/core/service/notifications/NotificationSubjectResolverTest.java
+++ b/src/test/java/com/otilm/core/service/notifications/NotificationSubjectResolverTest.java
@@ -2,6 +2,7 @@ package com.otilm.core.service.notifications;
 
 import com.otilm.api.model.common.events.data.ApprovalEventData;
 import com.otilm.api.model.common.events.data.CertificateExpiringEventData;
+import com.otilm.api.model.common.events.data.CommentEventData;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.core.service.notifications.NotificationSubjectResolver.SubjectRef;
 import java.util.UUID;
@@ -50,6 +51,21 @@ class NotificationSubjectResolverTest {
         subject = NotificationSubjectResolver.resolveSubject(Resource.APPROVAL, approvalUuid, approval);
 
         assertEquals(new SubjectRef(Resource.APPROVAL, approvalUuid), subject);
+    }
+
+    // Deliberate: the redirection also feeds the OBJECT-recipient path, so an admin can route comment
+    // notifications to a contact stored on the host object's attributes
+    @Test
+    void commentEventsResolveToTheHostObject() {
+        UUID commentUuid = UUID.randomUUID();
+        UUID hostUuid = UUID.randomUUID();
+        CommentEventData comment = new CommentEventData();
+        comment.setResource(Resource.CERTIFICATE);
+        comment.setObjectUuid(hostUuid);
+
+        SubjectRef subject = NotificationSubjectResolver.resolveSubject(Resource.COMMENT, commentUuid, comment);
+
+        assertEquals(new SubjectRef(Resource.CERTIFICATE, hostUuid), subject);
     }
 
     @Test

--- a/src/test/java/com/otilm/core/util/AuthServiceWireMockStubs.java
+++ b/src/test/java/com/otilm/core/util/AuthServiceWireMockStubs.java
@@ -1,0 +1,48 @@
+package com.otilm.core.util;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import java.util.UUID;
+
+/**
+ * The auth-service WireMock stubs that impersonation needs: user detail lookup and a superadmin authentication
+ * response. One place to update when the auth-service contract changes.
+ */
+public final class AuthServiceWireMockStubs {
+
+    private AuthServiceWireMockStubs() {
+    }
+
+    public static void stubImpersonation(WireMockServer mockServer, UUID userUuid, String username) {
+        mockServer.stubFor(WireMock.get(WireMock.urlPathMatching("/auth/users/[^/]+")).willReturn(WireMock.okJson("""
+                {
+                    "uuid": "%s",
+                    "username": "%s",
+                    "email": "testuser1@example.com",
+                    "groups": [],
+                    "roles": []
+                }
+                """.formatted(userUuid, username))));
+
+        mockServer.stubFor(WireMock.post(WireMock.urlPathMatching("/auth")).willReturn(WireMock.okJson("""
+                {
+                    "authenticated": true,
+                    "data": {
+                        "user": {
+                            "uuid": "%s",
+                            "username": "%s"
+                        },
+                        "roles": [
+                            {
+                                "name": "superadmin"
+                            }
+                        ],
+                        "permissions": {
+                            "allowAllResources": true,
+                            "resources": []
+                        }
+                    }
+                }
+                """.formatted(userUuid, username))));
+    }
+}

--- a/src/test/java/com/otilm/core/util/mockbeans/ProducerMocks.java
+++ b/src/test/java/com/otilm/core/util/mockbeans/ProducerMocks.java
@@ -4,13 +4,17 @@ import com.otilm.core.messaging.jms.producers.ActionProducer;
 import com.otilm.core.messaging.jms.producers.EventProducer;
 import com.otilm.core.messaging.jms.producers.NotificationProducer;
 import com.otilm.core.messaging.jms.producers.ValidationProducer;
+import com.otilm.core.messaging.model.NotificationMessage;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.event.EventListener;
 import org.springframework.core.type.classreading.MetadataReader;
 import org.springframework.core.type.classreading.MetadataReaderFactory;
 
@@ -53,6 +57,34 @@ public class ProducerMocks {
     @Primary
     ValidationProducer mockValidationProducer() {
         return mock(ValidationProducer.class);
+    }
+
+    @Bean
+    RecordedNotificationMessages recordedNotificationMessages() {
+        return new RecordedNotificationMessages();
+    }
+
+    /**
+     * Records every {@link NotificationMessage} published as an application event, synchronously at publish time. The
+     * mocked {@link NotificationProducer} never forwards messages to the broker, so tests assert on this recorder — and
+     * can replay a captured message into the listener — instead of consuming JMS.
+     */
+    public static class RecordedNotificationMessages {
+
+        private final List<NotificationMessage> messages = new CopyOnWriteArrayList<>();
+
+        @EventListener
+        public void onNotificationMessage(NotificationMessage message) {
+            messages.add(message);
+        }
+
+        public List<NotificationMessage> messages() {
+            return List.copyOf(messages);
+        }
+
+        public void clear() {
+            messages.clear();
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #2026

Event handlers and notification delivery for the comment subsystem merged in #2105 (Epic: OmniTrustILM/ilm#246). #2105 already publishes `COMMENT_CREATED`/`COMMENT_RESOLVED`; this PR makes them do something.

## What's here

- **Handlers** — `CommentCreatedEventHandler` and `CommentResolvedEventHandler` (bean names = event codes) on a shared `CommentEventsHandler` base. A root comment notifies the host object's owner — resolved once, at publish time, and published as a plain user recipient, so the self-exclusion decision and the delivered recipient can never disagree. A reply notifies the thread's participants (distinct authors, minus the actor); resolve/reopen notifies participants with the `resolved` flag in the payload. Group-scoped trigger associations are honored via the host object's group memberships.
- **Subject resolution** — `NotificationSubjectResolver` treats a comment event's subject as the **host object**: owner resolution, enrichment, persisted deep links and DEFAULT recipients all key on the host, matching handler-driven follow-ups. Profile-driven internal notifications persist the resolved subject as their target (a `COMMENT` target would deep-link nowhere).
- **DEFAULT recipients** — comment events join the owner+groups default arm, resolved against the subject; previously a DEFAULT profile on a comment event silently resolved to nobody.
- **Trigger conditions** — `FilterField` gains COMMENT properties (host resource, author as platform-user list, body, timestamps) including a new presence-only `SearchFieldTypeEnum.PRESENCE` for the parent reference: a raw UUID means nothing to a user, so only empty/not-empty is offered — 'Parent Comment is empty' is the roots-only condition. `ResourceToClass` maps COMMENT for trigger evaluation.
- **Internal notifications carry no comment body** — the notification points at the thread; user-authored Markdown never mirrors into persisted notification text. The event payload keeps the body verbatim for operator-bound templates.
- **Tests** — handler unit tests, the end-to-end handler ITest (group scoping, participants, owner, condition-scoped roots-only trigger, bodiless notifications), evaluator coverage for every new filter field, subject-resolver and DEFAULT-recipient units, thread-participant repository queries. Shared `AuthServiceWireMockStubs` dedupes the auth-service stub JSON; `ProducerMocks` gains a synchronous `NotificationMessage` recorder.

## Notes for reviewers

- OBJECT-recipient profiles on comment events are **deliberately reachable**: an admin who binds one is routing comment notifications to the contact stored on the host object's attributes. Pinned by `commentEventsResolveToTheHostObject`.
- The missing-handler guard in `EventListener` landed in #2105, so deployment ordering between the two PRs was already safe.
- Full suite: 5166 tests green.