### PR TITLE
Pin @ExternalAuthorization, clear deprecations, and fix denial auditing

### DIFF
--- a/src/main/java/com/otilm/core/aop/AuditLogAspect.java
+++ b/src/main/java/com/otilm/core/aop/AuditLogAspect.java
@@ -163,14 +163,8 @@ public class AuditLogAspect {
     }
 
     /**
-     * Names the denied permission in the audit message, when the authorization layer recorded one.
-     *
-     * <p>
-     * Not every {@link AccessDeniedException} carries a denied resource/action pair — only
-     * {@code ExternalAuthorizationCore} records it, so an object-level OPA failure or a rejected token type arrives
-     * with nothing recorded. {@code Resource.findByCode(null)} throws, and this runs inside the catch block that
-     * re-raises the denial: without the guard the denial is destroyed on its way out and the audit record is built with
-     * no operation result at all.
+     * Appends the recorded denied permission to the audit message, or returns the original message when no permission
+     * was recorded.
      */
     private static String appendDeniedPermission(String message) {
         String resourceName = AuthHelper.getDeniedPermissionResource();

--- a/src/main/java/com/otilm/core/aop/AuditLogAspect.java
+++ b/src/main/java/com/otilm/core/aop/AuditLogAspect.java
@@ -139,11 +139,7 @@ public class AuditLogAspect {
         } catch (Exception e) {
             String message = e.getMessage();
             if (e instanceof AccessDeniedException) {
-                String resourceNameAccessDenied = AuthHelper.getDeniedPermissionResource();
-                String resourceActionName = AuthHelper.getDeniedPermissionResourceAction();
-                message = "%s. Required '%s' action permission for resource '%s'"
-                        .formatted(message, BeautificationUtil.camelToHumanForm(resourceActionName),
-                                Resource.findByCode(resourceNameAccessDenied).getLabel());
+                message = appendDeniedPermission(message);
             }
 
             logBuilder.operationResult(OperationResult.FAILURE);
@@ -164,6 +160,27 @@ public class AuditLogAspect {
             logBuilder.timestamp(OffsetDateTime.now());
             auditLogsProducer.produceMessage(new AuditLogMessage(logBuilder.build(), output));
         }
+    }
+
+    /**
+     * Names the denied permission in the audit message, when the authorization layer recorded one.
+     *
+     * <p>
+     * Not every {@link AccessDeniedException} carries a denied resource/action pair — only
+     * {@code ExternalAuthorizationCore} records it, so an object-level OPA failure or a rejected token type arrives
+     * with nothing recorded. {@code Resource.findByCode(null)} throws, and this runs inside the catch block that
+     * re-raises the denial: without the guard the denial is destroyed on its way out and the audit record is built with
+     * no operation result at all.
+     */
+    private static String appendDeniedPermission(String message) {
+        String resourceName = AuthHelper.getDeniedPermissionResource();
+        String resourceActionName = AuthHelper.getDeniedPermissionResourceAction();
+        if (resourceName == null || resourceActionName == null) {
+            return message;
+        }
+        return "%s. Required '%s' action permission for resource '%s'"
+                .formatted(message, BeautificationUtil.camelToHumanForm(resourceActionName),
+                        Resource.findByCode(resourceName).getLabel());
     }
 
     /**

--- a/src/main/java/com/otilm/core/config/OpaSecuredAnnotationMetadataExtractor.java
+++ b/src/main/java/com/otilm/core/config/OpaSecuredAnnotationMetadataExtractor.java
@@ -42,7 +42,7 @@ public class OpaSecuredAnnotationMetadataExtractor {
                 .trace("Attributes extracted from secured annotation: [%s]"
                         .formatted(attributes
                                 .stream()
-                                .map(ExternalAuthorizationConfigAttribute::getAttribute)
+                                .map(ExternalAuthorizationConfigAttribute::describe)
                                 .collect(Collectors.joining(","))));
 
         return attributes;
@@ -60,7 +60,7 @@ public class OpaSecuredAnnotationMetadataExtractor {
                 .trace("Attributes extracted from dynamic secured annotation: [%s]"
                         .formatted(attributes
                                 .stream()
-                                .map(ExternalAuthorizationConfigAttribute::getAttribute)
+                                .map(ExternalAuthorizationConfigAttribute::describe)
                                 .collect(Collectors.joining(","))));
 
         return attributes;

--- a/src/main/java/com/otilm/core/security/authz/AbstractExternalAuthorizationManager.java
+++ b/src/main/java/com/otilm/core/security/authz/AbstractExternalAuthorizationManager.java
@@ -15,8 +15,15 @@ public abstract class AbstractExternalAuthorizationManager<T> implements Authori
 
     protected final Log logger = LogFactory.getLog(this.getClass());
 
+    /**
+     * Decides whether the authenticated caller may act on {@code object}.
+     *
+     * <p>
+     * <b>Never abstains.</b> The interface permits {@code null} to mean "no decision", but an unrecognised token type
+     * and a subclass that cannot decide both come back as an explicit denial instead.
+     */
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, T object) {
+    public AuthorizationDecision authorize(Supplier<Authentication> authenticationSupplier, T object) {
         Authentication authentication = authenticationSupplier.get();
         if (!(authentication instanceof PlatformAuthenticationToken
                 || authentication instanceof AnonymousAuthenticationToken)) {
@@ -26,7 +33,7 @@ public abstract class AbstractExternalAuthorizationManager<T> implements Authori
         }
 
         if (!canDecide(authentication, object)) {
-            logger.trace("Abstaining from voting as voter can't decide for given object.");
+            logger.trace("Denying as this manager can't decide for the given object.");
             return new AuthorizationDecision(false);
         }
 
@@ -36,6 +43,23 @@ public abstract class AbstractExternalAuthorizationManager<T> implements Authori
             return checkInternal((AnonymousAuthenticationToken) authentication, object);
         }
 
+    }
+
+    /**
+     * Delegates to {@link #authorize}, which holds the decision.
+     *
+     * <p>
+     * This override cannot simply be deleted while we are on Spring Security 6.5, where {@code check} is both abstract
+     * and deprecated. Spring Security 7 removes it and widens the surviving {@code authorize} to
+     * {@code Supplier<? extends Authentication>}, so that upgrade both drops this method and changes the signature
+     * above.
+     *
+     * @deprecated removed in Spring Security 7; call {@link #authorize} instead.
+     */
+    @Deprecated(forRemoval = true)
+    @Override
+    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, T object) {
+        return authorize(authenticationSupplier, object);
     }
 
     protected abstract AuthorizationDecision checkInternal(PlatformAuthenticationToken authentication, T object);

--- a/src/main/java/com/otilm/core/security/authz/ExternalAuthorizationConfigAttribute.java
+++ b/src/main/java/com/otilm/core/security/authz/ExternalAuthorizationConfigAttribute.java
@@ -1,16 +1,23 @@
 package com.otilm.core.security.authz;
 
