### PR TITLE
Serve the cryptographic asset inventory contract with a 501 stub

### DIFF
--- a/src/main/java/com/otilm/core/api/web/CryptographicAssetControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/CryptographicAssetControllerImpl.java
@@ -1,0 +1,52 @@
+package com.otilm.core.api.web;
+
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.interfaces.core.web.CryptographicAssetController;
+import com.otilm.api.model.client.certificate.SearchRequestDto;
+import com.otilm.api.model.common.PaginationResponseDto;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetDetailDto;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetDto;
+import com.otilm.api.model.core.logging.enums.Module;
+import com.otilm.api.model.core.logging.enums.Operation;
+import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
+import com.otilm.core.aop.AuditLogged;
+import com.otilm.core.logging.LogResource;
+import com.otilm.core.security.authz.SecuredUUID;
+import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.service.CryptographicAssetExternalService;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CryptographicAssetControllerImpl implements CryptographicAssetController {
+
+    private CryptographicAssetExternalService cryptographicAssetService;
+
+    @Autowired
+    public void setCryptographicAssetService(CryptographicAssetExternalService cryptographicAssetService) {
+        this.cryptographicAssetService = cryptographicAssetService;
+    }
+
+    @Override
+    @AuditLogged(module = Module.CORE, resource = Resource.CRYPTO_ASSET, operation = Operation.LIST)
+    public PaginationResponseDto<CryptographicAssetDto> listCryptographicAssets(SearchRequestDto request) {
+        return cryptographicAssetService.listCryptographicAssets(SecurityFilter.create(), request);
+    }
+
+    @Override
+    @AuditLogged(module = Module.CORE, resource = Resource.CRYPTO_ASSET, operation = Operation.DETAIL)
+    public CryptographicAssetDetailDto getCryptographicAsset(@LogResource(uuid = true) UUID uuid)
+            throws NotFoundException {
+        return cryptographicAssetService.getCryptographicAsset(SecuredUUID.fromUUID(uuid));
+    }
+
+    @Override
+    @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.CRYPTO_ASSET,
+            operation = Operation.LIST)
+    public List<SearchFieldDataByGroupDto> getSearchableFieldInformation() {
+        return cryptographicAssetService.getSearchableFieldInformationByGroup();
+    }
+}

--- a/src/main/java/com/otilm/core/api/web/StatisticsControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/StatisticsControllerImpl.java
@@ -1,6 +1,7 @@
 package com.otilm.core.api.web;
 
 import com.otilm.api.interfaces.core.web.StatisticsController;
+import com.otilm.api.model.client.dashboard.CryptographicAssetStatisticsDto;
 import com.otilm.api.model.client.dashboard.SigningRecordStatisticsDto;
 import com.otilm.api.model.client.dashboard.SigningRecordStatisticsPeriod;
 import com.otilm.api.model.client.dashboard.StatisticsDto;
