### PR TITLE
Store discovery run messages as aggregated rows

### DIFF
--- a/src/main/java/com/otilm/core/api/web/DiscoveryControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/DiscoveryControllerImpl.java
@@ -161,8 +161,8 @@ public class DiscoveryControllerImpl implements DiscoveryController {
     }
 
     /*
-     * Discovery v2, not implemented yet: these eight exist because DiscoveryController declares them abstract, so this
-     * class does not compile without them.
+     * Discovery v2, not implemented yet: the stubs below exist because DiscoveryController declares them abstract, so
+     * this class does not compile without them.
      *
      * Stub response: 501, so a caller reaching one gets an answer it can act on.
      *

--- a/src/main/java/com/otilm/core/api/web/DiscoveryControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/DiscoveryControllerImpl.java
@@ -18,6 +18,7 @@ import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.connector.discovery.v2.DiscoverySupportedResourceDto;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.discovery.DiscoveryItemDto;
+import com.otilm.api.model.core.discovery.DiscoveryMessageDto;
 import com.otilm.api.model.core.logging.enums.Module;
 import com.otilm.api.model.core.logging.enums.Operation;
 import com.otilm.api.model.core.scheduler.ScheduleDiscoveryDto;
@@ -160,7 +161,7 @@ public class DiscoveryControllerImpl implements DiscoveryController {
     }
 
     /*
-     * Discovery v2, not implemented yet: these seven exist because DiscoveryController declares them abstract, so this
+     * Discovery v2, not implemented yet: these eight exist because DiscoveryController declares them abstract, so this
      * class does not compile without them.
      *
      * Stub response: 501, so a caller reaching one gets an answer it can act on.
@@ -176,6 +177,12 @@ public class DiscoveryControllerImpl implements DiscoveryController {
     @Override
     public PaginationResponseDto<DiscoveryItemDto> getDiscoveryItems(String uuid, Resource resource,
             Boolean newlyDiscovered, int itemsPerPage, int pageNumber) throws NotFoundException {
+        throw notImplemented();
+    }
+
+    @Override
+    public PaginationResponseDto<DiscoveryMessageDto> getDiscoveryRunMessages(String uuid, int itemsPerPage,
+            int pageNumber) throws NotFoundException {
         throw notImplemented();
     }
 

--- a/src/main/java/com/otilm/core/dao/entity/Discovery.java
+++ b/src/main/java/com/otilm/core/dao/entity/Discovery.java
@@ -127,10 +127,6 @@ public class Discovery extends UniquelyIdentifiedAndAudited implements Serializa
     @Column(name = "started_by_user_uuid")
     private UUID startedByUserUuid;
 
-    @Column(name = "run_messages", columnDefinition = "jsonb")
-    @JdbcTypeCode(SqlTypes.JSON)
-    private List<String> runMessages;
-
     @Column(name = "stopped_at")
     private OffsetDateTime stoppedAt;
 

--- a/src/main/java/com/otilm/core/dao/entity/DiscoveryMessage.java
+++ b/src/main/java/com/otilm/core/dao/entity/DiscoveryMessage.java
@@ -13,7 +13,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 import java.util.UUID;
@@ -30,8 +29,7 @@ import org.hibernate.proxy.HibernateProxy;
  * bury its own first and most useful entry.
  *
  * <p>
- * Read-only through JPA: every write goes through {@code DiscoveryMessageWriter}'s upsert, which is what makes an
- * append safe without the run row's lock.
+ * Read-only through JPA: every write goes through {@code DiscoveryMessageWriter}'s upsert.
  */
 @Getter
 @Setter
@@ -39,7 +37,7 @@ import org.hibernate.proxy.HibernateProxy;
 @Entity
 @Table(name = "discovery_message", uniqueConstraints = @UniqueConstraint(name = "uq_discovery_message",
         columnNames = {"discovery_uuid", "code", "message_hash"}))
-public class DiscoveryMessage implements Serializable {
+public class DiscoveryMessage {
 
     /**
      * The run's ordering key, never exposed. A timestamp cannot serve: {@code now()} is transaction-start time, so
@@ -73,8 +71,7 @@ public class DiscoveryMessage implements Serializable {
 
     /**
      * Computed by the database, and mapped only so the test schema — generated from these annotations — carries the
-     * column the upsert's conflict target names. Hashed so that index entry stays inside the btree limit however long a
-     * message is configured to run.
+     * column the upsert's conflict target names. Hashed to keep that index entry inside the btree limit.
      */
     @Column(name = "message_hash", columnDefinition = "varchar generated always as (md5(message)) stored",
             insertable = false, updatable = false)

--- a/src/main/java/com/otilm/core/dao/entity/DiscoveryMessage.java
+++ b/src/main/java/com/otilm/core/dao/entity/DiscoveryMessage.java
@@ -1,0 +1,122 @@
+package com.otilm.core.dao.entity;
+
+import com.otilm.api.model.core.discovery.DiscoveryMessageSeverity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.proxy.HibernateProxy;
+
+/**
+ * One kind of problem a discovery run reported, with how often it happened. A repeat of the same {@code code} and text
+ * advances {@code occurrences} and {@code lastSeenAt} rather than adding a row, so a run against a broken estate cannot
+ * bury its own first and most useful entry.
+ *
+ * <p>
+ * Read-only through JPA: every write goes through {@code DiscoveryMessageWriter}'s upsert, which is what makes an
+ * append safe without the run row's lock.
+ */
+@Getter
+@Setter
+@ToString
+@Entity
+@Table(name = "discovery_message", uniqueConstraints = @UniqueConstraint(name = "uq_discovery_message",
+        columnNames = {"discovery_uuid", "code", "message_hash"}))
+public class DiscoveryMessage implements Serializable {
+
+    /**
+     * The run's ordering key, never exposed. A timestamp cannot serve: {@code now()} is transaction-start time, so
+     * every message one tick writes would tie, and a wall-clock column inverts across pods under clock skew.
+     */
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "discovery_uuid", nullable = false)
+    private UUID discoveryUuid;
+
+    // Mirrors ON DELETE CASCADE from the migration for the test environment, which generates its schema from
+    // the entities; the writable column stays the scalar discoveryUuid above.
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "discovery_uuid", insertable = false, updatable = false)
+    @ToString.Exclude
+    private Discovery discovery;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "severity", nullable = false)
+    private DiscoveryMessageSeverity severity;
+
+    @Column(name = "code", nullable = false)
+    private String code;
+
+    @Column(name = "message", nullable = false)
+    private String message;
+
+    /**
+     * Computed by the database, and mapped only so the test schema — generated from these annotations — carries the
+     * column the upsert's conflict target names. Hashed so that index entry stays inside the btree limit however long a
+     * message is configured to run.
+     */
+    @Column(name = "message_hash", columnDefinition = "varchar generated always as (md5(message)) stored",
+            insertable = false, updatable = false)
+    private String messageHash;
+
+    @Column(name = "occurrences", nullable = false)
+    private long occurrences;
+
+    // Both stamped by the database rather than by whichever pod appended, so the window a fault was active in
+    // reads the same however many nodes contributed to it. Transaction-start time, so they are a window and not
+    // an order -- see id.
+    @Column(name = "first_seen_at", nullable = false)
+    private OffsetDateTime firstSeenAt;
+
+    @Column(name = "last_seen_at", nullable = false)
+    private OffsetDateTime lastSeenAt;
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+        Class<?> oEffectiveClass = o instanceof HibernateProxy proxy
+                ? proxy.getHibernateLazyInitializer().getPersistentClass()
+                : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy proxy
+                ? proxy.getHibernateLazyInitializer().getPersistentClass()
+                : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) {
+            return false;
+        }
+        DiscoveryMessage that = (DiscoveryMessage) o;
+        return getId() != null && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy proxy
+                ? proxy.getHibernateLazyInitializer().getPersistentClass().hashCode()
+                : getClass().hashCode();
+    }
+}

--- a/src/main/java/com/otilm/core/dao/entity/DiscoveryMessage.java
+++ b/src/main/java/com/otilm/core/dao/entity/DiscoveryMessage.java
@@ -93,7 +93,7 @@ public class DiscoveryMessage {
     private OffsetDateTime lastSeenAt;
 
     @Override
-    public final boolean equals(Object o) {
+    public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
@@ -114,7 +114,7 @@ public class DiscoveryMessage {
     }
 
     @Override
-    public final int hashCode() {
+    public int hashCode() {
         return this instanceof HibernateProxy proxy
                 ? proxy.getHibernateLazyInitializer().getPersistentClass().hashCode()
                 : getClass().hashCode();

--- a/src/main/java/com/otilm/core/dao/entity/DiscoveryMessage.java
+++ b/src/main/java/com/otilm/core/dao/entity/DiscoveryMessage.java
@@ -9,6 +9,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -35,8 +36,10 @@ import org.hibernate.proxy.HibernateProxy;
 @Setter
 @ToString
 @Entity
-@Table(name = "discovery_message", uniqueConstraints = @UniqueConstraint(name = "uq_discovery_message",
-        columnNames = {"discovery_uuid", "code", "message_hash"}))
+@Table(name = "discovery_message",
+        uniqueConstraints = @UniqueConstraint(name = "uq_discovery_message",
+                columnNames = {"discovery_uuid", "code", "message_hash"}),
+        indexes = @Index(name = "idx_discovery_message_run", columnList = "discovery_uuid, id"))
 public class DiscoveryMessage {
 
     /**

--- a/src/main/java/com/otilm/core/dao/repository/DiscoveryCertificateRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/DiscoveryCertificateRepository.java
@@ -47,6 +47,9 @@ public interface DiscoveryCertificateRepository extends SecurityFilterRepository
 
     long countByDiscoveryUuidAndNewlyDiscoveredTrueAndProcessedFalseAndProcessedErrorIsNull(UUID discoveryUuid);
 
+    /** The same count narrowed to one batch's rows — what decides whether a failed batch will be tried again. */
+    long countByUuidInAndNewlyDiscoveredTrueAndProcessedFalseAndProcessedErrorIsNull(Collection<UUID> uuids);
+
     /** Whether any row of the run recorded a reason it could not be imported — what makes a run end WARNING. */
     boolean existsByDiscoveryUuidAndProcessedErrorIsNotNull(UUID discoveryUuid);
 

--- a/src/main/java/com/otilm/core/dao/repository/DiscoveryMessageRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/DiscoveryMessageRepository.java
@@ -23,6 +23,17 @@ public interface DiscoveryMessageRepository extends JpaRepository<DiscoveryMessa
      * new rows only — a repeat always lands, however many rows the run already has, because aggregating onto an
      * existing row grows nothing.
      *
+     * <p>
+     * The window widens, never moves. {@code now()} is transaction-start time, so a transaction that began earlier can
+     * commit later and would otherwise rewind {@code last_seen_at} — past {@code first_seen_at} entirely, when it
+     * aggregates onto a row a shorter, later transaction created. {@code LEAST}/{@code GREATEST} make both ends
+     * monotonic, which is what lets the pair be read as the span a fault was active.
+     *
+     * <p>
+     * The bounds are soft ceilings, not guarantees: the counts and the insert are not atomic against each other, so
+     * appenders that each read a count one below the limit all pass and a run can exceed it by the number of concurrent
+     * appenders. Locking to close that would reintroduce the serialisation this design removes.
+     *
      * @return 1 when the message was recorded, 0 when a bound refused it a row of its own
      */
     @Modifying
@@ -41,7 +52,9 @@ public interface DiscoveryMessageRepository extends JpaRepository<DiscoveryMessa
                    AND (SELECT count(*) FROM {h-schema}discovery_message
                         WHERE discovery_uuid = CAST(:discoveryUuid AS UUID)) < :maxPerRun)
             ON CONFLICT (discovery_uuid, code, message_hash) DO UPDATE
-                SET occurrences = m.occurrences + EXCLUDED.occurrences, last_seen_at = EXCLUDED.last_seen_at
+                SET occurrences = m.occurrences + EXCLUDED.occurrences,
+                    first_seen_at = LEAST(m.first_seen_at, EXCLUDED.first_seen_at),
+                    last_seen_at = GREATEST(m.last_seen_at, EXCLUDED.last_seen_at)
             """, nativeQuery = true)
     int appendWithinBounds(@Param("discoveryUuid") UUID discoveryUuid, @Param("severity") String severity,
             @Param("code") String code, @Param("message") String message, @Param("occurrences") long occurrences,
@@ -58,14 +71,16 @@ public interface DiscoveryMessageRepository extends JpaRepository<DiscoveryMessa
             VALUES (CAST(:discoveryUuid AS UUID), CAST(:severity AS VARCHAR), CAST(:code AS VARCHAR),
                     CAST(:message AS VARCHAR), CAST(:occurrences AS BIGINT), now(), now())
             ON CONFLICT (discovery_uuid, code, message_hash) DO UPDATE
-                SET occurrences = m.occurrences + EXCLUDED.occurrences, last_seen_at = EXCLUDED.last_seen_at
+                SET occurrences = m.occurrences + EXCLUDED.occurrences,
+                    first_seen_at = LEAST(m.first_seen_at, EXCLUDED.first_seen_at),
+                    last_seen_at = GREATEST(m.last_seen_at, EXCLUDED.last_seen_at)
             """, nativeQuery = true)
     void append(@Param("discoveryUuid") UUID discoveryUuid, @Param("severity") String severity,
             @Param("code") String code, @Param("message") String message, @Param("occurrences") long occurrences);
 
     /**
-     * Whether the run collected anything at or above a given severity — what the terminal decision asks, in place of
-     * the old "is the log non-empty", which downgraded a run over a problem that had since been recovered.
+     * Whether the run collected anything at or above a given severity — what the terminal decision asks, so a run that
+     * recovered from a problem it recorded is not downgraded for it.
      */
     boolean existsByDiscoveryUuidAndSeverityIn(UUID discoveryUuid, Collection<DiscoveryMessageSeverity> severities);
 

--- a/src/main/java/com/otilm/core/dao/repository/DiscoveryMessageRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/DiscoveryMessageRepository.java
@@ -24,6 +24,11 @@ public interface DiscoveryMessageRepository extends JpaRepository<DiscoveryMessa
      * existing row grows nothing.
      *
      * <p>
+     * A row's severity is the highest ever recorded for it, which is what stops the run-level suppression row —
+     * covering every code at once — understating the worst it stands for. The {@code CASE} compares the member names
+     * {@code @Enumerated(STRING)} stores, so renaming a constant means changing this too.
+     *
+     * <p>
      * The window widens, never moves. {@code now()} is transaction-start time, so a transaction that began earlier can
      * commit later and would otherwise rewind {@code last_seen_at} — past {@code first_seen_at} entirely, when it
      * aggregates onto a row a shorter, later transaction created. {@code LEAST}/{@code GREATEST} make both ends
@@ -53,6 +58,10 @@ public interface DiscoveryMessageRepository extends JpaRepository<DiscoveryMessa
                         WHERE discovery_uuid = CAST(:discoveryUuid AS UUID)) < :maxPerRun)
             ON CONFLICT (discovery_uuid, code, message_hash) DO UPDATE
                 SET occurrences = m.occurrences + EXCLUDED.occurrences,
+                    severity = CASE
+                        WHEN 'ERROR' IN (m.severity, EXCLUDED.severity) THEN 'ERROR'
+                        WHEN 'WARNING' IN (m.severity, EXCLUDED.severity) THEN 'WARNING'
+                        ELSE m.severity END,
                     first_seen_at = LEAST(m.first_seen_at, EXCLUDED.first_seen_at),
                     last_seen_at = GREATEST(m.last_seen_at, EXCLUDED.last_seen_at)
             """, nativeQuery = true)
@@ -72,6 +81,10 @@ public interface DiscoveryMessageRepository extends JpaRepository<DiscoveryMessa
                     CAST(:message AS VARCHAR), CAST(:occurrences AS BIGINT), now(), now())
             ON CONFLICT (discovery_uuid, code, message_hash) DO UPDATE
                 SET occurrences = m.occurrences + EXCLUDED.occurrences,
+                    severity = CASE
+                        WHEN 'ERROR' IN (m.severity, EXCLUDED.severity) THEN 'ERROR'
+                        WHEN 'WARNING' IN (m.severity, EXCLUDED.severity) THEN 'WARNING'
+                        ELSE m.severity END,
                     first_seen_at = LEAST(m.first_seen_at, EXCLUDED.first_seen_at),
                     last_seen_at = GREATEST(m.last_seen_at, EXCLUDED.last_seen_at)
             """, nativeQuery = true)