-import org.springframework.security.access.ConfigAttribute;
+/**
+ * One resolved property of an {@code @ExternalAuthorization} annotation on its way to the OPA request.
+ *
+ * <p>
+ * Deliberately not a Spring Security {@code ConfigAttribute}: nothing in the framework consumes these, and that
+ * interface is removed in Spring Security 7.
+ */
+public record ExternalAuthorizationConfigAttribute(String attributeName, Object attributeValue) {
 
-public record ExternalAuthorizationConfigAttribute(String attributeName,
-        Object attributeValue) implements ConfigAttribute {
-
-    @Override
-    public String getAttribute() {
+    /**
+     * Renders the attribute for the trace logs in {@code OpaSecuredAnnotationMetadataExtractor}, which reference it as
+     * a method reference rather than calling it directly.
+     */
+    public String describe() {
         return "%s=%s".formatted(this.attributeName, this.attributeValue);
     }
 
-    public String getAttributeValueAsString() {
+    public String attributeValueAsString() {
         return attributeValue.toString();
     }
 }

--- a/src/main/java/com/otilm/core/security/authz/ExternalAuthorizationConfigAttribute.java
+++ b/src/main/java/com/otilm/core/security/authz/ExternalAuthorizationConfigAttribute.java
@@ -9,10 +9,7 @@ package com.otilm.core.security.authz;
  */
 public record ExternalAuthorizationConfigAttribute(String attributeName, Object attributeValue) {
 
-    /**
-     * Renders the attribute for the trace logs in {@code OpaSecuredAnnotationMetadataExtractor}, which reference it as
-     * a method reference rather than calling it directly.
-     */
+    /** Renders the attribute for trace logging. */
     public String describe() {
         return "%s=%s".formatted(this.attributeName, this.attributeValue);
     }

--- a/src/main/java/com/otilm/core/security/authz/ExternalMethodAuthorizationManager.java
+++ b/src/main/java/com/otilm/core/security/authz/ExternalMethodAuthorizationManager.java
@@ -62,7 +62,7 @@ public class ExternalMethodAuthorizationManager extends AbstractExternalAuthoriz
                 .filter(this::shouldBeSendToOpa)
                 .collect(Collectors
                         .toMap(ExternalAuthorizationConfigAttribute::attributeName,
-                                ExternalAuthorizationConfigAttribute::getAttributeValueAsString));
+                                ExternalAuthorizationConfigAttribute::attributeValueAsString));
         return new AuthorizationRequest(properties, extractUUIDsFromMethodArguments(methodInvocation),
                 extractParentUUIDsFromMethodArguments(methodInvocation), hasSecurityFilterParam(methodInvocation),
                 extractParentUUIDGetterClass(attributes), methodInvocation.getMethod().getName());

--- a/src/main/java/com/otilm/core/security/authz/ObjectFilterAspect.java
+++ b/src/main/java/com/otilm/core/security/authz/ObjectFilterAspect.java
@@ -83,7 +83,7 @@ public class ObjectFilterAspect {
                 .stream()
                 .collect(Collectors
                         .toMap(ExternalAuthorizationConfigAttribute::attributeName,
-                                ExternalAuthorizationConfigAttribute::getAttributeValueAsString));
+                                ExternalAuthorizationConfigAttribute::attributeValueAsString));
         populateSecurityFilter(properties, secFilter);
 
         return joinPoint.proceed(arguments);

--- a/src/main/java/com/otilm/core/util/AuthHelper.java
+++ b/src/main/java/com/otilm/core/util/AuthHelper.java
@@ -46,7 +46,13 @@ public class AuthHelper {
     // Access control request attributes
     public static final String REQ_ATTR_RESOURCE_NAME = "INTERNAL_ATTRIB_DENIED_RESOURCE_NAME";
     public static final String REQ_ATTR_RESOURCE_ACTION_NAME = "INTERNAL_ATTRIB_DENIED_RESOURCE_ACTION_NAME";
-    public static final int REQ_ATTR_ACCESS_CONTROL_SCOPE = 121;
+    /**
+     * Request scope, not session scope: {@code ServletRequestAttributes} routes every scope other than
+     * {@link RequestAttributes#SCOPE_REQUEST} to the HTTP session, creating one if needed. A later request that
+     * recorded no denial of its own then reads this one, and is told about a decision it never triggered. Session scope
+     * also persists a session row for every denial.
+     */
+    public static final int REQ_ATTR_ACCESS_CONTROL_SCOPE = RequestAttributes.SCOPE_REQUEST;
 
     // system users and roles names
     public static final String SYSTEM_USER_HEADER_NAME = "systemUsername";

--- a/src/test/java/com/otilm/core/integration/aop/AuditLogAspectITest.java
+++ b/src/test/java/com/otilm/core/integration/aop/AuditLogAspectITest.java
@@ -23,7 +23,9 @@ import com.otilm.core.dao.repository.AuditLogRepository;
 import com.otilm.core.logging.LoggingHelper;
 import com.otilm.core.messaging.jms.listeners.AuditLogsListener;
 import com.otilm.core.messaging.model.AuditLogMessage;
+import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.service.SettingExternalService;
+import com.otilm.core.util.AuthHelper;
 import com.otilm.core.util.BaseSpringBootTest;
 import java.util.List;
 import java.util.Optional;
@@ -35,6 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
@@ -64,6 +67,27 @@ class AuditLogAspectITest extends BaseSpringBootTest {
         @AuditLogged(module = Module.PROTOCOLS, resource = Resource.SIGNING_RECORD, operation = Operation.SIGN)
         public void performAndSucceed() {
             // no override — aspect must record SUCCESS
+        }
+
+        /**
+         * Denies without recording a denied resource/action pair, the way an OPA transport failure or a token type the
+         * authorization manager does not recognise does.
+         */
+        @AuditLogged(module = Module.PROTOCOLS, resource = Resource.SIGNING_RECORD, operation = Operation.SIGN)
+        public void denyWithoutRecordingPermission() {
+            throw new AccessDeniedException("An error occurred when calling OPA.");
+        }
+
+        /**
+         * Denies after recording a pair, the way {@code ExternalAuthorizationCore} does for every resource-level
+         * decision it returns.
+         */
+        @AuditLogged(module = Module.PROTOCOLS, resource = Resource.SIGNING_RECORD, operation = Operation.SIGN)
+        public void denyRecordingPermission() {
+            AuthHelper
+                    .setDeniedPermissionResourceAction(Resource.SIGNING_RECORD.getCode(),
+                            ResourceAction.LIST.getCode());
+            throw new AccessDeniedException("Access Denied");
         }
     }
 
@@ -207,6 +231,59 @@ class AuditLogAspectITest extends BaseSpringBootTest {
         List<AuditLog> auditLogs = auditLogRepository.findAll();
         Assertions.assertEquals(1, auditLogs.size());
         Assertions.assertEquals(OperationResult.SUCCESS, auditLogs.getFirst().getOperationResult());
+    }
+
+    /**
+     * A denial that recorded no resource/action pair has to pass through the aspect unchanged. The aspect names the
+     * denied permission in its message, and reading that pair without a null guard threw from inside the aspect's own
+     * catch block: the denial was destroyed on its way out, and the audit record was produced with no operation result.
+     */
+    @Test
+    void deniedWithoutRecordedPermission_auditsFailureAndRethrowsTheDenial() {
+        // given
+        Mockito.doAnswer(invocation -> {
+            auditLogsListener.processMessage(invocation.getArgument(0));
+            return null;
+        }).when(auditLogsProducer).produceMessage(Mockito.any());
+        turnOnLogging();
+
+        // when
+        Assertions
+                .assertThrows(AccessDeniedException.class,
+                        () -> runInRequestScope(swallowsAndOverridesBean::denyWithoutRecordingPermission));
+
+        // then
+        List<AuditLog> auditLogs = auditLogRepository.findAll();
+        Assertions.assertEquals(1, auditLogs.size());
+        Assertions.assertEquals(OperationResult.FAILURE, auditLogs.getFirst().getOperationResult());
+    }
+
+    /**
+     * The other half of the same branch: when the authorization layer did record a pair, the audit message has to name
+     * it. An operator reading the audit trail needs to see which permission was missing, not just that access was
+     * denied.
+     */
+    @Test
+    void deniedWithRecordedPermission_namesThePermissionInTheAuditMessage() {
+        // given
+        Mockito.doAnswer(invocation -> {
+            auditLogsListener.processMessage(invocation.getArgument(0));
+            return null;
+        }).when(auditLogsProducer).produceMessage(Mockito.any());
+        turnOnLogging();
+
+        // when
+        Assertions
+                .assertThrows(AccessDeniedException.class,
+                        () -> runInRequestScope(swallowsAndOverridesBean::denyRecordingPermission));
+
+        // then
+        List<AuditLog> auditLogs = auditLogRepository.findAll();
+        Assertions.assertEquals(1, auditLogs.size());
+        Assertions.assertEquals(OperationResult.FAILURE, auditLogs.getFirst().getOperationResult());
+        Assertions
+                .assertEquals("Access Denied. Required 'List' action permission for resource 'Signing Record'",
+                        auditLogs.getFirst().getMessage());
     }
 
     /**

--- a/src/test/java/com/otilm/core/integration/aop/AuditLogAspectITest.java
+++ b/src/test/java/com/otilm/core/integration/aop/AuditLogAspectITest.java
@@ -233,11 +233,6 @@ class AuditLogAspectITest extends BaseSpringBootTest {
         Assertions.assertEquals(OperationResult.SUCCESS, auditLogs.getFirst().getOperationResult());
     }
 
-    /**
-     * A denial that recorded no resource/action pair has to pass through the aspect unchanged. The aspect names the
-     * denied permission in its message, and reading that pair without a null guard threw from inside the aspect's own
-     * catch block: the denial was destroyed on its way out, and the audit record was produced with no operation result.
-     */
     @Test
     void deniedWithoutRecordedPermission_auditsFailureAndRethrowsTheDenial() {
         // given
@@ -258,11 +253,6 @@ class AuditLogAspectITest extends BaseSpringBootTest {
         Assertions.assertEquals(OperationResult.FAILURE, auditLogs.getFirst().getOperationResult());
     }
 
-    /**
-     * The other half of the same branch: when the authorization layer did record a pair, the audit message has to name
-     * it. An operator reading the audit trail needs to see which permission was missing, not just that access was
-     * denied.
-     */
     @Test
     void deniedWithRecordedPermission_namesThePermissionInTheAuditMessage() {
         // given
@@ -286,10 +276,6 @@ class AuditLogAspectITest extends BaseSpringBootTest {
                         auditLogs.getFirst().getMessage());
     }
 
-    /**
-     * Binds a request scope around the action so the request-scoped {@link AuditResultOverride} resolves — production
-     * audited methods always run inside a DispatcherServlet request, but the test invokes the bean directly.
-     */
     private void runInRequestScope(Runnable action) {
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(new MockHttpServletRequest()));
         try {

--- a/src/test/java/com/otilm/core/integration/api/web/ExternalAuthorizationHttpITest.java
+++ b/src/test/java/com/otilm/core/integration/api/web/ExternalAuthorizationHttpITest.java
@@ -1,0 +1,110 @@
+package com.otilm.core.integration.api.web;
+
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.util.BaseSpringBootTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Regression suite for {@code @ExternalAuthorization} over HTTP: the real security filter chain, the method-security
+ * advisor on the service bean behind the controller, and the translation of a denial into a response by
+ * {@code ExceptionHandlingAdvice.handleAccessDeniedException}.
+ *
+ * <p>
+ * The denial cases double as the guard on request-scoped denied-permission recording: the test schema has no Spring
+ * Session tables, so if the denied resource/action ever goes back to session scope, recording it creates a session and
+ * these tests fail on the {@code core.spring_session} insert. Add the DDL to make that failure go away and the guard is
+ * gone with it.
+ *
+ * <p>
+ * {@code /v1/statistics/signingRecords} is the target because {@code SigningRecordServiceImpl} guards it with both a
+ * resource and a parent resource, and takes a {@code SecurityFilter} rather than a {@code SecuredUUID} — so one
+ * endpoint exercises parent-before-child ordering and the no-object-UUID request shape that
+ * {@code ExternalMethodAuthorizationManager} derives from the method arguments.
+ */
+@AutoConfigureMockMvc
+class ExternalAuthorizationHttpITest extends BaseSpringBootTest {
+
+    private static final String STATISTICS_ENDPOINT = "/v1/statistics/signingRecords";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    /**
+     * The body's own {@code statusCode} field is not asserted: it is filled in by the interfaces module, which reported
+     * 400 for every error until interfaces#887. Assert it once core consumes a build carrying that fix.
+     */
+    @Test
+    void returnsForbiddenProblemJsonNamingTheDeniedResourceAndAction() throws Exception {
+        denyResourceAccess(Resource.SIGNING_RECORD, ResourceAction.LIST);
+
+        mockMvc
+                .perform(get(STATISTICS_ENDPOINT))
+                .andExpectAll(status().isForbidden(), content().contentType("application/problem+json"),
+                        jsonPath("$.code").value("ACCESS_DENIED"),
+                        jsonPath("$.message").value("Access Denied. Required 'List' permission for 'Signing Record'"));
+    }
+
+    /**
+     * The denied pair reported to the caller must be the check that actually failed. When the parent is denied the
+     * message has to name the parent resource, otherwise an operator is sent to fix a permission that was never the
+     * problem.
+     */
+    @Test
+    void namesTheParentResourceWhenTheParentCheckIsDenied() throws Exception {
+        denyResourceAccess(Resource.SIGNING_PROFILE, ResourceAction.LIST);
+
+        mockMvc
+                .perform(get(STATISTICS_ENDPOINT))
+                .andExpectAll(status().isForbidden(), jsonPath("$.code").value("ACCESS_DENIED"),
+                        jsonPath("$.message").value("Access Denied. Required 'List' permission for 'Signing Profile'"));
+    }
+
+    /**
+     * The other branch of the denied-pair reader: an object-level OPA failure propagates the
+     * {@code AccessDeniedException} that {@code OpaClient} raises straight out of
+     * {@code AuthHelper.loadObjectPermissions}, and nothing on that path records a resource/action pair. The caller
+     * still gets a 403 rather than a 500, with the generic message instead of a named permission.
+     *
+     * <p>
+     * A resource-level denial cannot exercise this branch — {@code ExternalAuthorizationCore.decideBasedOnOpaResult}
+     * records the pair before returning one, including when the OPA call itself failed.
+     */
+    @Test
+    void returnsForbiddenWhenTheDenialRecordedNoPermissionPair() throws Exception {
+        when(opaClient.checkObjectAccess(any(), any(), any(), any()))
+                .thenThrow(new AccessDeniedException("An error occurred when calling OPA."));
+
+        mockMvc
+                .perform(get(STATISTICS_ENDPOINT))
+                .andExpectAll(status().isForbidden(), jsonPath("$.code").value("ACCESS_DENIED"),
+                        jsonPath("$.message").value(startsWith("Access denied for the specified operation")));
+    }
+
+    /**
+     * A method taking a {@code SecurityFilter} authorizes the action broadly and narrows the result set afterwards, so
+     * no object UUIDs are submitted. Sending UUIDs here would change the policy input for every list endpoint.
+     */
+    @Test
+    void sendsNoObjectUuidsForASecurityFilterEndpoint() throws Exception {
+        mockMvc.perform(get(STATISTICS_ENDPOINT)).andExpect(status().isOk());
+
+        assertThat(captureOpaRequests())
+                .as("the guarded service method was reached through the advisor")
+                .isNotEmpty()
+                .allSatisfy(request -> assertThat(request.getObjectUUIDs()).isNull());
+    }
+}

--- a/src/test/java/com/otilm/core/integration/api/web/ExternalAuthorizationHttpITest.java
+++ b/src/test/java/com/otilm/core/integration/api/web/ExternalAuthorizationHttpITest.java
@@ -58,11 +58,6 @@ class ExternalAuthorizationHttpITest extends BaseSpringBootTest {
                         jsonPath("$.message").value("Access Denied. Required 'List' permission for 'Signing Record'"));
     }
 
-    /**
-     * The denied pair reported to the caller must be the check that actually failed. When the parent is denied the
-     * message has to name the parent resource, otherwise an operator is sent to fix a permission that was never the
-     * problem.
-     */
     @Test
     void namesTheParentResourceWhenTheParentCheckIsDenied() throws Exception {
         denyResourceAccess(Resource.SIGNING_PROFILE, ResourceAction.LIST);
@@ -73,16 +68,6 @@ class ExternalAuthorizationHttpITest extends BaseSpringBootTest {
                         jsonPath("$.message").value("Access Denied. Required 'List' permission for 'Signing Profile'"));
     }
 
-    /**
-     * The other branch of the denied-pair reader: an object-level OPA failure propagates the
-     * {@code AccessDeniedException} that {@code OpaClient} raises straight out of
-     * {@code AuthHelper.loadObjectPermissions}, and nothing on that path records a resource/action pair. The caller
-     * still gets a 403 rather than a 500, with the generic message instead of a named permission.
-     *
-     * <p>
-     * A resource-level denial cannot exercise this branch — {@code ExternalAuthorizationCore.decideBasedOnOpaResult}
-     * records the pair before returning one, including when the OPA call itself failed.
-     */
     @Test
     void returnsForbiddenWhenTheDenialRecordedNoPermissionPair() throws Exception {
         when(opaClient.checkObjectAccess(any(), any(), any(), any()))
@@ -94,10 +79,6 @@ class ExternalAuthorizationHttpITest extends BaseSpringBootTest {
                         jsonPath("$.message").value(startsWith("Access denied for the specified operation")));
     }
 
-    /**
-     * A method taking a {@code SecurityFilter} authorizes the action broadly and narrows the result set afterwards, so
-     * no object UUIDs are submitted. Sending UUIDs here would change the policy input for every list endpoint.
-     */
     @Test
     void sendsNoObjectUuidsForASecurityFilterEndpoint() throws Exception {
         mockMvc.perform(get(STATISTICS_ENDPOINT)).andExpect(status().isOk());

--- a/src/test/java/com/otilm/core/integration/api/web/ExternalAuthorizationHttpITest.java
+++ b/src/test/java/com/otilm/core/integration/api/web/ExternalAuthorizationHttpITest.java
@@ -20,20 +20,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 /**
  * Regression suite for {@code @ExternalAuthorization} over HTTP: the real security filter chain, the method-security
- * advisor on the service bean behind the controller, and the translation of a denial into a response by
- * {@code ExceptionHandlingAdvice.handleAccessDeniedException}.
+ * advisor behind the controller, and {@code ExceptionHandlingAdvice.handleAccessDeniedException}.
  *
  * <p>
- * The denial cases double as the guard on request-scoped denied-permission recording: the test schema has no Spring
- * Session tables, so if the denied resource/action ever goes back to session scope, recording it creates a session and
- * these tests fail on the {@code core.spring_session} insert. Add the DDL to make that failure go away and the guard is
- * gone with it.
- *
- * <p>
- * {@code /v1/statistics/signingRecords} is the target because {@code SigningRecordServiceImpl} guards it with both a
- * resource and a parent resource, and takes a {@code SecurityFilter} rather than a {@code SecuredUUID} — so one
- * endpoint exercises parent-before-child ordering and the no-object-UUID request shape that
- * {@code ExternalMethodAuthorizationManager} derives from the method arguments.
+ * The denial cases also guard request-scoped denied-permission recording, since the test schema has no Spring Session
+ * tables; {@code /v1/statistics/signingRecords} is the target because it is guarded by both a resource and a parent
+ * resource and takes a {@code SecurityFilter} rather than a {@code SecuredUUID}.
  */
 @AutoConfigureMockMvc
 class ExternalAuthorizationHttpITest extends BaseSpringBootTest {

--- a/src/test/java/com/otilm/core/integration/security/authz/ExternalAuthorizationDynamicITest.java
+++ b/src/test/java/com/otilm/core/integration/security/authz/ExternalAuthorizationDynamicITest.java
@@ -25,8 +25,6 @@ import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authz.SecuredResource;
 import com.otilm.core.security.authz.SecuredUUID;
-import com.otilm.core.security.authz.opa.dto.OpaRequestedResource;
-import com.otilm.core.security.authz.opa.dto.OpaResourceAccessResult;
 import com.otilm.core.service.ComplianceExternalService;
 import com.otilm.core.service.ResourceExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
@@ -36,10 +34,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authorization.AuthorizationDeniedException;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.when;
 
 /**
  * End-to-end tests for the {@link com.otilm.core.security.authz.ExternalAuthorizationDynamic} annotation exercised
@@ -69,7 +63,7 @@ class ExternalAuthorizationDynamicITest extends BaseSpringBootTest {
 
     @Test
     void deniesWhenOpaRejectsResolvedResourceAndAnnotationAction() {
-        denyResourceAction(Resource.CERTIFICATE, ResourceAction.UPDATE);
+        denyResourceAccess(Resource.CERTIFICATE, ResourceAction.UPDATE);
 
         List<BaseAttributeContentV3<?>> content = List.of(new StringAttributeContentV3("value"));
         SecuredResource securedResource = SecuredResource.fromResource(Resource.CERTIFICATE);
@@ -84,7 +78,7 @@ class ExternalAuthorizationDynamicITest extends BaseSpringBootTest {
     void resolvesResourceFromArgumentSoOtherResourceStaysAuthorized() throws NotFoundException, AttributeException {
         Certificate certificate = persistCertificate();
         UUID attributeUuid = persistCertificateCustomAttribute();
-        denyResourceAction(Resource.ATTRIBUTE, ResourceAction.UPDATE);
+        denyResourceAccess(Resource.ATTRIBUTE, ResourceAction.UPDATE);
 
         List<BaseAttributeContentV3<?>> content = List.of(new StringAttributeContentV3("value"));
         List<ResponseAttribute> updated = resourceService
@@ -102,25 +96,13 @@ class ExternalAuthorizationDynamicITest extends BaseSpringBootTest {
      */
     @Test
     void authorizesAgainstSecuredResourceNotBareResourceArgument() {
-        denyResourceAction(Resource.SECRET, ResourceAction.DETAIL);
+        denyResourceAccess(Resource.SECRET, ResourceAction.DETAIL);
 
         SecuredResource securedResource = SecuredResource.fromResource(Resource.SECRET);
         UUID objectUuid = UUID.randomUUID();
         Assertions
                 .assertThrows(AuthorizationDeniedException.class, () -> complianceService
                         .getComplianceCheckResult(securedResource, null, Resource.CERTIFICATE, objectUuid));
-    }
-
-    private void denyResourceAction(Resource resource, ResourceAction action) {
-        when(opaClient.checkResourceAccess(any(), argThat(req -> isRequestFor(req, resource, action)), any(), any()))
-                .thenReturn(OpaResourceAccessResult.unauthorized());
-    }
-
-    private static boolean isRequestFor(OpaRequestedResource requestedResource, Resource resource,
-            ResourceAction action) {
-        return requestedResource != null && requestedResource.getProperties() != null
-                && resource.getCode().equals(requestedResource.getProperties().get("name"))
-                && action.getCode().equals(requestedResource.getProperties().get("action"));
     }
 
     private Certificate persistCertificate() {

--- a/src/test/java/com/otilm/core/integration/security/authz/ExternalAuthorizationStaticITest.java
+++ b/src/test/java/com/otilm/core/integration/security/authz/ExternalAuthorizationStaticITest.java
@@ -1,0 +1,177 @@
+package com.otilm.core.integration.security.authz;
+
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.security.authz.SecuredParentUUID;
+import com.otilm.core.security.authz.SecuredUUID;
+import com.otilm.core.security.authz.opa.dto.OpaRequestedResource;
+import com.otilm.core.service.LocationExternalService;
+import com.otilm.core.service.SigningRecordExternalService;
+import com.otilm.core.util.BaseSpringBootTest;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Regression suite for the static {@link com.otilm.core.security.authz.ExternalAuthorization} annotation exercised
+ * through the real Spring AOP stack, entered via the advisor wired in {@code MethodSecurityConfig}.
+ *
+ * <p>
+ * The sibling {@code ExternalAuthorizationDynamicITest} covers {@code @ExternalAuthorizationDynamic}, whose resource is
+ * resolved from an argument. This class covers the annotation used by every other guarded service method, pinning the
+ * request actually sent to OPA: resource, action, object UUIDs and parent-before-child ordering.
+ *
+ * <p>
+ * Both target resources are declared without owner or group associations, so a denied OPA decision is not rescued by
+ * the group/owner fallback in {@code ExternalAuthorizationCore.checkGroupOwnerAssociations} and reaches the caller as a
+ * denial. Choosing resources with associations would test the fallback instead of the advisor.
+ */
+class ExternalAuthorizationStaticITest extends BaseSpringBootTest {
+
+    @Autowired
+    private SigningRecordExternalService signingRecordService;
+
+    @Autowired
+    private LocationExternalService locationService;
+
+    /**
+     * Asserts OPA was consulted as well as that the call succeeded: an unadvised bean would also return a result, so
+     * the return value alone would pass even if the advisor never ran.
+     */
+    @Test
+    void permitsWhenOpaAuthorizesAnnotatedResourceAndAction() {
+        assertThat(signingRecordService.getSearchableFieldInformation())
+                .as("an authorized call runs to completion through the advisor")
+                .isNotNull();
+        assertThat(captureOpaRequests()).isNotEmpty();
+    }
+
+    /**
+     * A token-type rejection produces the same {@link AuthorizationDeniedException} without ever consulting OPA. The
+     * captured request is therefore the discriminator: asserting the type alone would stay green even if the platform
+     * token stopped being injected and this path went unexercised.
+     */
+    @Test
+    void deniesWhenOpaRejectsAnnotatedResourceAndAction() {
+        denyResourceAccess(Resource.SIGNING_RECORD, ResourceAction.LIST);
+
+        assertThatThrownBy(() -> signingRecordService.getSearchableFieldInformation())
+                .isInstanceOf(AuthorizationDeniedException.class);
+
+        assertThat(captureOpaRequests()).anySatisfy(request -> {
+            assertThat(request.getProperties()).containsEntry("name", Resource.SIGNING_RECORD.getCode());
+            assertThat(request.getProperties()).containsEntry("action", ResourceAction.LIST.getCode());
+        });
+    }
+
+    /**
+     * An unrecognised token type is rejected by {@code AbstractExternalAuthorizationManager} before any policy call, so
+     * the absence of an OPA request is what distinguishes this denial from one OPA itself made.
+     */
+    @Test
+    void deniesWhenAuthenticationIsNotAPlatformToken() {
+        SecurityContextHolder
+                .getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken("someone", "secret", List.of()));
+
+        assertThatThrownBy(() -> signingRecordService.getSearchableFieldInformation())
+                .isInstanceOf(AuthorizationDeniedException.class);
+        verify(opaClient, never()).checkResourceAccess(any(), any(), any(), any());
+    }
+
+    @Test
+    void sendsAnnotatedResourceAndActionToOpa() {
+        signingRecordService.getSearchableFieldInformation();
+
+        assertThat(captureOpaRequests())
+                .as("the resource and action named on the annotation are what OPA is asked about")
+                .anySatisfy(request -> {
+                    assertThat(request.getProperties()).containsEntry("name", Resource.SIGNING_RECORD.getCode());
+                    assertThat(request.getProperties()).containsEntry("action", ResourceAction.LIST.getCode());
+                });
+    }
+
+    /**
+     * The parent has to be evaluated before the child so that a denied parent can short-circuit the child check, as
+     * {@link #skipsChildCheckWhenParentIsDenied} requires. Submission order is the only evidence of that sequencing.
+     */
+    @Test
+    void checksParentBeforeChild() {
+        assertThatThrownBy(() -> locationService
+                .getLocation(SecuredParentUUID.fromUUID(UUID.randomUUID()), SecuredUUID.fromUUID(UUID.randomUUID())))
+                .as("authorization passes, so the method body runs and fails to find the location")
+                .isInstanceOf(NotFoundException.class);
+
+        List<OpaRequestedResource> requests = captureOpaRequests();
+        assertThat(requests).hasSize(2);
+        assertThat(requests.get(0).getProperties())
+                .containsEntry("name", Resource.ENTITY.getCode())
+                .containsEntry("action", ResourceAction.DETAIL.getCode());
+        assertThat(requests.get(1).getProperties())
+                .containsEntry("name", Resource.LOCATION.getCode())
+                .containsEntry("action", ResourceAction.DETAIL.getCode());
+    }
+
+    /**
+     * Each check carries the UUID of the object it guards. A check reusing the other's UUID would ask OPA about an
+     * object the caller never named, and the answer would authorize the wrong one.
+     */
+    @Test
+    void sendsEachCheckItsOwnObjectUuid() {
+        UUID entityUuid = UUID.randomUUID();
+        UUID locationUuid = UUID.randomUUID();
+
+        assertThatThrownBy(() -> locationService
+                .getLocation(SecuredParentUUID.fromUUID(entityUuid), SecuredUUID.fromUUID(locationUuid)))
+                .isInstanceOf(NotFoundException.class);
+
+        List<OpaRequestedResource> requests = captureOpaRequests();
+        assertThat(requests).hasSize(2);
+        assertThat(requests.get(0).getObjectUUIDs()).containsExactly(entityUuid.toString());
+        assertThat(requests.get(1).getObjectUUIDs()).containsExactly(locationUuid.toString());
+    }
+
+    /**
+     * The {@code parentName} and {@code parentAction} properties are internal routing hints and must not reach OPA.
+     */
+    @Test
+    void omitsInternalRoutingHintsFromTheOpaRequest() {
+        assertThatThrownBy(() -> locationService
+                .getLocation(SecuredParentUUID.fromUUID(UUID.randomUUID()), SecuredUUID.fromUUID(UUID.randomUUID())))
+                .isInstanceOf(NotFoundException.class);
+
+        assertThat(captureOpaRequests())
+                .isNotEmpty()
+                .allSatisfy(request -> assertThat(request.getProperties())
+                        .doesNotContainKeys("parentName", "parentAction"));
+    }
+
+    /**
+     * A denied parent must short-circuit: the child resource is never submitted to OPA. Without this ordering a caller
+     * denied on the parent could still have the child evaluated, which leaks whether the child permits the action.
+     */
+    @Test
+    void skipsChildCheckWhenParentIsDenied() {
+        denyResourceAccess(Resource.ENTITY, ResourceAction.DETAIL);
+
+        assertThatThrownBy(() -> locationService
+                .getLocation(SecuredParentUUID.fromUUID(UUID.randomUUID()), SecuredUUID.fromUUID(UUID.randomUUID())))
+                .isInstanceOf(AuthorizationDeniedException.class);
+
+        assertThat(captureOpaRequests())
+                .as("only the parent resource is submitted to OPA")
+                .allSatisfy(request -> assertThat(request.getProperties())
+                        .containsEntry("name", Resource.ENTITY.getCode()));
+    }
+}

--- a/src/test/java/com/otilm/core/integration/security/authz/ExternalAuthorizationStaticITest.java
+++ b/src/test/java/com/otilm/core/integration/security/authz/ExternalAuthorizationStaticITest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -77,6 +78,16 @@ class ExternalAuthorizationStaticITest extends BaseSpringBootTest {
         verify(opaClient, never()).checkResourceAccess(any(), any(), any(), any());
     }
 
+    /** Missing identity, as distinct from the wrong identity above: no authentication at all. */
+    @Test
+    void deniesWhenThereIsNoAuthentication() {
+        SecurityContextHolder.clearContext();
+
+        assertThatThrownBy(() -> signingRecordService.getSearchableFieldInformation())
+                .isInstanceOf(AuthenticationCredentialsNotFoundException.class);
+        verify(opaClient, never()).checkResourceAccess(any(), any(), any(), any());
+    }
+
     @Test
     void sendsAnnotatedResourceAndActionToOpa() {
         signingRecordService.getSearchableFieldInformation();
@@ -91,8 +102,10 @@ class ExternalAuthorizationStaticITest extends BaseSpringBootTest {
 
     @Test
     void checksParentBeforeChild() {
-        assertThatThrownBy(() -> locationService
-                .getLocation(SecuredParentUUID.fromUUID(UUID.randomUUID()), SecuredUUID.fromUUID(UUID.randomUUID())))
+        SecuredParentUUID entity = SecuredParentUUID.fromUUID(UUID.randomUUID());
+        SecuredUUID location = SecuredUUID.fromUUID(UUID.randomUUID());
+
+        assertThatThrownBy(() -> locationService.getLocation(entity, location))
                 .as("authorization passes, so the method body runs and fails to find the location")
                 .isInstanceOf(NotFoundException.class);
 
@@ -110,10 +123,10 @@ class ExternalAuthorizationStaticITest extends BaseSpringBootTest {
     void sendsEachCheckItsOwnObjectUuid() {
         UUID entityUuid = UUID.randomUUID();
         UUID locationUuid = UUID.randomUUID();
+        SecuredParentUUID entity = SecuredParentUUID.fromUUID(entityUuid);
+        SecuredUUID location = SecuredUUID.fromUUID(locationUuid);
 
-        assertThatThrownBy(() -> locationService
-                .getLocation(SecuredParentUUID.fromUUID(entityUuid), SecuredUUID.fromUUID(locationUuid)))
-                .isInstanceOf(NotFoundException.class);
+        assertThatThrownBy(() -> locationService.getLocation(entity, location)).isInstanceOf(NotFoundException.class);
 
         List<OpaRequestedResource> requests = captureOpaRequests();
         assertThat(requests).hasSize(2);
@@ -123,9 +136,10 @@ class ExternalAuthorizationStaticITest extends BaseSpringBootTest {
 
     @Test
     void omitsInternalRoutingHintsFromTheOpaRequest() {
-        assertThatThrownBy(() -> locationService
-                .getLocation(SecuredParentUUID.fromUUID(UUID.randomUUID()), SecuredUUID.fromUUID(UUID.randomUUID())))
-                .isInstanceOf(NotFoundException.class);
+        SecuredParentUUID entity = SecuredParentUUID.fromUUID(UUID.randomUUID());
+        SecuredUUID location = SecuredUUID.fromUUID(UUID.randomUUID());
+
+        assertThatThrownBy(() -> locationService.getLocation(entity, location)).isInstanceOf(NotFoundException.class);
 
         assertThat(captureOpaRequests())
                 .isNotEmpty()
@@ -136,9 +150,10 @@ class ExternalAuthorizationStaticITest extends BaseSpringBootTest {
     @Test
     void skipsChildCheckWhenParentIsDenied() {
         denyResourceAccess(Resource.ENTITY, ResourceAction.DETAIL);
+        SecuredParentUUID entity = SecuredParentUUID.fromUUID(UUID.randomUUID());
+        SecuredUUID location = SecuredUUID.fromUUID(UUID.randomUUID());
 
-        assertThatThrownBy(() -> locationService
-                .getLocation(SecuredParentUUID.fromUUID(UUID.randomUUID()), SecuredUUID.fromUUID(UUID.randomUUID())))
+        assertThatThrownBy(() -> locationService.getLocation(entity, location))
                 .isInstanceOf(AuthorizationDeniedException.class);
 
         assertThat(captureOpaRequests())

--- a/src/test/java/com/otilm/core/integration/security/authz/ExternalAuthorizationStaticITest.java
+++ b/src/test/java/com/otilm/core/integration/security/authz/ExternalAuthorizationStaticITest.java
@@ -26,17 +26,12 @@ import static org.mockito.Mockito.verify;
 
 /**
  * Regression suite for the static {@link com.otilm.core.security.authz.ExternalAuthorization} annotation exercised
- * through the real Spring AOP stack, entered via the advisor wired in {@code MethodSecurityConfig}.
- *
- * <p>
- * The sibling {@code ExternalAuthorizationDynamicITest} covers {@code @ExternalAuthorizationDynamic}, whose resource is
- * resolved from an argument. This class covers the annotation used by every other guarded service method, pinning the
- * request actually sent to OPA: resource, action, object UUIDs and parent-before-child ordering.
+ * through the real Spring AOP stack, pinning the resource, action, object UUIDs and parent-before-child ordering of
+ * what reaches OPA.
  *
  * <p>
  * Both target resources are declared without owner or group associations, so a denied OPA decision is not rescued by
- * the group/owner fallback in {@code ExternalAuthorizationCore.checkGroupOwnerAssociations} and reaches the caller as a
- * denial. Choosing resources with associations would test the fallback instead of the advisor.
+ * the fallback in {@code ExternalAuthorizationCore.checkGroupOwnerAssociations}.
  */
 class ExternalAuthorizationStaticITest extends BaseSpringBootTest {
 
@@ -78,7 +73,6 @@ class ExternalAuthorizationStaticITest extends BaseSpringBootTest {
         verify(opaClient, never()).checkResourceAccess(any(), any(), any(), any());
     }
 
-    /** Missing identity, as distinct from the wrong identity above: no authentication at all. */
     @Test
     void deniesWhenThereIsNoAuthentication() {
         SecurityContextHolder.clearContext();

--- a/src/test/java/com/otilm/core/integration/security/authz/ExternalAuthorizationStaticITest.java
+++ b/src/test/java/com/otilm/core/integration/security/authz/ExternalAuthorizationStaticITest.java
@@ -45,10 +45,6 @@ class ExternalAuthorizationStaticITest extends BaseSpringBootTest {
     @Autowired
     private LocationExternalService locationService;
 
-    /**
-     * Asserts OPA was consulted as well as that the call succeeded: an unadvised bean would also return a result, so
-     * the return value alone would pass even if the advisor never ran.
-     */
     @Test
     void permitsWhenOpaAuthorizesAnnotatedResourceAndAction() {
         assertThat(signingRecordService.getSearchableFieldInformation())
@@ -57,11 +53,6 @@ class ExternalAuthorizationStaticITest extends BaseSpringBootTest {
         assertThat(captureOpaRequests()).isNotEmpty();
     }
 
-    /**
-     * A token-type rejection produces the same {@link AuthorizationDeniedException} without ever consulting OPA. The
-     * captured request is therefore the discriminator: asserting the type alone would stay green even if the platform
-     * token stopped being injected and this path went unexercised.
-     */
     @Test
     void deniesWhenOpaRejectsAnnotatedResourceAndAction() {
         denyResourceAccess(Resource.SIGNING_RECORD, ResourceAction.LIST);
@@ -75,10 +66,6 @@ class ExternalAuthorizationStaticITest extends BaseSpringBootTest {
         });
     }
 
-    /**
-     * An unrecognised token type is rejected by {@code AbstractExternalAuthorizationManager} before any policy call, so
-     * the absence of an OPA request is what distinguishes this denial from one OPA itself made.
-     */
     @Test
     void deniesWhenAuthenticationIsNotAPlatformToken() {
         SecurityContextHolder
@@ -102,10 +89,6 @@ class ExternalAuthorizationStaticITest extends BaseSpringBootTest {
                 });
     }
 
-    /**
-     * The parent has to be evaluated before the child so that a denied parent can short-circuit the child check, as
-     * {@link #skipsChildCheckWhenParentIsDenied} requires. Submission order is the only evidence of that sequencing.
-     */
     @Test
     void checksParentBeforeChild() {
         assertThatThrownBy(() -> locationService
@@ -123,10 +106,6 @@ class ExternalAuthorizationStaticITest extends BaseSpringBootTest {
                 .containsEntry("action", ResourceAction.DETAIL.getCode());
     }
 
-    /**
-     * Each check carries the UUID of the object it guards. A check reusing the other's UUID would ask OPA about an
-     * object the caller never named, and the answer would authorize the wrong one.
-     */
     @Test
     void sendsEachCheckItsOwnObjectUuid() {
         UUID entityUuid = UUID.randomUUID();
@@ -142,9 +121,6 @@ class ExternalAuthorizationStaticITest extends BaseSpringBootTest {
         assertThat(requests.get(1).getObjectUUIDs()).containsExactly(locationUuid.toString());
     }
 
-    /**
-     * The {@code parentName} and {@code parentAction} properties are internal routing hints and must not reach OPA.
-     */
     @Test
     void omitsInternalRoutingHintsFromTheOpaRequest() {
         assertThatThrownBy(() -> locationService
@@ -157,10 +133,6 @@ class ExternalAuthorizationStaticITest extends BaseSpringBootTest {
                         .doesNotContainKeys("parentName", "parentAction"));
     }
 
-    /**
-     * A denied parent must short-circuit: the child resource is never submitted to OPA. Without this ordering a caller
-     * denied on the parent could still have the child evaluated, which leaks whether the child permits the action.
-     */
     @Test
     void skipsChildCheckWhenParentIsDenied() {
         denyResourceAccess(Resource.ENTITY, ResourceAction.DETAIL);

--- a/src/test/java/com/otilm/core/security/authz/AbstractExternalAuthorizationManagerTest.java
+++ b/src/test/java/com/otilm/core/security/authz/AbstractExternalAuthorizationManagerTest.java
@@ -8,12 +8,15 @@ import java.util.List;
 import java.util.UUID;
 import lombok.Setter;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class AbstractExternalAuthorizationManagerTest {
@@ -22,25 +25,50 @@ class AbstractExternalAuthorizationManagerTest {
 
     Authentication authentication = createPlatformAuthentication();
 
+    /**
+     * {@code check} is deprecated but still abstract on Spring Security 6.5, and the interface's own {@code verify}
+     * default routes through it, so its delegation has to keep returning the same decision as {@code authorize} until
+     * the method is removed.
+     *
+     * <p>
+     * Both outcomes are exercised because denial is what every other exit of {@code authorize} returns as well: pinned
+     * to deny alone, a {@code check} that stopped delegating and returned a constant denial would still pass.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @SuppressWarnings("removal")
+    void deprecatedCheckReturnsTheSameDecisionAsAuthorize(boolean granted) {
+        // given
+        manager.setCheckResult(new AuthorizationDecision(granted));
+
+        // when
+        AuthorizationDecision viaCheck = manager.check(() -> authentication, new Object());
+        AuthorizationDecision viaAuthorize = manager.authorize(() -> authentication, new Object());
+
+        // then
+        assertEquals(granted, viaCheck.isGranted());
+        assertEquals(viaAuthorize.isGranted(), viaCheck.isGranted());
+    }
+
     @Test
-    void abstainsIfAuthenticationIsNotOfTypePlatformAuthenticationToken() {
+    void deniesIfAuthenticationIsNotOfTypePlatformAuthenticationToken() {
         // given
         Authentication auth = new UsernamePasswordAuthenticationToken(null, null);
 
         // when
-        AuthorizationDecision result = manager.check(() -> auth, new Object());
+        AuthorizationDecision result = manager.authorize(() -> auth, new Object());
 
         // then
         assertFalse(result.isGranted());
     }
 
     @Test
-    void abstainsIfCantDecideForGivenObject() {
+    void deniesIfCantDecideForGivenObject() {
         // given
         manager.setCanDecideForGivenObject(false);
 
         // when
-        AuthorizationDecision result = manager.check(() -> authentication, new Object());
+        AuthorizationDecision result = manager.authorize(() -> authentication, new Object());
 
         // then
         assertFalse(result.isGranted());
@@ -52,7 +80,7 @@ class AbstractExternalAuthorizationManagerTest {
         manager.setCheckResult(new AuthorizationDecision(false));
 
         // when
-        AuthorizationDecision result = manager.check(() -> authentication, new Object());
+        AuthorizationDecision result = manager.authorize(() -> authentication, new Object());
 
         // then
         assertFalse(result.isGranted());
@@ -64,7 +92,7 @@ class AbstractExternalAuthorizationManagerTest {
         manager.setAnonymousCheckResult(new AuthorizationDecision(false));
 
         // when
-        AuthorizationDecision result = manager.check(this::getAnonymousToken, new Object());
+        AuthorizationDecision result = manager.authorize(this::getAnonymousToken, new Object());
 
         // then
         assertFalse(result.isGranted());

--- a/src/test/java/com/otilm/core/security/authz/AbstractExternalAuthorizationManagerTest.java
+++ b/src/test/java/com/otilm/core/security/authz/AbstractExternalAuthorizationManagerTest.java
@@ -25,15 +25,6 @@ class AbstractExternalAuthorizationManagerTest {
 
     Authentication authentication = createPlatformAuthentication();
 
-    /**
-     * {@code check} is deprecated but still abstract on Spring Security 6.5, and the interface's own {@code verify}
-     * default routes through it, so its delegation has to keep returning the same decision as {@code authorize} until
-     * the method is removed.
-     *
-     * <p>
-     * Both outcomes are exercised because denial is what every other exit of {@code authorize} returns as well: pinned
-     * to deny alone, a {@code check} that stopped delegating and returned a constant denial would still pass.
-     */
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @SuppressWarnings("removal")

--- a/src/test/java/com/otilm/core/security/authz/ExternalMethodAuthorizationManagerTest.java
+++ b/src/test/java/com/otilm/core/security/authz/ExternalMethodAuthorizationManagerTest.java
@@ -76,7 +76,7 @@ class ExternalMethodAuthorizationManagerTest {
         when(metadataExtractor.extractAttributes(any())).thenReturn(List.of());
 
         // when
-        AuthorizationDecision result = manager.check(() -> authentication, methodInvocationWithoutSecuredUUIDs());
+        AuthorizationDecision result = manager.authorize(() -> authentication, methodInvocationWithoutSecuredUUIDs());
 
         // then
         Assertions.assertTrue(result.isGranted());
@@ -91,7 +91,7 @@ class ExternalMethodAuthorizationManagerTest {
         when(metadataExtractor.extractAttributes(any())).thenReturn(List.of());
 
         // when
-        AuthorizationDecision result = manager.check(() -> authentication, methodInvocationWithoutSecuredUUIDs());
+        AuthorizationDecision result = manager.authorize(() -> authentication, methodInvocationWithoutSecuredUUIDs());
 
         // then
         Assertions.assertFalse(result.isGranted());
@@ -105,7 +105,7 @@ class ExternalMethodAuthorizationManagerTest {
         when(metadataExtractor.extractAttributes(any())).thenReturn(List.of());
 
         // when
-        AuthorizationDecision result = manager.check(() -> authentication, methodInvocationWithoutSecuredUUIDs());
+        AuthorizationDecision result = manager.authorize(() -> authentication, methodInvocationWithoutSecuredUUIDs());
 
         // then
         Assertions.assertFalse(result.isGranted());
@@ -122,7 +122,7 @@ class ExternalMethodAuthorizationManagerTest {
         MethodInvocation mi = methodInvocationWithSecuredUUID("abfbc322-29e1-11ed-a261-0242ac120002");
 
         // when
-        manager.check(() -> authentication, mi);
+        manager.authorize(() -> authentication, mi);
 
         // then
         OpaRequestedResource resource = resourceCaptor.getValue();
@@ -141,7 +141,7 @@ class ExternalMethodAuthorizationManagerTest {
                 "abfbc322-29e1-11ed-a261-0242ac120003");
 
         // when
-        manager.check(() -> authentication, mi);
+        manager.authorize(() -> authentication, mi);
 
         // then
         OpaRequestedResource resource = resourceCaptor.getValue();
@@ -161,7 +161,9 @@ class ExternalMethodAuthorizationManagerTest {
         when(metadataExtractor.extractAttributes(any())).thenReturn(attributes);
 
         // when
-        manager.check(() -> authentication, methodInvocationWithSecuredUUID("abfbc322-29e1-11ed-a261-0242ac120002"));
+        manager
+                .authorize(() -> authentication,
+                        methodInvocationWithSecuredUUID("abfbc322-29e1-11ed-a261-0242ac120002"));
 
         // then
         OpaRequestedResource resource = resourceCaptor.getValue();
@@ -181,7 +183,9 @@ class ExternalMethodAuthorizationManagerTest {
         when(metadataExtractor.extractAttributes(any())).thenReturn(attributes);
 
         // when
-        manager.check(() -> authentication, methodInvocationWithSecuredUUID("abfbc322-29e1-11ed-a261-0242ac120002"));
+        manager
+                .authorize(() -> authentication,
+                        methodInvocationWithSecuredUUID("abfbc322-29e1-11ed-a261-0242ac120002"));
 
         // then
         OpaRequestedResource resource = resourceCaptor.getValue();
@@ -197,7 +201,7 @@ class ExternalMethodAuthorizationManagerTest {
         MethodInvocation mi = methodInvocationWithoutSecuredUUIDs();
 
         // when
-        AuthorizationDecision result = manager.check(() -> authentication, mi);
+        AuthorizationDecision result = manager.authorize(() -> authentication, mi);
 
         // then
         assertFalse(result.isGranted());
@@ -214,7 +218,7 @@ class ExternalMethodAuthorizationManagerTest {
         Authentication anonymousToken = AuthenticationTokenTestHelper.getAnonymousToken("anonymousUser");
 
         // when
-        manager.check(() -> anonymousToken, methodInvocationWithoutSecuredUUIDs());
+        manager.authorize(() -> anonymousToken, methodInvocationWithoutSecuredUUIDs());
 
         // then
         String principal = principalCaptor.getValue();
@@ -238,7 +242,7 @@ class ExternalMethodAuthorizationManagerTest {
                 SecuredResource.fromResource(Resource.RA_PROFILE));
 
         // when
-        AuthorizationDecision result = manager.check(() -> authentication, invocation);
+        AuthorizationDecision result = manager.authorize(() -> authentication, invocation);
 
         // then
         Assertions.assertTrue(result.isGranted());
@@ -252,7 +256,7 @@ class ExternalMethodAuthorizationManagerTest {
                 target.getClass().getMethod("dynamicListMethod", SecuredResource.class), (SecuredResource) null);
 
         // when
-        AuthorizationDecision result = manager.check(() -> authentication, invocation);
+        AuthorizationDecision result = manager.authorize(() -> authentication, invocation);
 
         // then
         assertFalse(result.isGranted());

--- a/src/test/java/com/otilm/core/util/AuthHelperDeniedPermissionTest.java
+++ b/src/test/java/com/otilm/core/util/AuthHelperDeniedPermissionTest.java
@@ -61,8 +61,8 @@ class AuthHelperDeniedPermissionTest {
     }
 
     /**
-     * The regression this pins: with the pair held at session scope, a second request on the same session reads the
-     * first request's denial, so a 403 can name a permission that was never checked.
+     * At session scope, a second request on the same session reads the first request's denial, so a 403 can name a
+     * permission that was never checked.
      */
     @Test
     void deniedPairDoesNotLeakIntoALaterRequestOnTheSameSession() {

--- a/src/test/java/com/otilm/core/util/AuthHelperDeniedPermissionTest.java
+++ b/src/test/java/com/otilm/core/util/AuthHelperDeniedPermissionTest.java
@@ -1,0 +1,88 @@
+package com.otilm.core.util;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Scope contract of the denied resource/action pair recorded on an authorization failure.
+ *
+ * <p>
+ * The pair is read back by {@code ExceptionHandlingAdvice} to name the permission in a 403 body and by
+ * {@code AuditLogAspect} to log it. Both read it during the same request that wrote it, so the pair must not outlive
+ * that request: a denial reaching either reader with a previous request's pair still visible would report a decision
+ * the caller never triggered.
+ */
+class AuthHelperDeniedPermissionTest {
+
+    @AfterEach
+    void clearRequestContext() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    private MockHttpServletRequest bindRequest() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+        return request;
+    }
+
+    private MockHttpServletRequest bindRequest(MockHttpSession session) {
+        MockHttpServletRequest request = bindRequest();
+        request.setSession(session);
+        return request;
+    }
+
+    @Test
+    void deniedPairIsReadableWithinTheRequestThatRecordedIt() {
+        bindRequest();
+
+        AuthHelper.setDeniedPermissionResourceAction("certificates", "detail");
+
+        assertThat(AuthHelper.getDeniedPermissionResource()).isEqualTo("certificates");
+        assertThat(AuthHelper.getDeniedPermissionResourceAction()).isEqualTo("detail");
+    }
+
+    /**
+     * Session scope would create a session here, which persists a session row for every 403 and lets the pair escape
+     * into later requests.
+     */
+    @Test
+    void recordingADeniedPairCreatesNoSession() {
+        MockHttpServletRequest request = bindRequest();
+
+        AuthHelper.setDeniedPermissionResourceAction("certificates", "detail");
+
+        assertThat(request.getSession(false)).as("recording a denial must not create a session").isNull();
+    }
+
+    /**
+     * The regression this pins: with the pair held at session scope, a second request on the same session reads the
+     * first request's denial, so a 403 can name a permission that was never checked.
+     */
+    @Test
+    void deniedPairDoesNotLeakIntoALaterRequestOnTheSameSession() {
+        MockHttpSession sharedSession = new MockHttpSession();
+        bindRequest(sharedSession);
+        AuthHelper.setDeniedPermissionResourceAction("certificates", "detail");
+
+        bindRequest(sharedSession);
+
+        assertThat(AuthHelper.getDeniedPermissionResource())
+                .as("the pair must not survive into the next request")
+                .isNull();
+        assertThat(AuthHelper.getDeniedPermissionResourceAction()).isNull();
+    }
+
+    @Test
+    void readingWithNoBoundRequestYieldsNothing() {
+        RequestContextHolder.resetRequestAttributes();
+
+        assertThat(AuthHelper.getDeniedPermissionResource()).isNull();
+        assertThat(AuthHelper.getDeniedPermissionResourceAction()).isNull();
+    }
+}

--- a/src/test/java/com/otilm/core/util/BaseSpringBootTest.java
+++ b/src/test/java/com/otilm/core/util/BaseSpringBootTest.java
@@ -13,6 +13,7 @@ import com.otilm.core.security.authn.PlatformUserDetails;
 import com.otilm.core.security.authn.client.AuthenticationInfo;
 import com.otilm.core.security.authz.opa.OpaClient;
 import com.otilm.core.security.authz.opa.dto.OpaObjectAccessResult;
+import com.otilm.core.security.authz.opa.dto.OpaRequestedResource;
 import com.otilm.core.security.authz.opa.dto.OpaResourceAccessResult;
 import com.otilm.core.service.SettingInternalService;
 import java.sql.SQLException;
@@ -20,6 +21,7 @@ import java.util.List;
 import java.util.UUID;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -99,6 +101,17 @@ public class BaseSpringBootTest {
                                         && action.getCode().equals(req.getProperties().get("action"))),
                         Mockito.any(), Mockito.any()))
                 .thenReturn(denied);
+    }
+
+    /**
+     * Every resource-access request submitted to OPA so far, in submission order.
+     */
+    protected List<OpaRequestedResource> captureOpaRequests() {
+        ArgumentCaptor<OpaRequestedResource> captor = ArgumentCaptor.forClass(OpaRequestedResource.class);
+        Mockito
+                .verify(opaClient, Mockito.atLeastOnce())
+                .checkResourceAccess(Mockito.any(), captor.capture(), Mockito.any(), Mockito.any());
+        return captor.getAllValues();
     }
 
     /**

--- a/src/test/java/com/otilm/core/util/BaseSpringBootTest.java
+++ b/src/test/java/com/otilm/core/util/BaseSpringBootTest.java
@@ -34,6 +34,7 @@ import org.springframework.test.context.TestExecutionListeners.MergeMode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest
@@ -108,8 +109,7 @@ public class BaseSpringBootTest {
      */
     protected List<OpaRequestedResource> captureOpaRequests() {
         ArgumentCaptor<OpaRequestedResource> captor = ArgumentCaptor.forClass(OpaRequestedResource.class);
-        Mockito
-                .verify(opaClient, Mockito.atLeastOnce())
+        verify(opaClient, Mockito.atLeastOnce())
                 .checkResourceAccess(Mockito.any(), captor.capture(), Mockito.any(), Mockito.any());
         return captor.getAllValues();
     }


### PR DESCRIPTION
**Closes #2015. This pins the `@ExternalAuthorization` stack with a regression suite, clears every Spring Security deprecation in that stack, and fixes one real bug the suite found: a denial with no recorded permission destroyed the audit record and the denial with it.**

Three strands of work, all in one commit because the tests are what made the other two safe.

## 1. The bug

`AuditLogAspect` names the denied permission in its audit message. To do that it reads a resource/action pair that the authorization layer records on the request.

**Not every denial records that pair.** Only `ExternalAuthorizationCore` writes it. An object-level OPA failure and a rejected token type both arrive with nothing recorded.

**When it's fine:** a resource-level denial. `ExternalAuthorizationCore.decideBasedOnOpaResult` records the pair before it returns one — including when the OPA call itself failed, because `checkAccess` swallows the exception and returns `unauthorized()`. Every one of these paths has a pair to read.

**When it breaks:** an object-level OPA failure. `AuthHelper.loadObjectPermissions` has no try/catch, so the `AccessDeniedException` propagates with nothing recorded. `Resource.findByCode(null)` then throws from inside the aspect's own catch block — the block that was about to re-raise the denial. The denial is destroyed on its way out. The `finally` block still runs and writes an audit record with no operation result, so the insert fails too.

The fix is a null guard, in an extracted `appendDeniedPermission` helper.

## 2. The deprecations

| API | On 6.5.11 (today) | On 7.1.0 (target) | What we did |
|---|---|---|---|
| `AuthorizationManager.check` | abstract **and** deprecated | gone | kept, delegates to `authorize` |
| `AuthorizationManager.authorize` | default method | the only method | now holds the decision |
| `ConfigAttribute` | deprecated | gone | removed |
| `security.access.AccessDeniedException` | not deprecated | still there | left alone |

**`check` is both abstract and deprecated on 6.5.11.** That is why this cannot be finished today. We are required to implement it and warned for doing so. The decision logic moved to `authorize`, which survives; `check` is now `@Deprecated(forRemoval = true)` and does nothing but delegate.

**One thing will still break at 7.1.0.** The supplier widens from `Supplier<Authentication>` to `Supplier<? extends Authentication>`, so our override stops being an override. It is one parameter type in one class, and the note is in the Javadoc on `check` so the upgrade finds both changes together.

`AccessDeniedException` is **not** deprecated and still exists in 7.1.0. We import it in 22 places. It is easy to assume the whole `security.access` package dies with `ConfigAttribute`; it does not.

## 3. The regression suite

The suite pins what the annotation stack actually sends to OPA: resource, action, object UUIDs, and parent-before-child ordering. A denied parent must short-circuit the child check, because evaluating the child leaks whether it would have permitted the action.

The HTTP tests double as a guard on request scope. The test schema has no Spring Session tables, so if the denied pair ever moves back to session scope, recording it creates a session and those tests fail on the `core.spring_session` insert. Add the DDL to make that failure go away and the guard is gone with it.

## Verification

- Full suite: **5208 tests, 0 failures**.
- New-lines coverage: **94.1%**, against the 80% gate.
- Fix 1 is mutation-checked. With the null guard removed the new test fails, so it discriminates rather than just passing.
- `ContextSignatureGuardTest` BASELINE is unchanged at 58 — no new Spring context was purchased.

Two full runs each hit a flake that is not from this branch. `DiscoveryServiceMessagingITest` timed out connecting to the broker; `SigningProfileServiceImplITest` failed on the connector-mock port collision, and **the failing test moved between two otherwise identical runs**. Both classes pass in isolation on this commit.

## Worth knowing for the rest of the migration

Fifteen test call sites moved from `check` to `authorize` by hand. None of them produced a deprecation warning, because calling a non-deprecated override does not warn. `-Xlint:deprecation` cannot see them, so a compiler-driven sweep would have missed every one. **Warning counts are not a complete inventory.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