@@ -9,6 +10,7 @@ import com.otilm.api.model.core.logging.enums.Module;
 import com.otilm.api.model.core.logging.enums.Operation;
 import com.otilm.core.aop.AuditLogged;
 import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.service.CryptographicAssetExternalService;
 import com.otilm.core.service.SigningRecordExternalService;
 import com.otilm.core.service.StatisticsExternalService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +21,7 @@ public class StatisticsControllerImpl implements StatisticsController {
 
     private StatisticsExternalService statisticsService;
     private SigningRecordExternalService signingRecordService;
+    private CryptographicAssetExternalService cryptographicAssetService;
 
     @Autowired
     public void setStatisticsService(StatisticsExternalService statisticsService) {
@@ -28,6 +31,11 @@ public class StatisticsControllerImpl implements StatisticsController {
     @Autowired
     public void setSigningRecordService(SigningRecordExternalService signingRecordService) {
         this.signingRecordService = signingRecordService;
+    }
+
+    @Autowired
+    public void setCryptographicAssetService(CryptographicAssetExternalService cryptographicAssetService) {
+        this.cryptographicAssetService = cryptographicAssetService;
     }
 
     @Override
@@ -40,5 +48,11 @@ public class StatisticsControllerImpl implements StatisticsController {
     @AuditLogged(module = Module.SIGNING, resource = Resource.SIGNING_RECORD, operation = Operation.STATISTICS)
     public SigningRecordStatisticsDto getSigningRecordStatistics(SigningRecordStatisticsPeriod period) {
         return signingRecordService.getSigningRecordStatistics(period, SecurityFilter.create());
+    }
+
+    @Override
+    @AuditLogged(module = Module.CORE, resource = Resource.CRYPTO_ASSET, operation = Operation.STATISTICS)
+    public CryptographicAssetStatisticsDto getCryptographicAssetStatistics() {
+        return cryptographicAssetService.getCryptographicAssetStatistics();
     }
 }

--- a/src/main/java/com/otilm/core/model/auth/Resource.java
+++ b/src/main/java/com/otilm/core/model/auth/Resource.java
@@ -79,6 +79,7 @@ public enum Resource {
 
     // CBOMS
     CBOM("cboms"),
+    CRYPTO_ASSET("cryptoAssets"),
 
     // SIGNING
     TIME_QUALITY_CONFIGURATION("timeQualityConfigurations"),

--- a/src/main/java/com/otilm/core/service/CryptographicAssetExternalService.java
+++ b/src/main/java/com/otilm/core/service/CryptographicAssetExternalService.java
@@ -1,0 +1,61 @@
+package com.otilm.core.service;
+
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.model.client.certificate.SearchRequestDto;
+import com.otilm.api.model.client.dashboard.CryptographicAssetStatisticsDto;
+import com.otilm.api.model.common.PaginationResponseDto;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetDetailDto;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetDto;
+import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
+import com.otilm.core.security.authz.SecuredUUID;
+import com.otilm.core.security.authz.SecurityFilter;
+import java.util.List;
+
+/**
+ * Read side of the cryptographic asset inventory — the deduplicated cross-CBOM asset view served under
+ * {@code /v1/cryptoAssets}. Assets enter the inventory through the CBOM document sync, so this service has no write
+ * operations; the sync itself stays on the CBOM services.
+ *
+ * <p>
+ * Every operation currently rejects with {@link com.otilm.api.exception.NotSupportedException}: the API contract is
+ * ratified (interfaces#909, interfaces#913) but the inventory projection and its persistence are not built yet. The
+ * authorization annotations on the implementation are live, so the resource and its actions reach the auth service
+ * before the data does and the endpoints answer 403 to an unpermitted caller rather than 501.
+ */
+public interface CryptographicAssetExternalService {
+
+    /**
+     * List one page of the deduplicated cross-CBOM asset inventory, narrowed by the filters in the request.
+     *
+     * @param filter security filter narrowing the result to the caller's permitted objects
+     * @param request search request carrying the filters, sort and paging
+     * @return one page of matching assets
+     */
+    PaginationResponseDto<CryptographicAssetDto> listCryptographicAssets(SecurityFilter filter,
+            SearchRequestDto request);
+
+    /**
+     * Retrieve one asset with its verdict provenance, normalized properties, per-source payloads and recorded object
+     * identifiers.
+     *
+     * @param uuid secured unique identifier of the asset
+     * @return the asset detail
+     * @throws NotFoundException if no asset with the given UUID is in the inventory
+     */
+    CryptographicAssetDetailDto getCryptographicAsset(SecuredUUID uuid) throws NotFoundException;
+
+    /**
+     * Fields the list operation accepts in its filters, grouped by field source.
+     *
+     * @return the searchable field definitions
+     */
+    List<SearchFieldDataByGroupDto> getSearchableFieldInformationByGroup();
+
+    /**
+     * Count badges, distribution maps and the sync-completeness block for the inventory dashboard. Shares the list
+     * permission with {@link #listCryptographicAssets} rather than carrying a gate of its own.
+     *
+     * @return the dashboard statistics
+     */
+    CryptographicAssetStatisticsDto getCryptographicAssetStatistics();
+}

--- a/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
@@ -1,0 +1,61 @@
+package com.otilm.core.service.impl;
+
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.exception.NotSupportedException;
+import com.otilm.api.model.client.certificate.SearchRequestDto;
+import com.otilm.api.model.client.dashboard.CryptographicAssetStatisticsDto;
+import com.otilm.api.model.common.PaginationResponseDto;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetDetailDto;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetDto;
+import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
+import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.security.authz.ExternalAuthorization;
+import com.otilm.core.security.authz.SecuredUUID;
+import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.service.CryptographicAssetExternalService;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/**
+ * Serves the ratified cryptographic asset inventory contract with a refusal on every operation: the inventory
+ * projection over stored CBOM documents does not exist yet, so there is nothing to read. The authorization annotations
+ * are the working part — they register {@code cryptoAssets:list} and {@code cryptoAssets:detail} with the auth service
+ * on context refresh, which is what lets roles be defined and the frontend's generated client be wired against the real
+ * gates while the read model is built.
+ *
+ * <p>
+ * {@link NotSupportedException} maps to HTTP 501 in {@code ExceptionHandlingAdvice}, so a permitted caller learns the
+ * operation is not implemented while an unpermitted one is still refused with 403 by the authorization aspect ahead of
+ * this body.
+ */
+@Service
+public class CryptographicAssetServiceImpl implements CryptographicAssetExternalService {
+
+    private static final String NOT_IMPLEMENTED = "Cryptographic asset inventory is not implemented yet";
+
+    @Override
+    @ExternalAuthorization(resource = Resource.CRYPTO_ASSET, action = ResourceAction.LIST)
+    public PaginationResponseDto<CryptographicAssetDto> listCryptographicAssets(SecurityFilter filter,
+            SearchRequestDto request) {
+        throw new NotSupportedException(NOT_IMPLEMENTED);
+    }
+
+    @Override
+    @ExternalAuthorization(resource = Resource.CRYPTO_ASSET, action = ResourceAction.DETAIL)
+    public CryptographicAssetDetailDto getCryptographicAsset(SecuredUUID uuid) throws NotFoundException {
+        throw new NotSupportedException(NOT_IMPLEMENTED);
+    }
+
+    @Override
+    @ExternalAuthorization(resource = Resource.CRYPTO_ASSET, action = ResourceAction.LIST)
+    public List<SearchFieldDataByGroupDto> getSearchableFieldInformationByGroup() {
+        throw new NotSupportedException(NOT_IMPLEMENTED);
+    }
+
+    @Override
+    @ExternalAuthorization(resource = Resource.CRYPTO_ASSET, action = ResourceAction.LIST)
+    public CryptographicAssetStatisticsDto getCryptographicAssetStatistics() {
+        throw new NotSupportedException(NOT_IMPLEMENTED);
+    }
+}

--- a/src/test/java/com/otilm/core/integration/api/web/CryptographicAssetControllerStubITest.java
+++ b/src/test/java/com/otilm/core/integration/api/web/CryptographicAssetControllerStubITest.java
@@ -1,0 +1,62 @@
+package com.otilm.core.integration.api.web;
+
+import com.otilm.api.exception.NotSupportedException;
+import com.otilm.api.interfaces.core.web.CryptographicAssetController;
+import com.otilm.api.interfaces.core.web.StatisticsController;
+import com.otilm.api.model.client.certificate.SearchRequestDto;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.core.auth.ContextRefreshListener;
+import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.model.auth.ResourceSyncRequestDto;
+import com.otilm.core.util.BaseSpringBootTest;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The cryptographic asset inventory endpoints exist so the contract ratified in interfaces#909 is served by a real
+ * bean, but the read model behind them is not built yet. This pins both halves of that state: every operation refuses
+ * with {@link NotSupportedException} (HTTP 501), and the resource still reaches the auth service with its list and
+ * detail actions, so roles can be defined against it before the data arrives.
+ *
+ * <p>
+ * When the inventory is implemented, the refusal assertions are what should fail first.
+ */
+class CryptographicAssetControllerStubITest extends BaseSpringBootTest {
+
+    @Autowired
+    private CryptographicAssetController cryptographicAssetController;
+
+    @Autowired
+    private StatisticsController statisticsController;
+
+    @Autowired
+    private ContextRefreshListener contextRefreshListener;
+
+    @Test
+    void everyInventoryOperationRefusesAsNotImplemented() {
+        assertThatThrownBy(() -> cryptographicAssetController.listCryptographicAssets(new SearchRequestDto()))
+                .isInstanceOf(NotSupportedException.class);
+        assertThatThrownBy(() -> cryptographicAssetController.getCryptographicAsset(UUID.randomUUID()))
+                .isInstanceOf(NotSupportedException.class);
+        assertThatThrownBy(() -> cryptographicAssetController.getSearchableFieldInformation())
+                .isInstanceOf(NotSupportedException.class);
+        assertThatThrownBy(() -> statisticsController.getCryptographicAssetStatistics())
+                .isInstanceOf(NotSupportedException.class);
+    }
+
+    @Test
+    void theResourceIsRegisteredWithItsReadActions() {
+        ResourceSyncRequestDto synced = contextRefreshListener
+                .getResources()
+                .stream()
+                .filter(resource -> resource.getName().getCode().equals(Resource.CRYPTO_ASSET.getCode()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Resource not synced: " + Resource.CRYPTO_ASSET.getCode()));
+
+        assertThat(synced.getActions()).contains(ResourceAction.LIST.getCode(), ResourceAction.DETAIL.getCode());
+    }
+}

--- a/src/test/java/com/otilm/core/integration/service/AuthServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/AuthServiceITest.java
@@ -503,6 +503,19 @@ class AuthServiceITest extends BaseSpringBootTest {
                         ]
                     },
                     {
+                        "uuid": "8f3c9e5a-7d21-4b6f-9c48-2e5a1d0b7c93",
+                        "name": "cryptoAssets",
+                        "displayName": "Cryptographic Assets",
+                        "objectAccess": false,
+                        "actions": [
+                            {
+                                "uuid": "53421445-5d6e-4257-b59d-235aaf26e61e",
+                                "name": "list",
+                                "displayName": "List"
+                            }
+                        ]
+                    },
+                    {
                         "uuid": "2a44538f-b607-48cf-ba2a-e8d2b5f71402",
                         "name": "discoveries",
                         "displayName": "Discoveries",


### PR DESCRIPTION
Depends on OmniTrustILM/interfaces#913 (and the contract from interfaces#909). CI here will fail to compile until that merges and the interfaces snapshot is published.

## What

- `CryptographicAssetControllerImpl` — implements `/v1/cryptoAssets` list, detail and searchable-fields.
- `CryptographicAssetExternalService` + `CryptographicAssetServiceImpl` — every operation throws `NotSupportedException` (HTTP 501 via `ExceptionHandlingAdvice`).
- `StatisticsControllerImpl.getCryptographicAssetStatistics()` — same refusal; core did not compile without it once #909 landed.
- `com.otilm.core.model.auth.Resource` — adds `CRYPTO_ASSET("cryptoAssets")`.

## Why a service layer rather than throwing in the controller

The authorization annotations are the part that actually works. `@ExternalAuthorization(resource = CRYPTO_ASSET, action = LIST/DETAIL)` registers the resource and its actions with the auth service on context refresh, so roles can be defined and the frontend wired against the real gates while the read model is built. An unpermitted caller gets 403 from the aspect ahead of the 501. A controller-only stub would leave the endpoints ungated and the resource actionless in the role editor.

The statistics operation shares the `LIST` action rather than carrying a gate of its own, per the contract's Javadoc.

## The auth-sync enum

Core carries a second resource enum (`com.otilm.core.model.auth.Resource`) that `ContextRefreshListener` resolves codes against. Without the `CRYPTO_ASSET` entry, context refresh fails at startup with `Unknown Resource Name cryptoAssets` — caught by booting the context in the new test, not by compilation.

## Not in scope

The inventory read model itself: the projection over stored CBOM documents, its filter fields and the dashboard aggregates. The new test's refusal assertions are what should fail first when that lands.

## Verification

- 2652 unit tests, 0 failures; all ArchUnit rules pass (including the external-service authorization rules)
- New `CryptographicAssetControllerStubITest`: boots the context, pins the 501 on all four operations and the `list`/`detail` registration
- `spotless:check` clean
- Built against interfaces #913 installed locally as 2.20.0-SNAPSHOT

🤖 Generated with [Claude Code](https://claude.com/claude-code)