--- a/src/main/java/com/otilm/core/dao/repository/DiscoveryMessageRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/DiscoveryMessageRepository.java
@@ -1,0 +1,76 @@
+package com.otilm.core.dao.repository;
+
+import com.otilm.api.model.core.discovery.DiscoveryMessageSeverity;
+import com.otilm.core.dao.entity.DiscoveryMessage;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DiscoveryMessageRepository extends JpaRepository<DiscoveryMessage, Long> {
+
+    /**
+     * Records one occurrence group of a problem, aggregating onto the row already carrying it.
+     *
+     * <p>
+     * No lock is taken anywhere: a concurrent append of the same problem loses the race to the unique index and lands
+     * in the {@code DO UPDATE}, so the two counts add rather than one overwriting the other. The bound is a guard on
+     * new rows only — a repeat always lands, however many rows the run already has, because aggregating onto an
+     * existing row grows nothing.
+     *
+     * @return 1 when the message was recorded, 0 when a bound refused it a row of its own
+     */
+    @Modifying
+    @Query(value = """
+            INSERT INTO {h-schema}discovery_message AS m
+                (discovery_uuid, severity, code, message, occurrences, first_seen_at, last_seen_at)
+            SELECT CAST(:discoveryUuid AS UUID), CAST(:severity AS VARCHAR), CAST(:code AS VARCHAR),
+                   CAST(:message AS VARCHAR), CAST(:occurrences AS BIGINT), now(), now()
+            WHERE EXISTS (SELECT 1 FROM {h-schema}discovery_message
+                          WHERE discovery_uuid = CAST(:discoveryUuid AS UUID)
+                            AND code = CAST(:code AS VARCHAR)
+                            AND message_hash = md5(CAST(:message AS TEXT)))
+               OR ((SELECT count(*) FROM {h-schema}discovery_message
+                    WHERE discovery_uuid = CAST(:discoveryUuid AS UUID)
+                      AND code = CAST(:code AS VARCHAR)) < :maxPerCode
+                   AND (SELECT count(*) FROM {h-schema}discovery_message
+                        WHERE discovery_uuid = CAST(:discoveryUuid AS UUID)) < :maxPerRun)
+            ON CONFLICT (discovery_uuid, code, message_hash) DO UPDATE
+                SET occurrences = m.occurrences + EXCLUDED.occurrences, last_seen_at = EXCLUDED.last_seen_at
+            """, nativeQuery = true)
+    int appendWithinBounds(@Param("discoveryUuid") UUID discoveryUuid, @Param("severity") String severity,
+            @Param("code") String code, @Param("message") String message, @Param("occurrences") long occurrences,
+            @Param("maxPerCode") int maxPerCode, @Param("maxPerRun") int maxPerRun);
+
+    /**
+     * As {@link #appendWithinBounds}, for the two messages that must land whatever the run has already collected: the
+     * reason a run ended, and the row saying that other messages were dropped.
+     */
+    @Modifying
+    @Query(value = """
+            INSERT INTO {h-schema}discovery_message AS m
+                (discovery_uuid, severity, code, message, occurrences, first_seen_at, last_seen_at)
+            VALUES (CAST(:discoveryUuid AS UUID), CAST(:severity AS VARCHAR), CAST(:code AS VARCHAR),
+                    CAST(:message AS VARCHAR), CAST(:occurrences AS BIGINT), now(), now())
+            ON CONFLICT (discovery_uuid, code, message_hash) DO UPDATE
+                SET occurrences = m.occurrences + EXCLUDED.occurrences, last_seen_at = EXCLUDED.last_seen_at
+            """, nativeQuery = true)
+    void append(@Param("discoveryUuid") UUID discoveryUuid, @Param("severity") String severity,
+            @Param("code") String code, @Param("message") String message, @Param("occurrences") long occurrences);
+
+    /**
+     * Whether the run collected anything at or above a given severity — what the terminal decision asks, in place of
+     * the old "is the log non-empty", which downgraded a run over a problem that had since been recovered.
+     */
+    boolean existsByDiscoveryUuidAndSeverityIn(UUID discoveryUuid, Collection<DiscoveryMessageSeverity> severities);
+
+    /** The run's log, oldest first. Ordered by the identity column; see {@code DiscoveryMessage.id}. */
+    List<DiscoveryMessage> findByDiscoveryUuidOrderByIdAsc(UUID discoveryUuid);
+
+    long countByDiscoveryUuid(UUID discoveryUuid);
+}

--- a/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
@@ -410,7 +410,7 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
         if (counts.allClear()) {
             return new DiscoveryResult(DiscoveryStatus.PROCESSING, originalMessage);
         }
-        List<String> sentences = new ArrayList<>(counts.describeGaps());
+        List<String> sentences = new ArrayList<>(counts.renderGaps());
         if (counts.hasPerCertificateDetail()) {
             sentences.add("See the discovery certificate list for per-certificate detail.");
         }

--- a/src/main/java/com/otilm/core/events/handlers/discovery/DiscoveryRunCounts.java
+++ b/src/main/java/com/otilm/core/events/handlers/discovery/DiscoveryRunCounts.java
@@ -1,5 +1,8 @@
 package com.otilm.core.events.handlers.discovery;
 
+import com.otilm.api.model.core.discovery.DiscoveryMessageSeverity;
+import com.otilm.core.model.discovery.DiscoveryMessageCode;
+import com.otilm.core.model.discovery.DiscoveryMessageDraft;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,33 +27,72 @@ public record DiscoveryRunCounts(long inventoryGaps, long keyGaps, long notAttem
     }
 
     /**
-     * One sentence per reason this unit of work fell short, in a fixed order. Empty when nothing did.
+     * One run message per reason this unit of work fell short, in a fixed order. Empty when nothing did.
      *
      * <p>
-     * Shared by the two flows that report gaps at different granularities: the v1 pass counts a whole run and turns
-     * these into its final status message, while a v2 {@code PROCESS} batch counts only itself and files them in the
-     * run's message log as it goes. Both say the same thing about the same counts.
+     * A v2 {@code PROCESS} batch counts only itself, so each of these carries its own count as occurrences rather than
+     * inside its text: every batch reporting the same kind of gap aggregates onto one row, where embedding the count
+     * would mint a distinct message per batch and bury the run's first one.
      */
