### PR TITLE
Resolve subclass-declared OID filter fields through the metamodel attribute

### DIFF
--- a/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
+++ b/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
@@ -309,7 +309,7 @@ public class FilterPredicatesBuilder {
      * @throws ValidationException if {@code fieldAttribute} is declared on a subtype but is not singular
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
-    static Path<?> resolveFieldPath(final From from, final Attribute<?, ?> fieldAttribute) {
+    static <Y> Path<Y> resolveFieldPath(final From from, final Attribute<?, ?> fieldAttribute) {
         if (!isDeclaredOnStrictSubtypeOf(from, fieldAttribute)) {
             return from.get(fieldAttribute.getName());
         }
@@ -318,7 +318,7 @@ public class FilterPredicatesBuilder {
                     + fieldAttribute.getDeclaringType().getJavaType().getSimpleName()
                     + " and is not singular, which filter resolution does not support");
         }
-        return from.get((SingularAttribute) singularAttribute);
+        return from.get(singularAttribute);
     }
 
     private static boolean isDeclaredOnStrictSubtypeOf(final From<?, ?> from, final Attribute<?, ?> fieldAttribute) {

--- a/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
+++ b/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
@@ -37,6 +37,7 @@ import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Subquery;
 import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.PluralAttribute;
+import jakarta.persistence.metamodel.SingularAttribute;
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -294,6 +295,37 @@ public class FilterPredicatesBuilder {
         return preparedValue;
     }
 
+    /**
+     * Resolves {@code fieldAttribute} as a path on {@code from}.
+     *
+     * <p>
+     * An attribute declared on an inheritance subtype of what {@code from} resolves to is addressed through the
+     * metamodel attribute itself rather than by name. The resulting path carries no restriction to that subtype, so the
+     * query still spans the whole hierarchy. Every other attribute is addressed by name.
+     *
+     * @param from the root or join the filter field is resolved against
+     * @param fieldAttribute the attribute being filtered on
+     * @return the path to the attribute
+     * @throws ValidationException if {@code fieldAttribute} is declared on a subtype but is not singular
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Path<?> resolveFieldPath(final From from, final Attribute<?, ?> fieldAttribute) {
+        if (!isDeclaredOnStrictSubtypeOf(from, fieldAttribute)) {
+            return from.get(fieldAttribute.getName());
+        }
+        if (!(fieldAttribute instanceof SingularAttribute<?, ?> singularAttribute)) {
+            throw new ValidationException("Filter field " + fieldAttribute.getName() + " is declared on subtype "
+                    + fieldAttribute.getDeclaringType().getJavaType().getSimpleName()
+                    + " and is not singular, which filter resolution does not support");
+        }
+        return from.get((SingularAttribute) singularAttribute);
+    }
+
+    private static boolean isDeclaredOnStrictSubtypeOf(final From<?, ?> from, final Attribute<?, ?> fieldAttribute) {
+        final Class<?> declaringType = fieldAttribute.getDeclaringType().getJavaType();
+        return !declaringType.equals(from.getJavaType()) && from.getJavaType().isAssignableFrom(declaringType);
+    }
+
     private static <T> Predicate getPropertyFilterPredicate(final CriteriaBuilder criteriaBuilder,
             final CommonAbstractCriteria query, final Root<T> root, SearchFilterRequestDto filterDto,
             Map<String, From> joinedAssociations) {
@@ -310,7 +342,7 @@ public class FilterPredicatesBuilder {
 
         Expression expression = null;
         if (filterField.getFieldAttribute() != null && !isCountOperator(filterDto.getCondition())) {
-            expression = from.get(filterField.getFieldAttribute().getName());
+            expression = resolveFieldPath(from, filterField.getFieldAttribute());
         }
 
         boolean isJsonArray = false;
@@ -319,28 +351,28 @@ public class FilterPredicatesBuilder {
             if (isJsonArray) {
                 expression = criteriaBuilder
                         .function("jsonb_path_query_array", String.class,
-                                from.get(filterField.getFieldAttribute().getName()),
+                                resolveFieldPath(from, filterField.getFieldAttribute()),
                                 criteriaBuilder.literal(getArrayJsonPath(filterField.getJsonPath())));
             } else {
                 expression = switch (filterField.getJsonPath().length) {
                     case 1 -> criteriaBuilder
                             .function(JSONB_EXTRACT_PATH_TEXT_FUNCTION_NAME, String.class,
-                                    from.get(filterField.getFieldAttribute().getName()),
+                                    resolveFieldPath(from, filterField.getFieldAttribute()),
                                     criteriaBuilder.literal(filterField.getJsonPath()[0]));
                     case 2 -> criteriaBuilder
                             .function(JSONB_EXTRACT_PATH_TEXT_FUNCTION_NAME, String.class,
-                                    from.get(filterField.getFieldAttribute().getName()),
+                                    resolveFieldPath(from, filterField.getFieldAttribute()),
                                     criteriaBuilder.literal(filterField.getJsonPath()[0]),
                                     criteriaBuilder.literal(filterField.getJsonPath()[1]));
                     case 3 -> criteriaBuilder
                             .function(JSONB_EXTRACT_PATH_TEXT_FUNCTION_NAME, String.class,
-                                    from.get(filterField.getFieldAttribute().getName()),
+                                    resolveFieldPath(from, filterField.getFieldAttribute()),
                                     criteriaBuilder.literal(filterField.getJsonPath()[0]),
                                     criteriaBuilder.literal(filterField.getJsonPath()[1]),
                                     criteriaBuilder.literal(filterField.getJsonPath()[2]));
                     case 4 -> criteriaBuilder
                             .function(JSONB_EXTRACT_PATH_TEXT_FUNCTION_NAME, String.class,
-                                    from.get(filterField.getFieldAttribute().getName()),
+                                    resolveFieldPath(from, filterField.getFieldAttribute()),
                                     criteriaBuilder.literal(filterField.getJsonPath()[0]),
                                     criteriaBuilder.literal(filterField.getJsonPath()[1]),
                                     criteriaBuilder.literal(filterField.getJsonPath()[2]),
@@ -660,7 +692,7 @@ public class FilterPredicatesBuilder {
                     .where(criteriaBuilder
                             .isTrue(criteriaBuilder
                                     .function(functionName, Boolean.class, criteriaBuilder.literal(value.toString()),
-                                            subFrom.get(filterField.getFieldAttribute().getName()))));
+                                            resolveFieldPath(subFrom, filterField.getFieldAttribute()))));
             return criteriaBuilder.not(criteriaBuilder.exists(subquery));
         }).toArray(Predicate[]::new);
         return notExistsPredicates.length == 1 ? notExistsPredicates[0] : criteriaBuilder.and(notExistsPredicates);
@@ -851,7 +883,7 @@ public class FilterPredicatesBuilder {
                                         resource == Resource.CRYPTOGRAPHIC_KEY
                                                 ? originalRoot.get(CryptographicKeyItem_.keyUuid)
                                                 : originalRoot.get(UniquelyIdentified_.uuid)),
-                        joinGroup.get(fieldAttribute.getName()).in(filterValues));
+                        resolveFieldPath(joinGroup, fieldAttribute).in(filterValues));
 
         return criteriaBuilder.not(criteriaBuilder.exists(subquery));
     }

--- a/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
+++ b/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
@@ -309,7 +309,7 @@ public class FilterPredicatesBuilder {
      * @throws ValidationException if {@code fieldAttribute} is declared on a subtype but is not singular
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private static Path<?> resolveFieldPath(final From from, final Attribute<?, ?> fieldAttribute) {
+    static Path<?> resolveFieldPath(final From from, final Attribute<?, ?> fieldAttribute) {
         if (!isDeclaredOnStrictSubtypeOf(from, fieldAttribute)) {
             return from.get(fieldAttribute.getName());
         }

--- a/src/main/java/com/otilm/core/util/SortOrderBuilder.java
+++ b/src/main/java/com/otilm/core/util/SortOrderBuilder.java
@@ -12,7 +12,7 @@ import com.otilm.core.enums.FilterField;
 import com.otilm.core.enums.ResourceToClass;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Expression;
-import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.From;
 import jakarta.persistence.criteria.Order;
 import jakarta.persistence.criteria.Root;
 import java.util.ArrayList;
@@ -103,14 +103,15 @@ public final class SortOrderBuilder {
                 : criteriaBuilder.least((Expression) expression);
     }
 
+    /**
+     * Resolves the field attribute through the metamodel, because Hibernate 7 drops the implicit downcast a name lookup
+     * needs for an attribute declared on a subtype of the root.
+     */
     private static Expression<?> resolveExpression(Root<?> root, FilterField field) {
-        String path = FilterPredicatesBuilder.buildPathToProperty(field.getJoinAttributes(), field.getFieldAttribute());
+        String joinPath = FilterPredicatesBuilder.buildPathToProperty(field.getJoinAttributes(), null);
         try {
-            if (!path.contains(".")) {
-                return FilterPredicatesBuilder.prepareExpression(root, path);
-            }
-            Join<?, ?> join = FilterPredicatesBuilder.prepareJoin(root, path.substring(0, path.lastIndexOf('.')));
-            return FilterPredicatesBuilder.prepareExpression(join, path.substring(path.lastIndexOf('.') + 1));
+            From<?, ?> from = joinPath.isEmpty() ? root : FilterPredicatesBuilder.prepareJoin(root, joinPath);
+            return FilterPredicatesBuilder.resolveFieldPath(from, field.getFieldAttribute());
         } catch (IllegalArgumentException e) {
             throw new ValidationException(
                     ValidationError.create("Field %s cannot be sorted on this resource.".formatted(field.name())));

--- a/src/test/java/com/otilm/core/integration/search/SubclassFilterFieldSearchITest.java
+++ b/src/test/java/com/otilm/core/integration/search/SubclassFilterFieldSearchITest.java
@@ -1,0 +1,146 @@
+package com.otilm.core.integration.search;
+
+import com.otilm.api.model.client.certificate.SearchRequestDto;
+import com.otilm.api.model.core.oid.CustomOidEntryListResponseDto;
+import com.otilm.api.model.core.oid.CustomOidEntryResponseDto;
+import com.otilm.api.model.core.oid.ExtensionValueEncoding;
+import com.otilm.api.model.core.oid.OidCategory;
+import com.otilm.api.model.core.search.FilterConditionOperator;
+import com.otilm.core.dao.entity.oid.CertificateExtensionCustomOidEntry;
+import com.otilm.core.dao.entity.oid.GenericCustomOidEntry;
+import com.otilm.core.dao.entity.oid.RdnAttributeTypeCustomOidEntry;
+import com.otilm.core.dao.repository.CustomOidEntryRepository;
+import com.otilm.core.enums.FilterField;
+import com.otilm.core.service.CustomOidEntryExternalService;
+import com.otilm.core.util.BaseSpringBootTest;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.otilm.core.util.builders.SearchFilterRequestDtoBuilder.aPropertyFilter;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for filter fields whose attribute is declared on an inheritance subtype of the criteria root.
+ *
+ * <p>
+ * Fixtures deliberately mix categories so that a filter which silently narrowed the query to the declaring subtype
+ * would be visible, in the returned page and in the total alike.
+ */
+class SubclassFilterFieldSearchITest extends BaseSpringBootTest {
+
+    private static final String GENERIC_OID = "1.1.1";
+    private static final String EXTENSION_OID = "1.1.2";
+    private static final String RDN_COMMON_NAME_OID = "1.1.3";
+    private static final String RDN_ORG_UNIT_OID = "1.1.4";
+    private static final String RDN_WITHOUT_CODE_OID = "1.1.5";
+
+    @Autowired
+    private CustomOidEntryExternalService customOidEntryService;
+
+    @Autowired
+    private CustomOidEntryRepository customOidEntryRepository;
+
+    @BeforeEach
+    void seedEntriesOfEveryCategory() {
+        GenericCustomOidEntry generic = new GenericCustomOidEntry();
+        generic.setOid(GENERIC_OID);
+        generic.setCategory(OidCategory.GENERIC);
+        generic.setDisplayName("generic entry");
+        customOidEntryRepository.save(generic);
+
+        CertificateExtensionCustomOidEntry extension = new CertificateExtensionCustomOidEntry();
+        extension.setOid(EXTENSION_OID);
+        extension.setCategory(OidCategory.CERTIFICATE_EXTENSION);
+        extension.setDisplayName("extension entry");
+        extension.setDefaultCritical(true);
+        extension.setValueEncoding(ExtensionValueEncoding.IA5_STRING);
+        customOidEntryRepository.save(extension);
+
+        rdnEntry(RDN_COMMON_NAME_OID, "rdn common name entry", "CN", List.of("COMMON", "CN2"));
+        rdnEntry(RDN_ORG_UNIT_OID, "rdn organizational unit entry", "OU", List.of("ORGUNIT"));
+        rdnEntry(RDN_WITHOUT_CODE_OID, "rdn without a code entry", null, new ArrayList<>());
+    }
+
+    @Test
+    void resolvesCodeDeclaredOnTheSubclass() {
+        CustomOidEntryListResponseDto response = search(FilterField.OID_ENTRY_CODE, FilterConditionOperator.EQUALS,
+                "CN");
+
+        assertThat(response.getOidEntries())
+                .extracting(CustomOidEntryResponseDto::getOid)
+                .containsExactly(RDN_COMMON_NAME_OID);
+    }
+
+    @Test
+    void resolvesAltCodesDeclaredOnTheSubclass() {
+        CustomOidEntryListResponseDto response = search(FilterField.OID_ENTRY_ALT_CODES,
+                FilterConditionOperator.CONTAINS, "ORGUNIT");
+
+        assertThat(response.getOidEntries())
+                .extracting(CustomOidEntryResponseDto::getOid)
+                .containsExactly(RDN_ORG_UNIT_OID);
+    }
+
+    @Test
+    void aSubclassFilterStillSpansEntriesOfEveryCategory() {
+        CustomOidEntryListResponseDto response = search(FilterField.OID_ENTRY_CODE, FilterConditionOperator.EMPTY,
+                null);
+
+        assertThat(response.getOidEntries())
+                .extracting(CustomOidEntryResponseDto::getOid)
+                .containsExactlyInAnyOrder(GENERIC_OID, EXTENSION_OID, RDN_WITHOUT_CODE_OID);
+    }
+
+    @Test
+    void theTotalAgreesWithThePageForANegatedSubclassFilter() {
+        CustomOidEntryListResponseDto response = search(FilterField.OID_ENTRY_CODE, FilterConditionOperator.NOT_EQUALS,
+                "CN");
+
+        assertThat(response.getOidEntries())
+                .extracting(CustomOidEntryResponseDto::getOid)
+                .containsExactlyInAnyOrder(GENERIC_OID, EXTENSION_OID, RDN_ORG_UNIT_OID, RDN_WITHOUT_CODE_OID);
+        assertThat(response.getTotalItems()).isEqualTo(4);
+        assertThat(response.getTotalItems()).isEqualTo(response.getOidEntries().size());
+    }
+
+    @Test
+    void theTotalAgreesWithThePageForAnEmptySubclassFilter() {
+        CustomOidEntryListResponseDto response = search(FilterField.OID_ENTRY_CODE, FilterConditionOperator.EMPTY,
+                null);
+
+        assertThat(response.getTotalItems()).isEqualTo(3);
+        assertThat(response.getTotalItems()).isEqualTo(response.getOidEntries().size());
+    }
+
+    @Test
+    void baseClassFieldsResolveAgainstEveryCategory() {
+        CustomOidEntryListResponseDto response = search(FilterField.OID_ENTRY_DISPLAY_NAME,
+                FilterConditionOperator.CONTAINS, "entry");
+
+        assertThat(response.getOidEntries())
+                .extracting(CustomOidEntryResponseDto::getOid)
+                .containsExactlyInAnyOrder(GENERIC_OID, EXTENSION_OID, RDN_COMMON_NAME_OID, RDN_ORG_UNIT_OID,
+                        RDN_WITHOUT_CODE_OID);
+    }
+
+    private CustomOidEntryListResponseDto search(FilterField field, FilterConditionOperator operator,
+            Serializable value) {
+        SearchRequestDto request = new SearchRequestDto();
+        request.setFilters(List.of(aPropertyFilter(field, operator, value)));
+        return customOidEntryService.listCustomOidEntries(request);
+    }
+
+    private void rdnEntry(String oid, String displayName, String code, List<String> altCodes) {
+        RdnAttributeTypeCustomOidEntry entry = new RdnAttributeTypeCustomOidEntry();
+        entry.setOid(oid);
+        entry.setCategory(OidCategory.RDN_ATTRIBUTE_TYPE);
+        entry.setDisplayName(displayName);
+        entry.setCode(code);
+        entry.setAltCodes(altCodes);
+        customOidEntryRepository.save(entry);
+    }
+}

--- a/src/test/java/com/otilm/core/integration/search/SubclassFilterFieldSearchITest.java
+++ b/src/test/java/com/otilm/core/integration/search/SubclassFilterFieldSearchITest.java
@@ -6,11 +6,16 @@ import com.otilm.api.model.core.oid.CustomOidEntryResponseDto;
 import com.otilm.api.model.core.oid.ExtensionValueEncoding;
 import com.otilm.api.model.core.oid.OidCategory;
 import com.otilm.api.model.core.search.FilterConditionOperator;
+import com.otilm.api.model.core.search.FilterFieldSource;
+import com.otilm.api.model.core.search.SortDirection;
 import com.otilm.core.dao.entity.oid.CertificateExtensionCustomOidEntry;
+import com.otilm.core.dao.entity.oid.CustomOidEntry;
 import com.otilm.core.dao.entity.oid.GenericCustomOidEntry;
 import com.otilm.core.dao.entity.oid.RdnAttributeTypeCustomOidEntry;
 import com.otilm.core.dao.repository.CustomOidEntryRepository;
+import com.otilm.core.dao.repository.SortSpecification;
 import com.otilm.core.enums.FilterField;
+import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.CustomOidEntryExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import java.io.Serializable;
@@ -125,6 +130,25 @@ class SubclassFilterFieldSearchITest extends BaseSpringBootTest {
                 .extracting(CustomOidEntryResponseDto::getOid)
                 .containsExactlyInAnyOrder(GENERIC_OID, EXTENSION_OID, RDN_COMMON_NAME_OID, RDN_ORG_UNIT_OID,
                         RDN_WITHOUT_CODE_OID);
+    }
+
+    /**
+     * Descending, so the expected order contradicts both the fixture insertion order and the oid order.
+     */
+    @Test
+    void ordersBySubclassDeclaredCodeAcrossEveryCategory() {
+        List<CustomOidEntry> entries = customOidEntryRepository
+                .findUsingSecurityFilter(SecurityFilter.create(), List.of(), null, null, null, new SortSpecification(
+                        FilterFieldSource.PROPERTY, FilterField.OID_ENTRY_CODE.name(), SortDirection.DESC));
+
+        assertThat(entries)
+                .extracting(CustomOidEntry::getOid)
+                .containsExactlyInAnyOrder(GENERIC_OID, EXTENSION_OID, RDN_COMMON_NAME_OID, RDN_ORG_UNIT_OID,
+                        RDN_WITHOUT_CODE_OID);
+        assertThat(entries)
+                .extracting(CustomOidEntry::getOid)
+                .filteredOn(oid -> oid.equals(RDN_COMMON_NAME_OID) || oid.equals(RDN_ORG_UNIT_OID))
+                .containsExactly(RDN_ORG_UNIT_OID, RDN_COMMON_NAME_OID);
     }
 
     private CustomOidEntryListResponseDto search(FilterField field, FilterConditionOperator operator,

--- a/src/test/java/com/otilm/core/integration/util/FilterPredicatesBuilderITest.java
+++ b/src/test/java/com/otilm/core/integration/util/FilterPredicatesBuilderITest.java
@@ -42,6 +42,7 @@ import com.otilm.api.model.core.logging.records.ActorRecord;
 import com.otilm.api.model.core.logging.records.LogRecord;
 import com.otilm.api.model.core.logging.records.ResourceObjectIdentity;
 import com.otilm.api.model.core.logging.records.ResourceRecord;
+import com.otilm.api.model.core.logging.records.SourceRecord;
 import com.otilm.api.model.core.search.FilterConditionOperator;
 import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.core.attribute.engine.AttributeEngine;
@@ -1838,6 +1839,63 @@ class FilterPredicatesBuilderITest extends BaseSpringBootTest {
 
     }
 
+    @Test
+    void testAuditLogSourceFilters_twoSegmentJsonPath() {
+        AuditLog localCall = createAuditLog(List.of(),
+                SourceRecord.builder().method("GET").path("/v1/certificates").ipAddress("127.0.0.1").build());
+        AuditLog remoteCall = createAuditLog(List.of(),
+                SourceRecord.builder().method("GET").path("/v1/keys").ipAddress("10.0.0.7").build());
+        AuditLog withoutSource = createAuditLog(List.of());
+        SearchRequestDto searchRequestDto = new SearchRequestDto();
+
+        searchRequestDto
+                .setFilters(List.of(aPropertyEqualsFilter(FilterField.AUDIT_LOG_SOURCE_IP_ADDRESS, "127.0.0.1")));
+        Assertions
+                .assertEquals(Set.of(localCall.getId()),
+                        extractIdsFromAuditLogResponse(auditLogService.listAuditLogs(searchRequestDto)));
+
+        searchRequestDto.setFilters(List.of(aPropertyEqualsFilter(FilterField.AUDIT_LOG_SOURCE_PATH, "/v1/keys")));
+        Assertions
+                .assertEquals(Set.of(remoteCall.getId()),
+                        extractIdsFromAuditLogResponse(auditLogService.listAuditLogs(searchRequestDto)));
+
+        searchRequestDto.setFilters(List.of(aPropertyEmptyFilter(FilterField.AUDIT_LOG_SOURCE_IP_ADDRESS)));
+        Assertions
+                .assertEquals(Set.of(withoutSource.getId()),
+                        extractIdsFromAuditLogResponse(auditLogService.listAuditLogs(searchRequestDto)));
+    }
+
+    @Test
+    void testGroupNameNotEqualsFilter_matchesResourcesOutsideTheNamedGroup() {
+        Group excludedGroup = new Group();
+        excludedGroup.setName("excluded group");
+        groupRepository.save(excludedGroup);
+        Group otherGroup = new Group();
+        otherGroup.setName("other group");
+        groupRepository.save(otherGroup);
+
+        associateGroupWithCertificate(excludedGroup, certificate1);
+        associateGroupWithCertificate(otherGroup, certificate2);
+
+        CertificateSearchRequestDto searchRequestDto = new CertificateSearchRequestDto();
+        searchRequestDto.setFilters(List.of(aPropertyNotEqualsFilter(FilterField.GROUP_NAME, "excluded group")));
+
+        Assertions
+                .assertEquals(Set.of(certificate2.getUuid(), certificate3.getUuid()),
+                        getUuidsFromListCertificatesResponse(
+                                certificateService.listCertificates(new SecurityFilter(), searchRequestDto)));
+    }
+
+    private void associateGroupWithCertificate(final Group group, final Certificate certificate) {
+        certificate.setGroups(Set.of(group));
+        certificateRepository.save(certificate);
+        GroupAssociation association = new GroupAssociation();
+        association.setGroupUuid(group.getUuid());
+        association.setResource(Resource.CERTIFICATE);
+        association.setObjectUuid(certificate.getUuid());
+        groupAssociationRepository.save(association);
+    }
+
     // ─── Exception paths ───────────────────────────────────────────────────
 
     @Test
@@ -2060,6 +2118,10 @@ class FilterPredicatesBuilderITest extends BaseSpringBootTest {
     }
 
     private AuditLog createAuditLog(List<ResourceObjectIdentity> resourceObjects) {
+        return createAuditLog(resourceObjects, null);
+    }
+
+    private AuditLog createAuditLog(List<ResourceObjectIdentity> resourceObjects, SourceRecord source) {
         AuditLog entity = new AuditLog();
         entity.setVersion("1.0");
         entity.setModule(Module.AUTH);
@@ -2079,6 +2141,7 @@ class FilterPredicatesBuilderITest extends BaseSpringBootTest {
                         .actor(new ActorRecord(ActorType.USER, AuthMethod.CERTIFICATE, null, null))
                         .operation(Operation.LOGOUT)
                         .operationResult(OperationResult.FAILURE)
+                        .source(source)
                         .resource(new ResourceRecord(Resource.USER, resourceObjects))
                         .build());
         auditLogRepository.save(entity);

--- a/src/test/java/com/otilm/core/util/FilterPredicatesBuilderFieldPathTest.java
+++ b/src/test/java/com/otilm/core/util/FilterPredicatesBuilderFieldPathTest.java
@@ -1,0 +1,109 @@
+package com.otilm.core.util;
+
+import com.otilm.api.exception.ValidationException;
+import jakarta.persistence.criteria.From;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.ManagedType;
+import jakarta.persistence.metamodel.PluralAttribute;
+import jakarta.persistence.metamodel.SingularAttribute;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link FilterPredicatesBuilder#resolveFieldPath}.
+ *
+ * <p>
+ * The metamodel is stubbed rather than derived from real entities, because the interesting cases are defined by where
+ * an attribute is declared relative to the path being resolved against, not by any particular entity. The plural
+ * subtype case has no counterpart among today's filter fields and can only be reached this way.
+ */
+@SuppressWarnings({"unchecked", "rawtypes"})
+class FilterPredicatesBuilderFieldPathTest {
+
+    private static class Base {
+    }
+
+    private static class Sub extends Base {
+    }
+
+    @Test
+    void attributeDeclaredOnThePathsOwnType_isResolvedByName() {
+        final From from = fromOfType(Base.class);
+        final Path<?> expectedPath = pathReturnedByName(from, "displayName");
+
+        final Path<?> resolvedPath = FilterPredicatesBuilder
+                .resolveFieldPath(from, singularAttribute("displayName", Base.class));
+
+        assertThat(resolvedPath).isSameAs(expectedPath);
+    }
+
+    @Test
+    void attributeDeclaredOnASupertype_isResolvedByName() {
+        final From from = fromOfType(Sub.class);
+        final Path<?> expectedPath = pathReturnedByName(from, "uuid");
+
+        final Path<?> resolvedPath = FilterPredicatesBuilder
+                .resolveFieldPath(from, singularAttribute("uuid", Base.class));
+
+        assertThat(resolvedPath).isSameAs(expectedPath);
+    }
+
+    @Test
+    void singularAttributeDeclaredOnASubtype_isResolvedThroughTheAttribute() {
+        final From from = fromOfType(Base.class);
+        final SingularAttribute attribute = singularAttribute("code", Sub.class);
+        final Path<?> expectedPath = mock(Path.class);
+        when(from.get(attribute)).thenReturn(expectedPath);
+
+        final Path<?> resolvedPath = FilterPredicatesBuilder.resolveFieldPath(from, attribute);
+
+        assertThat(resolvedPath).isSameAs(expectedPath);
+        verify(from, never()).get(anyString());
+    }
+
+    @Test
+    void pluralAttributeDeclaredOnASubtype_isRejected() {
+        final From from = fromOfType(Base.class);
+        final PluralAttribute attribute = mock(PluralAttribute.class);
+        stubDeclaration(attribute, "altCodes", Sub.class);
+
+        assertThatThrownBy(() -> FilterPredicatesBuilder.resolveFieldPath(from, attribute))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("altCodes")
+                .hasMessageContaining("Sub");
+        verify(from, never()).get(anyString());
+    }
+
+    private static From fromOfType(final Class<?> javaType) {
+        final From from = mock(From.class);
+        when(from.getJavaType()).thenReturn(javaType);
+        return from;
+    }
+
+    private static Path<?> pathReturnedByName(final From from, final String attributeName) {
+        final Path<?> path = mock(Path.class);
+        when(from.get(attributeName)).thenReturn(path);
+        return path;
+    }
+
+    private static SingularAttribute singularAttribute(final String name, final Class<?> declaringJavaType) {
+        final SingularAttribute attribute = mock(SingularAttribute.class);
+        stubDeclaration(attribute, name, declaringJavaType);
+        return attribute;
+    }
+
+    private static void stubDeclaration(final Attribute attribute, final String name, final Class<?> declaringType) {
+        final ManagedType managedType = mock(ManagedType.class);
+        when(managedType.getJavaType()).thenReturn(declaringType);
+        when(attribute.getDeclaringType()).thenReturn(managedType);
+        when(attribute.getName()).thenReturn(name);
+    }
+}


### PR DESCRIPTION
**Two OID filter fields stop resolving under Hibernate 7, and the obvious fix — an explicit Criteria `treat` — silently corrupts the result count, so the field is resolved through its metamodel attribute instead.**

Closes #2149.

## What breaks, and when

`FilterField.OID_ENTRY_CODE` and `OID_ENTRY_ALT_CODES` name attributes declared on the subclass `RdnAttributeTypeCustomOidEntry`. `CustomOidEntryRepository` roots its criteria at the base `CustomOidEntry`. `FilterPredicatesBuilder` resolved those filter fields **by name** against that root.

**When it's fine — today, on `main`.** Hibernate 6 performs an implicit downcast. Filtering OID entries by code and alt-code is not broken in production.

**When it breaks — after the Hibernate 7 bump.** Hibernate 7 does not perform the downcast. It fails with:

```
PathElementException: Could not resolve attribute 'altCodes'
  of com.otilm.core.dao.entity.oid.CustomOidEntry
```

This is **intentional**, documented in the [Hibernate 7.0 migration guide](https://docs.hibernate.org/orm/7.0/migration-guide/) under *Criteria API and Implicit Treats*:

> Since Hibernate 7.0, aligning with the JPA specification, the Criteria API will no longer allow retrieving subtype attributes this way, and it's going to require an explicit `jakarta.persistence.criteria.CriteriaBuilder#treat` to be called on the path first to downcast it to the subtype which defines the attribute. Implicit treats are still going to be applied when an HQL query dereferences a path belonging to an inheritance subtype.

Only the **string-based** Criteria `Path#get` is affected. HQL is not. The typed `Path#get(SingularAttribute)` overload is not either — and that is what this PR uses.

## Why an explicit `treat` is the wrong fix

`CriteriaBuilder.treat` does make the attribute resolve. It also **restricts the query to the subtype**. Hibernate applies that restriction to the count query while dropping it from the matching list query.

Measured on mixed-category fixtures — 2 non-RDN entries, 3 RDN entries — on Hibernate 6.6, before and after adding the treat:

| Filter | Returned page | `totalItems` |
|---|---|---|
| `OID_ENTRY_CODE` NOT_EQUALS `CN` | unchanged, 4 rows | **4 → 2** |
| `OID_ENTRY_CODE` NOT_CONTAINS `C` | unchanged, 4 rows | **4 → 2** |
| `OID_ENTRY_CODE` EMPTY | unchanged, 3 rows | **3 → 1** |

The page and the count disagree **inside a single response**. The generated SQL shows why:

```sql
-- list: treat dropped, plain column reference
select distinct ... from core.custom_oid_entry coe1_0
 where coe1_0.code is null

-- count: treat materialised as a subtype-restricted derived table
select count(distinct coe1_0.oid)
  from (select * from core.custom_oid_entry t where t.category='RDN_ATTRIBUTE_TYPE') coe1_0
 where coe1_0.code is null
```

The same experiment on **Hibernate 7.4 produces byte-identical output**. This is not version drift. A `treat` is wrong on both lines.

## The approach

Resolve the field through the **metamodel attribute** rather than through its name. `FilterField` already holds the `Attribute` object; the builder was discarding it and passing `getName()`.

Hibernate honours the attribute object directly instead of looking its name up on the path's own type. **No downcast is needed, and no subtype restriction is added.**

The subtype test is derived from the attribute's own declaring type rather than from a list of known fields, so a future subclass filter field is covered without further change. Every filter-field resolution site in the builder routes through the helper: the main path, the five JSON-path branches (the array arm and the one- through four-segment arms), the native-array `NOT EXISTS` subquery, and the group-join subquery.

`SortOrderBuilder.resolveExpression` routes through it too, so ordering by a subclass-declared field resolves the same way filtering does. It previously built one dotted string path and resolved the last segment by name; under Hibernate 7 that segment raises `PathElementException`, which extends `IllegalArgumentException` and so is caught by `resolveExpression`'s own handler and reported as *"Field OID_ENTRY_CODE cannot be sorted on this resource"* — the sort would have disappeared rather than failed. Not reachable today: `SortSpecification.from` has no production caller yet.

A subtype-declared attribute that is **not singular** has no such route. Rather than fall back to the name lookup, `resolveFieldPath` rejects it with a `ValidationException`. No filter field is plural today — `code` and `altCodes` are both generated as `SingularAttribute` — so the branch is unreachable. The next person to add a subclass filter field gets a clear error instead of a silent regression.

**One caveat, stated plainly.** `Path.get(SingularAttribute<? super X, Y>)` strictly expects an attribute declared on `X` or a supertype. Passing a subtype attribute is outside the JPA contract; it works because of how Hibernate resolves it. That trades one Hibernate-specific behaviour for another. This one is verified on 6.6 **and** 7.4 and is exactly behaviour-preserving. `treat` is spec-correct but changes results.

## The integration tests are a forward guard; the unit test is current coverage

`main` builds on Hibernate 6.6, where the name-based lookup still resolves. `SubclassFilterFieldSearchITest` therefore passes with or without this change **today**. It only starts failing without it once the Hibernate 7 bump lands.

What it does guard on the current line is the page-versus-total agreement. Those two tests go red the moment anyone reintroduces the `treat`, on either Hibernate version.

`FilterPredicatesBuilderFieldPathTest` is the exception: it drives `resolveFieldPath` against a stubbed metamodel and does cover the resolution branches today, including the plural-subtype guard that no filter field can reach.

## Evidence

| Check | Result |
|---|---|
| 6.6 before the fix vs 6.6 after it, 20 recorded filter cases | byte-identical — no-op confirmed |
| 7.4 after the fix vs the 6.6 baseline | byte-identical — resolves correctly, same semantics |
| `CustomOidEntryServiceITest` on 7.4 | 22/22 green, was red |
| `NativeArrayFilterSearchITest` on 7.4 | 42/42 green |
| New `SubclassFilterFieldSearchITest` under the `treat` variant | 2 of 6 fail on count agreement |
| `SubclassFilterFieldSearchITest` + 3 filter suites on 6.6 | 127/127 green |
| Spotless, Checkstyle | pass |
| SonarCloud quality gate | passed — 87.5% coverage on new code |

The 8 `FilterPredicatesBuilderITest` failures on the 4.1 baseline branch are unrelated literal quoting (`'test'` vs `test`) and reproduce identically without this change. They belong to #2017.

