### PR TITLE
Build preview Docker images for pull requests labelled preview

### DIFF
--- a/.github/workflows/build_preview_docker.yml
+++ b/.github/workflows/build_preview_docker.yml
@@ -1,0 +1,139 @@
+name: Build Preview Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:   { description: "PR number", required: true }
+      head_sha:    { description: "Head commit SHA", required: true }
+      head_repo:   { description: "Fork repo full_name", required: true }
+      head_branch: { description: "Fork branch", required: true }
+      base_ref:    { description: "Base branch", required: true }
+
+run-name: >-
+  Docker Preview • PR #${{ inputs.pr_number }}
+  • ${{ inputs.head_repo }}@${{ inputs.head_branch }} → ${{ inputs.base_ref }}
+  • ${{ inputs.head_sha }}
+
+# Superseding an earlier run cancels it, and finalize_check closes the stale
+# commit's check as cancelled rather than leaving it at in_progress.
+concurrency:
+  group: preview-pr-${{ inputs.pr_number }}-docker
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  # A dispatched run does not attach to the PR on its own, so the build reports
+  # through a check created against the head commit.
+  create_check:
+    name: Create GitHub Check
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      check_id: ${{ steps.create_check.outputs.check_id }}
+    steps:
+      - name: Generate token
+        id: app_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.SONAR_GH_APP_ID }}
+          private_key: ${{ secrets.SONAR_GH_APP_PRIVATE_KEY }}
+
+      - name: Create GitHub Check (in_progress)
+        id: create_check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          HEAD_SHA: ${{ inputs.head_sha }}
+        with:
+          github-token: ${{ steps.app_token.outputs.token }}
+          script: |
+            const check = await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: "Docker preview build",
+              head_sha: process.env.HEAD_SHA,
+              status: "in_progress"
+            });
+            core.setOutput("check_id", check.data.id);
+
+  build:
+    name: Build & push preview image
+    needs: [create_check]
+    permissions:
+      contents: read
+      # The Maven pre-build resolves the com.otilm parent POM from GitHub
+      # Packages, which refuses an unauthenticated read.
+      packages: read
+    # Deliberately unpinned: this is a first-party OmniTrustILM reusable workflow
+    # and edits to it are meant to reach every repo without a bump here.
+    uses: OmniTrustILM/.github/.github/workflows/containers-build-and-push.yml@main
+    secrets:
+      CONTAINER_REGISTRY_USERNAME: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
+      CONTAINER_REGISTRY_PASSWORD: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+    with:
+      image: ilm-preview/core
+      cache-scope: core-preview
+      pre-build: maven
+      # Pinning the commit rather than the branch keeps the published tag
+      # honest when a push lands mid-run. A fork commit resolves here because
+      # fork objects live in this repository's network.
+      ref: ${{ inputs.head_sha }}
+      # A preview is not a release: it carries no signature, and its checkout is
+      # a fork branch rather than the canonical README.
+      sign: false
+      push-readme: false
+      # Replaces the default rules, which would otherwise publish rolling
+      # develop-latest and develop-<sha> tags onto the preview path.
+      tag-rules: type=raw,value=pr-${{ inputs.pr_number }}-${{ inputs.head_sha }}
+
+  finalize_check:
+    name: Finalize GitHub Check
+    runs-on: ubuntu-latest
+    needs: [create_check, build]
+    permissions: {}
+    # Keyed on the check id rather than on create_check's conclusion, which reads
+    # 'cancelled' or 'failure' in exactly the cases where a created check still
+    # needs closing. The id is recorded a round trip after the check exists, so a
+    # run cancelled inside that window strands its check on the superseded commit.
+    # The current commit always gets a fresh check either way.
+    if: ${{ always() && needs.create_check.outputs.check_id != '' }}
+    steps:
+      - name: Generate token
+        id: app_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.SONAR_GH_APP_ID }}
+          private_key: ${{ secrets.SONAR_GH_APP_PRIVATE_KEY }}
+
+      - name: Report the build result on the check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CHECK_ID: ${{ needs.create_check.outputs.check_id }}
+          CREATE_RESULT: ${{ needs.create_check.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+        with:
+          github-token: ${{ steps.app_token.outputs.token }}
+          script: |
+            const build = process.env.BUILD_RESULT;
+            const create = process.env.CREATE_RESULT;
+
+            // The build is skipped whenever create_check did not succeed, so the
+            // check reports that job's outcome instead. create_check can fail
+            // after emitting the check id, because the token action revokes the
+            // token in a post step.
+            let conclusion;
+            if (build === "success") {
+              conclusion = "success";
+            } else if (build === "cancelled" || create === "cancelled") {
+              conclusion = "cancelled";
+            } else {
+              conclusion = "failure";
+            }
+
+            await github.rest.checks.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              check_run_id: Number(process.env.CHECK_ID),
+              status: "completed",
+              conclusion
+            });