-    public List<String> describeGaps() {
-        List<String> sentences = new ArrayList<>();
+    public List<DiscoveryMessageDraft> describeGaps() {
+        return gaps()
+                .stream()
+                .map(gap -> new DiscoveryMessageDraft(DiscoveryMessageSeverity.WARNING, gap.code(), gap.message(),
+                        gap.count()))
+                .toList();
+    }
+
+    /**
+     * The same reasons as counted sentences, for the v1 pass — which counts a whole run in one go and turns them into
+     * its final status message, where a count that is not in the text has nowhere else to appear.
+     */
+    public List<String> renderGaps() {
+        return gaps().stream().map(Gap::sentence).toList();
+    }
+
+    /**
+     * The kinds of gap, listed once so the aggregated message and the counted sentence cannot drift apart.
+     */
+    private List<Gap> gaps() {
+        List<Gap> gaps = new ArrayList<>();
         if (inventoryGaps > 0) {
-            sentences.add("%d certificate(s) could not be imported into the inventory.".formatted(inventoryGaps));
+            gaps
+                    .add(new Gap(DiscoveryMessageCode.INVENTORY_GAP,
+                            "A discovered certificate could not be imported into the inventory.",
+                            "%d certificate(s) could not be imported into the inventory.".formatted(inventoryGaps),
+                            inventoryGaps));
         }
         if (keyGaps > 0) {
-            sentences
-                    .add("%d certificate(s) were imported without all of their public keys associated."
-                            .formatted(keyGaps));
+            gaps
+                    .add(new Gap(DiscoveryMessageCode.KEY_ASSOCIATION_GAP,
+                            "A certificate was imported without all of its public keys associated.",
+                            "%d certificate(s) were imported without all of their public keys associated."
+                                    .formatted(keyGaps),
+                            keyGaps));
         }
         if (notAttempted > 0) {
-            sentences.add("%d certificate(s) could not be processed to a result.".formatted(notAttempted));
+            gaps
+                    .add(new Gap(DiscoveryMessageCode.CERTIFICATE_NOT_PROCESSED,
+                            "A discovered certificate could not be processed to a result.",
+                            "%d certificate(s) could not be processed to a result.".formatted(notAttempted),
+                            notAttempted));
         }
         if (bookkeepingFailures > 0) {
-            sentences.add("Some per-certificate detail could not be recorded.");
+            gaps
+                    .add(new Gap(DiscoveryMessageCode.BOOKKEEPING_INCOMPLETE,
+                            "Some per-certificate detail could not be recorded.",
+                            "Some per-certificate detail could not be recorded.", bookkeepingFailures));
         }
         if (validationNotQueued) {
-            sentences.add("Validation of the discovered certificates could not be requested.");
+            gaps
+                    .add(new Gap(DiscoveryMessageCode.VALIDATION_NOT_REQUESTED,
+                            "Validation of the discovered certificates could not be requested.",
+                            "Validation of the discovered certificates could not be requested.", 1));
         }
-        return sentences;
+        return gaps;
+    }
+
+    private record Gap(DiscoveryMessageCode code, String message, String sentence, long count) {
     }
 
     /**

--- a/src/main/java/com/otilm/core/model/discovery/DiscoveryMessageCode.java
+++ b/src/main/java/com/otilm/core/model/discovery/DiscoveryMessageCode.java
@@ -5,10 +5,9 @@ package com.otilm.core.model.discovery;
  * code instead, straight from {@code DiscoveryErrorEvent}.
  *
  * <p>
- * The code names the <em>kind</em> of problem, and is what an operator or a support engineer matches on. It is also
- * what aggregation and the per-code bound group by, so a code must stay stable across releases and must never carry
- * anything run-specific: an identifier folded into a code would mint a fresh kind per certificate, which is the growth
- * this shape exists to stop.
+ * The code names the <em>kind</em> of problem — what an operator or a support engineer matches on — and is what
+ * aggregation and the per-code bound group by, so it must stay stable across releases and carry nothing run-specific
+ * (see {@link DiscoveryMessageDraft}).
  *
  * <p>
  * Each code has exactly one producer, which owns the severity and the curated text that go with it.
@@ -41,6 +40,9 @@ public enum DiscoveryMessageCode {
 
     /** A processing batch that did not complete and went back for another attempt. */
     BATCH_PROCESSING_FAILED("batchProcessingFailed"),
+
+    /** Stands in for a connector's own code when it reported an error without naming one. */
+    CONNECTOR_ERROR("connectorError"),
 
     /** How the run ended; the message is the terminal reason and the severity follows the terminal status. */
     RUN_ENDED("runEnded"),

--- a/src/main/java/com/otilm/core/model/discovery/DiscoveryMessageCode.java
+++ b/src/main/java/com/otilm/core/model/discovery/DiscoveryMessageCode.java
@@ -41,6 +41,9 @@ public enum DiscoveryMessageCode {
     /** A processing batch that did not complete and went back for another attempt. */
     BATCH_PROCESSING_FAILED("batchProcessingFailed"),
 
+    /** A processing batch that failed once its rows were already imported, so nothing is left to retry. */
+    BATCH_PROCESSING_ABANDONED("batchProcessingAbandoned"),
+
     /** Stands in for a connector's own code when it reported an error without naming one. */
     CONNECTOR_ERROR("connectorError"),
 

--- a/src/main/java/com/otilm/core/model/discovery/DiscoveryMessageCode.java
+++ b/src/main/java/com/otilm/core/model/discovery/DiscoveryMessageCode.java
@@ -1,0 +1,60 @@
+package com.otilm.core.model.discovery;
+
+/**
+ * The codes Core assigns to run messages it produces itself. A connector-reported problem carries the connector's own
+ * code instead, straight from {@code DiscoveryErrorEvent}.
+ *
+ * <p>
+ * The code names the <em>kind</em> of problem, and is what an operator or a support engineer matches on. It is also
+ * what aggregation and the per-code bound group by, so a code must stay stable across releases and must never carry
+ * anything run-specific: an identifier folded into a code would mint a fresh kind per certificate, which is the growth
+ * this shape exists to stop.
+ *
+ * <p>
+ * Each code has exactly one producer, which owns the severity and the curated text that go with it.
+ */
+public enum DiscoveryMessageCode {
+
+    /** A staged item the connector sent without the sequence that staging orders by. */
+    ITEM_SEQUENCE_MISSING("itemSequenceMissing"),
+
+    /** An item declared a certificate whose payload was not one. */
+    CERTIFICATE_PAYLOAD_INVALID("certificatePayloadInvalid"),
+
+    /** A discovered certificate that could not be staged; the message is the shaped reason. */
+    CERTIFICATE_STAGING_FAILED("certificateStagingFailed"),
+
+    /** A certificate the connector reported that never reached the inventory. */
+    INVENTORY_GAP("inventoryGap"),
+
+    /** A certificate imported without all of its public keys associated. */
+    KEY_ASSOCIATION_GAP("keyAssociationGap"),
+
+    /** A staged certificate that never reached a verdict either way. */
+    CERTIFICATE_NOT_PROCESSED("certificateNotProcessed"),
+
+    /** Per-certificate detail whose own write failed, leaving what is persisted knowingly incomplete. */
+    BOOKKEEPING_INCOMPLETE("bookkeepingIncomplete"),
+
+    /** Validation of the run's certificates was never requested. */
+    VALIDATION_NOT_REQUESTED("validationNotRequested"),
+
+    /** A processing batch that did not complete and went back for another attempt. */
+    BATCH_PROCESSING_FAILED("batchProcessingFailed"),
+
+    /** How the run ended; the message is the terminal reason and the severity follows the terminal status. */
+    RUN_ENDED("runEnded"),
+
+    /** Stands in for everything a run had no room left to keep, whatever kind it was. */
+    MESSAGES_SUPPRESSED("messagesSuppressed");
+
+    private final String code;
+
+    DiscoveryMessageCode(String code) {
+        this.code = code;
+    }
+
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/com/otilm/core/model/discovery/DiscoveryMessageDraft.java
+++ b/src/main/java/com/otilm/core/model/discovery/DiscoveryMessageDraft.java
@@ -14,7 +14,9 @@ import com.otilm.api.model.core.discovery.DiscoveryMessageSeverity;
  * <p>
  * Where a staged row exists the detail is relocated, not lost: why one certificate failed to <em>import</em> is on that
  * certificate's own row ({@code discovery_certificate.processed_error}). Failures before a row exists — staging, an
- * invalid payload, a missing sequence — identify themselves only in the server log.
+ * invalid payload, a missing sequence — name what they hit in the application log only, which is where they were before
+ * this log existed. These messages are a bounded summary above it rather than a replacement for it: naming every
+ * occurrence here is what would make the log too long to read.
  *
  * @param occurrences how many times this producer saw the problem in the work it is reporting on
  */

--- a/src/main/java/com/otilm/core/model/discovery/DiscoveryMessageDraft.java
+++ b/src/main/java/com/otilm/core/model/discovery/DiscoveryMessageDraft.java
@@ -1,0 +1,34 @@
+package com.otilm.core.model.discovery;
+
+import com.otilm.api.model.core.discovery.DiscoveryMessageSeverity;
+
+/**
+ * One problem a producer wants recorded against a run, before the writer bounds and aggregates it.
+ *
+ * <p>
+ * <b>{@code message} names the kind of problem and nothing about the occurrence</b> — not a count, not a certificate,
+ * not a host, not a reference. Anything run-specific makes every message distinct, which turns aggregation back into
+ * accumulation and buries a run's first and most useful entry under its ten thousandth. The count in particular belongs
+ * in {@code occurrences}, which adds across every batch reporting the same thing.
+ *
+ * <p>
+ * The rule loses no detail, it puts it where a reader can act on it: why one certificate failed is on that
+ * certificate's own row ({@code discovery_certificate.processed_error}), served by the certificate list a run's
+ * terminal message points at. Two surfaces, two questions — this one answers what went wrong with the run, the row
+ * answers what went wrong with the certificate.
+ *
+ * @param occurrences how many times this producer saw the problem in the work it is reporting on
+ */
+public record DiscoveryMessageDraft(DiscoveryMessageSeverity severity, String code, String message, long occurrences) {
+
+    public DiscoveryMessageDraft {
+        if (occurrences < 1) {
+            throw new IllegalArgumentException("A discovery run message records at least one occurrence");
+        }
+    }
+
+    public DiscoveryMessageDraft(DiscoveryMessageSeverity severity, DiscoveryMessageCode code, String message,
+            long occurrences) {
+        this(severity, code.code(), message, occurrences);
+    }
+}

--- a/src/main/java/com/otilm/core/model/discovery/DiscoveryMessageDraft.java
+++ b/src/main/java/com/otilm/core/model/discovery/DiscoveryMessageDraft.java
@@ -12,10 +12,9 @@ import com.otilm.api.model.core.discovery.DiscoveryMessageSeverity;
  * in {@code occurrences}, which adds across every batch reporting the same thing.
  *
  * <p>
- * The rule loses no detail, it puts it where a reader can act on it: why one certificate failed is on that
- * certificate's own row ({@code discovery_certificate.processed_error}), served by the certificate list a run's
- * terminal message points at. Two surfaces, two questions — this one answers what went wrong with the run, the row
- * answers what went wrong with the certificate.
+ * Where a staged row exists the detail is relocated, not lost: why one certificate failed to <em>import</em> is on that
+ * certificate's own row ({@code discovery_certificate.processed_error}). Failures before a row exists — staging, an
+ * invalid payload, a missing sequence — identify themselves only in the server log.
  *
  * @param occurrences how many times this producer saw the problem in the work it is reporting on
  */
@@ -24,6 +23,15 @@ public record DiscoveryMessageDraft(DiscoveryMessageSeverity severity, String co
     public DiscoveryMessageDraft {
         if (occurrences < 1) {
             throw new IllegalArgumentException("A discovery run message records at least one occurrence");
+        }
+        // Refused here rather than at the insert: code is the one field taken verbatim from outside the platform,
+        // and both columns are NOT NULL, so a connector that omits its code would otherwise roll back whatever
+        // transaction the append had joined -- a whole drained page, for a field this can simply reject.
+        if (code == null || code.isBlank()) {
+            throw new IllegalArgumentException("A discovery run message needs a code naming the kind of problem");
+        }
+        if (message == null || message.isBlank()) {
+            throw new IllegalArgumentException("A discovery run message needs text for a person to read");
         }
     }
 

--- a/src/main/java/com/otilm/core/model/discovery/DiscoveryRunLifecycle.java
+++ b/src/main/java/com/otilm/core/model/discovery/DiscoveryRunLifecycle.java
@@ -1,14 +1,13 @@
 package com.otilm.core.model.discovery;
 
+import com.otilm.api.model.core.discovery.DiscoveryMessageSeverity;
 import com.otilm.api.model.core.discovery.DiscoveryStatus;
-import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Set;
 
 /**
- * Run-level bookkeeping shared by the ingestor and the tick workers: which statuses are final, and how a run's
- * user-visible message log grows.
+ * Run-level bookkeeping shared by the ingestor and the tick workers: which statuses are final, and what a run's ending
+ * means for its message log.
  */
 public final class DiscoveryRunLifecycle {
 
@@ -18,12 +17,6 @@ public final class DiscoveryRunLifecycle {
      */
     private static final Set<DiscoveryStatus> TERMINAL = EnumSet
             .of(DiscoveryStatus.COMPLETED, DiscoveryStatus.WARNING, DiscoveryStatus.FAILED, DiscoveryStatus.CANCELLED);
-
-    /**
-     * Cap on {@code run_messages}. A run that fails per item can produce one line per item, and the column is a single
-     * JSONB value rewritten on every append — unbounded growth would make each append quadratic in the failure count.
-     */
-    static final int MAX_RUN_MESSAGES = 200;
 
     private DiscoveryRunLifecycle() {
     }
@@ -48,20 +41,14 @@ public final class DiscoveryRunLifecycle {
     }
 
     /**
-     * Returns the run's message log with {@code messages} appended, oldest lines dropped once the cap is reached.
-     *
-     * <p>
-     * A new list rather than a mutation of {@code current}: the value is a JSONB column, so Hibernate detects the
-     * change by comparing instances and an in-place edit can go unwritten.
+     * How much the message recording a run's ending matters, which is the run's own outcome: a run that completed
+     * cleanly says so for the record, and one that failed or was cancelled lost the work it was doing.
      */
-    public static List<String> append(List<String> current, List<String> messages) {
-        List<String> merged = current == null ? new ArrayList<>() : new ArrayList<>(current);
-        merged.addAll(messages);
-        int overflow = merged.size() - MAX_RUN_MESSAGES;
-        return overflow <= 0 ? merged : new ArrayList<>(merged.subList(overflow, merged.size()));
-    }
-
-    public static List<String> append(List<String> current, String message) {
-        return append(current, List.of(message));
+    public static DiscoveryMessageSeverity severityOf(DiscoveryStatus terminalStatus) {
+        return switch (terminalStatus) {
+            case COMPLETED -> DiscoveryMessageSeverity.INFO;
+            case WARNING -> DiscoveryMessageSeverity.WARNING;
+            default -> DiscoveryMessageSeverity.ERROR;
+        };
     }
 }

--- a/src/main/java/com/otilm/core/service/handler/CertificateHandler.java
+++ b/src/main/java/com/otilm/core/service/handler/CertificateHandler.java
@@ -179,8 +179,9 @@ public class CertificateHandler {
      * @param refsDedupeWithinRun true only for v2: the certificate's {@code uuid} is the connector's per-occurrence
      * key, stored as {@code uniqueRef} and enforced by the run's unique index. A v1 provider uuid names the certificate
      * itself, so it is not stored.
-     * @return one description per certificate that could not be staged; v1 discards these, v2 files them in the run's
-     * message log.
+     * @return the shaped reason for each certificate that could not be staged, named by kind rather than by which
+     * certificate hit it — v2 files these in the run's message log, where the same reason across a whole run aggregates
+     * onto one entry and the certificate that hit it is already in the log above. v1 discards them.
      */
     @Transactional
     public List<String> stageDiscoveredCertificates(String batch, Discovery discovery,
@@ -219,9 +220,7 @@ public class CertificateHandler {
                 logger
                         .error("Unable to create discovery certificate {} in batch {} for discovery {}. Message: {}",
                                 identifier, batch, discovery.getName(), e.getMessage(), e);
-                failures
-                        .add("Certificate %s could not be staged: %s"
-                                .formatted(identifier, DiscoveryFailureReason.shape(e)));
+                failures.add(DiscoveryFailureReason.shape(e));
             }
         }
         return failures;

--- a/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryEventIngestor.java
+++ b/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryEventIngestor.java
@@ -12,20 +12,25 @@ import com.otilm.api.model.connector.discovery.v2.DiscoveryResultsResponseDto;
 import com.otilm.api.model.connector.discovery.v2.event.DiscoveryErrorEvent;
 import com.otilm.api.model.connector.discovery.v2.event.DiscoveryProgressEvent;
 import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.discovery.DiscoveryMessageSeverity;
 import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.repository.CryptographicKeyItemRepository;
 import com.otilm.core.dao.repository.DiscoveryCertificateRepository;
 import com.otilm.core.dao.repository.DiscoveryRepository;
+import com.otilm.core.model.discovery.DiscoveryMessageCode;
+import com.otilm.core.model.discovery.DiscoveryMessageDraft;
 import com.otilm.core.model.discovery.DiscoveryRunLifecycle;
 import com.otilm.core.model.discovery.DiscoveryWorkType;
 import com.otilm.core.service.handler.CertificateHandler;
 import com.otilm.core.service.writer.discovery.DiscoveryItemWriter;
+import com.otilm.core.service.writer.discovery.DiscoveryMessageWriter;
 import com.otilm.core.service.writer.discovery.DiscoveryWorkWriter;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -53,16 +58,19 @@ public class DiscoveryEventIngestor {
     private final CertificateHandler certificateHandler;
     private final CryptographicKeyItemRepository keyItemRepository;
     private final DiscoveryCertificateRepository certificateRepository;
+    private final DiscoveryMessageWriter messageWriter;
 
     public DiscoveryEventIngestor(DiscoveryRepository discoveryRepository, DiscoveryItemWriter itemWriter,
             DiscoveryWorkWriter workWriter, CertificateHandler certificateHandler,
-            CryptographicKeyItemRepository keyItemRepository, DiscoveryCertificateRepository certificateRepository) {
+            CryptographicKeyItemRepository keyItemRepository, DiscoveryCertificateRepository certificateRepository,
+            DiscoveryMessageWriter messageWriter) {
         this.discoveryRepository = discoveryRepository;
         this.itemWriter = itemWriter;
         this.workWriter = workWriter;
         this.certificateHandler = certificateHandler;
         this.keyItemRepository = keyItemRepository;
         this.certificateRepository = certificateRepository;
+        this.messageWriter = messageWriter;
     }
 
     /**
@@ -127,12 +135,12 @@ public class DiscoveryEventIngestor {
             case PROGRESS -> run.setProgress(snapshotOf((DiscoveryProgressEvent) event));
             case ERROR -> {
                 DiscoveryErrorEvent error = (DiscoveryErrorEvent) event;
-                // Only the code is recorded; connector-authored prose goes to the log, not the API-visible
-                // run_messages.
+                // The connector's code identifies the problem; its prose goes to the log rather than to the
+                // API-visible message, which carries curated text only.
                 logger.warn("Discovery {} connector error {}: {}", discoveryUuid, error.getCode(), error.getMessage());
-                run
-                        .setRunMessages(DiscoveryRunLifecycle
-                                .append(run.getRunMessages(), "Connector reported %s".formatted(error.getCode())));
+                messageWriter
+                        .append(discoveryUuid, new DiscoveryMessageDraft(DiscoveryMessageSeverity.ERROR,
+                                error.getCode(), "The Discovery Provider reported a problem with this run.", 1));
             }
             case STATE_CHANGED -> scheduleNow(run, DiscoveryWorkType.STATUS);
             case RESULT_BATCH -> scheduleNow(run, DiscoveryWorkType.DRAIN);
@@ -153,10 +161,11 @@ public class DiscoveryEventIngestor {
             return;
         }
         logger.warn("Discovery {} received {} item(s) with no sequence: {}", run.getUuid(), refs.size(), refs);
-        run
-                .setRunMessages(DiscoveryRunLifecycle
-                        .append(run.getRunMessages(),
-                                "%d item(s) arrived without a sequence and were skipped".formatted(refs.size())));
+        messageWriter
+                .append(run.getUuid(),
+                        new DiscoveryMessageDraft(DiscoveryMessageSeverity.WARNING,
+                                DiscoveryMessageCode.ITEM_SEQUENCE_MISSING,
+                                "A discovered item arrived without a sequence and was skipped.", refs.size()));
     }
 
     /**
@@ -206,16 +215,44 @@ public class DiscoveryEventIngestor {
             }
         }
         registerMetadataDefinitions(run, items);
-        List<String> problems = new ArrayList<>();
-        malformedPayloads
-                .forEach(ref -> problems
-                        .add("Certificate %s could not be staged: its payload was not a certificate".formatted(ref)));
+        List<DiscoveryMessageDraft> problems = new ArrayList<>();
+        if (!malformedPayloads.isEmpty()) {
+            // The references are logged rather than filed: naming one in the message would make every malformed
+            // payload its own kind of problem.
+            logger
+                    .warn("Discovery {} received {} item(s) declared certificates whose payload was not one: {}",
+                            run.getUuid(), malformedPayloads.size(), malformedPayloads);
+            problems
+                    .add(new DiscoveryMessageDraft(DiscoveryMessageSeverity.WARNING,
+                            DiscoveryMessageCode.CERTIFICATE_PAYLOAD_INVALID,
+                            "A discovered certificate could not be staged: its payload was not a certificate.",
+                            malformedPayloads.size()));
+        }
         if (!certificates.isEmpty()) {
-            problems.addAll(certificateHandler.stageDiscoveredCertificates(batchLabel(items), run, certificates, true));
+            problems
+                    .addAll(stagingFailures(certificateHandler
+                            .stageDiscoveredCertificates(batchLabel(items), run, certificates, true)));
         }
-        if (!problems.isEmpty()) {
-            run.setRunMessages(DiscoveryRunLifecycle.append(run.getRunMessages(), problems));
-        }
+        messageWriter.appendAll(run.getUuid(), problems);
+    }
+
+    /**
+     * Groups the page's staging failures by the reason they share, so a page that failed the same way a thousand times
+     * files one message counted a thousand times rather than a thousand of them.
+     */
+    private static List<DiscoveryMessageDraft> stagingFailures(List<String> reasons) {
+        // Insertion-ordered, so the log keeps the reasons in the order the page hit them rather than in hash
+        // order, which would differ from one run to the next.
+        return reasons
+                .stream()
+                .collect(Collectors.groupingBy(reason -> reason, LinkedHashMap::new, Collectors.counting()))
+                .entrySet()
+                .stream()
+                .map(byReason -> new DiscoveryMessageDraft(DiscoveryMessageSeverity.WARNING,
+                        DiscoveryMessageCode.CERTIFICATE_STAGING_FAILED,
+                        "A discovered certificate could not be staged: %s.".formatted(byReason.getKey()),
+                        byReason.getValue()))
+                .toList();
     }
 
     /**

--- a/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryEventIngestor.java
+++ b/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryEventIngestor.java
@@ -153,12 +153,10 @@ public class DiscoveryEventIngestor {
     }
 
     /**
-     * The connector's own code, or Core's stand-in when what arrived is not one. This is the event a connector sends
-     * when something has already gone wrong for it, so a bad code loses the report rather than the report being refused
-     * — but the value becomes the identity of a kind of problem and reaches clients as it arrived, so it is classified
-     * the way this platform classifies everything else a connector authors. Accepted whole or replaced, never trimmed
-     * into an identity no connector sent: two over-long codes sharing a prefix would otherwise aggregate onto one
-     * entry. The raw value is logged by the caller either way.
+     * The connector's own code, or Core's stand-in when what arrived is not one. The value becomes the identity of a
+     * kind of problem and reaches clients as it arrived, so it is accepted whole or replaced — never trimmed into an
+     * identity no connector sent, which is how two over-long codes sharing a prefix would aggregate onto one entry. The
+     * report itself is never refused, and the raw value is logged by the caller either way.
      */
     private static String reportedCode(DiscoveryErrorEvent error) {
         String code = error.getCode();

--- a/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryEventIngestor.java
+++ b/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryEventIngestor.java
@@ -140,12 +140,22 @@ public class DiscoveryEventIngestor {
                 logger.warn("Discovery {} connector error {}: {}", discoveryUuid, error.getCode(), error.getMessage());
                 messageWriter
                         .append(discoveryUuid, new DiscoveryMessageDraft(DiscoveryMessageSeverity.ERROR,
-                                error.getCode(), "The Discovery Provider reported a problem with this run.", 1));
+                                reportedCode(error), "The Discovery Provider reported a problem with this run.", 1));
             }
             case STATE_CHANGED -> scheduleNow(run, DiscoveryWorkType.STATUS);
             case RESULT_BATCH -> scheduleNow(run, DiscoveryWorkType.DRAIN);
             case HEARTBEAT -> logger.trace("Heartbeat for discovery {}", discoveryUuid);
         }
+    }
+
+    /**
+     * The connector's own code, or Core's stand-in when it named none. The contract requires one, but this is the event
+     * a connector sends when something has already gone wrong for it, and refusing to record that because the code is
+     * missing would lose the report entirely.
+     */
+    private static String reportedCode(DiscoveryErrorEvent error) {
+        String code = error.getCode();
+        return code == null || code.isBlank() ? DiscoveryMessageCode.CONNECTOR_ERROR.code() : code;
     }
 
     /**

--- a/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryEventIngestor.java
+++ b/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryEventIngestor.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +52,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class DiscoveryEventIngestor {
 
     private static final Logger logger = LoggerFactory.getLogger(DiscoveryEventIngestor.class);
+
+    /** Plausibly a connector's own identifier rather than prose or a fragment of payload. */
+    private static final Pattern REPORTABLE_CODE = Pattern.compile("[A-Za-z0-9._-]{1,64}");
 
     private final DiscoveryRepository discoveryRepository;
     private final DiscoveryItemWriter itemWriter;
@@ -149,13 +153,18 @@ public class DiscoveryEventIngestor {
     }
 
     /**
-     * The connector's own code, or Core's stand-in when it named none. The contract requires one, but this is the event
-     * a connector sends when something has already gone wrong for it, and refusing to record that because the code is
-     * missing would lose the report entirely.
+     * The connector's own code, or Core's stand-in when what arrived is not one. This is the event a connector sends
+     * when something has already gone wrong for it, so a bad code loses the report rather than the report being refused
+     * — but the value becomes the identity of a kind of problem and reaches clients as it arrived, so it is classified
+     * the way this platform classifies everything else a connector authors. Accepted whole or replaced, never trimmed
+     * into an identity no connector sent: two over-long codes sharing a prefix would otherwise aggregate onto one
+     * entry. The raw value is logged by the caller either way.
      */
     private static String reportedCode(DiscoveryErrorEvent error) {
         String code = error.getCode();
-        return code == null || code.isBlank() ? DiscoveryMessageCode.CONNECTOR_ERROR.code() : code;
+        return code != null && REPORTABLE_CODE.matcher(code).matches()
+                ? code
+                : DiscoveryMessageCode.CONNECTOR_ERROR.code();
     }
 
     /**

--- a/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryProcessTickWorker.java
+++ b/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryProcessTickWorker.java
@@ -223,9 +223,9 @@ public class DiscoveryProcessTickWorker {
      * often trip the write too, and an exception escaping there skips the stall path — so the attempt counter never
      * climbs and the budget never ends a failing run.
      */
-    private void recordQuietly(UUID discoveryUuid, String what, Runnable record) {
+    private void recordQuietly(UUID discoveryUuid, String what, Runnable write) {
         try {
-            record.run();
+            write.run();
         } catch (Exception e) {
             logger.error("Could not record {} for discovery {}: {}", what, discoveryUuid, e.getMessage(), e);
         }

--- a/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryProcessTickWorker.java
+++ b/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryProcessTickWorker.java
@@ -168,12 +168,21 @@ public class DiscoveryProcessTickWorker {
             logger
                     .error("Processing batch {} of discovery {} did not complete: {}", attempt, run.getUuid(),
                             e.getMessage(), e);
-            // INFO, because the rows are still in the backlog and another tick will try them again. What a failed
-            // batch leaves behind is what decides the run's ending: rows that ran out of attempts carry their own
-            // reason, and a stall that exhausts the budget ends the run itself.
+            // INFO only while the rows are still in the backlog for another tick to retry: rows that run out of
+            // attempts carry their own reason, and a stall that exhausts the budget ends the run itself. A batch
+            // that threw after stamping its last row leaves nothing to retry, so no later tick revisits the
+            // failure -- and an ending decided on severity would read that run as clean.
+            boolean retryable = backlogOf(run.getUuid()) > 0;
             messageWriter
-                    .append(run.getUuid(), DiscoveryMessageSeverity.INFO, DiscoveryMessageCode.BATCH_PROCESSING_FAILED,
-                            "A batch of discovered certificates did not complete and went back for another attempt.");
+                    .append(run.getUuid(), retryable ? DiscoveryMessageSeverity.INFO : DiscoveryMessageSeverity.WARNING,
+                            retryable
+                                    ? DiscoveryMessageCode.BATCH_PROCESSING_FAILED
+                                    : DiscoveryMessageCode.BATCH_PROCESSING_ABANDONED,
+                            retryable
+                                    ? "A batch of discovered certificates did not complete and went back for another "
+                                            + "attempt."
+                                    : "A batch of discovered certificates failed after its rows were imported, and "
+                                            + "will not be tried again.");
             return;
         }
         // Outside the catch above, and never folded into it: the batch itself succeeded, so filing a failure to
@@ -185,6 +194,13 @@ public class DiscoveryProcessTickWorker {
             logger
                     .error("Could not record what batch {} of discovery {} fell short on: {}", attempt, run.getUuid(),
                             e.getMessage(), e);
+            // appendAll returns early on an empty list, so reaching here proves the batch fell short of something.
+            // One more attempt, at a single row: a run that ends clean because its warning was lost is worse than
+            // one saying only that something was lost.
+            messageWriter
+                    .append(run.getUuid(), DiscoveryMessageSeverity.WARNING,
+                            DiscoveryMessageCode.BOOKKEEPING_INCOMPLETE,
+                            "Some of what a batch fell short on could not be recorded.");
         }
     }
 

--- a/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryProcessTickWorker.java
+++ b/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryProcessTickWorker.java
@@ -158,10 +158,10 @@ public class DiscoveryProcessTickWorker {
      * Runs the batch through the import pipeline and files what it could not import on the run.
      */
     private void importBatch(Discovery run, int attempt, List<DiscoveryCertificate> batch) {
+        DiscoveryRunCounts counts;
         try {
             authenticateAsTheRunsUser(run);
-            DiscoveryRunCounts counts = importHandler.processBatch(run, batch);
-            messageWriter.appendAll(run.getUuid(), counts.describeGaps());
+            counts = importHandler.processBatch(run, batch);
         } catch (Exception e) {
             // Swallowed, not rethrown: an unchanged backlog sends this batch to the bounded stall path instead of
             // the listener's log-and-acknowledge.
@@ -174,6 +174,17 @@ public class DiscoveryProcessTickWorker {
             messageWriter
                     .append(run.getUuid(), DiscoveryMessageSeverity.INFO, DiscoveryMessageCode.BATCH_PROCESSING_FAILED,
                             "A batch of discovered certificates did not complete and went back for another attempt.");
+            return;
+        }
+        // Outside the catch above, and never folded into it: the batch itself succeeded, so filing a failure to
+        // record its gaps as BATCH_PROCESSING_FAILED would file them at INFO -- the one severity the terminal
+        // decision ignores -- and let a run that fell short finish clean.
+        try {
+            messageWriter.appendAll(run.getUuid(), counts.describeGaps());
+        } catch (Exception e) {
+            logger
+                    .error("Could not record what batch {} of discovery {} fell short on: {}", attempt, run.getUuid(),
+                            e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryProcessTickWorker.java
+++ b/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryProcessTickWorker.java
@@ -43,9 +43,12 @@ public class DiscoveryProcessTickWorker {
 
     private static final Logger logger = LoggerFactory.getLogger(DiscoveryProcessTickWorker.class);
 
-    /** The severities that mean the run did not get everything done, whatever its rows say. */
+    /**
+     * The severities that mean the run did not get everything done, whatever its rows say. Anything above {@code INFO},
+     * so a severity added later counts until someone decides it should not.
+     */
     private static final Set<DiscoveryMessageSeverity> UNRECOVERED = EnumSet
-            .of(DiscoveryMessageSeverity.WARNING, DiscoveryMessageSeverity.ERROR);
+            .complementOf(EnumSet.of(DiscoveryMessageSeverity.INFO));
 
     private final DiscoveryRepository discoveryRepository;
     private final DiscoveryCertificateRepository certificateRepository;
@@ -179,17 +182,20 @@ public class DiscoveryProcessTickWorker {
             // of attempts carry their own reason, and a stall that exhausts the budget ends the run itself. Judged
             // on this batch and never the run, because another batch's pending rows would make a failure that
             // stamped all of its own look retryable -- and nothing would ever revisit it.
-            boolean retryable = pendingIn(batch) > 0;
-            messageWriter
-                    .append(run.getUuid(), retryable ? DiscoveryMessageSeverity.INFO : DiscoveryMessageSeverity.WARNING,
-                            retryable
-                                    ? DiscoveryMessageCode.BATCH_PROCESSING_FAILED
-                                    : DiscoveryMessageCode.BATCH_PROCESSING_ABANDONED,
-                            retryable
-                                    ? "A batch of discovered certificates did not complete and went back for another "
-                                            + "attempt."
-                                    : "A batch of discovered certificates failed after its rows were imported, and "
-                                            + "will not be tried again.");
+            recordQuietly(run.getUuid(), "a batch that did not complete", () -> {
+                boolean retryable = pendingIn(batch) > 0;
+                messageWriter
+                        .append(run.getUuid(),
+                                retryable ? DiscoveryMessageSeverity.INFO : DiscoveryMessageSeverity.WARNING,
+                                retryable
+                                        ? DiscoveryMessageCode.BATCH_PROCESSING_FAILED
+                                        : DiscoveryMessageCode.BATCH_PROCESSING_ABANDONED,
+                                retryable
+                                        ? "A batch of discovered certificates did not complete and went back for "
+                                                + "another attempt."
+                                        : "A batch of discovered certificates failed after its rows were imported, "
+                                                + "and will not be tried again.");
+            });
             return;
         }
         // Outside the catch above, and never folded into it: the batch itself succeeded, so filing a failure to
@@ -204,10 +210,24 @@ public class DiscoveryProcessTickWorker {
             // appendAll returns early on an empty list, so reaching here proves the batch fell short of something.
             // One more attempt, at a single row: a run that ends clean because its warning was lost is worse than
             // one saying only that something was lost.
-            messageWriter
-                    .append(run.getUuid(), DiscoveryMessageSeverity.WARNING,
-                            DiscoveryMessageCode.BOOKKEEPING_INCOMPLETE,
-                            "Some of what a batch fell short on could not be recorded.");
+            recordQuietly(run.getUuid(), "that a batch's gaps were lost",
+                    () -> messageWriter
+                            .append(run.getUuid(), DiscoveryMessageSeverity.WARNING,
+                                    DiscoveryMessageCode.BOOKKEEPING_INCOMPLETE,
+                                    "Some of what a batch fell short on could not be recorded."));
+        }
+    }
+
+    /**
+     * Records a message that must not take the tick down with it. The same outage that tripped the caller's catch will
+     * often trip the write too, and an exception escaping there skips the stall path — so the attempt counter never
+     * climbs and the budget never ends a failing run.
+     */
+    private void recordQuietly(UUID discoveryUuid, String what, Runnable record) {
+        try {
+            record.run();
+        } catch (Exception e) {
+            logger.error("Could not record {} for discovery {}: {}", what, discoveryUuid, e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryProcessTickWorker.java
+++ b/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryProcessTickWorker.java
@@ -154,6 +154,13 @@ public class DiscoveryProcessTickWorker {
                 .countByDiscoveryUuidAndNewlyDiscoveredTrueAndProcessedFalseAndProcessedErrorIsNull(discoveryUuid);
     }
 
+    /** How much of one batch is still waiting for a verdict. A row stamped with a reason is not waiting. */
+    private long pendingIn(List<DiscoveryCertificate> batch) {
+        return certificateRepository
+                .countByUuidInAndNewlyDiscoveredTrueAndProcessedFalseAndProcessedErrorIsNull(
+                        batch.stream().map(DiscoveryCertificate::getUuid).toList());
+    }
+
     /**
      * Runs the batch through the import pipeline and files what it could not import on the run.
      */
@@ -168,11 +175,11 @@ public class DiscoveryProcessTickWorker {
             logger
                     .error("Processing batch {} of discovery {} did not complete: {}", attempt, run.getUuid(),
                             e.getMessage(), e);
-            // INFO only while the rows are still in the backlog for another tick to retry: rows that run out of
-            // attempts carry their own reason, and a stall that exhausts the budget ends the run itself. A batch
-            // that threw after stamping its last row leaves nothing to retry, so no later tick revisits the
-            // failure -- and an ending decided on severity would read that run as clean.
-            boolean retryable = backlogOf(run.getUuid()) > 0;
+            // INFO only while this batch's own rows are still pending for another tick to retry: rows that run out
+            // of attempts carry their own reason, and a stall that exhausts the budget ends the run itself. Judged
+            // on this batch and never the run, because another batch's pending rows would make a failure that
+            // stamped all of its own look retryable -- and nothing would ever revisit it.
+            boolean retryable = pendingIn(batch) > 0;
             messageWriter
                     .append(run.getUuid(), retryable ? DiscoveryMessageSeverity.INFO : DiscoveryMessageSeverity.WARNING,
                             retryable

--- a/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryProcessTickWorker.java
+++ b/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryProcessTickWorker.java
@@ -1,26 +1,32 @@
 package com.otilm.core.service.handler.discovery;
 
+import com.otilm.api.model.core.discovery.DiscoveryMessageSeverity;
 import com.otilm.api.model.core.discovery.DiscoveryStatus;
 import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.entity.DiscoveryCertificate;
 import com.otilm.core.dao.repository.DiscoveryCertificateRepository;
+import com.otilm.core.dao.repository.DiscoveryMessageRepository;
 import com.otilm.core.dao.repository.DiscoveryRepository;
 import com.otilm.core.events.handlers.CertificateDiscoveredEventHandler;
 import com.otilm.core.events.handlers.discovery.DiscoveryRunCounts;
 import com.otilm.core.messaging.jms.configuration.DiscoveryWorkProperties;
 import com.otilm.core.messaging.jms.producers.DiscoveryWorkProducer;
 import com.otilm.core.messaging.model.DiscoveryWorkMessage;
+import com.otilm.core.model.discovery.DiscoveryMessageCode;
 import com.otilm.core.model.discovery.DiscoveryRunLifecycle;
 import com.otilm.core.model.discovery.DiscoveryWorkType;
 import com.otilm.core.service.handler.discovery.DiscoveryRunTerminator.Ending;
 import com.otilm.core.service.writer.DiscoveryWriter;
+import com.otilm.core.service.writer.discovery.DiscoveryMessageWriter;
 import com.otilm.core.service.writer.discovery.DiscoveryWorkWriter;
 import com.otilm.core.util.AuthHelper;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,31 +43,40 @@ public class DiscoveryProcessTickWorker {
 
     private static final Logger logger = LoggerFactory.getLogger(DiscoveryProcessTickWorker.class);
 
+    /** The severities that mean the run did not get everything done, whatever its rows say. */
+    private static final Set<DiscoveryMessageSeverity> UNRECOVERED = EnumSet
+            .of(DiscoveryMessageSeverity.WARNING, DiscoveryMessageSeverity.ERROR);
+
     private final DiscoveryRepository discoveryRepository;
     private final DiscoveryCertificateRepository certificateRepository;
+    private final DiscoveryMessageRepository messageRepository;
     private final CertificateDiscoveredEventHandler importHandler;
     private final DiscoveryWorkWriter workWriter;
     private final DiscoveryWorkProducer workProducer;
     private final DiscoveryRunTerminator terminator;
     private final DiscoveryWriter discoveryWriter;
+    private final DiscoveryMessageWriter messageWriter;
     private final AuthHelper authHelper;
     private final DiscoveryWorkProperties workProperties;
     private final int batchSize;
     private final Duration continuationBackstop;
 
     public DiscoveryProcessTickWorker(DiscoveryRepository discoveryRepository,
-            DiscoveryCertificateRepository certificateRepository, CertificateDiscoveredEventHandler importHandler,
-            DiscoveryWorkWriter workWriter, DiscoveryWorkProducer workProducer, DiscoveryRunTerminator terminator,
-            DiscoveryWriter discoveryWriter, AuthHelper authHelper, DiscoveryWorkProperties workProperties,
+            DiscoveryCertificateRepository certificateRepository, DiscoveryMessageRepository messageRepository,
+            CertificateDiscoveredEventHandler importHandler, DiscoveryWorkWriter workWriter,
+            DiscoveryWorkProducer workProducer, DiscoveryRunTerminator terminator, DiscoveryWriter discoveryWriter,
+            DiscoveryMessageWriter messageWriter, AuthHelper authHelper, DiscoveryWorkProperties workProperties,
             @Value("${discovery.processing.batch-size:200}") int batchSize,
             @Value("${discovery.work.continuation-backstop:PT1M}") Duration continuationBackstop) {
         this.discoveryRepository = discoveryRepository;
         this.certificateRepository = certificateRepository;
+        this.messageRepository = messageRepository;
         this.importHandler = importHandler;
         this.workWriter = workWriter;
         this.workProducer = workProducer;
         this.terminator = terminator;
         this.discoveryWriter = discoveryWriter;
+        this.messageWriter = messageWriter;
         this.authHelper = authHelper;
         this.workProperties = workProperties;
         // Fails at construction, not at the first tick.
@@ -146,16 +161,19 @@ public class DiscoveryProcessTickWorker {
         try {
             authenticateAsTheRunsUser(run);
             DiscoveryRunCounts counts = importHandler.processBatch(run, batch);
-            discoveryWriter.appendRunMessages(run.getUuid(), counts.describeGaps());
+            messageWriter.appendAll(run.getUuid(), counts.describeGaps());
         } catch (Exception e) {
             // Swallowed, not rethrown: an unchanged backlog sends this batch to the bounded stall path instead of
             // the listener's log-and-acknowledge.
             logger
                     .error("Processing batch {} of discovery {} did not complete: {}", attempt, run.getUuid(),
                             e.getMessage(), e);
-            discoveryWriter
-                    .appendRunMessages(run.getUuid(),
-                            List.of("A batch of discovered certificates could not be processed."));
+            // INFO, because the rows are still in the backlog and another tick will try them again. What a failed
+            // batch leaves behind is what decides the run's ending: rows that ran out of attempts carry their own
+            // reason, and a stall that exhausts the budget ends the run itself.
+            messageWriter
+                    .append(run.getUuid(), DiscoveryMessageSeverity.INFO, DiscoveryMessageCode.BATCH_PROCESSING_FAILED,
+                            "A batch of discovered certificates did not complete and went back for another attempt.");
         }
     }
 
@@ -232,9 +250,11 @@ public class DiscoveryProcessTickWorker {
             return null;
         }
         // Run-level gaps (a failed bookkeeping write, validation never requested) leave every row clean, so the
-        // message log is checked too.
+        // message log is checked too -- by severity, not by whether it holds anything. A run collects messages for
+        // things it recovered from, and ending a run whose every row imported on the strength of one of those
+        // would report a warning about nothing an operator can act on.
         boolean rowsFailed = certificateRepository.existsByDiscoveryUuidAndProcessedErrorIsNotNull(run.getUuid());
-        boolean runLevelGaps = run.getRunMessages() != null && !run.getRunMessages().isEmpty();
+        boolean runLevelGaps = messageRepository.existsByDiscoveryUuidAndSeverityIn(run.getUuid(), UNRECOVERED);
         if (!rowsFailed && !runLevelGaps) {
             return new Ending(DiscoveryStatus.COMPLETED, "Discovery completed successfully.");
         }

--- a/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryRunTerminator.java
+++ b/src/main/java/com/otilm/core/service/handler/discovery/DiscoveryRunTerminator.java
@@ -5,6 +5,7 @@ import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.repository.DiscoveryRepository;
 import com.otilm.core.events.transaction.TransactionHandler;
 import com.otilm.core.model.discovery.DiscoveryRunLifecycle;
+import com.otilm.core.service.writer.discovery.DiscoveryMessageWriter;
 import com.otilm.core.service.writer.discovery.DiscoveryWorkWriter;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -26,12 +27,14 @@ public class DiscoveryRunTerminator {
 
     private final DiscoveryRepository discoveryRepository;
     private final DiscoveryWorkWriter workWriter;
+    private final DiscoveryMessageWriter messageWriter;
     private final TransactionHandler transactionHandler;
 
     public DiscoveryRunTerminator(DiscoveryRepository discoveryRepository, DiscoveryWorkWriter workWriter,
-            TransactionHandler transactionHandler) {
+            DiscoveryMessageWriter messageWriter, TransactionHandler transactionHandler) {
         this.discoveryRepository = discoveryRepository;
         this.workWriter = workWriter;
+        this.messageWriter = messageWriter;
         this.transactionHandler = transactionHandler;
     }
 
@@ -99,7 +102,7 @@ public class DiscoveryRunTerminator {
         run.setMessage(reason);
         run.setEndTime(OffsetDateTime.now(ZoneOffset.UTC));
         run.setRunMeta(null);
-        run.setRunMessages(DiscoveryRunLifecycle.append(run.getRunMessages(), reason));
+        messageWriter.appendRunEnded(run.getUuid(), DiscoveryRunLifecycle.severityOf(status), reason);
         logger.info("Discovery {} ended as {}: {}", run.getUuid(), status, reason);
     }
 }

--- a/src/main/java/com/otilm/core/service/writer/DiscoveryWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/DiscoveryWriter.java
@@ -4,11 +4,9 @@ import com.otilm.api.model.client.discovery.DiscoveryDetailDto;
 import com.otilm.api.model.core.discovery.DiscoveryStatus;
 import com.otilm.core.dao.repository.DiscoveryCertificateRepository;
 import com.otilm.core.dao.repository.DiscoveryRepository;
-import com.otilm.core.model.discovery.DiscoveryRunLifecycle;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -62,24 +60,6 @@ public class DiscoveryWriter {
     @Transactional
     public void updateProgressMessage(UUID discoveryUuid, String message) {
         discoveryRepository.updateMessage(discoveryUuid, message);
-    }
-
-    /**
-     * Adds to the run's advisory message log — the narrative an operator reads to understand a run that finished with
-     * warnings, kept for the life of the run rather than overwritten like the headline message.
-     *
-     * <p>
-     * Takes the run's row lock: the log is a single JSONB value, so a read-modify-write that raced another appender
-     * would silently drop one of the two messages.
-     */
-    @Transactional
-    public void appendRunMessages(UUID discoveryUuid, List<String> messages) {
-        if (messages.isEmpty()) {
-            return;
-        }
-        discoveryRepository
-                .findWithLockByUuid(discoveryUuid)
-                .ifPresent(run -> run.setRunMessages(DiscoveryRunLifecycle.append(run.getRunMessages(), messages)));
     }
 
     /**

--- a/src/main/java/com/otilm/core/service/writer/discovery/DiscoveryMessageWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/discovery/DiscoveryMessageWriter.java
@@ -134,9 +134,9 @@ public class DiscoveryMessageWriter {
         logger
                 .debug("Discovery {} kept no row for a {} message; it is at its {} bound", discoveryUuid, code,
                         runIsFull ? "per-run" : "per-code");
-        // The severity of whatever overflowed first, which the upsert raises as worse things fold into the same row.
-        // Nothing is floored on the way in: a row standing only for informational messages would otherwise report a
-        // warning, and the terminal decision reads exactly that.
+        // The severity of whatever overflowed first; the upsert raises the row as worse things fold into it. Not
+        // floored on the way in, or a row standing only for informational messages would report a warning that the
+        // terminal decision then reads.
         if (runIsFull) {
             write(discoveryUuid, draft.severity(), DiscoveryMessageCode.MESSAGES_SUPPRESSED.code(),
                     RUN_SUPPRESSION_MESSAGE, draft.occurrences());

--- a/src/main/java/com/otilm/core/service/writer/discovery/DiscoveryMessageWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/discovery/DiscoveryMessageWriter.java
@@ -91,12 +91,12 @@ public class DiscoveryMessageWriter {
     @Transactional
     public void append(UUID discoveryUuid, DiscoveryMessageSeverity severity, DiscoveryMessageCode code,
             String message) {
-        record(discoveryUuid, new DiscoveryMessageDraft(severity, code, message, 1));
+        recordMessage(discoveryUuid, new DiscoveryMessageDraft(severity, code, message, 1));
     }
 
     @Transactional
     public void append(UUID discoveryUuid, DiscoveryMessageDraft draft) {
-        record(discoveryUuid, draft);
+        recordMessage(discoveryUuid, draft);
     }
 
     @Transactional
@@ -106,7 +106,7 @@ public class DiscoveryMessageWriter {
             // and per page to write nothing.
             return;
         }
-        drafts.forEach(draft -> record(discoveryUuid, draft));
+        drafts.forEach(draft -> recordMessage(discoveryUuid, draft));
     }
 
     /**
@@ -118,7 +118,7 @@ public class DiscoveryMessageWriter {
         write(discoveryUuid, severity, DiscoveryMessageCode.RUN_ENDED.code(), shorten(reason, maxMessageLength), 1);
     }
 
-    private void record(UUID discoveryUuid, DiscoveryMessageDraft draft) {
+    private void recordMessage(UUID discoveryUuid, DiscoveryMessageDraft draft) {
         String code = shorten(draft.code(), MAX_CODE_LENGTH);
         String message = shorten(draft.message(), maxMessageLength);
         int recorded = messageRepository

--- a/src/main/java/com/otilm/core/service/writer/discovery/DiscoveryMessageWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/discovery/DiscoveryMessageWriter.java
@@ -1,0 +1,152 @@
+package com.otilm.core.service.writer.discovery;
+
+import com.otilm.api.model.core.discovery.DiscoveryMessageSeverity;
+import com.otilm.core.dao.repository.DiscoveryMessageRepository;
+import com.otilm.core.model.discovery.DiscoveryMessageCode;
+import com.otilm.core.model.discovery.DiscoveryMessageDraft;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The one way anything writes to a run's message log, and the one place its bounds are enforced.
+ *
+ * <p>
+ * <b>The bounds are fixed, not configured.</b> They are safety limits against a producer or a connector that
+ * misbehaves, not tuning dials — a well-behaved run reaches around sixteen distinct kinds against a ceiling of fifty,
+ * and no deployment holds information that would tell it to move one.
+ *
+ * <p>
+ * An append never takes the run row's write lock: the upsert aggregates a repeat onto the row already carrying it, so
+ * two appenders add their counts instead of one overwriting the other. That is what lets a producer record a problem
+ * without queueing behind whatever else is holding the run.
+ *
+ * <p>
+ * <b>{@code REQUIRED} throughout, never {@code REQUIRES_NEW}.</b> Most callers append while holding the run row's
+ * {@code SELECT ... FOR UPDATE}, and the row inserted here takes a {@code FOR KEY SHARE} lock on that same run row
+ * through its foreign key. From a separate transaction that wait can never be satisfied — the append would block on a
+ * lock its own caller holds, and the run would hang rather than fail.
+ *
+ * <p>
+ * <b>Overflow drops the newest and keeps the oldest.</b> A bound refuses new rows once reached; it never evicts one
+ * already recorded. An operator opening a degraded run is looking for what started it, and the log a run keeps must
+ * still contain that after the same fault has repeated ten thousand times.
+ */
+@Service
+public class DiscoveryMessageWriter {
+
+    private static final Logger logger = LoggerFactory.getLogger(DiscoveryMessageWriter.class);
+
+    /** Stands in for the distinct messages of one kind a run had no room to keep. */
+    static final String CODE_SUPPRESSION_MESSAGE = "Further distinct messages of this kind were not recorded.";
+
+    /** Stands in for everything a run had no room to keep once it was full. */
+    static final String RUN_SUPPRESSION_MESSAGE = "Further messages were not recorded: this run reached the limit on "
+            + "how many kinds of problem it may keep.";
+
+    private static final String ELLIPSIS = "...";
+
+    /** A code is Core's own or comes from a closed connector vocabulary; a long one is a misbehaving connector. */
+    private static final int MAX_CODE_LENGTH = 64;
+
+    /** Around six distinct texts are reachable per code; the rest is headroom for a producer that misbehaves. */
+    private static final int MAX_PER_CODE = 20;
+
+    /** Must stay at or above {@link #MAX_PER_CODE}, or no code could reach its own bound. */
+    private static final int MAX_PER_RUN = 50;
+
+    /** Every message is Core-authored and runs to 60-120 characters; this only catches a future producer. */
+    private static final int MAX_MESSAGE_LENGTH = 500;
+
+    private final DiscoveryMessageRepository messageRepository;
+    private final int maxPerCode;
+    private final int maxPerRun;
+    private final int maxMessageLength;
+
+    @Autowired
+    public DiscoveryMessageWriter(DiscoveryMessageRepository messageRepository) {
+        this(messageRepository, MAX_PER_CODE, MAX_PER_RUN, MAX_MESSAGE_LENGTH);
+    }
+
+    /**
+     * Bounds low enough for a test to reach overflow. Production takes the constructor above.
+     */
+    public DiscoveryMessageWriter(DiscoveryMessageRepository messageRepository, int maxPerCode, int maxPerRun,
+            int maxMessageLength) {
+        this.messageRepository = messageRepository;
+        this.maxPerCode = maxPerCode;
+        this.maxPerRun = maxPerRun;
+        this.maxMessageLength = maxMessageLength;
+    }
+
+    /** Records one occurrence of a problem Core produced itself. */
+    @Transactional
+    public void append(UUID discoveryUuid, DiscoveryMessageSeverity severity, DiscoveryMessageCode code,
+            String message) {
+        record(discoveryUuid, new DiscoveryMessageDraft(severity, code, message, 1));
+    }
+
+    @Transactional
+    public void append(UUID discoveryUuid, DiscoveryMessageDraft draft) {
+        record(discoveryUuid, draft);
+    }
+
+    @Transactional
+    public void appendAll(UUID discoveryUuid, List<DiscoveryMessageDraft> drafts) {
+        drafts.forEach(draft -> record(discoveryUuid, draft));
+    }
+
+    /**
+     * Records how a run ended, exempt from every bound. A run's ending is the one message an operator is guaranteed to
+     * look for, so it must land even on the run that filled its log ten thousand messages ago.
+     */
+    @Transactional
+    public void appendRunEnded(UUID discoveryUuid, DiscoveryMessageSeverity severity, String reason) {
+        write(discoveryUuid, severity, DiscoveryMessageCode.RUN_ENDED.code(), shorten(reason, maxMessageLength), 1);
+    }
+
+    private void record(UUID discoveryUuid, DiscoveryMessageDraft draft) {
+        String code = shorten(draft.code(), MAX_CODE_LENGTH);
+        String message = shorten(draft.message(), maxMessageLength);
+        int recorded = messageRepository
+                .appendWithinBounds(discoveryUuid, draft.severity().name(), code, message, draft.occurrences(),
+                        maxPerCode, maxPerRun);
+        if (recorded > 0) {
+            return;
+        }
+        // Which bound refused it decides what stands in for it: one row per kind while only that kind is full,
+        // and a single run-level row once the run itself is, so a connector minting a fresh code per error
+        // cannot grow the log one suppression row at a time.
+        boolean runIsFull = messageRepository.countByDiscoveryUuid(discoveryUuid) >= maxPerRun;
+        logger
+                .debug("Discovery {} kept no row for a {} message; it is at its {} bound", discoveryUuid, code,
+                        runIsFull ? "per-run" : "per-code");
+        if (runIsFull) {
+            write(discoveryUuid, draft.severity(), DiscoveryMessageCode.MESSAGES_SUPPRESSED.code(),
+                    RUN_SUPPRESSION_MESSAGE, draft.occurrences());
+        } else {
+            write(discoveryUuid, draft.severity(), code, CODE_SUPPRESSION_MESSAGE, draft.occurrences());
+        }
+    }
+
+    /**
+     * The unbounded write. A suppression row keeps the severity of whichever message first overflowed into it; the
+     * messages it stands in for are gone, so there is nothing left to raise it from.
+     */
+    private void write(UUID discoveryUuid, DiscoveryMessageSeverity severity, String code, String message,
+            long occurrences) {
+        messageRepository.append(discoveryUuid, severity.name(), code, message, occurrences);
+    }
+
+    /** Cut text says so, since the part that identifies one failure from another is often at the end. */
+    private static String shorten(String text, int limit) {
+        if (text == null || text.length() <= limit) {
+            return text;
+        }
+        return text.substring(0, limit - ELLIPSIS.length()) + ELLIPSIS;
+    }
+}

--- a/src/main/java/com/otilm/core/service/writer/discovery/DiscoveryMessageWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/discovery/DiscoveryMessageWriter.java
@@ -17,13 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * <p>
  * <b>The bounds are fixed, not configured.</b> They are safety limits against a producer or a connector that
- * misbehaves, not tuning dials — a well-behaved run reaches around sixteen distinct kinds against a ceiling of fifty,
- * and no deployment holds information that would tell it to move one.
+ * misbehaves, not tuning dials, and soft ceilings under concurrency at that — see
+ * {@link DiscoveryMessageRepository#appendWithinBounds}.
  *
  * <p>
- * An append never takes the run row's write lock: the upsert aggregates a repeat onto the row already carrying it, so
- * two appenders add their counts instead of one overwriting the other. That is what lets a producer record a problem
- * without queueing behind whatever else is holding the run.
+ * An append takes no lock of its own and never reads the log to write it, so no caller has to remember to lock the run
+ * row to be safe — again, see {@link DiscoveryMessageRepository#appendWithinBounds}. It does still queue behind one
+ * held {@code FOR UPDATE}, for the reason below.
  *
  * <p>
  * <b>{@code REQUIRED} throughout, never {@code REQUIRES_NEW}.</b> Most callers append while holding the run row's
@@ -41,10 +41,10 @@ public class DiscoveryMessageWriter {
 
     private static final Logger logger = LoggerFactory.getLogger(DiscoveryMessageWriter.class);
 
-    /** Stands in for the distinct messages of one kind a run had no room to keep. */
-    static final String CODE_SUPPRESSION_MESSAGE = "Further distinct messages of this kind were not recorded.";
+    /** Stands in for the messages of one kind a run had no room to keep; its count is the occurrences dropped. */
+    static final String CODE_SUPPRESSION_MESSAGE = "Further messages of this kind were not recorded.";
 
-    /** Stands in for everything a run had no room to keep once it was full. */
+    /** Stands in for everything a run had no room to keep once it was full; its count is the occurrences dropped. */
     static final String RUN_SUPPRESSION_MESSAGE = "Further messages were not recorded: this run reached the limit on "
             + "how many kinds of problem it may keep.";
 
@@ -53,13 +53,13 @@ public class DiscoveryMessageWriter {
     /** A code is Core's own or comes from a closed connector vocabulary; a long one is a misbehaving connector. */
     private static final int MAX_CODE_LENGTH = 64;
 
-    /** Around six distinct texts are reachable per code; the rest is headroom for a producer that misbehaves. */
+    /** Only a handful of distinct texts are reachable per code; the rest is headroom for a producer that misbehaves. */
     private static final int MAX_PER_CODE = 20;
 
     /** Must stay at or above {@link #MAX_PER_CODE}, or no code could reach its own bound. */
     private static final int MAX_PER_RUN = 50;
 
-    /** Every message is Core-authored and runs to 60-120 characters; this only catches a future producer. */
+    /** Every message is Core-authored and far shorter than this; it only catches a future producer. */
     private static final int MAX_MESSAGE_LENGTH = 500;
 
     private final DiscoveryMessageRepository messageRepository;
@@ -97,6 +97,11 @@ public class DiscoveryMessageWriter {
 
     @Transactional
     public void appendAll(UUID discoveryUuid, List<DiscoveryMessageDraft> drafts) {
+        if (drafts.isEmpty()) {
+            // The clean path for both hot callers, which would otherwise open and commit a transaction per batch
+            // and per page to write nothing.
+            return;
+        }
         drafts.forEach(draft -> record(discoveryUuid, draft));
     }
 
@@ -126,16 +131,26 @@ public class DiscoveryMessageWriter {
                 .debug("Discovery {} kept no row for a {} message; it is at its {} bound", discoveryUuid, code,
                         runIsFull ? "per-run" : "per-code");
         if (runIsFull) {
-            write(discoveryUuid, draft.severity(), DiscoveryMessageCode.MESSAGES_SUPPRESSED.code(),
+            write(discoveryUuid, standInSeverity(draft.severity()), DiscoveryMessageCode.MESSAGES_SUPPRESSED.code(),
                     RUN_SUPPRESSION_MESSAGE, draft.occurrences());
         } else {
-            write(discoveryUuid, draft.severity(), code, CODE_SUPPRESSION_MESSAGE, draft.occurrences());
+            write(discoveryUuid, standInSeverity(draft.severity()), code, CODE_SUPPRESSION_MESSAGE,
+                    draft.occurrences());
         }
     }
 
     /**
-     * The unbounded write. A suppression row keeps the severity of whichever message first overflowed into it; the
-     * messages it stands in for are gone, so there is nothing left to raise it from.
+     * At least {@code WARNING}, whatever overflowed: a suppression row exists because the run lost information about
+     * itself, and the run-level one stands in for several codes, so the first arrival's severity says nothing about the
+     * rest. It may understate an {@code ERROR} it covers, but can never hide one from the terminal decision.
+     */
+    private static DiscoveryMessageSeverity standInSeverity(DiscoveryMessageSeverity suppressed) {
+        return suppressed == DiscoveryMessageSeverity.ERROR ? suppressed : DiscoveryMessageSeverity.WARNING;
+    }
+
+    /**
+     * The unbounded write. {@code occurrences} on a suppression row counts the occurrences it stands in for, not the
+     * distinct messages, which is why its text does not name a number.
      */
     private void write(UUID discoveryUuid, DiscoveryMessageSeverity severity, String code, String message,
             long occurrences) {

--- a/src/main/java/com/otilm/core/service/writer/discovery/DiscoveryMessageWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/discovery/DiscoveryMessageWriter.java
@@ -141,8 +141,8 @@ public class DiscoveryMessageWriter {
 
     /**
      * At least {@code WARNING}, whatever overflowed: a suppression row exists because the run lost information about
-     * itself, and the run-level one stands in for several codes, so the first arrival's severity says nothing about the
-     * rest. It may understate an {@code ERROR} it covers, but can never hide one from the terminal decision.
+     * itself, which is worth a warning even when everything behind it was routine. Anything worse it later stands in
+     * for raises it, since the upsert keeps the highest severity a row has ever carried.
      */
     private static DiscoveryMessageSeverity standInSeverity(DiscoveryMessageSeverity suppressed) {
         return suppressed == DiscoveryMessageSeverity.ERROR ? suppressed : DiscoveryMessageSeverity.WARNING;

--- a/src/main/java/com/otilm/core/service/writer/discovery/DiscoveryMessageWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/discovery/DiscoveryMessageWriter.java
@@ -35,6 +35,10 @@ import org.springframework.transaction.annotation.Transactional;
  * <b>Overflow drops the newest and keeps the oldest.</b> A bound refuses new rows once reached; it never evicts one
  * already recorded. An operator opening a degraded run is looking for what started it, and the log a run keeps must
  * still contain that after the same fault has repeated ten thousand times.
+ *
+ * <p>
+ * {@code occurrences} counts at least once, not exactly once. A redelivered tick aggregates onto the row it already
+ * wrote rather than adding a second one, but it does add to that row's count.
  */
 @Service
 public class DiscoveryMessageWriter {
@@ -130,22 +134,15 @@ public class DiscoveryMessageWriter {
         logger
                 .debug("Discovery {} kept no row for a {} message; it is at its {} bound", discoveryUuid, code,
                         runIsFull ? "per-run" : "per-code");
+        // The severity of whatever overflowed first, which the upsert raises as worse things fold into the same row.
+        // Nothing is floored on the way in: a row standing only for informational messages would otherwise report a
+        // warning, and the terminal decision reads exactly that.
         if (runIsFull) {
-            write(discoveryUuid, standInSeverity(draft.severity()), DiscoveryMessageCode.MESSAGES_SUPPRESSED.code(),
+            write(discoveryUuid, draft.severity(), DiscoveryMessageCode.MESSAGES_SUPPRESSED.code(),
                     RUN_SUPPRESSION_MESSAGE, draft.occurrences());
         } else {
-            write(discoveryUuid, standInSeverity(draft.severity()), code, CODE_SUPPRESSION_MESSAGE,
-                    draft.occurrences());
+            write(discoveryUuid, draft.severity(), code, CODE_SUPPRESSION_MESSAGE, draft.occurrences());
         }
-    }
-
-    /**
-     * At least {@code WARNING}, whatever overflowed: a suppression row exists because the run lost information about
-     * itself, which is worth a warning even when everything behind it was routine. Anything worse it later stands in
-     * for raises it, since the upsert keeps the highest severity a row has ever carried.
-     */
-    private static DiscoveryMessageSeverity standInSeverity(DiscoveryMessageSeverity suppressed) {
-        return suppressed == DiscoveryMessageSeverity.ERROR ? suppressed : DiscoveryMessageSeverity.WARNING;
     }
 
     /**

--- a/src/main/resources/db/migration/V202608251000__discovery_run_message_rows.sql
+++ b/src/main/resources/db/migration/V202608251000__discovery_run_message_rows.sql
@@ -1,5 +1,9 @@
 -- Run messages move off the run row: from a JSONB array of strings rewritten whole under the run's write lock
 -- to one row per distinct problem, appended by upsert and aggregated by occurrence count.
+--
+-- The old column is dropped without backfill: it was added in this same unreleased cycle (V202608141100), so
+-- only mainline and staging runs carry values, and those are bare strings with no code or severity to map onto
+-- the new shape.
 
 CREATE TABLE "discovery_message" (
     -- Ordering only, never exposed; a timestamp cannot order these (see DiscoveryMessage.id).

--- a/src/main/resources/db/migration/V202608251000__discovery_run_message_rows.sql
+++ b/src/main/resources/db/migration/V202608251000__discovery_run_message_rows.sql
@@ -2,14 +2,13 @@
 -- to one row per distinct problem, appended by upsert and aggregated by occurrence count.
 
 CREATE TABLE "discovery_message" (
-    -- Ordering only, never exposed. A timestamp cannot order these: now() is transaction-start time, so every
-    -- message a tick writes ties, and a wall-clock column inverts across pods under clock skew.
+    -- Ordering only, never exposed; a timestamp cannot order these (see DiscoveryMessage.id).
     "id" BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     "discovery_uuid" UUID NOT NULL,
     "severity" VARCHAR NOT NULL,
     "code" VARCHAR NOT NULL,           -- kind of problem: connector-supplied for connector errors, else Core's own
     "message" VARCHAR NOT NULL,
-    -- Hashed so the unique index stays inside the btree entry limit whatever the configured message bound is.
+    -- Hashed to keep the unique index entry inside the btree limit whatever the message length.
     "message_hash" VARCHAR GENERATED ALWAYS AS (md5("message")) STORED,
     "occurrences" BIGINT NOT NULL DEFAULT 1,
     "first_seen_at" TIMESTAMPTZ NOT NULL,

--- a/src/main/resources/db/migration/V202608251000__discovery_run_message_rows.sql
+++ b/src/main/resources/db/migration/V202608251000__discovery_run_message_rows.sql
@@ -1,0 +1,25 @@
+-- Run messages move off the run row: from a JSONB array of strings rewritten whole under the run's write lock
+-- to one row per distinct problem, appended by upsert and aggregated by occurrence count.
+
+CREATE TABLE "discovery_message" (
+    -- Ordering only, never exposed. A timestamp cannot order these: now() is transaction-start time, so every
+    -- message a tick writes ties, and a wall-clock column inverts across pods under clock skew.
+    "id" BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    "discovery_uuid" UUID NOT NULL,
+    "severity" VARCHAR NOT NULL,
+    "code" VARCHAR NOT NULL,           -- kind of problem: connector-supplied for connector errors, else Core's own
+    "message" VARCHAR NOT NULL,
+    -- Hashed so the unique index stays inside the btree entry limit whatever the configured message bound is.
+    "message_hash" VARCHAR GENERATED ALWAYS AS (md5("message")) STORED,
+    "occurrences" BIGINT NOT NULL DEFAULT 1,
+    "first_seen_at" TIMESTAMPTZ NOT NULL,
+    "last_seen_at" TIMESTAMPTZ NOT NULL,
+    CONSTRAINT "discovery_message_to_discovery_key" FOREIGN KEY ("discovery_uuid")
+        REFERENCES "discovery" ("uuid") ON DELETE CASCADE,
+    CONSTRAINT "uq_discovery_message" UNIQUE ("discovery_uuid", "code", "message_hash")
+);
+
+-- Serves the run's listing, and the per-run bound the writer checks before every new row.
+CREATE INDEX "idx_discovery_message_run" ON "discovery_message" ("discovery_uuid", "id");
+
+ALTER TABLE "discovery" DROP COLUMN "run_messages";

--- a/src/test/java/com/otilm/core/integration/discovery/DiscoveryEventIngestorITest.java
+++ b/src/test/java/com/otilm/core/integration/discovery/DiscoveryEventIngestorITest.java
@@ -14,12 +14,15 @@ import com.otilm.api.model.connector.discovery.v2.event.DiscoveryProgressEvent;
 import com.otilm.api.model.connector.discovery.v2.event.DiscoveryResultBatchEvent;
 import com.otilm.api.model.connector.discovery.v2.event.DiscoveryStateChangedEvent;
 import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.discovery.DiscoveryMessageSeverity;
 import com.otilm.api.model.core.discovery.DiscoveryStatus;
 import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.entity.DiscoveryItem;
+import com.otilm.core.dao.entity.DiscoveryMessage;
 import com.otilm.core.dao.entity.DiscoveryWork;
 import com.otilm.core.dao.repository.DiscoveryCertificateRepository;
 import com.otilm.core.dao.repository.DiscoveryItemRepository;
+import com.otilm.core.dao.repository.DiscoveryMessageRepository;
 import com.otilm.core.dao.repository.DiscoveryRepository;
 import com.otilm.core.dao.repository.DiscoveryWorkRepository;
 import com.otilm.core.model.discovery.DiscoveryWorkType;
@@ -55,6 +58,8 @@ class DiscoveryEventIngestorITest extends BaseSpringBootTest {
     private DiscoveryCertificateRepository certificateRepository;
     @Autowired
     private DiscoveryWorkRepository workRepository;
+    @Autowired
+    private DiscoveryMessageRepository messageRepository;
     @PersistenceContext
     private EntityManager entityManager;
 
@@ -190,13 +195,15 @@ class DiscoveryEventIngestorITest extends BaseSpringBootTest {
 
         ingestor.applyAdvisoryEvent(run.getUuid(), event);
 
-        Discovery reloaded = reload(run);
-        // The code is a connector-declared identifier; the message beside it is connector prose, and this log
-        // is read through the API -- so the prose stays in the log and never on the run.
-        assertThat(reloaded.getRunMessages())
-                .containsExactly("Connector reported HOST_UNREACHABLE")
-                .noneMatch(message -> message.contains("10.0.0.7"));
-        assertThat(reloaded.getStatus()).isEqualTo(DiscoveryStatus.IN_PROGRESS);
+        // The code is the connector-declared identifier, which the message row is keyed by; the prose beside it
+        // is the connector's own, and this log is read through the API -- so that prose stays in the log file
+        // and never reaches the run.
+        assertThat(messages(run)).singleElement().satisfies(message -> {
+            assertThat(message.getCode()).isEqualTo("HOST_UNREACHABLE");
+            assertThat(message.getSeverity()).isEqualTo(DiscoveryMessageSeverity.ERROR);
+            assertThat(message.getMessage()).doesNotContain("10.0.0.7");
+        });
+        assertThat(reload(run).getStatus()).isEqualTo(DiscoveryStatus.IN_PROGRESS);
         assertThat(agenda(run)).isEmpty();
     }
 
@@ -308,5 +315,11 @@ class DiscoveryEventIngestorITest extends BaseSpringBootTest {
         entityManager.flush();
         entityManager.clear();
         return workRepository.findAll().stream().filter(w -> w.getDiscoveryUuid().equals(run.getUuid())).toList();
+    }
+
+    private List<DiscoveryMessage> messages(Discovery run) {
+        entityManager.flush();
+        entityManager.clear();
+        return messageRepository.findByDiscoveryUuidOrderByIdAsc(run.getUuid());
     }
 }

--- a/src/test/java/com/otilm/core/integration/discovery/DiscoveryMessageWriterITest.java
+++ b/src/test/java/com/otilm/core/integration/discovery/DiscoveryMessageWriterITest.java
@@ -104,6 +104,25 @@ class DiscoveryMessageWriterITest extends BaseSpringBootTest {
     }
 
     @Test
+    void aSuppressionRow_countsTheOccurrencesItStandsInForRatherThanTheMessages() {
+        Discovery run = v2Run();
+        for (int i = 1; i <= MAX_PER_CODE; i++) {
+            writer.append(run.getUuid(), gap("failure number " + i, 1));
+        }
+
+        writer.append(run.getUuid(), gap("a kind with no room left", 5));
+
+        assertThat(messages(run)).last().satisfies(suppressed -> {
+            assertThat(suppressed.getOccurrences())
+                    .as("five occurrences went unrecorded, not one message")
+                    .isEqualTo(5);
+            assertThat(suppressed.getSeverity())
+                    .as("a run that lost information about itself is at least a warning")
+                    .isEqualTo(DiscoveryMessageSeverity.WARNING);
+        });
+    }
+
+    @Test
     void aRepeatOfSomethingAlreadyRecorded_landsEvenOnceTheBoundIsReached() {
         Discovery run = v2Run();
         for (int i = 1; i <= 4; i++) {
@@ -112,7 +131,6 @@ class DiscoveryMessageWriterITest extends BaseSpringBootTest {
 
         writer.append(run.getUuid(), gap("failure number 1", 5));
 
-        // Aggregating onto a row that exists grows nothing, so the bound has no reason to refuse it.
         assertThat(messages(run))
                 .filteredOn(message -> "failure number 1".equals(message.getMessage()))
                 .singleElement()

--- a/src/test/java/com/otilm/core/integration/discovery/DiscoveryMessageWriterITest.java
+++ b/src/test/java/com/otilm/core/integration/discovery/DiscoveryMessageWriterITest.java
@@ -1,0 +1,231 @@
+package com.otilm.core.integration.discovery;
+
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.discovery.DiscoveryMessageSeverity;
+import com.otilm.api.model.core.discovery.DiscoveryStatus;
+import com.otilm.core.dao.entity.Discovery;
+import com.otilm.core.dao.entity.DiscoveryMessage;
+import com.otilm.core.dao.repository.DiscoveryMessageRepository;
+import com.otilm.core.dao.repository.DiscoveryRepository;
+import com.otilm.core.model.discovery.DiscoveryMessageCode;
+import com.otilm.core.model.discovery.DiscoveryMessageDraft;
+import com.otilm.core.service.writer.discovery.DiscoveryMessageWriter;
+import com.otilm.core.util.BaseSpringBootTest;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * What a run's message log does under repetition and under pressure, against real PostgreSQL: the upsert has to
+ * aggregate rather than accumulate, the bounds have to hold without evicting what an operator came for, and the order
+ * has to survive a tick that writes several messages inside one transaction.
+ *
+ * <p>
+ * The writer is built here rather than autowired, with bounds low enough that overflow is reachable. Setting those
+ * through {@code @TestPropertySource} would fork a second Spring context for this one class; the bean's own wiring is
+ * exercised by every other discovery ITest, and its transaction semantics do not enter into it — the test's transaction
+ * is the ambient one either way.
+ */
+@Transactional
+class DiscoveryMessageWriterITest extends BaseSpringBootTest {
+
+    private static final int MAX_PER_CODE = 3;
+    private static final int MAX_PER_RUN = 5;
+    private static final int MAX_LENGTH = 40;
+
+    private DiscoveryMessageWriter writer;
+
+    @Autowired
+    private DiscoveryMessageRepository messageRepository;
+    @Autowired
+    private DiscoveryRepository discoveryRepository;
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+        writer = new DiscoveryMessageWriter(messageRepository, MAX_PER_CODE, MAX_PER_RUN, MAX_LENGTH);
+    }
+
+    @Test
+    void theSameProblemTwice_aggregatesOntoOneRowRatherThanAddingASecond() {
+        Discovery run = v2Run();
+
+        writer.append(run.getUuid(), gap("the host refused the connection", 3));
+        writer.append(run.getUuid(), gap("the host refused the connection", 4));
+
+        assertThat(messages(run)).singleElement().satisfies(message -> {
+            assertThat(message.getOccurrences())
+                    .as("the counts add: a batch reporting the same gap must not overwrite the one before it")
+                    .isEqualTo(7);
+            assertThat(message.getLastSeenAt()).isAfterOrEqualTo(message.getFirstSeenAt());
+        });
+    }
+
+    @Test
+    void sameTextUnderADifferentCode_isADifferentProblem() {
+        Discovery run = v2Run();
+
+        writer.append(run.getUuid(), gap("could not be staged", 1));
+        writer
+                .append(run.getUuid(), new DiscoveryMessageDraft(DiscoveryMessageSeverity.WARNING,
+                        DiscoveryMessageCode.CERTIFICATE_STAGING_FAILED, "could not be staged", 1));
+
+        assertThat(messages(run)).hasSize(2);
+    }
+
+    @Test
+    void distinctProblemsPastThePerCodeBound_foldIntoOneSuppressionRowAndLeaveTheOldestAlone() {
+        Discovery run = v2Run();
+
+        for (int i = 1; i <= 6; i++) {
+            writer.append(run.getUuid(), gap("failure number " + i, 1));
+        }
+
+        List<DiscoveryMessage> log = messages(run);
+        assertThat(log).hasSize(4);
+        assertThat(log)
+                .extracting(DiscoveryMessage::getMessage)
+                .as("the oldest three survive: an operator opening a degraded run is looking for what started it")
+                .startsWith("failure number 1", "failure number 2", "failure number 3");
+        assertThat(log.get(3).getOccurrences())
+                .as("the three it had no room for are counted rather than lost silently")
+                .isEqualTo(3);
+        assertThat(log.get(3).getCode())
+                .as("suppression is per code, so what was dropped is still attributable")
+                .isEqualTo(DiscoveryMessageCode.INVENTORY_GAP.code());
+    }
+
+    @Test
+    void aRepeatOfSomethingAlreadyRecorded_landsEvenOnceTheBoundIsReached() {
+        Discovery run = v2Run();
+        for (int i = 1; i <= 4; i++) {
+            writer.append(run.getUuid(), gap("failure number " + i, 1));
+        }
+
+        writer.append(run.getUuid(), gap("failure number 1", 5));
+
+        // Aggregating onto a row that exists grows nothing, so the bound has no reason to refuse it.
+        assertThat(messages(run))
+                .filteredOn(message -> "failure number 1".equals(message.getMessage()))
+                .singleElement()
+                .satisfies(message -> assertThat(message.getOccurrences()).isEqualTo(6));
+    }
+
+    @Test
+    void aFullRun_foldsEveryFurtherKindIntoASingleRow() {
+        Discovery run = v2Run();
+        // Three of one kind fills that code; codes minted per problem then fill the run.
+        for (int i = 1; i <= 3; i++) {
+            writer.append(run.getUuid(), gap("failure number " + i, 1));
+        }
+        for (int i = 1; i <= 6; i++) {
+            writer
+                    .append(run.getUuid(), new DiscoveryMessageDraft(DiscoveryMessageSeverity.ERROR,
+                            "connectorCode" + i, "the connector reported a problem", 1));
+        }
+
+        List<DiscoveryMessage> log = messages(run);
+        assertThat(log)
+                .extracting(DiscoveryMessage::getCode)
+                .as("a connector minting a fresh code per error cannot grow the log one suppression row at a time")
+                .filteredOn(DiscoveryMessageCode.MESSAGES_SUPPRESSED.code()::equals)
+                .hasSize(1);
+        // Three of the first kind, the two connector codes that fitted, and the one row standing in for the rest.
+        assertThat(log).hasSize(6);
+    }
+
+    @Test
+    void howARunEnded_landsOnARunThatIsAlreadyFull() {
+        Discovery run = v2Run();
+        for (int i = 1; i <= 9; i++) {
+            writer
+                    .append(run.getUuid(),
+                            new DiscoveryMessageDraft(DiscoveryMessageSeverity.WARNING, "code" + i, "a problem", 1));
+        }
+
+        writer.appendRunEnded(run.getUuid(), DiscoveryMessageSeverity.WARNING, "Discovery completed with warnings.");
+
+        assertThat(messages(run))
+                .extracting(DiscoveryMessage::getCode)
+                .as("a run's ending is the one message an operator is guaranteed to look for")
+                .contains(DiscoveryMessageCode.RUN_ENDED.code());
+    }
+
+    @Test
+    void messagesWrittenInOneTransaction_comeBackInTheOrderTheyWereWritten() {
+        Discovery run = v2Run();
+
+        // now() is transaction-start time, so all four share a timestamp to the microsecond. Only the identity
+        // column separates them, which is why the listing orders by it.
+        for (int i = 1; i <= 4; i++) {
+            writer
+                    .append(run.getUuid(),
+                            new DiscoveryMessageDraft(DiscoveryMessageSeverity.INFO, "code" + i, "problem " + i, 1));
+        }
+
+        List<DiscoveryMessage> log = messages(run);
+        assertThat(log)
+                .extracting(DiscoveryMessage::getMessage)
+                .containsExactly("problem 1", "problem 2", "problem 3", "problem 4");
+        assertThat(log)
+                .extracting(DiscoveryMessage::getFirstSeenAt)
+                .as("the timestamps tie, which is what makes them useless as an order")
+                .containsOnly(log.getFirst().getFirstSeenAt());
+    }
+
+    @Test
+    void messageLongerThanTheBound_isShortenedAndSaysSo() {
+        Discovery run = v2Run();
+
+        writer.append(run.getUuid(), gap("x".repeat(200), 1));
+
+        assertThat(messages(run)).singleElement().satisfies(message -> {
+            assertThat(message.getMessage()).hasSize(MAX_LENGTH).endsWith("...");
+        });
+    }
+
+    @Test
+    void deletingTheRun_takesItsMessagesWithIt() {
+        Discovery run = v2Run();
+        writer.append(run.getUuid(), gap("the host refused the connection", 1));
+        entityManager.flush();
+
+        discoveryRepository.delete(run);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(messageRepository.countByDiscoveryUuid(run.getUuid())).isZero();
+    }
+
+    private static DiscoveryMessageDraft gap(String message, long occurrences) {
+        return new DiscoveryMessageDraft(DiscoveryMessageSeverity.WARNING, DiscoveryMessageCode.INVENTORY_GAP, message,
+                occurrences);
+    }
+
+    private List<DiscoveryMessage> messages(Discovery run) {
+        entityManager.flush();
+        entityManager.clear();
+        return messageRepository.findByDiscoveryUuidOrderByIdAsc(run.getUuid());
+    }
+
+    private Discovery v2Run() {
+        Discovery run = new Discovery();
+        run.setName("v2-scan-" + UUID.randomUUID());
+        run.setKind("IP-HostName");
+        run.setStatus(DiscoveryStatus.IN_PROGRESS);
+        run.setConnectorStatus(DiscoveryStatus.IN_PROGRESS);
+        run.setConnectorUuid(UUID.randomUUID());
+        run.setConnectorName("network-discovery");
+        run.setConnectorInterfaceUuid(UUID.randomUUID());
+        run.setResources(List.of(Resource.CERTIFICATE));
+        return discoveryRepository.saveAndFlush(run);
+    }
+}

--- a/src/test/java/com/otilm/core/integration/discovery/DiscoveryProcessTickWorkerITest.java
+++ b/src/test/java/com/otilm/core/integration/discovery/DiscoveryProcessTickWorkerITest.java
@@ -372,9 +372,7 @@ class DiscoveryProcessTickWorkerITest extends BaseSpringBootTest {
 
         worker.tick(run.getUuid(), 0);
 
-        // The run has two rows left, but none of them belongs to the batch that failed, so nothing will ever
-        // retry it. Judging by the run's backlog would call this retryable and file it at a severity the ending
-        // ignores.
+        // Two rows are left, but none belongs to the batch that failed, so nothing will ever retry it.
         assertThat(backlog(run)).isEqualTo(2);
         assertThat(messages(run))
                 .extracting(DiscoveryMessage::getCode)

--- a/src/test/java/com/otilm/core/integration/discovery/DiscoveryProcessTickWorkerITest.java
+++ b/src/test/java/com/otilm/core/integration/discovery/DiscoveryProcessTickWorkerITest.java
@@ -1,12 +1,15 @@
 package com.otilm.core.integration.discovery;
 
+import com.otilm.api.model.core.discovery.DiscoveryMessageSeverity;
 import com.otilm.api.model.core.discovery.DiscoveryStatus;
 import com.otilm.core.dao.entity.CertificateContent;
 import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.entity.DiscoveryCertificate;
+import com.otilm.core.dao.entity.DiscoveryMessage;
 import com.otilm.core.dao.entity.DiscoveryWork;
 import com.otilm.core.dao.repository.CertificateContentRepository;
 import com.otilm.core.dao.repository.DiscoveryCertificateRepository;
+import com.otilm.core.dao.repository.DiscoveryMessageRepository;
 import com.otilm.core.dao.repository.DiscoveryRepository;
 import com.otilm.core.dao.repository.DiscoveryWorkRepository;
 import com.otilm.core.events.handlers.CertificateDiscoveredEventHandler;
@@ -14,11 +17,13 @@ import com.otilm.core.events.handlers.discovery.DiscoveryRunCounts;
 import com.otilm.core.messaging.jms.configuration.DiscoveryWorkProperties;
 import com.otilm.core.messaging.jms.producers.DiscoveryWorkProducer;
 import com.otilm.core.messaging.model.DiscoveryWorkMessage;
+import com.otilm.core.model.discovery.DiscoveryMessageCode;
 import com.otilm.core.model.discovery.DiscoveryWorkType;
 import com.otilm.core.service.handler.discovery.DiscoveryProcessTickWorker;
 import com.otilm.core.service.handler.discovery.DiscoveryRunTerminator;
 import com.otilm.core.service.handler.discovery.DiscoveryRunTerminator.Ending;
 import com.otilm.core.service.writer.DiscoveryWriter;
+import com.otilm.core.service.writer.discovery.DiscoveryMessageWriter;
 import com.otilm.core.service.writer.discovery.DiscoveryWorkWriter;
 import com.otilm.core.util.AuthHelper;
 import com.otilm.core.util.BaseSpringBootTest;
@@ -86,6 +91,10 @@ class DiscoveryProcessTickWorkerITest extends BaseSpringBootTest {
     private DiscoveryWriter discoveryWriter;
     @Autowired
     private DiscoveryWorkWriter workWriter;
+    @Autowired
+    private DiscoveryMessageWriter messageWriter;
+    @Autowired
+    private DiscoveryMessageRepository messageRepository;
 
     private static final UUID RUN_OWNER = UUID.fromString("3f1d9a52-0000-4000-8000-00000000beef");
 
@@ -171,9 +180,13 @@ class DiscoveryProcessTickWorkerITest extends BaseSpringBootTest {
                 .as("the second tick claims the remainder, never the stamped row")
                 .containsExactly(3, 2);
         assertThat(backlog(run)).isZero();
-        // WARNING rather than COMPLETED: the caught batch failure appended to the run's message log, and the
-        // terminal decision reads that log as evidence.
-        assertThat(reload(run).getStatus()).isEqualTo(DiscoveryStatus.WARNING);
+        // COMPLETED, though the log carries the batch that died: the retry imported every row it left behind,
+        // so there is nothing for an operator to act on. The message stays as the record of what happened, at a
+        // severity that says the run recovered from it.
+        assertThat(reload(run).getStatus()).isEqualTo(DiscoveryStatus.COMPLETED);
+        assertThat(messages(run))
+                .extracting(DiscoveryMessage::getCode)
+                .contains(DiscoveryMessageCode.BATCH_PROCESSING_FAILED.code());
     }
 
     @Test
@@ -298,10 +311,38 @@ class DiscoveryProcessTickWorkerITest extends BaseSpringBootTest {
 
         worker.tick(run.getUuid(), 0);
 
-        assertThat(reload(run).getRunMessages())
+        assertThat(messages(run))
                 .as("an operator watching a long run sees what is going wrong while it is still going wrong")
-                .containsExactly("1 certificate(s) could not be imported into the inventory.");
+                .singleElement()
+                .satisfies(gap -> {
+                    assertThat(gap.getCode()).isEqualTo(DiscoveryMessageCode.INVENTORY_GAP.code());
+                    assertThat(gap.getSeverity()).isEqualTo(DiscoveryMessageSeverity.WARNING);
+                    assertThat(gap.getOccurrences()).isEqualTo(1);
+                    // The count is the occurrence column, not part of the text: it is what lets the next batch
+                    // reporting the same gap add to this row instead of writing a second one.
+                    assertThat(gap.getMessage()).doesNotContain("1 ");
+                });
         assertThat(reload(run).getStatus()).isEqualTo(DiscoveryStatus.PROCESSING);
+    }
+
+    @Test
+    void twoBatchesFallingShortTheSameWay_shareOneEntryCountedTwice() throws Exception {
+        Discovery run = processingRun();
+        stageCertificates(run, 2);
+        importsWith(new DiscoveryRunCounts(1, 0, 0, 0, false));
+
+        // Two ticks, each its own transaction: the second aggregates onto what the first committed.
+        worker.tick(run.getUuid(), 0);
+        worker.tick(run.getUuid(), 0);
+
+        assertThat(messages(run))
+                .filteredOn(message -> DiscoveryMessageCode.INVENTORY_GAP.code().equals(message.getCode()))
+                .as("a run degraded the same way all day long is one entry, not one per batch")
+                .singleElement()
+                .satisfies(gap -> {
+                    assertThat(gap.getOccurrences()).isEqualTo(2);
+                    assertThat(gap.getLastSeenAt()).isAfter(gap.getFirstSeenAt());
+                });
     }
 
     @Test
@@ -312,9 +353,14 @@ class DiscoveryProcessTickWorkerITest extends BaseSpringBootTest {
 
         worker.tick(run.getUuid(), 0);
 
-        assertThat(reload(run).getRunMessages())
+        assertThat(messages(run))
                 .as("only the terminal line, so a clean run's log is not noise")
-                .containsExactly("Discovery completed successfully.");
+                .singleElement()
+                .satisfies(ending -> {
+                    assertThat(ending.getCode()).isEqualTo(DiscoveryMessageCode.RUN_ENDED.code());
+                    assertThat(ending.getMessage()).isEqualTo("Discovery completed successfully.");
+                    assertThat(ending.getSeverity()).isEqualTo(DiscoveryMessageSeverity.INFO);
+                });
     }
 
     @Test
@@ -370,7 +416,9 @@ class DiscoveryProcessTickWorkerITest extends BaseSpringBootTest {
     void warningFromRunLevelEvidenceAlone_doesNotSendTheOperatorToTheCertificateList() throws Exception {
         Discovery run = processingRun();
         // A run-level gap with every row clean: a bookkeeping write that failed, or validation never queued.
-        discoveryWriter.appendRunMessages(run.getUuid(), List.of("Validation was not requested for 3 certificates."));
+        messageWriter
+                .append(run.getUuid(), DiscoveryMessageSeverity.WARNING, DiscoveryMessageCode.VALIDATION_NOT_REQUESTED,
+                        "Validation of the discovered certificates could not be requested.");
 
         worker.tick(run.getUuid(), 0);
 
@@ -403,13 +451,16 @@ class DiscoveryProcessTickWorkerITest extends BaseSpringBootTest {
     @Test
     void endingDecidedUnderTheLock_readsTheRunAsItStandsWhenTheEndingCommits() {
         Discovery run = processingRun();
-        // A late drain page appended a complaint after the worker had already read the run. Deciding from the
-        // caller's stale copy would report this run as completed successfully while it carries a warning.
-        discoveryWriter.appendRunMessages(run.getUuid(), List.of("2 item(s) arrived without a sequence"));
+        // A late drain page appended a complaint after the worker had already read the run. Deciding from
+        // anything read before the lock would report this run as completed successfully while it carries a
+        // warning.
+        messageWriter
+                .append(run.getUuid(), DiscoveryMessageSeverity.WARNING, DiscoveryMessageCode.ITEM_SEQUENCE_MISSING,
+                        "A discovered item arrived without a sequence and was skipped.");
 
         boolean ended = terminator
                 .endWith(run.getUuid(),
-                        locked -> locked.getRunMessages().isEmpty()
+                        locked -> messageRepository.countByDiscoveryUuid(locked.getUuid()) == 0
                                 ? new Ending(DiscoveryStatus.COMPLETED, "Discovery completed successfully.")
                                 : new Ending(DiscoveryStatus.WARNING, "Discovery completed with warnings."));
 
@@ -471,6 +522,10 @@ class DiscoveryProcessTickWorkerITest extends BaseSpringBootTest {
 
     private Discovery reload(Discovery run) {
         return discoveryRepository.findByUuid(run.getUuid()).orElseThrow();
+    }
+
+    private List<DiscoveryMessage> messages(Discovery run) {
+        return messageRepository.findByDiscoveryUuidOrderByIdAsc(run.getUuid());
     }
 
     private List<DiscoveryCertificate> stageCertificates(Discovery run, int count) {

--- a/src/test/java/com/otilm/core/integration/discovery/DiscoveryProcessTickWorkerITest.java
+++ b/src/test/java/com/otilm/core/integration/discovery/DiscoveryProcessTickWorkerITest.java
@@ -364,6 +364,34 @@ class DiscoveryProcessTickWorkerITest extends BaseSpringBootTest {
     }
 
     @Test
+    void batchWithNothingLeftToRetry_isJudgedOnItsOwnRowsNotTheRunsBacklog() throws Exception {
+        Discovery run = processingRun();
+        // Three rows at a batch size of one, so the first batch finishes while the run still has a backlog.
+        stageCertificates(run, 3);
+        stampsEveryRowThenDies();
+
+        worker.tick(run.getUuid(), 0);
+
+        // The run has two rows left, but none of them belongs to the batch that failed, so nothing will ever
+        // retry it. Judging by the run's backlog would call this retryable and file it at a severity the ending
+        // ignores.
+        assertThat(backlog(run)).isEqualTo(2);
+        assertThat(messages(run))
+                .extracting(DiscoveryMessage::getCode)
+                .contains(DiscoveryMessageCode.BATCH_PROCESSING_ABANDONED.code())
+                .doesNotContain(DiscoveryMessageCode.BATCH_PROCESSING_FAILED.code());
+
+        importsCleanly();
+        worker.tick(run.getUuid(), 0);
+        worker.tick(run.getUuid(), 0);
+
+        assertThat(backlog(run)).isZero();
+        assertThat(reload(run).getStatus())
+                .as("the batch that was never retried is what the run ends on")
+                .isEqualTo(DiscoveryStatus.WARNING);
+    }
+
+    @Test
     void cleanBatch_addsNothingToTheRunMessageLog() throws Exception {
         Discovery run = processingRun();
         stageCertificates(run, 1);

--- a/src/test/java/com/otilm/core/integration/discovery/DiscoveryProcessTickWorkerITest.java
+++ b/src/test/java/com/otilm/core/integration/discovery/DiscoveryProcessTickWorkerITest.java
@@ -346,6 +346,24 @@ class DiscoveryProcessTickWorkerITest extends BaseSpringBootTest {
     }
 
     @Test
+    void batchThatFailedWithNothingLeftToRetry_endsTheRunAsAWarning() throws Exception {
+        Discovery run = processingRun();
+        stageCertificates(run, 1);
+        stampsEveryRowThenDies();
+
+        worker.tick(run.getUuid(), 0);
+
+        // The rows are imported and the backlog is empty, so no later tick will revisit this failure. Filing it
+        // as retryable would leave the only record of it at a severity the ending ignores.
+        assertThat(backlog(run)).isZero();
+        assertThat(messages(run))
+                .extracting(DiscoveryMessage::getCode)
+                .contains(DiscoveryMessageCode.BATCH_PROCESSING_ABANDONED.code())
+                .doesNotContain(DiscoveryMessageCode.BATCH_PROCESSING_FAILED.code());
+        assertThat(reload(run).getStatus()).isEqualTo(DiscoveryStatus.WARNING);
+    }
+
+    @Test
     void cleanBatch_addsNothingToTheRunMessageLog() throws Exception {
         Discovery run = processingRun();
         stageCertificates(run, 1);
@@ -471,6 +489,19 @@ class DiscoveryProcessTickWorkerITest extends BaseSpringBootTest {
     /** Stubs the pipeline to do what a clean import does: stamp every row of the batch as processed. */
     private void importsCleanly() throws Exception {
         importsWith(new DiscoveryRunCounts(0, 0, 0, 0, false));
+    }
+
+    /**
+     * A pipeline pass that stamps every row and then dies — a failure in the post-import work that runs after the
+     * groups have already committed.
+     */
+    private void stampsEveryRowThenDies() throws Exception {
+        doAnswer(invocation -> {
+            List<DiscoveryCertificate> batch = invocation.getArgument(1);
+            claimedBatchSizes.add(batch.size());
+            discoveryWriter.markProcessed(batch.stream().map(DiscoveryCertificate::getUuid).toList(), null);
+            throw new IllegalStateException("bookkeeping failed after the import committed");
+        }).when(importHandler).processBatch(any(), anyList());
     }
 
     /** A pipeline pass that commits one row's outcome and then dies — a pod lost part way through a batch. */

--- a/src/test/java/com/otilm/core/integration/discovery/DiscoveryStatusTickWorkerITest.java
+++ b/src/test/java/com/otilm/core/integration/discovery/DiscoveryStatusTickWorkerITest.java
@@ -7,12 +7,15 @@ import com.otilm.api.model.common.error.ProblemDetailExtended;
 import com.otilm.api.model.connector.discovery.v2.DiscoveryProgressDto;
 import com.otilm.api.model.connector.discovery.v2.DiscoveryRunState;
 import com.otilm.api.model.connector.discovery.v2.DiscoveryStatusResponseDto;
+import com.otilm.api.model.core.discovery.DiscoveryMessageSeverity;
 import com.otilm.api.model.core.discovery.DiscoveryStatus;
 import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.entity.DiscoveryWork;
+import com.otilm.core.dao.repository.DiscoveryMessageRepository;
 import com.otilm.core.dao.repository.DiscoveryRepository;
 import com.otilm.core.dao.repository.DiscoveryWorkRepository;
 import com.otilm.core.messaging.jms.configuration.DiscoveryWorkProperties;
+import com.otilm.core.model.discovery.DiscoveryMessageCode;
 import com.otilm.core.model.discovery.DiscoveryWorkType;
 import com.otilm.core.service.handler.discovery.DiscoveryStatusTickWorker;
 import com.otilm.core.service.handler.discovery.DiscoveryV2Client;
@@ -56,6 +59,8 @@ class DiscoveryStatusTickWorkerITest extends BaseSpringBootTest {
     private DiscoveryRepository discoveryRepository;
     @Autowired
     private DiscoveryWorkRepository workRepository;
+    @Autowired
+    private DiscoveryMessageRepository messageRepository;
     @Autowired
     private DiscoveryWorkWriter workWriter;
     @Autowired
@@ -171,6 +176,16 @@ class DiscoveryStatusTickWorkerITest extends BaseSpringBootTest {
         assertThat(reloaded.getEndTime()).isNotNull();
         assertThat(reloaded.getRunMeta()).isNull();
         assertThat(agenda(run)).isEmpty();
+        // How a run ended is recorded at a severity that follows its status, and only an ending written through the
+        // real terminator proves that mapping: the reason reaches the log as ERROR, not as the WARNING a run that
+        // merely fell short would carry.
+        assertThat(messageRepository.findByDiscoveryUuidOrderByIdAsc(run.getUuid()))
+                .singleElement()
+                .satisfies(ending -> {
+                    assertThat(ending.getCode()).isEqualTo(DiscoveryMessageCode.RUN_ENDED.code());
+                    assertThat(ending.getSeverity()).isEqualTo(DiscoveryMessageSeverity.ERROR);
+                    assertThat(ending.getMessage()).isEqualTo(reloaded.getMessage());
+                });
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/repository/DiscoveryRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/repository/DiscoveryRepositoryITest.java
@@ -60,7 +60,6 @@ class DiscoveryRepositoryITest extends BaseSpringBootTest {
         run.setResources(List.of(Resource.CERTIFICATE, Resource.CRYPTOGRAPHIC_KEY));
         run.setLastAppliedSequence(17L);
         run.setProgress(progress);
-        run.setRunMessages(List.of("host 10.0.0.7 refused the connection"));
         run.setStoppedAt(stoppedAt);
         run.setConnectorState("running");
         UUID runUuid = discoveryRepository.saveAndFlush(run).getUuid();
@@ -80,7 +79,6 @@ class DiscoveryRepositoryITest extends BaseSpringBootTest {
         assertThat(back.getProgress().getPhase()).isEqualTo("scanning");
         assertThat(back.getProgress().getByResource()).containsOnlyKeys(Resource.CRYPTOGRAPHIC_KEY);
         assertThat(back.getProgress().getByResource().get(Resource.CRYPTOGRAPHIC_KEY).getProcessed()).isEqualTo(3L);
-        assertThat(back.getRunMessages()).containsExactly("host 10.0.0.7 refused the connection");
         assertThat(back.getConnectorState()).isEqualTo("running");
         // Compared as instants: the driver may hand the timestamptz back under a different zone offset.
         assertThat(back.getStoppedAt().toInstant()).isEqualTo(stoppedAt.toInstant());

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/discovery/DiscoveryRunReaperUnitTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/discovery/DiscoveryRunReaperUnitTest.java
@@ -1,5 +1,6 @@
 package com.otilm.core.messaging.jms.listeners.discovery;
 
+import com.otilm.api.model.core.discovery.DiscoveryMessageSeverity;
 import com.otilm.api.model.core.discovery.DiscoveryStatus;
 import com.otilm.core.cluster.ClusterOperationSynchronizer;
 import com.otilm.core.dao.entity.Discovery;
@@ -9,6 +10,7 @@ import com.otilm.core.events.transaction.TransactionHandler;
 import com.otilm.core.service.handler.discovery.DiscoveryProviderAdapter;
 import com.otilm.core.service.handler.discovery.DiscoveryProviderAdapterFactory;
 import com.otilm.core.service.handler.discovery.DiscoveryRunTerminator;
+import com.otilm.core.service.writer.discovery.DiscoveryMessageWriter;
 import com.otilm.core.service.writer.discovery.DiscoveryWorkWriter;
 import com.otilm.core.util.DiscoveryRunMetaFixture;
 import java.time.Duration;
@@ -55,6 +57,8 @@ class DiscoveryRunReaperUnitTest {
     @Mock
     private DiscoveryWorkWriter workWriter;
     @Mock
+    private DiscoveryMessageWriter messageWriter;
+    @Mock
     private DiscoveryProviderAdapterFactory adapterFactory;
     @Mock
     private DiscoveryProviderAdapter adapter;
@@ -72,8 +76,8 @@ class DiscoveryRunReaperUnitTest {
         // is what these tests assert on. Its collaborators are unused by applyTerminalState.
         reaper = new DiscoveryRunReaper(discoveryRepository, workRepository, workWriter, adapterFactory,
                 transactionHandler, clusterSynchronizer,
-                new DiscoveryRunTerminator(discoveryRepository, workWriter, transactionHandler), Duration.ofMinutes(5),
-                Duration.ofDays(7));
+                new DiscoveryRunTerminator(discoveryRepository, workWriter, messageWriter, transactionHandler),
+                Duration.ofMinutes(5), Duration.ofDays(7));
         // Execute the transactional lambdas inline so the real selection/reap logic runs under the test.
         lenient()
                 .when(transactionHandler.runInNewTransaction(any(Supplier.class)))
@@ -122,9 +126,10 @@ class DiscoveryRunReaperUnitTest {
         assertThatCode(() -> reaper.reap()).doesNotThrowAnyException();
 
         assertThat(healthy.getStatus()).isEqualTo(DiscoveryStatus.FAILED);
-        assertThat(healthy.getRunMessages())
-                .as("a reaped run must carry the same ending in its log as one a worker ended")
-                .containsExactly("Discovery work lost; the run can no longer be driven");
+        // A reaped run must record the same ending in its log as one a worker ended.
+        verify(messageWriter)
+                .appendRunEnded(healthy.getUuid(), DiscoveryMessageSeverity.ERROR,
+                        "Discovery work lost; the run can no longer be driven");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/model/discovery/DiscoveryMessageDraftTest.java
+++ b/src/test/java/com/otilm/core/model/discovery/DiscoveryMessageDraftTest.java
@@ -7,9 +7,8 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
- * The draft refuses what the message table cannot store, so a producer's mistake fails where it was made rather than as
- * a constraint violation that rolls back whatever transaction the append had joined — a whole drained page, for a field
- * the draft can simply reject.
+ * The draft refuses what the message table cannot store, so a producer's mistake fails where it was made. Why that
+ * matters is on {@link DiscoveryMessageDraft} itself.
  */
 class DiscoveryMessageDraftTest {
 

--- a/src/test/java/com/otilm/core/model/discovery/DiscoveryMessageDraftTest.java
+++ b/src/test/java/com/otilm/core/model/discovery/DiscoveryMessageDraftTest.java
@@ -1,0 +1,50 @@
+package com.otilm.core.model.discovery;
+
+import com.otilm.api.model.core.discovery.DiscoveryMessageSeverity;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * The draft refuses what the message table cannot store, so a producer's mistake fails where it was made rather than as
+ * a constraint violation that rolls back whatever transaction the append had joined — a whole drained page, for a field
+ * the draft can simply reject.
+ */
+class DiscoveryMessageDraftTest {
+
+    @Test
+    void aCodeThatNamesNothingIsRefused() {
+        for (String noCode : new String[]{null, "", "   "}) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new DiscoveryMessageDraft(DiscoveryMessageSeverity.WARNING, noCode, "text", 1))
+                    .withMessageContaining("code");
+        }
+    }
+
+    @Test
+    void textNobodyCouldReadIsRefused() {
+        for (String noText : new String[]{null, "", "   "}) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new DiscoveryMessageDraft(DiscoveryMessageSeverity.WARNING, "aCode", noText, 1))
+                    .withMessageContaining("text");
+        }
+    }
+
+    @Test
+    void aProblemThatHappenedNoTimesIsRefused() {
+        // A message exists because something happened, so a count below one describes nothing the log can hold.
+        for (long never : new long[]{0, -1}) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new DiscoveryMessageDraft(DiscoveryMessageSeverity.INFO, "aCode", "text", never))
+                    .withMessageContaining("occurrence");
+        }
+    }
+
+    @Test
+    void aDraftNamingAKindOfProblemIsAccepted() {
+        assertThatCode(() -> new DiscoveryMessageDraft(DiscoveryMessageSeverity.WARNING,
+                DiscoveryMessageCode.INVENTORY_GAP, "A discovered certificate could not be imported.", 12))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/otilm/core/service/handler/discovery/DiscoveryEventIngestorTest.java
+++ b/src/test/java/com/otilm/core/service/handler/discovery/DiscoveryEventIngestorTest.java
@@ -13,6 +13,7 @@ import com.otilm.core.dao.repository.DiscoveryCertificateRepository;
 import com.otilm.core.dao.repository.DiscoveryRepository;
 import com.otilm.core.service.handler.CertificateHandler;
 import com.otilm.core.service.writer.discovery.DiscoveryItemWriter;
+import com.otilm.core.service.writer.discovery.DiscoveryMessageWriter;
 import com.otilm.core.service.writer.discovery.DiscoveryWorkWriter;
 import java.util.List;
 import java.util.Optional;
@@ -50,13 +51,15 @@ class DiscoveryEventIngestorTest {
     private CryptographicKeyItemRepository keyItemRepository;
     @Mock
     private DiscoveryCertificateRepository certificateRepository;
+    @Mock
+    private DiscoveryMessageWriter messageWriter;
 
     private DiscoveryEventIngestor ingestor;
 
     @BeforeEach
     void setUp() {
         ingestor = new DiscoveryEventIngestor(discoveryRepository, itemWriter, workWriter, certificateHandler,
-                keyItemRepository, certificateRepository);
+                keyItemRepository, certificateRepository, messageWriter);
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/handler/discovery/DiscoveryTickWorkerConfigTest.java
+++ b/src/test/java/com/otilm/core/service/handler/discovery/DiscoveryTickWorkerConfigTest.java
@@ -53,8 +53,8 @@ class DiscoveryTickWorkerConfigTest {
     }
 
     private static DiscoveryProcessTickWorker processWorkerWith(int batchSize, Duration continuationBackstop) {
-        return new DiscoveryProcessTickWorker(null, null, null, null, null, null, null, null, null, batchSize,
-                continuationBackstop);
+        return new DiscoveryProcessTickWorker(null, null, null, null, null, null, null, null, null, null, null,
+                batchSize, continuationBackstop);
     }
 
     private static DiscoveryDrainTickWorker drainWorkerWith(int maxItems, long maxBytes) {


### PR DESCRIPTION
## TLDR

`discovery.run_messages` was a JSONB array on the run row: rewritten whole under that row's write lock on every append, and capped at 200 by dropping the oldest — which inverted its purpose, since an operator opening a `WARNING` found 200 near-identical tail sentences and no trace of what started the run.

This replaces it with a `discovery_message` child table holding one row per *distinct* problem plus an occurrence counter. Appends are an upsert that takes no run-row lock. The terminal status decision now reads message **severity** instead of whether the log is non-empty.

Closes #2127.

> **Does not build until OmniTrustILM/interfaces#912 merges.** `DiscoveryMessageSeverity` comes from there, and `DiscoveryController.getDiscoveryRunMessages` is declared there — served here by the existing 501 stub block, since the listing itself belongs to #1964.

## What changed

- **Schema.** `discovery_message`: `id BIGINT GENERATED ALWAYS AS IDENTITY`, FK `ON DELETE CASCADE`, unique on `(discovery_uuid, code, message_hash)`. `run_messages` is dropped without backfill — it was added in this same unreleased cycle.
- **Writes.** One writer bean. `INSERT … ON CONFLICT DO UPDATE SET occurrences = occurrences + n`, so two appenders add their counts rather than one overwriting the other, and no caller has to take the run row to be safe.
- **Producers.** Per-batch gap summaries carry their counts in `occurrences` rather than in the text, and staging failures are named by kind rather than by which certificate hit them, so repeats aggregate instead of accumulating. Per-certificate detail keeps its existing home on `discovery_certificate.processed_error`.
- **Ending.** A run ends `COMPLETED` unless a row carries a reason of its own or the run collected a `WARNING`/`ERROR` message. A batch that failed transiently and was reimported cleanly is recorded at `INFO` and no longer downgrades the run.

## Three things worth a reviewer's attention

1. **Ordering is the identity column, never a timestamp.** `now()` is transaction-start time, so every message one tick writes ties, and a wall-clock column inverts across pods. An ITest asserts the timestamps *do* tie, which is what makes that real rather than asserted.
2. **`message_hash` is a stored generated column** (`md5(message)`), not an expression index. ITests build their schema from the entities (`ddl-auto: create-drop`, Flyway off) and an expression index cannot be mapped, so `ON CONFLICT` would have no matching constraint in any ITest.
3. **The writer is `REQUIRED` throughout, never `REQUIRES_NEW`.** Most callers append while holding the run row's `SELECT … FOR UPDATE`, and the inserted row takes `FOR KEY SHARE` on that same row through its FK. From a separate transaction that wait can never be satisfied — the run would hang rather than fail.

## Bounds are constants, not configuration

The issue originally asked for these to be configurable. Two of the three are unreachable in practice and none has an operator tuning story, so they ship as constants in the writer. #2127's Definition of Done has been updated to match, rather than left disagreeing with the code. It is a decision rather than an omission: an estate with more than fifty kinds of problem has no operator remedy, but the log is advisory, a suppression row says data was dropped, and `MAX_PER_CODE <= MAX_PER_RUN` is an invariant a dial would let an operator break.

## Verification

- 824 tests green (`Discovery*`, `Certificate*`, `*ArchTest`, `ContextSignatureGuardTest`); checkstyle and spotless clean.
- The migration was applied against a throwaway PostgreSQL 17 to check the DDL, the upsert's aggregation, the generated hash column and the FK cascade.