--- a/.github/workflows/dispatch-preview-docker.yml
+++ b/.github/workflows/dispatch-preview-docker.yml
@@ -1,0 +1,134 @@
+name: Dispatch preview docker
+on:
+  workflow_run:
+    workflows: [ "Prepare preview" ]
+    types: [ completed ]
+
+permissions:
+  actions: write # download artifact + create workflow dispatch
+  contents: read
+  pull-requests: read # re-read the PR to confirm the preview label
+
+jobs:
+  dispatch:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download PR context artifact from upstream run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pr-context
+          path: pr_context
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # A pull_request run executes the workflow file from the PR head, so a fork
+      # authors the job that writes this artifact and controls every value in it.
+      # Only the PR number is taken from here, and the step below binds the PR it
+      # names to this run's own head before any build input is exported.
+      - name: Read the PR number from the artifact
+        id: ctx
+        run: |
+          pr_number="$(jq -r '.pr_number' pr_context/pr-context.json)"
+          if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr_number in pr-context.json is not a number"
+            exit 1
+          fi
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      # The label is the authorisation to build and publish fork-authored code
+      # with this repository's credentials, so it is confirmed against the API
+      # rather than against the artifact, which the fork wrote. Every build input
+      # is taken from the same response for the same reason.
+      - name: Resolve the PR and confirm the preview label
+        id: pr
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(process.env.PR_NUMBER)
+            });
+
+            if (pr.state !== "open") {
+              core.setFailed(`PR #${pr.number} is ${pr.state}; refusing to build a preview.`);
+              return;
+            }
+            if (!pr.labels.some(label => label.name === "preview")) {
+              core.setFailed(`PR #${pr.number} does not carry the preview label; refusing to build a preview.`);
+              return;
+            }
+            // Null once the fork is deleted, which would otherwise surface as an
+            // opaque 422 from the dispatch call below.
+            if (!pr.head.repo) {
+              core.setFailed(`PR #${pr.number} has no head repository; the fork was probably deleted.`);
+              return;
+            }
+
+            // Bind the PR to the run that asked for the build. The number came from
+            // the fork-written artifact, so without this a fork could name any
+            // labelled PR and drive its builds: the concurrency group is keyed on
+            // the PR number, so repeated dispatches would cancel that PR's own
+            // preview builds. The workflow_run payload is GitHub's, not the fork's.
+            const run = context.payload.workflow_run;
+            if (pr.head.repo.full_name !== run.head_repository.full_name ||
+                pr.head.ref !== run.head_branch) {
+              core.setFailed(
+                `PR #${pr.number} is ${pr.head.repo.full_name}@${pr.head.ref}, but this run is ` +
+                `${run.head_repository.full_name}@${run.head_branch}; refusing to build another PR.`
+              );
+              return;
+            }
+
+            // The branch moved on while this relay was in flight. The push that
+            // moved it starts its own run, so this one has nothing left to do.
+            if (pr.head.sha !== run.head_sha) {
+              core.notice(
+                `PR #${pr.number} has moved from ${run.head_sha} to ${pr.head.sha}; a newer run will build it.`
+              );
+              core.setOutput("dispatch", "false");
+              return;
+            }
+
+            core.setOutput("dispatch", "true");
+            core.setOutput("pr_number", String(pr.number));
+            core.setOutput("head_sha", pr.head.sha);
+            core.setOutput("head_repo", pr.head.repo.full_name);
+            core.setOutput("head_branch", pr.head.ref);
+            core.setOutput("base_ref", pr.base.ref);
+
+      # A branch name may legally contain a quote or a backtick, so PR-derived
+      # values reach the script through the environment. Interpolating them into
+      # the body would let a crafted name execute with this token.
+      - name: Dispatch build preview docker workflow with inputs
+        if: ${{ steps.pr.outputs.dispatch == 'true' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          HEAD_REPO: ${{ steps.pr.outputs.head_repo }}
+          HEAD_BRANCH: ${{ steps.pr.outputs.head_branch }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'build_preview_docker.yml',
+              // The build workflow always comes from the default branch. Using the
+              // PR's base branch would run whatever branch-local copy it happens to
+              // carry, or fail outright on a release or hotfix branch that has none.
+              // base_ref stays an input, as build metadata.
+              ref: context.payload.repository.default_branch,
+              inputs: {
+                pr_number: process.env.PR_NUMBER,
+                head_sha: process.env.HEAD_SHA,
+                head_repo: process.env.HEAD_REPO,
+                head_branch: process.env.HEAD_BRANCH,
+                base_ref: process.env.BASE_REF
+              }
+            });

--- a/.github/workflows/prepare_preview.yml
+++ b/.github/workflows/prepare_preview.yml
@@ -1,0 +1,53 @@
+name: Prepare preview
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Prepare preview
+    runs-on: ubuntu-latest
+
+    # Run when "preview" is the label just applied, or when an already labelled PR
+    # gets a new commit. Testing the label list on every event would also rebuild
+    # for unrelated label changes while "preview" happens to be present.
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'preview') ||
+      ((github.event.action == 'synchronize' || github.event.action == 'reopened') &&
+       contains(github.event.pull_request.labels.*.name, 'preview'))
+
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      # Package up PR context for downstream workflow_run
+      - name: Prepare PR context artifact
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          jq -n \
+            --arg pr_number "$PR_NUMBER" \
+            --arg head_sha "$HEAD_SHA" \
+            --arg head_repo "$HEAD_REPO" \
+            --arg head_branch "$HEAD_BRANCH" \
+            --arg base_ref "$BASE_REF" \
+            '{pr_number: $pr_number, head_sha: $head_sha, head_repo: $head_repo, head_branch: $head_branch, base_ref: $base_ref}' \
+            > pr-context.json
+
+      - name: Upload PR context
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-context
+          path: pr-context.json
+          retention-days: 1
+          if-no-files-found: error


### PR DESCRIPTION
Adds three workflows that build a preview container image when a pull request carries the `preview` label.

- `prepare_preview.yml` writes the pull request context as an artifact.
- `dispatch-preview-docker.yml` reads the pull request through the API, requires the `preview` label, and dispatches the build.
- `build_preview_docker.yml` reports a `Docker preview build` check against the head commit and publishes `ilm-preview/core` tagged `pr-<number>-<sha>`.