### PR TITLE
Serve the cryptographic asset inventory list and searchable fields

### DIFF
--- a/src/main/java/com/otilm/core/api/web/CryptographicAssetControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/CryptographicAssetControllerImpl.java
@@ -11,6 +11,7 @@ import com.otilm.api.model.core.logging.enums.Module;
 import com.otilm.api.model.core.logging.enums.Operation;
 import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
 import com.otilm.core.aop.AuditLogged;
+import com.otilm.core.auth.AuthEndpoint;
 import com.otilm.core.logging.LogResource;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
@@ -32,6 +33,7 @@ public class CryptographicAssetControllerImpl implements CryptographicAssetContr
 
     @Override
     @AuditLogged(module = Module.CORE, resource = Resource.CRYPTO_ASSET, operation = Operation.LIST)
+    @AuthEndpoint(resourceName = Resource.CRYPTO_ASSET)
     public PaginationResponseDto<CryptographicAssetDto> listCryptographicAssets(SearchRequestDto request) {
         return cryptographicAssetService.listCryptographicAssets(SecurityFilter.create(), request);
     }

--- a/src/main/java/com/otilm/core/dao/repository/CbomRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CbomRepository.java
@@ -59,4 +59,8 @@ public interface CbomRepository extends SecurityFilterRepository<Cbom, UUID> {
             """)
     int updateAssetSyncState(@Param("uuid") UUID uuid, @Param("state") CbomAssetSyncState state,
             @Param("error") String error, @Param("syncedAt") OffsetDateTime syncedAt);
+
+    /** Distinct CBOM serial numbers, the value list of the inventory's source-CBOM filter. */
+    @Query("SELECT DISTINCT c.serialNumber FROM Cbom c ORDER BY c.serialNumber")
+    List<String> findDistinctSerialNumber();
 }

--- a/src/main/java/com/otilm/core/dao/repository/CbomRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CbomRepository.java
@@ -59,8 +59,4 @@ public interface CbomRepository extends SecurityFilterRepository<Cbom, UUID> {
             """)
     int updateAssetSyncState(@Param("uuid") UUID uuid, @Param("state") CbomAssetSyncState state,
             @Param("error") String error, @Param("syncedAt") OffsetDateTime syncedAt);
-
-    /** Distinct CBOM serial numbers, the value list of the inventory's source-CBOM filter. */
-    @Query("SELECT DISTINCT c.serialNumber FROM Cbom c ORDER BY c.serialNumber")
-    List<String> findDistinctSerialNumber();
 }

--- a/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepository.java
@@ -72,6 +72,15 @@ public interface SecurityFilterRepository<T, ID> extends JpaRepository<T, ID> {
     Long countUsingSecurityFilter(SecurityFilter filter,
             TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause);
 
+    /**
+     * Row count without the DISTINCT the variant above emits. Correct only where no predicate can duplicate the root
+     * row: every joining shape must go through EXISTS subqueries and the resource's security filter must add no join of
+     * its own. Where that holds, prefer this one -- Postgres cannot parallelize {@code count(DISTINCT ...)}, which at
+     * millions of rows is seconds against milliseconds for a plain {@code count(*)}.
+     */
+    Long countRowsUsingSecurityFilter(SecurityFilter filter,
+            TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause);
+
     Integer deleteUsingSecurityFilter(SecurityFilter filter,
             TriFunction<Root<T>, CriteriaBuilder, CriteriaDelete<T>, Predicate> additionalWhereClause);
 

--- a/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepositoryImpl.java
+++ b/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepositoryImpl.java
@@ -260,9 +260,16 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
     @Override
     public Long countUsingSecurityFilter(SecurityFilter filter,
             TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause) {
-        CriteriaQuery<Long> cr = createCountCriteriaBuilder(filter, additionalWhereClause);
+        CriteriaQuery<Long> cr = createCountCriteriaBuilder(filter, additionalWhereClause, true);
         List<Long> crlist = entityManager.createQuery(cr).getResultList();
         return crlist.get(0);
+    }
+
+    @Override
+    public Long countRowsUsingSecurityFilter(SecurityFilter filter,
+            TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause) {
+        CriteriaQuery<Long> cr = createCountCriteriaBuilder(filter, additionalWhereClause, false);
+        return entityManager.createQuery(cr).getResultList().get(0);
     }
 
     @Override
@@ -463,12 +470,13 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
     }
 
     private CriteriaQuery<Long> createCountCriteriaBuilder(final SecurityFilter filter,
-            final TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause) {
+            final TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause,
+            final boolean distinct) {
         final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         final Class<T> entity = this.entityInformation.getJavaType();
         final CriteriaQuery<Long> cr = cb.createQuery(Long.class);
         final Root<T> root = cr.from(entity);
-        cr.select(cb.countDistinct(root));
+        cr.select(distinct ? cb.countDistinct(root) : cb.count(root));
         final List<Predicate> predicates = getPredicates(filter, additionalWhereClause, root, cb, cr);
         return predicates.isEmpty() ? cr : cr.where(predicates.toArray(new Predicate[]{}));
     }

--- a/src/main/java/com/otilm/core/dao/repository/cbom/CryptoAssetRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/cbom/CryptoAssetRepository.java
@@ -182,27 +182,89 @@ public interface CryptoAssetRepository extends SecurityFilterRepository<CryptoAs
      * token. Class-level canonicalization -- folding P-256 and secp256r1 into one secg/* representative -- is the
      * ingest pipeline's obligation (core#2072): these lists offer exactly what that pipeline stores, one entry per
      * stored spelling, and become the ratified class representatives the moment it writes them.
+     *
+     * <p>
+     * Native recursive CTEs -- a loose index scan. Postgres has no btree skip scan, so {@code SELECT DISTINCT} walks
+     * the whole table (a parallel seq scan pinning workers): hundreds of milliseconds per column at millions of rows,
+     * for eight columns on every filter-panel open. The CTE instead hops index-min to index-min over the per-column
+     * btrees the migration already ships -- O(distinct values x log rows), reliably milliseconds. {@code min()} ignores
+     * NULLs, and the strictly-greater walk makes the values distinct and sorted by construction.
      */
-    @Query("SELECT DISTINCT a.algorithmFamily FROM CryptoAsset a WHERE a.algorithmFamily IS NOT NULL "
-            + "ORDER BY a.algorithmFamily")
+    @Query(value = """
+            WITH RECURSIVE vals AS (
+                SELECT min(algorithm_family) AS v FROM {h-schema}crypto_asset
+                UNION ALL
+                SELECT (SELECT min(algorithm_family) FROM {h-schema}crypto_asset WHERE algorithm_family > vals.v)
+                FROM vals WHERE vals.v IS NOT NULL
+            )
+            SELECT v FROM vals WHERE v IS NOT NULL ORDER BY v
+            """, nativeQuery = true)
     List<String> findDistinctAlgorithmFamily();
 
-    @Query("SELECT DISTINCT a.primitive FROM CryptoAsset a WHERE a.primitive IS NOT NULL ORDER BY a.primitive")
+    @Query(value = """
+            WITH RECURSIVE vals AS (
+                SELECT min(primitive) AS v FROM {h-schema}crypto_asset
+                UNION ALL
+                SELECT (SELECT min(primitive) FROM {h-schema}crypto_asset WHERE primitive > vals.v)
+                FROM vals WHERE vals.v IS NOT NULL
+            )
+            SELECT v FROM vals WHERE v IS NOT NULL ORDER BY v
+            """, nativeQuery = true)
     List<String> findDistinctPrimitive();
 
-    @Query("SELECT DISTINCT a.parameterSet FROM CryptoAsset a WHERE a.parameterSet IS NOT NULL ORDER BY a.parameterSet")
+    @Query(value = """
+            WITH RECURSIVE vals AS (
+                SELECT min(parameter_set) AS v FROM {h-schema}crypto_asset
+                UNION ALL
+                SELECT (SELECT min(parameter_set) FROM {h-schema}crypto_asset WHERE parameter_set > vals.v)
+                FROM vals WHERE vals.v IS NOT NULL
+            )
+            SELECT v FROM vals WHERE v IS NOT NULL ORDER BY v
+            """, nativeQuery = true)
     List<String> findDistinctParameterSet();
 
-    @Query("SELECT DISTINCT a.curve FROM CryptoAsset a WHERE a.curve IS NOT NULL ORDER BY a.curve")
+    @Query(value = """
+            WITH RECURSIVE vals AS (
+                SELECT min(curve) AS v FROM {h-schema}crypto_asset
+                UNION ALL
+                SELECT (SELECT min(curve) FROM {h-schema}crypto_asset WHERE curve > vals.v)
+                FROM vals WHERE vals.v IS NOT NULL
+            )
+            SELECT v FROM vals WHERE v IS NOT NULL ORDER BY v
+            """, nativeQuery = true)
     List<String> findDistinctCurve();
 
-    @Query("SELECT DISTINCT a.mode FROM CryptoAsset a WHERE a.mode IS NOT NULL ORDER BY a.mode")
+    @Query(value = """
+            WITH RECURSIVE vals AS (
+                SELECT min(mode) AS v FROM {h-schema}crypto_asset
+                UNION ALL
+                SELECT (SELECT min(mode) FROM {h-schema}crypto_asset WHERE mode > vals.v)
+                FROM vals WHERE vals.v IS NOT NULL
+            )
+            SELECT v FROM vals WHERE v IS NOT NULL ORDER BY v
+            """, nativeQuery = true)
     List<String> findDistinctMode();
 
-    @Query("SELECT DISTINCT a.padding FROM CryptoAsset a WHERE a.padding IS NOT NULL ORDER BY a.padding")
+    @Query(value = """
+            WITH RECURSIVE vals AS (
+                SELECT min(padding) AS v FROM {h-schema}crypto_asset
+                UNION ALL
+                SELECT (SELECT min(padding) FROM {h-schema}crypto_asset WHERE padding > vals.v)
+                FROM vals WHERE vals.v IS NOT NULL
+            )
+            SELECT v FROM vals WHERE v IS NOT NULL ORDER BY v
+            """, nativeQuery = true)
     List<String> findDistinctPadding();
 
-    @Query("SELECT DISTINCT a.variant FROM CryptoAsset a WHERE a.variant IS NOT NULL ORDER BY a.variant")
+    @Query(value = """
+            WITH RECURSIVE vals AS (
+                SELECT min(variant) AS v FROM {h-schema}crypto_asset
+                UNION ALL
+                SELECT (SELECT min(variant) FROM {h-schema}crypto_asset WHERE variant > vals.v)
+                FROM vals WHERE vals.v IS NOT NULL
+            )
+            SELECT v FROM vals WHERE v IS NOT NULL ORDER BY v
+            """, nativeQuery = true)
     List<String> findDistinctVariant();
 
     /**

--- a/src/main/java/com/otilm/core/dao/repository/cbom/CryptoAssetRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/cbom/CryptoAssetRepository.java
@@ -2,6 +2,8 @@ package com.otilm.core.dao.repository.cbom;
 
 import com.otilm.core.dao.entity.cbom.CryptoAsset;
 import com.otilm.core.dao.repository.SecurityFilterRepository;
+import com.otilm.core.model.cbom.CryptoAssetListRow;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -173,4 +175,46 @@ public interface CryptoAssetRepository extends SecurityFilterRepository<CryptoAs
     @Modifying
     @Query("DELETE FROM CryptoAsset a WHERE a.uuid = :uuid")
     int deleteAsset(@Param("uuid") UUID uuid);
+
+    /**
+     * Distinct stored values of one normalized filter column, for the searchable-fields value lists. The columns hold
+     * the canonical normalized spelling, so these lists can never offer two producer spellings of one value.
+     */
+    @Query("SELECT DISTINCT a.algorithmFamily FROM CryptoAsset a WHERE a.algorithmFamily IS NOT NULL "
+            + "ORDER BY a.algorithmFamily")
+    List<String> findDistinctAlgorithmFamily();
+
+    @Query("SELECT DISTINCT a.primitive FROM CryptoAsset a WHERE a.primitive IS NOT NULL ORDER BY a.primitive")
+    List<String> findDistinctPrimitive();
+
+    @Query("SELECT DISTINCT a.parameterSet FROM CryptoAsset a WHERE a.parameterSet IS NOT NULL ORDER BY a.parameterSet")
+    List<String> findDistinctParameterSet();
+
+    @Query("SELECT DISTINCT a.curve FROM CryptoAsset a WHERE a.curve IS NOT NULL ORDER BY a.curve")
+    List<String> findDistinctCurve();
+
+    @Query("SELECT DISTINCT a.mode FROM CryptoAsset a WHERE a.mode IS NOT NULL ORDER BY a.mode")
+    List<String> findDistinctMode();
+
+    @Query("SELECT DISTINCT a.padding FROM CryptoAsset a WHERE a.padding IS NOT NULL ORDER BY a.padding")
+    List<String> findDistinctPadding();
+
+    @Query("SELECT DISTINCT a.variant FROM CryptoAsset a WHERE a.variant IS NOT NULL ORDER BY a.variant")
+    List<String> findDistinctVariant();
+
+    /**
+     * List-page rows for the given assets. A projection rather than the entity: the list serves none of the JSONB
+     * payload columns, and a page can be 1000 rows. The occurrence total is summed over the per-source rows, whose
+     * count is deliberately uncapped (capping drops evidence payloads, never the count). Rows come back in no
+     * particular order -- IN provides none -- so the caller restores its page order.
+     */
+    @Query("""
+            SELECT new com.otilm.core.model.cbom.CryptoAssetListRow(a.uuid, a.name, a.assetType,
+                    a.pqcVerdict, a.sourceCount, a.identityGuard, COALESCE(SUM(s.occurrenceCount), 0L))
+            FROM CryptoAsset a
+            LEFT JOIN CryptoAssetSource s ON s.assetUuid = a.uuid
+            WHERE a.uuid IN :uuids
+            GROUP BY a.uuid, a.name, a.assetType, a.pqcVerdict, a.sourceCount, a.identityGuard
+            """)
+    List<CryptoAssetListRow> findListRowsByUuids(@Param("uuids") Collection<UUID> uuids);
 }

--- a/src/main/java/com/otilm/core/dao/repository/cbom/CryptoAssetRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/cbom/CryptoAssetRepository.java
@@ -178,7 +178,10 @@ public interface CryptoAssetRepository extends SecurityFilterRepository<CryptoAs
 
     /**
      * Distinct stored values of one normalized filter column, for the searchable-fields value lists. The columns hold
-     * the canonical normalized spelling, so these lists can never offer two producer spellings of one value.
+     * the stored normalized spelling (case/whitespace/Unicode-folded), so the lists collapse casing variants of one
+     * token. Class-level canonicalization -- folding P-256 and secp256r1 into one secg/* representative -- is the
+     * ingest pipeline's obligation (core#2072): these lists offer exactly what that pipeline stores, one entry per
+     * stored spelling, and become the ratified class representatives the moment it writes them.
      */
     @Query("SELECT DISTINCT a.algorithmFamily FROM CryptoAsset a WHERE a.algorithmFamily IS NOT NULL "
             + "ORDER BY a.algorithmFamily")
@@ -209,12 +212,12 @@ public interface CryptoAssetRepository extends SecurityFilterRepository<CryptoAs
      * particular order -- IN provides none -- so the caller restores its page order.
      */
     @Query("""
-            SELECT new com.otilm.core.model.cbom.CryptoAssetListRow(a.uuid, a.name, a.assetType,
+            SELECT new com.otilm.core.model.cbom.CryptoAssetListRow(a.uuid, a.name, a.oid, a.assetType,
                     a.pqcVerdict, a.sourceCount, a.identityGuard, COALESCE(SUM(s.occurrenceCount), 0L))
             FROM CryptoAsset a
             LEFT JOIN CryptoAssetSource s ON s.assetUuid = a.uuid
             WHERE a.uuid IN :uuids
-            GROUP BY a.uuid, a.name, a.assetType, a.pqcVerdict, a.sourceCount, a.identityGuard
+            GROUP BY a.uuid, a.name, a.oid, a.assetType, a.pqcVerdict, a.sourceCount, a.identityGuard
             """)
     List<CryptoAssetListRow> findListRowsByUuids(@Param("uuids") Collection<UUID> uuids);
 }

--- a/src/main/java/com/otilm/core/enums/FilterField.java
+++ b/src/main/java/com/otilm/core/enums/FilterField.java
@@ -80,6 +80,7 @@ import com.otilm.core.dao.entity.signing.SigningRecord_;
 import com.otilm.core.dao.entity.signing.TimeQualityConfiguration_;
 import com.otilm.core.dao.entity.signing.TspProfile_;
 import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.model.cbom.CryptoAssetIdentityGuard;
 import jakarta.persistence.metamodel.Attribute;
 import java.util.Arrays;
 import java.util.List;
@@ -414,6 +415,17 @@ public enum FilterField {
             "Identity Rule Set Version", SearchFieldTypeEnum.NUMBER),
     CBOM_ASSET_SOURCE_COUNT(Resource.CRYPTO_ASSET, null, null, CryptoAsset_.sourceCount, "Source CBOMs",
             SearchFieldTypeEnum.NUMBER),
+
+    // Free text spans lower(name)/lower(oid) and the refuted-OID opt-in couples with the OID
+    // predicates, so all three are built by dedicated branches in FilterPredicatesBuilder rather
+    // than the generic attribute path. CBOM_ASSET_SOURCE_CBOM matches through an EXISTS subquery,
+    // never a join: the uuid page query has no DISTINCT, and a row with several sources would
+    // otherwise repeat inside one page.
+    CBOM_ASSET_FREE_TEXT(Resource.CRYPTO_ASSET, null, null, null, "Text Search", SearchFieldTypeEnum.FREE_TEXT),
+    CBOM_ASSET_OID_REFUTED(Resource.CRYPTO_ASSET, null, null, CryptoAsset_.identityGuard, "OID Refuted",
+            SearchFieldTypeEnum.BOOLEAN, null, CryptoAssetIdentityGuard.REFUTED_OID, false, null),
+    CBOM_ASSET_SOURCE_CBOM(Resource.CRYPTO_ASSET, Resource.CBOM, null, Cbom_.serialNumber, "Source CBOM",
+            SearchFieldTypeEnum.LIST),
 
     // Signing Profile
     SIGNING_PROFILE_NAME(Resource.SIGNING_PROFILE, null, null, SigningProfile_.name, "Name",

--- a/src/main/java/com/otilm/core/enums/SearchFieldTypeEnum.java
+++ b/src/main/java/com/otilm/core/enums/SearchFieldTypeEnum.java
@@ -57,6 +57,10 @@ public enum SearchFieldTypeEnum {
     // only the presence of a value can be tested, never the value itself.
     PRESENCE(FilterFieldType.STRING, List.of(FilterConditionOperator.EMPTY, FilterConditionOperator.NOT_EMPTY), false,
             null),
+    // A single text input matched case-insensitively across several columns at once; which columns is
+    // defined per FilterField in FilterPredicatesBuilder. Only CONTAINS is offered: the field spans
+    // columns, so per-column operators (EQUALS, EMPTY, ...) have no single answer.
+    FREE_TEXT(FilterFieldType.STRING, List.of(FilterConditionOperator.CONTAINS), false, null),
     BOOLEAN(FilterFieldType.BOOLEAN,
             List
                     .of(FilterConditionOperator.EQUALS, FilterConditionOperator.NOT_EQUALS,

--- a/src/main/java/com/otilm/core/model/cbom/CryptoAssetIdentityGuard.java
+++ b/src/main/java/com/otilm/core/model/cbom/CryptoAssetIdentityGuard.java
@@ -17,8 +17,10 @@ package com.otilm.core.model.cbom;
  * subject DN. Two certificates can share a common name.</li>
  * <li>{@link #REFUTED_OID} -- an OID whose registry meaning contradicted the component's other properties, so what the
  * OID would have contributed -- a family, a size, a mode, a curve -- was discarded. An arc that is wrong about the
- * family is no reason to trust its size. The arc itself is unaffected: it is stored and filterable on every row,
- * refuted or not.</li>
+ * family is no reason to trust its size. The arc itself stays stored and auditable on every row, but the inventory
+ * search neutralizes it by default: a refuted OID answers value predicates (and the free-text OID side) only after the
+ * caller opts into the refuted facet, while its presence -- EMPTY/NOT_EMPTY -- stays a true fact
+ * (FilterPredicatesBuilder's carve-outs).</li>
  * </ul>
  *
  * <p>

--- a/src/main/java/com/otilm/core/model/cbom/CryptoAssetListRow.java
+++ b/src/main/java/com/otilm/core/model/cbom/CryptoAssetListRow.java
@@ -1,0 +1,14 @@
+package com.otilm.core.model.cbom;
+
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetType;
+import com.otilm.api.model.core.cryptoasset.PqcVerdict;
+import java.util.UUID;
+
+/**
+ * One inventory list row: the columns the list operation serves and nothing else -- never the merge payloads.
+ * {@code identityGuard} rides along because the wire's {@code quarantined} flag is derived from it in the service;
+ * {@code occurrenceCount} is the sum of the per-source occurrence counts.
+ */
+public record CryptoAssetListRow(UUID uuid, String name, CryptographicAssetType assetType, PqcVerdict pqcVerdict,
+        int sourceCount, CryptoAssetIdentityGuard identityGuard, long occurrenceCount) {
+}

--- a/src/main/java/com/otilm/core/model/cbom/CryptoAssetListRow.java
+++ b/src/main/java/com/otilm/core/model/cbom/CryptoAssetListRow.java
@@ -7,8 +7,9 @@ import java.util.UUID;
 /**
  * One inventory list row: the columns the list operation serves and nothing else -- never the merge payloads.
  * {@code identityGuard} rides along because the wire's {@code quarantined} flag is derived from it in the service;
+ * {@code oid} rides along as the fallback for the contract-required {@code name} on a nameless producer row;
  * {@code occurrenceCount} is the sum of the per-source occurrence counts.
  */
-public record CryptoAssetListRow(UUID uuid, String name, CryptographicAssetType assetType, PqcVerdict pqcVerdict,
-        int sourceCount, CryptoAssetIdentityGuard identityGuard, long occurrenceCount) {
+public record CryptoAssetListRow(UUID uuid, String name, String oid, CryptographicAssetType assetType,
+        PqcVerdict pqcVerdict, int sourceCount, CryptoAssetIdentityGuard identityGuard, long occurrenceCount) {
 }

--- a/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
@@ -116,9 +116,10 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
 
     /**
      * The group is PROPERTY only: crypto assets carry no attribute-engine attributes, so offering CUSTOM/META groups
-     * would advertise filter sources this resource does not serve. Curve values are canonical class representatives by
-     * construction -- the column stores the normalized spelling. The enum-backed and boolean fields get their values
-     * from {@link SearchHelper} (enum codes, or none).
+     * would advertise filter sources this resource does not serve. Curve values are the distinct stored spellings of
+     * the normalized column -- one entry per stored token; they become the ratified class representatives once
+     * core#2072's ingest canonicalization writes them (see the value-list queries' javadoc). The enum-backed and
+     * boolean fields get their values from {@link SearchHelper} (enum codes, or none).
      */
     @Override
     @ExternalAuthorization(resource = Resource.CRYPTO_ASSET, action = ResourceAction.LIST)
@@ -239,7 +240,10 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
     private static CryptographicAssetDto toDto(CryptoAssetListRow row) {
         CryptographicAssetDto dto = new CryptographicAssetDto();
         dto.setUuid(row.uuid());
-        dto.setName(row.name());
+        // The contract marks name REQUIRED and the wire mapper drops nulls, so a nameless producer row serves its
+        // recorded OID -- the same next-best stable label displayLabel gives the object picker. A row with neither
+        // still serializes without the field; that residual is interfaces' contract friction, raised on the PR.
+        dto.setName(row.name() != null ? row.name() : row.oid());
         dto.setType(row.assetType());
         dto.setSourceCbomCount(row.sourceCount());
         dto.setOccurrenceCount(row.occurrenceCount());

--- a/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
@@ -2,43 +2,104 @@ package com.otilm.core.service.impl;
 
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.exception.NotSupportedException;
+import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.certificate.SearchRequestDto;
 import com.otilm.api.model.client.dashboard.CryptographicAssetStatisticsDto;
 import com.otilm.api.model.common.PaginationResponseDto;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.cryptoasset.CryptographicAssetDetailDto;
 import com.otilm.api.model.core.cryptoasset.CryptographicAssetDto;
+import com.otilm.api.model.core.cryptoasset.PqcVerdict;
+import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
+import com.otilm.api.model.core.search.SearchFieldDataDto;
+import com.otilm.core.comparator.SearchFieldDataComparator;
+import com.otilm.core.dao.entity.cbom.CryptoAsset;
+import com.otilm.core.dao.entity.cbom.CryptoAsset_;
+import com.otilm.core.dao.repository.CbomRepository;
+import com.otilm.core.dao.repository.cbom.CryptoAssetRepository;
+import com.otilm.core.enums.FilterField;
 import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.model.cbom.CryptoAssetListRow;
 import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.CryptographicAssetExternalService;
+import com.otilm.core.util.FilterPredicatesBuilder;
+import com.otilm.core.util.RequestValidatorHelper;
+import com.otilm.core.util.SearchHelper;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.function.TriFunction;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 /**
- * Serves the ratified cryptographic asset inventory contract with a refusal on every operation: the inventory
- * projection over stored CBOM documents does not exist yet, so there is nothing to read. The authorization annotations
- * are the working part — they register {@code cryptoAssets:list} and {@code cryptoAssets:detail} with the auth service
- * on context refresh, which is what lets roles be defined and the frontend's generated client be wired against the real
- * gates while the read model is built.
+ * Serves the ratified cryptographic asset inventory contract. List and searchable-fields are real reads over the
+ * deduplicated cross-CBOM asset projection; detail, statistics and sync visibility remain {@link NotSupportedException}
+ * refusals until core#2145 builds them.
  *
  * <p>
- * {@link NotSupportedException} maps to HTTP 501 in {@code ExceptionHandlingAdvice}, so a permitted caller learns the
- * operation is not implemented while an unpermitted one is still refused with 403 by the authorization aspect ahead of
- * this body.
+ * {@link NotSupportedException} maps to HTTP 501 in {@code ExceptionHandlingAdvice}, so a permitted caller learns a
+ * still-refused operation is not implemented while an unpermitted caller is refused with 403 by the authorization
+ * aspect ahead of this body.
  */
 @Service
 public class CryptographicAssetServiceImpl implements CryptographicAssetExternalService {
 
     private static final String NOT_IMPLEMENTED = "Cryptographic asset inventory is not implemented yet";
 
+    // The OpenAPI schema documents 1000 as the maximum items per page; this is where it is actually enforced.
+    private static final int MAX_ITEMS_PER_PAGE = 1000;
+
+    private CryptoAssetRepository cryptoAssetRepository;
+
+    private CbomRepository cbomRepository;
+
+    @Autowired
+    public void setCryptoAssetRepository(CryptoAssetRepository cryptoAssetRepository) {
+        this.cryptoAssetRepository = cryptoAssetRepository;
+    }
+
+    @Autowired
+    public void setCbomRepository(CbomRepository cbomRepository) {
+        this.cbomRepository = cbomRepository;
+    }
+
     @Override
     @ExternalAuthorization(resource = Resource.CRYPTO_ASSET, action = ResourceAction.LIST)
     public PaginationResponseDto<CryptographicAssetDto> listCryptographicAssets(SecurityFilter filter,
             SearchRequestDto request) {
-        throw new NotSupportedException(NOT_IMPLEMENTED);
+        RequestValidatorHelper.revalidateSearchRequestDto(request);
+        validatePaging(request);
+        TriFunction<Root<CryptoAsset>, CriteriaBuilder, CriteriaQuery<?>, Predicate> where = (root, cb,
+                criteriaQuery) -> FilterPredicatesBuilder
+                        .getFiltersPredicate(cb, criteriaQuery, root, request.getFilters());
+        Pageable page = PageRequest.of(request.getPageNumber() - 1, request.getItemsPerPage());
+        // The documented order is name ASC, uuid ASC. Only the name term is spelled here: the repository appends
+        // the ascending-uuid tiebreak to every paged secured query (SortOrderBuilder), which is what keeps page
+        // boundaries deterministic inside a group of equal names.
+        List<UUID> pageUuids = cryptoAssetRepository
+                .findUuidsUsingSecurityFilter(filter, where, page, (root, cb) -> cb.asc(root.get(CryptoAsset_.name)));
+        long totalItems = cryptoAssetRepository.countUsingSecurityFilter(filter, where);
+        PaginationResponseDto<CryptographicAssetDto> response = new PaginationResponseDto<>();
+        response.setItems(loadPage(pageUuids));
+        response.setItemsPerPage(request.getItemsPerPage());
+        response.setPageNumber(request.getPageNumber());
+        response.setTotalItems(totalItems);
+        response.setTotalPages((int) Math.ceil((double) totalItems / request.getItemsPerPage()));
+        return response;
     }
 
     @Override
@@ -47,15 +108,106 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
         throw new NotSupportedException(NOT_IMPLEMENTED);
     }
 
+    /**
+     * The group is PROPERTY only: crypto assets carry no attribute-engine attributes, so offering CUSTOM/META groups
+     * would advertise filter sources this resource does not serve. Curve values are canonical class representatives by
+     * construction -- the column stores the normalized spelling. The enum-backed and boolean fields get their values
+     * from {@link SearchHelper} (enum codes, or none).
+     */
     @Override
     @ExternalAuthorization(resource = Resource.CRYPTO_ASSET, action = ResourceAction.LIST)
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformationByGroup() {
-        throw new NotSupportedException(NOT_IMPLEMENTED);
+        List<SearchFieldDataDto> fields = List
+                .of(SearchHelper.prepareSearch(FilterField.CBOM_ASSET_FREE_TEXT),
+                        SearchHelper.prepareSearch(FilterField.CBOM_ASSET_TYPE),
+                        SearchHelper.prepareSearch(FilterField.CBOM_ASSET_NAME),
+                        SearchHelper.prepareSearch(FilterField.CBOM_ASSET_OID),
+                        SearchHelper.prepareSearch(FilterField.CBOM_ASSET_OID_REFUTED),
+                        SearchHelper
+                                .prepareSearch(FilterField.CBOM_ASSET_ALGORITHM_FAMILY,
+                                        cryptoAssetRepository.findDistinctAlgorithmFamily()),
+                        SearchHelper
+                                .prepareSearch(FilterField.CBOM_ASSET_PRIMITIVE,
+                                        cryptoAssetRepository.findDistinctPrimitive()),
+                        SearchHelper
+                                .prepareSearch(FilterField.CBOM_ASSET_PARAMETER_SET,
+                                        cryptoAssetRepository.findDistinctParameterSet()),
+                        SearchHelper
+                                .prepareSearch(FilterField.CBOM_ASSET_CURVE, cryptoAssetRepository.findDistinctCurve()),
+                        SearchHelper
+                                .prepareSearch(FilterField.CBOM_ASSET_MODE, cryptoAssetRepository.findDistinctMode()),
+                        SearchHelper
+                                .prepareSearch(FilterField.CBOM_ASSET_PADDING,
+                                        cryptoAssetRepository.findDistinctPadding()),
+                        SearchHelper
+                                .prepareSearch(FilterField.CBOM_ASSET_VARIANT,
+                                        cryptoAssetRepository.findDistinctVariant()),
+                        SearchHelper.prepareSearch(FilterField.CBOM_ASSET_PQC_VERDICT),
+                        SearchHelper.prepareSearch(FilterField.CBOM_ASSET_PQC_RULESET_VERSION),
+                        SearchHelper.prepareSearch(FilterField.CBOM_ASSET_RULESET_VERSION),
+                        SearchHelper.prepareSearch(FilterField.CBOM_ASSET_SOURCE_COUNT),
+                        SearchHelper
+                                .prepareSearch(FilterField.CBOM_ASSET_SOURCE_CBOM,
+                                        cbomRepository.findDistinctSerialNumber()));
+        List<SearchFieldDataDto> sorted = new ArrayList<>(fields);
+        sorted.sort(new SearchFieldDataComparator());
+        return List.of(new SearchFieldDataByGroupDto(sorted, FilterFieldSource.PROPERTY));
     }
 
     @Override
     @ExternalAuthorization(resource = Resource.CRYPTO_ASSET, action = ResourceAction.LIST)
     public CryptographicAssetStatisticsDto getCryptographicAssetStatistics() {
         throw new NotSupportedException(NOT_IMPLEMENTED);
+    }
+
+    private static void validatePaging(SearchRequestDto request) {
+        // No crypto-asset field is marked sortable, and the contract permits sorting only on fields marked sortable.
+        if (request.getSort() != null) {
+            throw new ValidationException(
+                    "Sorting is not supported for the cryptographic asset inventory; results are ordered by name, then UUID.");
+        }
+        // PageRequest would otherwise turn an out-of-range value into a 500 rather than a shaped 422.
+        if (request.getPageNumber() < 1) {
+            throw new ValidationException("Page number must be at least 1, but was " + request.getPageNumber());
+        }
+        if (request.getItemsPerPage() < 1) {
+            throw new ValidationException("Items per page must be at least 1, but was " + request.getItemsPerPage());
+        }
+        if (request.getItemsPerPage() > MAX_ITEMS_PER_PAGE) {
+            request.setItemsPerPage(MAX_ITEMS_PER_PAGE);
+        }
+    }
+
+    private List<CryptographicAssetDto> loadPage(List<UUID> pageUuids) {
+        if (pageUuids.isEmpty()) {
+            return List.of();
+        }
+        Map<UUID, CryptoAssetListRow> rowsByUuid = cryptoAssetRepository
+                .findListRowsByUuids(pageUuids)
+                .stream()
+                .collect(Collectors.toMap(CryptoAssetListRow::uuid, Function.identity()));
+        return pageUuids
+                .stream()
+                // A uuid whose row vanished between the page and projection queries is skipped rather than failed.
+                .map(rowsByUuid::get)
+                .filter(Objects::nonNull)
+                .map(CryptographicAssetServiceImpl::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private static CryptographicAssetDto toDto(CryptoAssetListRow row) {
+        CryptographicAssetDto dto = new CryptographicAssetDto();
+        dto.setUuid(row.uuid());
+        dto.setName(row.name());
+        dto.setType(row.assetType());
+        dto.setSourceCbomCount(row.sourceCount());
+        dto.setOccurrenceCount(row.occurrenceCount());
+        // A never-evaluated asset is served as UNKNOWN, the ratified "the rules cannot classify this asset"
+        // verdict, because the contract marks the field required.
+        dto.setPqcVerdict(row.pqcVerdict() == null ? PqcVerdict.UNKNOWN : row.pqcVerdict());
+        // The guard records that a safety rule kept contradicting or ambiguous producer claims apart, which is
+        // exactly the contract's "contradicting claims quarantined pending reconciliation".
+        dto.setQuarantined(row.identityGuard() != null);
+        return dto;
     }
 }

--- a/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
@@ -3,13 +3,16 @@ package com.otilm.core.service.impl;
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.exception.NotSupportedException;
 import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.client.certificate.SearchFilterRequestDto;
 import com.otilm.api.model.client.certificate.SearchRequestDto;
 import com.otilm.api.model.client.dashboard.CryptographicAssetStatisticsDto;
+import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.common.PaginationResponseDto;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.cryptoasset.CryptographicAssetDetailDto;
 import com.otilm.api.model.core.cryptoasset.CryptographicAssetDto;
 import com.otilm.api.model.core.cryptoasset.PqcVerdict;
+import com.otilm.api.model.core.scheduler.PaginationRequestDto;
 import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
 import com.otilm.api.model.core.search.SearchFieldDataDto;
@@ -25,11 +28,13 @@ import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.CryptographicAssetExternalService;
+import com.otilm.core.service.ResourceExtensionService;
 import com.otilm.core.util.FilterPredicatesBuilder;
 import com.otilm.core.util.RequestValidatorHelper;
 import com.otilm.core.util.SearchHelper;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import java.util.ArrayList;
@@ -48,15 +53,16 @@ import org.springframework.stereotype.Service;
 /**
  * Serves the ratified cryptographic asset inventory contract. List and searchable-fields are real reads over the
  * deduplicated cross-CBOM asset projection; detail, statistics and sync visibility remain {@link NotSupportedException}
- * refusals until core#2145 builds them.
+ * refusals until core#2145 builds them. The service also serves the per-object listing behind {@code @AuthEndpoint} --
+ * the role editor's object picker.
  *
  * <p>
  * {@link NotSupportedException} maps to HTTP 501 in {@code ExceptionHandlingAdvice}, so a permitted caller learns a
  * still-refused operation is not implemented while an unpermitted caller is refused with 403 by the authorization
  * aspect ahead of this body.
  */
-@Service
-public class CryptographicAssetServiceImpl implements CryptographicAssetExternalService {
+@Service(Resource.Codes.CRYPTO_ASSET)
+public class CryptographicAssetServiceImpl implements CryptographicAssetExternalService, ResourceExtensionService {
 
     private static final String NOT_IMPLEMENTED = "Cryptographic asset inventory is not implemented yet";
 
@@ -160,6 +166,33 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
         throw new NotSupportedException(NOT_IMPLEMENTED);
     }
 
+    @Override
+    public NameAndUuidDto getResourceObjectInternal(UUID objectUuid) throws NotFoundException {
+        return cryptoAssetRepository.findResourceObject(objectUuid, CryptographicAssetServiceImpl::displayLabel);
+    }
+
+    @Override
+    @ExternalAuthorization(resource = Resource.CRYPTO_ASSET, action = ResourceAction.DETAIL)
+    public NameAndUuidDto getResourceObjectExternal(SecuredUUID objectUuid) throws NotFoundException {
+        return cryptoAssetRepository
+                .findResourceObject(objectUuid.getValue(), CryptographicAssetServiceImpl::displayLabel);
+    }
+
+    @Override
+    @ExternalAuthorization(resource = Resource.CRYPTO_ASSET, action = ResourceAction.LIST)
+    public List<NameAndUuidDto> listResourceObjects(SecurityFilter filter, List<SearchFilterRequestDto> filters,
+            PaginationRequestDto pagination) {
+        return cryptoAssetRepository
+                .listResourceObjects(filter, CryptographicAssetServiceImpl::displayLabel, null, pagination);
+    }
+
+    // DETAIL is this resource's own object-read gate, and it has no parent resource to chain through.
+    @Override
+    @ExternalAuthorization(resource = Resource.CRYPTO_ASSET, action = ResourceAction.DETAIL)
+    public void evaluatePermissionChain(SecuredUUID uuid) throws NotFoundException {
+        cryptoAssetRepository.findByUuid(uuid).orElseThrow(() -> new NotFoundException(CryptoAsset.class, uuid));
+    }
+
     private static void validatePaging(SearchRequestDto request) {
         // No crypto-asset field is marked sortable, and the contract permits sorting only on fields marked sortable.
         if (request.getSort() != null) {
@@ -193,6 +226,14 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
                 .filter(Objects::nonNull)
                 .map(CryptographicAssetServiceImpl::toDto)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * The role-permissions object picker's display label: the asset's name, or -- for a bare producer row with none --
+     * its recorded OID, the next-best stable label. Both are producer-derived display values.
+     */
+    private static Expression<String> displayLabel(Root<CryptoAsset> root, CriteriaBuilder cb) {
+        return cb.coalesce(root.get(CryptoAsset_.name), root.get(CryptoAsset_.oid));
     }
 
     private static CryptographicAssetDto toDto(CryptoAssetListRow row) {

--- a/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
@@ -17,14 +17,17 @@ import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
 import com.otilm.api.model.core.search.SearchFieldDataDto;
 import com.otilm.core.comparator.SearchFieldDataComparator;
+import com.otilm.core.dao.entity.Cbom_;
 import com.otilm.core.dao.entity.cbom.CryptoAsset;
 import com.otilm.core.dao.entity.cbom.CryptoAsset_;
 import com.otilm.core.dao.repository.CbomRepository;
 import com.otilm.core.dao.repository.cbom.CryptoAssetRepository;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.model.cbom.CryptoAssetIdentityGuard;
 import com.otilm.core.model.cbom.CryptoAssetListRow;
 import com.otilm.core.security.authz.ExternalAuthorization;
+import com.otilm.core.security.authz.ObjectFilterAspect;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.CryptographicAssetExternalService;
@@ -73,6 +76,8 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
 
     private CbomRepository cbomRepository;
 
+    private ObjectFilterAspect objectFilterAspect;
+
     @Autowired
     public void setCryptoAssetRepository(CryptoAssetRepository cryptoAssetRepository) {
         this.cryptoAssetRepository = cryptoAssetRepository;
@@ -81,6 +86,11 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
     @Autowired
     public void setCbomRepository(CbomRepository cbomRepository) {
         this.cbomRepository = cbomRepository;
+    }
+
+    @Autowired
+    public void setObjectFilterAspect(ObjectFilterAspect objectFilterAspect) {
+        this.objectFilterAspect = objectFilterAspect;
     }
 
     @Override
@@ -93,12 +103,16 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
                 criteriaQuery) -> FilterPredicatesBuilder
                         .getFiltersPredicate(cb, criteriaQuery, root, request.getFilters());
         Pageable page = PageRequest.of(request.getPageNumber() - 1, request.getItemsPerPage());
-        // The documented order is name ASC, uuid ASC. Only the name term is spelled here: the repository appends
-        // the ascending-uuid tiebreak to every paged secured query (SortOrderBuilder), which is what keeps page
-        // boundaries deterministic inside a group of equal names.
+        // The contract's "ordered by name ascending" means the SERVED name -- displayLabel's guarded coalesce --
+        // not the bare column, which would sort every oid-served row after the named ones (NULL sorts last).
+        // Only this term is spelled here: the repository appends the ascending-uuid tiebreak to every paged
+        // secured query (SortOrderBuilder), which keeps page boundaries deterministic inside equal labels.
         List<UUID> pageUuids = cryptoAssetRepository
-                .findUuidsUsingSecurityFilter(filter, where, page, (root, cb) -> cb.asc(root.get(CryptoAsset_.name)));
-        long totalItems = cryptoAssetRepository.countUsingSecurityFilter(filter, where);
+                .findUuidsUsingSecurityFilter(filter, where, page, (root, cb) -> cb.asc(displayLabel(root, cb)));
+        // The plain-count variant: every crypto-asset predicate is either single-column or an EXISTS subquery and
+        // the resource declares no groups or owner, so no query shape can duplicate a root row -- and
+        // count(DISTINCT) forfeits parallel aggregation, which at millions of rows is seconds per page request.
+        long totalItems = cryptoAssetRepository.countRowsUsingSecurityFilter(filter, where);
         PaginationResponseDto<CryptographicAssetDto> response = new PaginationResponseDto<>();
         response.setItems(loadPage(pageUuids));
         response.setItemsPerPage(request.getItemsPerPage());
@@ -152,10 +166,8 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
                         SearchHelper.prepareSearch(FilterField.CBOM_ASSET_PQC_VERDICT),
                         SearchHelper.prepareSearch(FilterField.CBOM_ASSET_PQC_RULESET_VERSION),
                         SearchHelper.prepareSearch(FilterField.CBOM_ASSET_RULESET_VERSION),
-                        SearchHelper.prepareSearch(FilterField.CBOM_ASSET_SOURCE_COUNT),
-                        SearchHelper
-                                .prepareSearch(FilterField.CBOM_ASSET_SOURCE_CBOM,
-                                        cbomRepository.findDistinctSerialNumber()));
+                        SearchHelper.prepareSearch(FilterField.CBOM_ASSET_SOURCE_COUNT), SearchHelper
+                                .prepareSearch(FilterField.CBOM_ASSET_SOURCE_CBOM, cbomSerialNumbersScopedToCaller()));
         List<SearchFieldDataDto> sorted = new ArrayList<>(fields);
         sorted.sort(new SearchFieldDataComparator());
         return List.of(new SearchFieldDataByGroupDto(sorted, FilterFieldSource.PROPERTY));
@@ -183,11 +195,21 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
     @ExternalAuthorization(resource = Resource.CRYPTO_ASSET, action = ResourceAction.LIST)
     public List<NameAndUuidDto> listResourceObjects(SecurityFilter filter, List<SearchFilterRequestDto> filters,
             PaginationRequestDto pagination) {
+        // A search typed into the role editor's picker arrives as filters; honour them the way the inventory list
+        // does (the entity-instance extension is the platform's filter-honouring precedent).
+        TriFunction<Root<CryptoAsset>, CriteriaBuilder, CriteriaQuery<?>, Predicate> where = filters == null
+                || filters.isEmpty()
+                        ? null
+                        : (root, cb, criteriaQuery) -> FilterPredicatesBuilder
+                                .getFiltersPredicate(cb, criteriaQuery, root, filters);
         return cryptoAssetRepository
-                .listResourceObjects(filter, CryptographicAssetServiceImpl::displayLabel, null, pagination);
+                .listResourceObjects(filter, CryptographicAssetServiceImpl::displayLabel, where, pagination);
     }
 
-    // DETAIL is this resource's own object-read gate, and it has no parent resource to chain through.
+    // DETAIL is this resource's own object-read gate, and it has no parent resource to chain through. Sibling
+    // extension services gate this with UPDATE because their one generic caller writes attribute content; that
+    // caller is unreachable here while hasCustomAttributes stays false, and DETAIL avoids syncing a spurious
+    // update action onto a read-only resource -- if custom attributes are ever enabled, this must become UPDATE.
     @Override
     @ExternalAuthorization(resource = Resource.CRYPTO_ASSET, action = ResourceAction.DETAIL)
     public void evaluatePermissionChain(SecuredUUID uuid) throws NotFoundException {
@@ -210,6 +232,31 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
         if (request.getItemsPerPage() > MAX_ITEMS_PER_PAGE) {
             request.setItemsPerPage(MAX_ITEMS_PER_PAGE);
         }
+        // The JPA offset is an int. An unchecked (pageNumber - 1) * itemsPerPage either throws deep in Hibernate
+        // (a 400, not the shaped 422) or -- worse -- wraps positive and silently serves the wrong page while
+        // echoing the requested page number.
+        if ((long) (request.getPageNumber() - 1) * request.getItemsPerPage() > Integer.MAX_VALUE) {
+            throw new ValidationException("Page number " + request.getPageNumber() + " with "
+                    + request.getItemsPerPage() + " items per page exceeds the addressable offset.");
+        }
+    }
+
+    /**
+     * The source-CBOM value list crosses a resource gate -- serial numbers belong to the CBOM resource, and every other
+     * platform value list stays inside its own resource's table. So this one is scoped by the caller's own
+     * {@code cboms:list} object access, populated the same way the rule-filter-fields listing scopes its field
+     * resources: a caller without CBOM access gets an empty value list (the filter itself keeps working by hand), never
+     * the platform's whole document inventory.
+     */
+    private List<String> cbomSerialNumbersScopedToCaller() {
+        SecurityFilter cbomFilter = SecurityFilter.create();
+        objectFilterAspect.populateSecurityFilter(Resource.CBOM, ResourceAction.LIST, null, null, cbomFilter);
+        return cbomRepository
+                .countGroupedUsingSecurityFilter(cbomFilter, null, Cbom_.serialNumber, null, null)
+                .keySet()
+                .stream()
+                .sorted()
+                .toList();
     }
 
     private List<CryptographicAssetDto> loadPage(List<UUID> pageUuids) {
@@ -230,29 +277,48 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
     }
 
     /**
-     * The role-permissions object picker's display label: the asset's name, or -- for a bare producer row with none --
-     * its recorded OID, the next-best stable label. Both are producer-derived display values.
+     * The display label, everywhere one is served: the list's {@code name}, the picker's label, and the list order. The
+     * producer name, else the recorded OID -- EXCEPT a {@code REFUTED_OID} row, whose OID must never be presented as
+     * fact: the refuted ruling's principle is that a client labels such a value instead of serving it bare, and neither
+     * this DTO nor the picker's carries a flag to label it with. Must stay in lock-step with {@link #servedName}, its
+     * in-memory twin.
      */
     private static Expression<String> displayLabel(Root<CryptoAsset> root, CriteriaBuilder cb) {
-        return cb.coalesce(root.get(CryptoAsset_.name), root.get(CryptoAsset_.oid));
+        Expression<String> oidUnlessRefuted = cb
+                .<String>selectCase()
+                .when(cb.equal(root.get(CryptoAsset_.identityGuard), CryptoAssetIdentityGuard.REFUTED_OID),
+                        cb.nullLiteral(String.class))
+                .otherwise(root.get(CryptoAsset_.oid));
+        return cb.coalesce(root.get(CryptoAsset_.name), oidUnlessRefuted);
+    }
+
+    /** The in-memory twin of {@link #displayLabel}; the list orders by that expression and serves this value. */
+    private static String servedName(CryptoAssetListRow row) {
+        if (row.name() != null) {
+            return row.name();
+        }
+        return row.identityGuard() == CryptoAssetIdentityGuard.REFUTED_OID ? null : row.oid();
     }
 
     private static CryptographicAssetDto toDto(CryptoAssetListRow row) {
         CryptographicAssetDto dto = new CryptographicAssetDto();
         dto.setUuid(row.uuid());
         // The contract marks name REQUIRED and the wire mapper drops nulls, so a nameless producer row serves its
-        // recorded OID -- the same next-best stable label displayLabel gives the object picker. A row with neither
-        // still serializes without the field; that residual is interfaces' contract friction, raised on the PR.
-        dto.setName(row.name() != null ? row.name() : row.oid());
+        // recorded OID unless that OID is refuted. A row with no servable label at all serializes without the
+        // field; that residual is interfaces' contract friction, raised on the PR.
+        dto.setName(servedName(row));
         dto.setType(row.assetType());
         dto.setSourceCbomCount(row.sourceCount());
         dto.setOccurrenceCount(row.occurrenceCount());
         // A never-evaluated asset is served as UNKNOWN, the ratified "the rules cannot classify this asset"
         // verdict, because the contract marks the field required.
         dto.setPqcVerdict(row.pqcVerdict() == null ? PqcVerdict.UNKNOWN : row.pqcVerdict());
-        // The guard records that a safety rule kept contradicting or ambiguous producer claims apart, which is
-        // exactly the contract's "contradicting claims quarantined pending reconciliation".
-        dto.setQuarantined(row.identityGuard() != null);
+        // The contract's sentence -- "sources make contradicting claims ... quarantined pending reconciliation" --
+        // describes exactly one guard: REFUTED_CERTIFICATE_DIGEST (contradicting claims, reconciliation queue).
+        // BARE_CN_SUBJECT is a permanent DN-scope split with, by the ratified addendum, no reconciliation path at
+        // all, and REFUTED_OID is one component contradicting itself; flagging either would advertise an operator
+        // queue that can never drain. Widening this needs the flag re-worded in interfaces, not a wider test here.
+        dto.setQuarantined(row.identityGuard() == CryptoAssetIdentityGuard.REFUTED_CERTIFICATE_DIGEST);
         return dto;
     }
 }

--- a/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
+++ b/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
@@ -51,6 +51,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +65,7 @@ import java.util.stream.Collectors;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.Duration;
+import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.JpaExpression;
 
 public class FilterPredicatesBuilder {
@@ -347,10 +349,24 @@ public class FilterPredicatesBuilder {
         // and NOT_EQUALS are answerable -- exactly what SearchHelper advertises for it. The rest are refused here:
         // the boolean value prep below would otherwise fail on a valueless EMPTY, and NOT_EMPTY would read "any
         // value is set" -- which for the refuted-OID facet means any guard at all, not refutedness.
-        if (filterField.getExpectedValue() != null && filterDto.getCondition() != FilterConditionOperator.EQUALS
-                && filterDto.getCondition() != FilterConditionOperator.NOT_EQUALS) {
-            throw new ValidationException("Condition " + filterDto.getCondition() + " is not supported for field "
-                    + filterField + "; the field supports EQUALS and NOT_EQUALS.");
+        if (filterField.getExpectedValue() != null) {
+            if (filterDto.getCondition() != FilterConditionOperator.EQUALS
+                    && filterDto.getCondition() != FilterConditionOperator.NOT_EQUALS) {
+                throw new ValidationException("Condition " + filterDto.getCondition() + " is not supported for field "
+                        + filterField + "; the field supports EQUALS and NOT_EQUALS.");
+            }
+            // The value prep below reads getValue().toString() through Boolean.parseBoolean, which turns a JSON
+            // array ["true"] into "[true]" -> false and silently INVERTS the predicate -- after the facet's mere
+            // presence has already disarmed the refuted-OID carve-outs for the whole request. Only a scalar
+            // boolean is meaningful; everything else is refused before any predicate is built.
+            Object rawValue = filterDto.getValue();
+            boolean scalarBoolean = rawValue != null && !(rawValue instanceof Collection<?>)
+                    && !rawValue.getClass().isArray()
+                    && ("true".equalsIgnoreCase(rawValue.toString()) || "false".equalsIgnoreCase(rawValue.toString()));
+            if (!scalarBoolean) {
+                throw new ValidationException(
+                        "Field " + filterField + " accepts a single boolean value, true or false.");
+            }
         }
 
         Expression expression = null;
@@ -624,6 +640,15 @@ public class FilterPredicatesBuilder {
      * Matches a single text input, case-insensitively, across the crypto-asset name and oid columns at once. A refuted
      * oid is excluded from its side of the match unless the caller opted into the refuted-OID facet, so the row stays
      * findable through its name but the neutralized oid cannot answer the query.
+     *
+     * <p>
+     * Index note, superseding migration V202608271000's rationale comment ("FilterPredicatesBuilder never emits
+     * lower()" -- true when the migration shipped, falsified by this method; the applied file is Flyway-checksum
+     * frozen, so the correction lives here). The conclusion still holds: infix {@code %x%} LIKE is unservable by any
+     * btree, so free text is a sequential scan by design in v1. Measured while confirming: prefix LIKE (STARTS_WITH) is
+     * equally unservable under a non-C collation without {@code text_pattern_ops}, so the upgrade path if this surface
+     * gets hot is a trigram GIN on lower(name)/lower(oid) for infix plus {@code text_pattern_ops} btrees for prefix --
+     * a new indexing migration, never an edit to the applied one.
      */
     private static <T> Predicate getCryptoAssetFreeTextPredicate(CriteriaBuilder criteriaBuilder, Root<T> root,
             FilterField filterField, SearchFilterRequestDto filterDto, List<Object> filterValues,
@@ -635,9 +660,16 @@ public class FilterPredicatesBuilder {
             throw new ValidationException(
                     "Free-text filter for field " + filterField + " supports only the CONTAINS operator.");
         }
+        if (filterValues.size() > 1) {
+            throw new ValidationException("Free-text filter for field " + filterField + " accepts a single value.");
+        }
 
+        // Bound as a parameter, never a literal: an inlined pattern lands verbatim in the SQL statement text --
+        // Postgres server logs, pg_stat_statements -- and people paste secrets into search boxes. lower() stays on
+        // the SQL side so both operands fold under the database's collation, not two different case rules.
         Expression<String> pattern = criteriaBuilder
-                .lower(criteriaBuilder.literal("%" + escapeLikeWildcards(filterValues.getFirst().toString()) + "%"));
+                .lower(((HibernateCriteriaBuilder) criteriaBuilder)
+                        .value("%" + escapeLikeWildcards(filterValues.getFirst().toString()) + "%"));
         Predicate nameMatches = criteriaBuilder
                 .like(criteriaBuilder.lower(root.get(CryptoAsset_.NAME)), pattern, LIKE_ESCAPE_CHAR);
         Predicate oidMatches = criteriaBuilder

--- a/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
+++ b/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
@@ -13,6 +13,7 @@ import com.otilm.core.dao.entity.AttributeContent2Object;
 import com.otilm.core.dao.entity.AttributeContent2Object_;
 import com.otilm.core.dao.entity.AttributeContentItem_;
 import com.otilm.core.dao.entity.AttributeDefinition_;
+import com.otilm.core.dao.entity.Cbom_;
 import com.otilm.core.dao.entity.CryptographicKeyItem;
 import com.otilm.core.dao.entity.CryptographicKeyItem_;
 import com.otilm.core.dao.entity.GroupAssociation;
@@ -20,9 +21,13 @@ import com.otilm.core.dao.entity.GroupAssociation_;
 import com.otilm.core.dao.entity.ResourceObjectAssociation_;
 import com.otilm.core.dao.entity.ScheduledJobHistory;
 import com.otilm.core.dao.entity.UniquelyIdentified_;
+import com.otilm.core.dao.entity.cbom.CryptoAssetSource;
+import com.otilm.core.dao.entity.cbom.CryptoAssetSource_;
+import com.otilm.core.dao.entity.cbom.CryptoAsset_;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.enums.ResourceToClass;
 import com.otilm.core.enums.SearchFieldTypeEnum;
+import com.otilm.core.model.cbom.CryptoAssetIdentityGuard;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import jakarta.persistence.criteria.CommonAbstractCriteria;
@@ -50,6 +55,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -77,17 +83,33 @@ public class FilterPredicatesBuilder {
     private static final String ARRAY_CONTAINS_FUNCTION_NAME = PostgresFunctionContributor.ARRAY_CONTAINS;
     private static final String ARRAY_ITEM_CONTAINS_FUNCTION_NAME = PostgresFunctionContributor.ARRAY_ITEM_CONTAINS;
 
+    private static final Set<FilterConditionOperator> OID_CONDITIONS_A_NULL_OID_SATISFIES = Set
+            .of(FilterConditionOperator.NOT_EQUALS, FilterConditionOperator.NOT_CONTAINS);
+    private static final Set<FilterConditionOperator> OID_CONDITIONS_A_NULL_OID_NEVER_SATISFIES = Set
+            .of(FilterConditionOperator.EQUALS, FilterConditionOperator.CONTAINS, FilterConditionOperator.STARTS_WITH,
+                    FilterConditionOperator.ENDS_WITH, FilterConditionOperator.MATCHES,
+                    FilterConditionOperator.NOT_MATCHES);
+
     public static <T> Predicate getFiltersPredicate(final CriteriaBuilder criteriaBuilder,
             final CommonAbstractCriteria query, final Root<T> root, final List<SearchFilterRequestDto> filterDtos) {
         Map<String, From> joinedAssociations = new HashMap<>();
+
+        // An explicit filter on the refuted-OID facet is the caller opting into matching refuted OID
+        // values, so the carve-outs below switch off for the whole request; the facet's own predicate
+        // then selects rows by refutedness. Without this, combining the facet with an OID filter would
+        // be self-contradictory and always empty.
+        boolean refutedOidsOptedIn = filterDtos != null && filterDtos
+                .stream()
+                .anyMatch(dto -> dto.getFieldSource() == FilterFieldSource.PROPERTY
+                        && FilterField.CBOM_ASSET_OID_REFUTED.name().equals(dto.getFieldIdentifier()));
 
         List<Predicate> predicates = new ArrayList<>();
         if (filterDtos != null) {
             for (SearchFilterRequestDto filterDto : filterDtos) {
                 if (filterDto.getFieldSource() == FilterFieldSource.PROPERTY) {
                     predicates
-                            .add(getPropertyFilterPredicate(criteriaBuilder, query, root, filterDto,
-                                    joinedAssociations));
+                            .add(getPropertyFilterPredicate(criteriaBuilder, query, root, filterDto, joinedAssociations,
+                                    refutedOidsOptedIn));
                 } else {
                     predicates.add(getAttributeFilterPredicate(criteriaBuilder, query, root, filterDto));
                 }
@@ -296,7 +318,7 @@ public class FilterPredicatesBuilder {
 
     private static <T> Predicate getPropertyFilterPredicate(final CriteriaBuilder criteriaBuilder,
             final CommonAbstractCriteria query, final Root<T> root, SearchFilterRequestDto filterDto,
-            Map<String, From> joinedAssociations) {
+            Map<String, From> joinedAssociations, boolean refutedOidsOptedIn) {
         final FilterField filterField = FilterField.valueOf(filterDto.getFieldIdentifier());
         From from = getJoinedAssociation(root, joinedAssociations, filterField, filterDto.getCondition());
 
@@ -306,6 +328,17 @@ public class FilterPredicatesBuilder {
                 && filterDto.getCondition() != FilterConditionOperator.NOT_EMPTY) {
             throw new ValidationException("Filter for field " + filterField + " with operator "
                     + filterDto.getCondition() + " requires at least one value.");
+        }
+
+        // FREE_TEXT has no single fieldAttribute (it spans several columns) and CBOM_ASSET_SOURCE_CBOM's
+        // fieldAttribute declares on Cbom, not on the crypto-asset root, so the generic from.get(...) below would
+        // throw for it. Both are therefore built by dedicated branches before that generic resolution runs.
+        if (filterField.getType() == SearchFieldTypeEnum.FREE_TEXT) {
+            return getCryptoAssetFreeTextPredicate(criteriaBuilder, root, filterField, filterDto, filterValues,
+                    refutedOidsOptedIn);
+        }
+        if (filterField == FilterField.CBOM_ASSET_SOURCE_CBOM) {
+            return getCryptoAssetSourceCbomPredicate(criteriaBuilder, query, root, filterDto, filterValues);
         }
 
         Expression expression = null;
@@ -560,7 +593,82 @@ public class FilterPredicatesBuilder {
 
             default -> throw new ValidationException("Unexpected value: " + conditionOperator);
         }
+
+        // A refuted OID must answer OID value predicates exactly as an absent one would: the stored value
+        // is auditable, but it must never decide membership. Conditions a NULL oid satisfies
+        // (the or(isNull, ...) negatives) admit refuted rows too; conditions a NULL oid can never satisfy
+        // exclude them. EMPTY/NOT_EMPTY stay untouched -- that an OID was recorded is a true fact.
+        if (filterField == FilterField.CBOM_ASSET_OID && !refutedOidsOptedIn) {
+            if (OID_CONDITIONS_A_NULL_OID_SATISFIES.contains(conditionOperator)) {
+                predicate = criteriaBuilder.or(predicate, oidRefuted(criteriaBuilder, from));
+            } else if (OID_CONDITIONS_A_NULL_OID_NEVER_SATISFIES.contains(conditionOperator)) {
+                predicate = criteriaBuilder.and(predicate, oidNotRefuted(criteriaBuilder, from));
+            }
+        }
         return predicate;
+    }
+
+    /**
+     * Matches a single text input, case-insensitively, across the crypto-asset name and oid columns at once. A refuted
+     * oid is excluded from its side of the match unless the caller opted into the refuted-OID facet, so the row stays
+     * findable through its name but the neutralized oid cannot answer the query.
+     */
+    private static <T> Predicate getCryptoAssetFreeTextPredicate(CriteriaBuilder criteriaBuilder, Root<T> root,
+            FilterField filterField, SearchFilterRequestDto filterDto, List<Object> filterValues,
+            boolean refutedOidsOptedIn) {
+        if (filterField != FilterField.CBOM_ASSET_FREE_TEXT) {
+            throw new ValidationException("Free-text filter is not defined for field " + filterField + ".");
+        }
+        if (filterDto.getCondition() != FilterConditionOperator.CONTAINS) {
+            throw new ValidationException(
+                    "Free-text filter for field " + filterField + " supports only the CONTAINS operator.");
+        }
+
+        Expression<String> pattern = criteriaBuilder
+                .lower(criteriaBuilder.literal("%" + filterValues.getFirst() + "%"));
+        Predicate nameMatches = criteriaBuilder.like(criteriaBuilder.lower(root.get(CryptoAsset_.NAME)), pattern);
+        Predicate oidMatches = criteriaBuilder.like(criteriaBuilder.lower(root.get(CryptoAsset_.OID)), pattern);
+        if (!refutedOidsOptedIn) {
+            oidMatches = criteriaBuilder.and(oidMatches, oidNotRefuted(criteriaBuilder, root));
+        }
+        return criteriaBuilder.or(nameMatches, oidMatches);
+    }
+
+    private static Predicate oidNotRefuted(CriteriaBuilder cb, From<?, ?> from) {
+        Path<CryptoAssetIdentityGuard> guard = from.get(CryptoAsset_.IDENTITY_GUARD);
+        return cb.or(cb.isNull(guard), cb.notEqual(guard, CryptoAssetIdentityGuard.REFUTED_OID));
+    }
+
+    private static Predicate oidRefuted(CriteriaBuilder cb, From<?, ?> from) {
+        return cb.equal(from.get(CryptoAsset_.IDENTITY_GUARD), CryptoAssetIdentityGuard.REFUTED_OID);
+    }
+
+    /**
+     * Matches through an EXISTS subquery against {@code crypto_asset_source}, never a join: the uuid page query this
+     * predicate feeds carries no DISTINCT, so a join would repeat a row that has several matching sources.
+     */
+    private static <T> Predicate getCryptoAssetSourceCbomPredicate(CriteriaBuilder cb, CommonAbstractCriteria query,
+            Root<T> root, SearchFilterRequestDto filterDto, List<Object> filterValues) {
+        Subquery<Integer> subquery = query.subquery(Integer.class);
+        Root<CryptoAssetSource> source = subquery.from(CryptoAssetSource.class);
+        Predicate correlation = cb
+                .equal(source.get(CryptoAssetSource_.assetUuid), root.get(UniquelyIdentified_.uuid.getName()));
+        FilterConditionOperator condition = filterDto.getCondition();
+        switch (condition) {
+            case EQUALS, NOT_EQUALS -> {
+                Join cbom = source.join(CryptoAssetSource_.cbom);
+                subquery.select(cb.literal(1)).where(correlation, cbom.get(Cbom_.serialNumber).in(filterValues));
+                return condition == FilterConditionOperator.EQUALS ? cb.exists(subquery) : cb.not(cb.exists(subquery));
+            }
+            case EMPTY, NOT_EMPTY -> {
+                subquery.select(cb.literal(1)).where(correlation);
+                return condition == FilterConditionOperator.NOT_EMPTY
+                        ? cb.exists(subquery)
+                        : cb.not(cb.exists(subquery));
+            }
+            default -> throw new ValidationException("Unexpected condition " + condition + " for filter field "
+                    + FilterField.CBOM_ASSET_SOURCE_CBOM + ".");
+        }
     }
 
     public static boolean isJsonArray(FilterField filterField) {

--- a/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
+++ b/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
@@ -81,6 +81,8 @@ public class FilterPredicatesBuilder {
     private static final String JSONB_EXTRACT_PATH_TEXT_FUNCTION_NAME = "jsonb_extract_path_text";
     private static final String TEXTREGEXEQ_FUNCTION_NAME = "textregexeq";
     private static final String ARRAY_CONTAINS_FUNCTION_NAME = PostgresFunctionContributor.ARRAY_CONTAINS;
+
+    private static final char LIKE_ESCAPE_CHAR = '\\';
     private static final String ARRAY_ITEM_CONTAINS_FUNCTION_NAME = PostgresFunctionContributor.ARRAY_ITEM_CONTAINS;
 
     private static final Set<FilterConditionOperator> OID_CONDITIONS_A_NULL_OID_SATISFIES = Set
@@ -339,6 +341,16 @@ public class FilterPredicatesBuilder {
         }
         if (filterField == FilterField.CBOM_ASSET_SOURCE_CBOM) {
             return getCryptoAssetSourceCbomPredicate(criteriaBuilder, query, root, filterDto, filterValues);
+        }
+
+        // An expectedValue field compares one stored constant against the boolean the caller sends, so only EQUALS
+        // and NOT_EQUALS are answerable -- exactly what SearchHelper advertises for it. The rest are refused here:
+        // the boolean value prep below would otherwise fail on a valueless EMPTY, and NOT_EMPTY would read "any
+        // value is set" -- which for the refuted-OID facet means any guard at all, not refutedness.
+        if (filterField.getExpectedValue() != null && filterDto.getCondition() != FilterConditionOperator.EQUALS
+                && filterDto.getCondition() != FilterConditionOperator.NOT_EQUALS) {
+            throw new ValidationException("Condition " + filterDto.getCondition() + " is not supported for field "
+                    + filterField + "; the field supports EQUALS and NOT_EQUALS.");
         }
 
         Expression expression = null;
@@ -625,13 +637,24 @@ public class FilterPredicatesBuilder {
         }
 
         Expression<String> pattern = criteriaBuilder
-                .lower(criteriaBuilder.literal("%" + filterValues.getFirst() + "%"));
-        Predicate nameMatches = criteriaBuilder.like(criteriaBuilder.lower(root.get(CryptoAsset_.NAME)), pattern);
-        Predicate oidMatches = criteriaBuilder.like(criteriaBuilder.lower(root.get(CryptoAsset_.OID)), pattern);
+                .lower(criteriaBuilder.literal("%" + escapeLikeWildcards(filterValues.getFirst().toString()) + "%"));
+        Predicate nameMatches = criteriaBuilder
+                .like(criteriaBuilder.lower(root.get(CryptoAsset_.NAME)), pattern, LIKE_ESCAPE_CHAR);
+        Predicate oidMatches = criteriaBuilder
+                .like(criteriaBuilder.lower(root.get(CryptoAsset_.OID)), pattern, LIKE_ESCAPE_CHAR);
         if (!refutedOidsOptedIn) {
             oidMatches = criteriaBuilder.and(oidMatches, oidNotRefuted(criteriaBuilder, root));
         }
         return criteriaBuilder.or(nameMatches, oidMatches);
+    }
+
+    /**
+     * LIKE's {@code %}, {@code _} and the escape character itself, escaped so free-text input matches literally. The
+     * generic CONTAINS on single columns leaves wildcards active (a platform-wide trait predating this field); the
+     * free-text box is new surface, and a search box promises literal matching.
+     */
+    private static String escapeLikeWildcards(String value) {
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
     }
 
     private static Predicate oidNotRefuted(CriteriaBuilder cb, From<?, ?> from) {

--- a/src/main/java/com/otilm/core/util/SearchHelper.java
+++ b/src/main/java/com/otilm/core/util/SearchHelper.java
@@ -70,7 +70,11 @@ public class SearchHelper {
      * available values.
      */
     public static List<FilterConditionOperator> availableConditions(final FilterField filterField) {
-        List<FilterConditionOperator> conditionOperators = filterField.getFieldAttribute() == null
+        // A FREE_TEXT field has no single attribute by design (it spans several columns), so the
+        // null-attribute downgrade to presence-only conditions must not apply to it.
+        boolean presenceOnly = filterField.getFieldAttribute() == null
+                && filterField.getType() != SearchFieldTypeEnum.FREE_TEXT;
+        List<FilterConditionOperator> conditionOperators = presenceOnly
                 ? new ArrayList<>(List.of(FilterConditionOperator.EMPTY, FilterConditionOperator.NOT_EMPTY))
                 : new ArrayList<>(getInitialCapacity(filterField));
 

--- a/src/test/java/com/otilm/core/integration/api/web/CryptographicAssetAuthorizationHttpITest.java
+++ b/src/test/java/com/otilm/core/integration/api/web/CryptographicAssetAuthorizationHttpITest.java
@@ -2,7 +2,10 @@ package com.otilm.core.integration.api.web;
 
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.cryptoasset.CryptographicAssetType;
+import com.otilm.core.cbom.asset.CryptoAssetIdentityCalculator;
 import com.otilm.core.cbom.asset.CryptoAssetIdentityFields;
+import com.otilm.core.dao.entity.Cbom;
+import com.otilm.core.dao.repository.CbomRepository;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.service.writer.cbom.CryptoAssetWriter;
 import com.otilm.core.util.BaseSpringBootTest;
@@ -47,11 +50,16 @@ class CryptographicAssetAuthorizationHttpITest extends BaseSpringBootTest {
     @Autowired
     private CryptoAssetWriter assetWriter;
 
+    @Autowired
+    private CbomRepository cbomRepository;
+
+    private CryptoAssetIdentityFields seededFields;
+
     @BeforeEach
     void seedAsset() {
-        assetWriter
-                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ECDSA",
-                        "1.2.840.10045.4.3.2", "ecdsa", "signature", "P-256", "secp256r1", null, null, null), null);
+        seededFields = new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ECDSA", "1.2.840.10045.4.3.2",
+                "ecdsa", "signature", "P-256", "secp256r1", null, null, null);
+        assetWriter.upsertIdentity(seededFields, null);
     }
 
     @Test
@@ -67,9 +75,12 @@ class CryptographicAssetAuthorizationHttpITest extends BaseSpringBootTest {
 
     @Test
     void servesBothOperationsWithoutMentioningTheIdentityKeyWhenPermitted() throws Exception {
+        // The positive control: the seeded row must actually reach the response, or a filter/security regression
+        // that empties the page would satisfy every doesNotContain assertion below vacuously.
         String listResponse = mockMvc
                 .perform(post(LIST_ENDPOINT).contentType("application/json").content("{}"))
-                .andExpect(status().isOk())
+                .andExpectAll(status().isOk(), jsonPath("$.totalItems").value(1),
+                        jsonPath("$.items[0].name").value("ecdsa"))
                 .andReturn()
                 .getResponse()
                 .getContentAsString();
@@ -82,5 +93,53 @@ class CryptographicAssetAuthorizationHttpITest extends BaseSpringBootTest {
                 .getResponse()
                 .getContentAsString();
         assertThat(searchableFieldsResponse).doesNotContainPattern(IDENTITY_KEY);
+
+        // The name pattern catches field names; a wire leak would realistically be the VALUE. The calculator can
+        // recompute this row's exact key from the same fixture input, so assert the strongest possible fact: the
+        // literal key appears in neither raw response.
+        String exactIdentityKey = CryptoAssetIdentityCalculator.calculate(seededFields);
+        assertThat(listResponse).doesNotContain(exactIdentityKey);
+        assertThat(searchableFieldsResponse).doesNotContain(exactIdentityKey);
+    }
+
+    @Test
+    void refusesInvalidPagingWithAShapedUnprocessableEntity() throws Exception {
+        mockMvc
+                .perform(post(LIST_ENDPOINT).contentType("application/json").content("{\"pageNumber\":0}"))
+                .andExpect(status().isUnprocessableEntity());
+    }
+
+    /**
+     * The source-CBOM value list crosses a resource gate -- CBOM serial numbers belong to the CBOM resource -- so it is
+     * scoped by the caller's own {@code cboms:list} access rather than served platform-wide: a caller holding only
+     * {@code cryptoAssets:list} still gets the searchable fields, but that one value list comes back empty.
+     */
+    @Test
+    void scopesTheSourceCbomValueListByTheCallersCbomAccess() throws Exception {
+        Cbom cbom = new Cbom();
+        cbom.setSerialNumber("urn:uuid:scoped");
+        cbom.setVersion(1);
+        cbom.setSpecVersion("1.7");
+        cbomRepository.save(cbom);
+
+        String permitted = mockMvc
+                .perform(get(SEARCHABLE_FIELDS_ENDPOINT))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        assertThat(permitted).contains("urn:uuid:scoped");
+
+        denyObjectAccess(Resource.CBOM, ResourceAction.LIST);
+        String scoped = mockMvc
+                .perform(get(SEARCHABLE_FIELDS_ENDPOINT))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        assertThat(scoped).doesNotContain("urn:uuid:scoped");
+        assertThat(scoped)
+                .describedAs("the fields themselves still serve; only the cross-resource value list is scoped")
+                .contains("CBOM_ASSET_SOURCE_CBOM");
     }
 }

--- a/src/test/java/com/otilm/core/integration/api/web/CryptographicAssetAuthorizationHttpITest.java
+++ b/src/test/java/com/otilm/core/integration/api/web/CryptographicAssetAuthorizationHttpITest.java
@@ -1,0 +1,86 @@
+package com.otilm.core.integration.api.web;
+
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetType;
+import com.otilm.core.cbom.asset.CryptoAssetIdentityFields;
+import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.service.writer.cbom.CryptoAssetWriter;
+import com.otilm.core.util.BaseSpringBootTest;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * {@code @ExternalAuthorization} over HTTP for the cryptographic asset inventory's list and searchable-fields
+ * endpoints, mirroring {@link ExternalAuthorizationHttpITest}'s style: the real security filter chain, the
+ * method-security advisor, and {@code ExceptionHandlingAdvice.handleAccessDeniedException}.
+ *
+ * <p>
+ * The permitted-path assertions also carry the wire-level identity-key criterion: neither endpoint's raw response ever
+ * mentions it.
+ */
+@AutoConfigureMockMvc
+class CryptographicAssetAuthorizationHttpITest extends BaseSpringBootTest {
+
+    private static final String LIST_ENDPOINT = "/v1/cryptoAssets";
+
+    private static final String SEARCHABLE_FIELDS_ENDPOINT = "/v1/cryptoAssets/search";
+
+    // The same detection rule IdentityKeyExposureFence uses, applied to the live wire response. A bare "identity"
+    // substring is not it: CBOM_ASSET_RULESET_VERSION's own label is "Identity Rule Set Version" -- "identity" as an
+    // ordinary adjective, naming the ruleset that computes identity, not the guarded value itself.
+    private static final Pattern IDENTITY_KEY = Pattern
+            .compile("identity[_\\-\\s]?key|absorbed[_\\-\\s]?key|canonical[_\\-\\s]?key", Pattern.CASE_INSENSITIVE);
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private CryptoAssetWriter assetWriter;
+
+    @BeforeEach
+    void seedAsset() {
+        assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ECDSA",
+                        "1.2.840.10045.4.3.2", "ecdsa", "signature", "P-256", "secp256r1", null, null, null), null);
+    }
+
+    @Test
+    void deniesBothOperationsWhenTheListActionIsDenied() throws Exception {
+        denyResourceAccess(Resource.CRYPTO_ASSET, ResourceAction.LIST);
+
+        mockMvc
+                .perform(post(LIST_ENDPOINT).contentType("application/json").content("{}"))
+                .andExpectAll(status().isForbidden(), jsonPath("$.code").value("ACCESS_DENIED"));
+        // Both operations share the LIST action.
+        mockMvc.perform(get(SEARCHABLE_FIELDS_ENDPOINT)).andExpect(status().isForbidden());
+    }
+
+    @Test
+    void servesBothOperationsWithoutMentioningTheIdentityKeyWhenPermitted() throws Exception {
+        String listResponse = mockMvc
+                .perform(post(LIST_ENDPOINT).contentType("application/json").content("{}"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        assertThat(listResponse).doesNotContainPattern(IDENTITY_KEY);
+
+        String searchableFieldsResponse = mockMvc
+                .perform(get(SEARCHABLE_FIELDS_ENDPOINT))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        assertThat(searchableFieldsResponse).doesNotContainPattern(IDENTITY_KEY);
+    }
+}

--- a/src/test/java/com/otilm/core/integration/api/web/CryptographicAssetControllerITest.java
+++ b/src/test/java/com/otilm/core/integration/api/web/CryptographicAssetControllerITest.java
@@ -48,7 +48,8 @@ class CryptographicAssetControllerITest extends BaseSpringBootTest {
 
         assertThat(cryptographicAssetController.getSearchableFieldInformation()).isNotEmpty();
 
-        assertThatThrownBy(() -> cryptographicAssetController.getCryptographicAsset(UUID.randomUUID()))
+        UUID anyUuid = UUID.randomUUID();
+        assertThatThrownBy(() -> cryptographicAssetController.getCryptographicAsset(anyUuid))
                 .isInstanceOf(NotSupportedException.class);
         assertThatThrownBy(() -> statisticsController.getCryptographicAssetStatistics())
                 .isInstanceOf(NotSupportedException.class);
@@ -64,5 +65,8 @@ class CryptographicAssetControllerITest extends BaseSpringBootTest {
                 .orElseThrow(() -> new AssertionError("Resource not synced: " + Resource.CRYPTO_ASSET.getCode()));
 
         assertThat(synced.getActions()).contains(ResourceAction.LIST.getCode(), ResourceAction.DETAIL.getCode());
+        assertThat(synced.getListObjectsEndpoint())
+                .describedAs("the one auth-sync behaviour @AuthEndpoint adds: the advertised object listing route")
+                .isEqualTo("/v1/cryptoAssets");
     }
 }

--- a/src/test/java/com/otilm/core/integration/api/web/CryptographicAssetControllerITest.java
+++ b/src/test/java/com/otilm/core/integration/api/web/CryptographicAssetControllerITest.java
@@ -4,7 +4,9 @@ import com.otilm.api.exception.NotSupportedException;
 import com.otilm.api.interfaces.core.web.CryptographicAssetController;
 import com.otilm.api.interfaces.core.web.StatisticsController;
 import com.otilm.api.model.client.certificate.SearchRequestDto;
+import com.otilm.api.model.common.PaginationResponseDto;
 import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetDto;
 import com.otilm.core.auth.ContextRefreshListener;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.model.auth.ResourceSyncRequestDto;
@@ -18,14 +20,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * The cryptographic asset inventory endpoints exist so the contract ratified in interfaces#909 is served by a real
- * bean, but the read model behind them is not built yet. This pins both halves of that state: every operation refuses
- * with {@link NotSupportedException} (HTTP 501), and the resource still reaches the auth service with its list and
- * detail actions, so roles can be defined against it before the data arrives.
+ * bean. The read model now serves list and searchable-fields as real reads over the deduplicated cross-CBOM asset
+ * projection; detail and statistics stay {@link NotSupportedException} refusals (HTTP 501) until core#2145 builds them.
+ * The resource still reaches the auth service with its list and detail actions, so roles can be defined against it
+ * independently of which operations are implemented.
  *
  * <p>
- * When the inventory is implemented, the refusal assertions are what should fail first.
+ * When detail and statistics are implemented, the refusal assertions below are what should fail first.
  */
-class CryptographicAssetControllerStubITest extends BaseSpringBootTest {
+class CryptographicAssetControllerITest extends BaseSpringBootTest {
 
     @Autowired
     private CryptographicAssetController cryptographicAssetController;
@@ -37,12 +40,15 @@ class CryptographicAssetControllerStubITest extends BaseSpringBootTest {
     private ContextRefreshListener contextRefreshListener;
 
     @Test
-    void everyInventoryOperationRefusesAsNotImplemented() {
-        assertThatThrownBy(() -> cryptographicAssetController.listCryptographicAssets(new SearchRequestDto()))
-                .isInstanceOf(NotSupportedException.class);
+    void listAndSearchableFieldsAreServedWhileDetailAndStatisticsRefuse() {
+        PaginationResponseDto<CryptographicAssetDto> page = cryptographicAssetController
+                .listCryptographicAssets(new SearchRequestDto());
+        assertThat(page.getItems()).isEmpty();
+        assertThat(page.getTotalItems()).isZero();
+
+        assertThat(cryptographicAssetController.getSearchableFieldInformation()).isNotEmpty();
+
         assertThatThrownBy(() -> cryptographicAssetController.getCryptographicAsset(UUID.randomUUID()))
-                .isInstanceOf(NotSupportedException.class);
-        assertThatThrownBy(() -> cryptographicAssetController.getSearchableFieldInformation())
                 .isInstanceOf(NotSupportedException.class);
         assertThatThrownBy(() -> statisticsController.getCryptographicAssetStatistics())
                 .isInstanceOf(NotSupportedException.class);

--- a/src/test/java/com/otilm/core/integration/cbom/CryptoAssetListQueryITest.java
+++ b/src/test/java/com/otilm/core/integration/cbom/CryptoAssetListQueryITest.java
@@ -1,0 +1,224 @@
+package com.otilm.core.integration.cbom;
+
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetType;
+import com.otilm.api.model.core.cryptoasset.PqcVerdict;
+import com.otilm.core.cbom.asset.CryptoAssetIdentityFields;
+import com.otilm.core.dao.entity.Cbom;
+import com.otilm.core.dao.entity.cbom.CryptoAsset;
+import com.otilm.core.dao.repository.CbomRepository;
+import com.otilm.core.dao.repository.cbom.CryptoAssetRepository;
+import com.otilm.core.model.cbom.CryptoAssetIdentityGuard;
+import com.otilm.core.model.cbom.CryptoAssetListRow;
+import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.service.writer.cbom.CryptoAssetSourceWriter;
+import com.otilm.core.service.writer.cbom.CryptoAssetWriter;
+import com.otilm.core.util.BaseSpringBootTest;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Root;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The repository support the inventory list operation (slice 3) will call: a deterministic name-ordered uuid page (uuid tiebreak appended by the repository), the
+ * distinct value lists behind the searchable fields, and the list-row projection.
+ *
+ * <p>
+ * {@link #pagingOrdersByNameThenUuidAndPagesDeterministically} predicts Postgres's own {@code uuid} ordering
+ * with {@link #sortedByUuidString}, not {@link UUID#compareTo} -- see that helper's javadoc for why.
+ */
+class CryptoAssetListQueryITest extends BaseSpringBootTest {
+
+    @Autowired
+    private CryptoAssetRepository assetRepository;
+
+    @Autowired
+    private CryptoAssetWriter assetWriter;
+
+    @Autowired
+    private CryptoAssetSourceWriter sourceWriter;
+
+    @Autowired
+    private CbomRepository cbomRepository;
+
+    /**
+     * Three same-named rows, not two: with only two tied rows, a broken tiebreak still has a coin-flip chance of
+     * incidentally returning them in ascending-uuid order, so the assertion below would only catch the regression about
+     * half the time. With three, only 1 of the 3! = 6 possible orderings among the ties matches what is asserted, so a
+     * dropped or misapplied tiebreak is caught 5 times out of 6.
+     */
+    @Test
+    void pagingOrdersByNameThenUuidAndPagesDeterministically() {
+        UUID aesA = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "AES", "oid-aes-a",
+                        null, null, null, null, null, null, null), null);
+        UUID aesB = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "  aes  ", "oid-aes-b",
+                        null, null, null, null, null, null, null), null);
+        UUID aesC = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "aes", "oid-aes-c",
+                        null, null, null, null, null, null, null), null);
+        UUID ecdsa = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ECDSA", "oid-ecdsa",
+                        null, null, null, null, null, null, null), null);
+        UUID nullNamed = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.CERTIFICATE, null, "oid-null-name",
+                        null, null, null, null, null, null, null), null);
+
+        List<UUID> aesByUuidAscending = sortedByUuidString(aesA, aesB, aesC);
+        UUID aesFirst = aesByUuidAscending.get(0);
+        UUID aesSecond = aesByUuidAscending.get(1);
+        UUID aesThird = aesByUuidAscending.get(2);
+
+        List<UUID> all = assetRepository
+                .findUuidsUsingSecurityFilter(SecurityFilter.create(), null, PageRequest.of(0, 10), nameAscending());
+        assertThat(all)
+                .describedAs("all three aes rows first (tiebroken by uuid ascending), then ecdsa, then the null name "
+                        + "last")
+                .containsExactly(aesFirst, aesSecond, aesThird, ecdsa, nullNamed);
+
+        List<UUID> page0 = assetRepository
+                .findUuidsUsingSecurityFilter(SecurityFilter.create(), null, PageRequest.of(0, 2), nameAscending());
+        List<UUID> page1 = assetRepository
+                .findUuidsUsingSecurityFilter(SecurityFilter.create(), null, PageRequest.of(1, 2), nameAscending());
+        List<UUID> page2 = assetRepository
+                .findUuidsUsingSecurityFilter(SecurityFilter.create(), null, PageRequest.of(2, 2), nameAscending());
+        assertThat(page0).describedAs("page 0 is the first two of the full order").containsExactly(aesFirst, aesSecond);
+        assertThat(page1)
+                .describedAs("page 1's boundary falls inside the tied 'aes' name group -- the tiebreak makes it "
+                        + "deterministic")
+                .containsExactly(aesThird, ecdsa);
+        assertThat(page2).describedAs("page 2 is the null-name row, still last").containsExactly(nullNamed);
+    }
+
+    @Test
+    void distinctValueQueriesReturnCanonicalSortedValuesWithoutNullsOrDuplicates() {
+        assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "rsa-signature",
+                        "oid-1", "rsa", null, null, "SECP256R1", null, null, null), null);
+        assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "rsa-signature-2",
+                        "oid-2", " RSA ", null, null, " secp256r1 ", null, null, null), null);
+        assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ecdsa-signature",
+                        "oid-3", "ecdsa", null, null, "P-256", null, null, null), null);
+        assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.CERTIFICATE, "bare", "oid-4", null,
+                        null, null, null, null, null, null), null);
+
+        assertThat(assetRepository.findDistinctCurve())
+                .describedAs("canonical values, sorted, no null, no duplicate spelling")
+                .containsExactly("p-256", "secp256r1");
+        assertThat(assetRepository.findDistinctAlgorithmFamily())
+                .describedAs("canonical values, sorted, no null, no duplicate spelling")
+                .containsExactly("ecdsa", "rsa");
+    }
+
+    @Test
+    void listRowsProjectSourceCountAndSumOccurrenceCountPerAsset() {
+        UUID sourced = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "AES", "oid-sourced",
+                        null, null, null, null, null, null, null), null);
+        UUID sourceless = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ECDSA",
+                        "oid-sourceless", null, null, null, null, null, null, null), null);
+        UUID guarded = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.CERTIFICATE, "some-cn", null, null,
+                        null, null, null, null, null, null), CryptoAssetIdentityGuard.BARE_CN_SUBJECT);
+
+        Cbom cbomOne = newCbom("urn:uuid:proj-one");
+        Cbom cbomTwo = newCbom("urn:uuid:proj-two");
+        sourceWriter
+                .upsertSource(sourced, cbomOne.getUuid(), Map.of("k", "v"),
+                        List.of(Map.of("location", "a"), Map.of("location", "b"), Map.of("location", "c")),
+                        OffsetDateTime.now());
+        sourceWriter
+                .upsertSource(sourced, cbomTwo.getUuid(), Map.of("k", "v"),
+                        List.of(Map.of("location", "d"), Map.of("location", "e")), OffsetDateTime.now());
+        assetWriter.applyPqcVerdict(sourced, PqcVerdict.NOT_READY, "rule", "reason", 3, Map.of());
+
+        List<CryptoAssetListRow> rows = assetRepository.findListRowsByUuids(List.of(sourced, sourceless, guarded));
+        assertThat(rows).hasSize(3);
+
+        CryptoAssetListRow sourcedRow = rowFor(rows, sourced);
+        assertThat(sourcedRow.occurrenceCount())
+                .describedAs("occurrences summed across both sources: 3 + 2")
+                .isEqualTo(5);
+        assertThat(sourcedRow.sourceCount()).describedAs("the writer's recompute maintains this").isEqualTo(2);
+        assertThat(sourcedRow.pqcVerdict()).isEqualTo(PqcVerdict.NOT_READY);
+        assertThat(sourcedRow.name()).isEqualTo("aes");
+        assertThat(sourcedRow.assetType()).isEqualTo(CryptographicAssetType.ALGORITHM);
+        assertThat(sourcedRow.identityGuard()).isNull();
+
+        CryptoAssetListRow sourcelessRow = rowFor(rows, sourceless);
+        assertThat(sourcelessRow.occurrenceCount())
+                .describedAs("no sources -- LEFT JOIN, not an inner join")
+                .isEqualTo(0);
+        assertThat(sourcelessRow.sourceCount()).isEqualTo(0);
+        assertThat(sourcelessRow.pqcVerdict()).describedAs("never evaluated").isNull();
+
+        CryptoAssetListRow guardedRow = rowFor(rows, guarded);
+        assertThat(guardedRow.identityGuard()).isEqualTo(CryptoAssetIdentityGuard.BARE_CN_SUBJECT);
+        assertThat(guardedRow.occurrenceCount()).isEqualTo(0);
+        assertThat(guardedRow.sourceCount()).isEqualTo(0);
+    }
+
+    @Test
+    void distinctSerialNumbersComeBackSorted() {
+        newCbom("urn:uuid:charlie");
+        newCbom("urn:uuid:alpha");
+        newCbom("urn:uuid:bravo");
+        // A second version of the same serial: DISTINCT must collapse it, not just ORDER BY sort the rest.
+        newCbom("urn:uuid:alpha", 2);
+
+        assertThat(cbomRepository.findDistinctSerialNumber())
+                .describedAs("the duplicated serial appears once, and the result is sorted")
+                .containsExactly("urn:uuid:alpha", "urn:uuid:bravo", "urn:uuid:charlie");
+    }
+
+    // ---- helpers ----
+
+    /**
+     * The list operation's default order. The uuid tiebreak is not spelled here: SortOrderBuilder appends it to every
+     * paged secured query, and this test exists to prove that appended tiebreak keeps the page boundaries stable.
+     */
+    private static BiFunction<Root<CryptoAsset>, CriteriaBuilder, Order> nameAscending() {
+        return (r, cb) -> cb.asc(r.get("name"));
+    }
+
+    /**
+     * The given UUIDs, ascending in Postgres's own {@code uuid} order. Postgres's comparator is an unsigned byte
+     * compare over the 16 bytes ({@code uuid_cmp}, {@code memcmp}-based); {@link UUID#toString()} lexicographic order
+     * matches it exactly, whereas {@link UUID#compareTo} does not -- it compares the two 64-bit halves as signed longs,
+     * which disagrees with Postgres whenever the leading byte's sign bit differs between two UUIDs compared.
+     */
+    private static List<UUID> sortedByUuidString(UUID... uuids) {
+        return Arrays.stream(uuids).sorted(Comparator.comparing(UUID::toString)).toList();
+    }
+
+    private static CryptoAssetListRow rowFor(List<CryptoAssetListRow> rows, UUID uuid) {
+        return rows.stream().filter(r -> r.uuid().equals(uuid)).findFirst().orElseThrow();
+    }
+
+    private Cbom newCbom(String serialNumber) {
+        return newCbom(serialNumber, 1);
+    }
+
+    private Cbom newCbom(String serialNumber, int version) {
+        Cbom cbom = new Cbom();
+        cbom.setSerialNumber(serialNumber);
+        cbom.setVersion(version);
+        cbom.setSpecVersion("1.7");
+        return cbomRepository.save(cbom);
+    }
+}

--- a/src/test/java/com/otilm/core/integration/cbom/CryptoAssetListQueryITest.java
+++ b/src/test/java/com/otilm/core/integration/cbom/CryptoAssetListQueryITest.java
@@ -30,12 +30,13 @@ import org.springframework.data.domain.PageRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * The repository support the inventory list operation (slice 3) will call: a deterministic name-ordered uuid page (uuid tiebreak appended by the repository), the
- * distinct value lists behind the searchable fields, and the list-row projection.
+ * The repository support the inventory list operation (slice 3) will call: a deterministic name-ordered uuid page (uuid
+ * tiebreak appended by the repository), the distinct value lists behind the searchable fields, and the list-row
+ * projection.
  *
  * <p>
- * {@link #pagingOrdersByNameThenUuidAndPagesDeterministically} predicts Postgres's own {@code uuid} ordering
- * with {@link #sortedByUuidString}, not {@link UUID#compareTo} -- see that helper's javadoc for why.
+ * {@link #pagingOrdersByNameThenUuidAndPagesDeterministically} predicts Postgres's own {@code uuid} ordering with
+ * {@link #sortedByUuidString}, not {@link UUID#compareTo} -- see that helper's javadoc for why.
  */
 class CryptoAssetListQueryITest extends BaseSpringBootTest {
 
@@ -117,10 +118,12 @@ class CryptoAssetListQueryITest extends BaseSpringBootTest {
                         null, null, null, null, null, null), null);
 
         assertThat(assetRepository.findDistinctCurve())
-                .describedAs("canonical values, sorted, no null, no duplicate spelling")
+                .describedAs(
+                        "distinct stored normalized values, sorted, no null; class folding (p-256 = secp256r1) is core#2072 ingest scope, not this query's")
                 .containsExactly("p-256", "secp256r1");
         assertThat(assetRepository.findDistinctAlgorithmFamily())
-                .describedAs("canonical values, sorted, no null, no duplicate spelling")
+                .describedAs(
+                        "distinct stored normalized values, sorted, no null; class folding (p-256 = secp256r1) is core#2072 ingest scope, not this query's")
                 .containsExactly("ecdsa", "rsa");
     }
 
@@ -157,6 +160,9 @@ class CryptoAssetListQueryITest extends BaseSpringBootTest {
         assertThat(sourcedRow.sourceCount()).describedAs("the writer's recompute maintains this").isEqualTo(2);
         assertThat(sourcedRow.pqcVerdict()).isEqualTo(PqcVerdict.NOT_READY);
         assertThat(sourcedRow.name()).isEqualTo("aes");
+        assertThat(sourcedRow.oid())
+                .describedAs("rides along as the nameless-row name fallback")
+                .isEqualTo("oid-sourced");
         assertThat(sourcedRow.assetType()).isEqualTo(CryptographicAssetType.ALGORITHM);
         assertThat(sourcedRow.identityGuard()).isNull();
 

--- a/src/test/java/com/otilm/core/integration/cbom/CryptoAssetListQueryITest.java
+++ b/src/test/java/com/otilm/core/integration/cbom/CryptoAssetListQueryITest.java
@@ -1,21 +1,28 @@
 package com.otilm.core.integration.cbom;
 
+import com.otilm.api.model.client.certificate.SearchFilterRequestDto;
 import com.otilm.api.model.core.cryptoasset.CryptographicAssetType;
 import com.otilm.api.model.core.cryptoasset.PqcVerdict;
+import com.otilm.api.model.core.search.FilterConditionOperator;
 import com.otilm.core.cbom.asset.CryptoAssetIdentityFields;
 import com.otilm.core.dao.entity.Cbom;
 import com.otilm.core.dao.entity.cbom.CryptoAsset;
 import com.otilm.core.dao.repository.CbomRepository;
 import com.otilm.core.dao.repository.cbom.CryptoAssetRepository;
+import com.otilm.core.enums.FilterField;
 import com.otilm.core.model.cbom.CryptoAssetIdentityGuard;
 import com.otilm.core.model.cbom.CryptoAssetListRow;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.writer.cbom.CryptoAssetSourceWriter;
 import com.otilm.core.service.writer.cbom.CryptoAssetWriter;
 import com.otilm.core.util.BaseSpringBootTest;
+import com.otilm.core.util.FilterPredicatesBuilder;
 import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -23,10 +30,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.BiFunction;
+import org.apache.commons.lang3.function.TriFunction;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 
+import static com.otilm.core.util.builders.SearchFilterRequestDtoBuilder.aPropertyFilter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -179,17 +188,44 @@ class CryptoAssetListQueryITest extends BaseSpringBootTest {
         assertThat(guardedRow.sourceCount()).isEqualTo(0);
     }
 
+    /**
+     * The service's page loader tolerates a uuid whose row vanished between the page query and this projection -- this
+     * is the repository half of that tolerance: an unknown uuid simply produces no row.
+     */
     @Test
-    void distinctSerialNumbersComeBackSorted() {
-        newCbom("urn:uuid:charlie");
-        newCbom("urn:uuid:alpha");
-        newCbom("urn:uuid:bravo");
-        // A second version of the same serial: DISTINCT must collapse it, not just ORDER BY sort the rest.
-        newCbom("urn:uuid:alpha", 2);
+    void listRowProjectionSkipsAVanishedUuid() {
+        UUID present = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "AES", "oid-present",
+                        null, null, null, null, null, null, null), null);
 
-        assertThat(cbomRepository.findDistinctSerialNumber())
-                .describedAs("the duplicated serial appears once, and the result is sorted")
-                .containsExactly("urn:uuid:alpha", "urn:uuid:bravo", "urn:uuid:charlie");
+        List<CryptoAssetListRow> rows = assetRepository.findListRowsByUuids(List.of(present, UUID.randomUUID()));
+
+        assertThat(rows).extracting(CryptoAssetListRow::uuid).containsExactly(present);
+    }
+
+    /**
+     * The list endpoint counts with the plain (non-DISTINCT) variant, which is only correct while no predicate can
+     * duplicate a root row. The source-CBOM EXISTS predicate is the shape that would do it as a join -- so this pins
+     * the two counts equal through exactly that predicate, over an asset with two matching sources.
+     */
+    @Test
+    void plainRowCountMatchesTheDistinctCountThroughTheSourceCbomPredicate() {
+        UUID doubled = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "AES", "oid-doubled",
+                        null, null, null, null, null, null, null), null);
+        Cbom one = newCbom("urn:uuid:count-one");
+        Cbom two = newCbom("urn:uuid:count-two");
+        sourceWriter.upsertSource(doubled, one.getUuid(), Map.of("k", "v"), List.of(), OffsetDateTime.now());
+        sourceWriter.upsertSource(doubled, two.getUuid(), Map.of("k", "v"), List.of(), OffsetDateTime.now());
+
+        SearchFilterRequestDto eitherSerial = aPropertyFilter(FilterField.CBOM_ASSET_SOURCE_CBOM,
+                FilterConditionOperator.EQUALS, (Serializable) List.of("urn:uuid:count-one", "urn:uuid:count-two"));
+        TriFunction<Root<CryptoAsset>, CriteriaBuilder, CriteriaQuery<?>, Predicate> where = (root, cb,
+                cr) -> FilterPredicatesBuilder.getFiltersPredicate(cb, cr, root, List.of(eitherSerial));
+
+        assertThat(assetRepository.countRowsUsingSecurityFilter(SecurityFilter.create(), where))
+                .isEqualTo(assetRepository.countUsingSecurityFilter(SecurityFilter.create(), where))
+                .isEqualTo(1L);
     }
 
     // ---- helpers ----

--- a/src/test/java/com/otilm/core/integration/search/CryptoAssetSearchITest.java
+++ b/src/test/java/com/otilm/core/integration/search/CryptoAssetSearchITest.java
@@ -286,6 +286,43 @@ class CryptoAssetSearchITest extends BaseSpringBootTest {
                 .containsExactlyInAnyOrder(bareCn, bare, populated);
     }
 
+    /**
+     * The facet advertises EQUALS and NOT_EQUALS only. A hand-built request with another condition must be refused with
+     * a shaped error: EMPTY used to reach the boolean value prep with no value (an NPE, so a 500), and NOT_EMPTY would
+     * have read "any guard is set" as "OID refuted" while silently switching the refuted carve-outs off for the whole
+     * request.
+     */
+    @Test
+    void theRefutedFacetRefusesConditionsItDoesNotAdvertise() {
+        assertThatThrownBy(() -> search(aPropertyEmptyFilter(FilterField.CBOM_ASSET_OID_REFUTED)))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("EMPTY");
+        assertThatThrownBy(() -> search(aPropertyNotEmptyFilter(FilterField.CBOM_ASSET_OID_REFUTED)))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("NOT_EMPTY");
+    }
+
+    /**
+     * LIKE's wildcards are not part of the free-text contract: the search string matches literally, so an underscore in
+     * producer vocabulary ("AES_128") cannot over-match lookalikes and a lone percent cannot dump the inventory.
+     */
+    @Test
+    void freeTextTreatsLikeWildcardsAsLiteralText() {
+        UUID underscored = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "AES_128",
+                        "oid-underscore", null, null, null, null, null, null, null), null);
+        assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "AESX128",
+                        "oid-lookalike", null, null, null, null, null, null, null), null);
+
+        assertThat(search(aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT, FilterConditionOperator.CONTAINS, "s_1")))
+                .describedAs("an underscore matches a literal underscore, not any character")
+                .containsExactly(underscored);
+        assertThat(search(aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT, FilterConditionOperator.CONTAINS, "%")))
+                .describedAs("a lone percent matches rows containing a literal percent -- here, none")
+                .isEmpty();
+    }
+
     @Test
     void theSourceCbomFilterMatchesThroughSourcesWithoutDuplicatingRows() {
         Cbom alpha = newCbom("urn:uuid:alpha");

--- a/src/test/java/com/otilm/core/integration/search/CryptoAssetSearchITest.java
+++ b/src/test/java/com/otilm/core/integration/search/CryptoAssetSearchITest.java
@@ -227,9 +227,9 @@ class CryptoAssetSearchITest extends BaseSpringBootTest {
 
     @Test
     void freeTextRefusesEveryOperatorExceptContains() {
-        assertThatThrownBy(() -> search(
-                aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT, FilterConditionOperator.EQUALS, "ecdsa")))
-                .isInstanceOf(ValidationException.class);
+        SearchFilterRequestDto equalsOperator = aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT,
+                FilterConditionOperator.EQUALS, "ecdsa");
+        assertThatThrownBy(() -> search(equalsOperator)).isInstanceOf(ValidationException.class);
     }
 
     /**
@@ -265,6 +265,37 @@ class CryptoAssetSearchITest extends BaseSpringBootTest {
         assertThat(search(aPropertyNotEmptyFilter(FilterField.CBOM_ASSET_OID)))
                 .describedAs("the recorded value stays auditable under NOT_EMPTY")
                 .containsExactlyInAnyOrder(populated, refuted);
+
+        // The remaining value-bearing operators reach the same carve-out sets: every positive shape answers as if
+        // the oid were absent, every negative shape admits the refuted row exactly as it admits a NULL oid.
+        assertThat(search(aPropertyFilter(FilterField.CBOM_ASSET_OID, FilterConditionOperator.STARTS_WITH, "2.16.840")))
+                .isEmpty();
+        assertThat(search(aPropertyFilter(FilterField.CBOM_ASSET_OID, FilterConditionOperator.ENDS_WITH, "3.4.4.2")))
+                .isEmpty();
+        assertThat(
+                search(aPropertyFilter(FilterField.CBOM_ASSET_OID, FilterConditionOperator.MATCHES, "^2\\.16\\.840.*")))
+                .isEmpty();
+        assertThat(search(
+                aPropertyFilter(FilterField.CBOM_ASSET_OID, FilterConditionOperator.NOT_MATCHES, "^1\\.2\\.840.*")))
+                .describedAs("NOT_MATCHES never matches a NULL oid, so the refuted row is excluded the same way")
+                .isEmpty();
+        assertThat(search(aPropertyFilter(FilterField.CBOM_ASSET_OID, FilterConditionOperator.NOT_CONTAINS, "1.2.840")))
+                .describedAs("NOT_CONTAINS admits a NULL oid, so it admits the refuted row too")
+                .containsExactlyInAnyOrder(refuted, bare);
+    }
+
+    @Test
+    void theSourceCbomFilterRefusesConditionsItDoesNotAdvertise() {
+        SearchFilterRequestDto contains = aPropertyFilter(FilterField.CBOM_ASSET_SOURCE_CBOM,
+                FilterConditionOperator.CONTAINS, "urn:uuid:a");
+        assertThatThrownBy(() -> search(contains)).isInstanceOf(ValidationException.class);
+    }
+
+    @Test
+    void freeTextRequiresAValue() {
+        SearchFilterRequestDto valueless = aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT,
+                FilterConditionOperator.CONTAINS, null);
+        assertThatThrownBy(() -> search(valueless)).isInstanceOf(ValidationException.class);
     }
 
     @Test
@@ -294,12 +325,50 @@ class CryptoAssetSearchITest extends BaseSpringBootTest {
      */
     @Test
     void theRefutedFacetRefusesConditionsItDoesNotAdvertise() {
-        assertThatThrownBy(() -> search(aPropertyEmptyFilter(FilterField.CBOM_ASSET_OID_REFUTED)))
-                .isInstanceOf(ValidationException.class)
-                .hasMessageContaining("EMPTY");
-        assertThatThrownBy(() -> search(aPropertyNotEmptyFilter(FilterField.CBOM_ASSET_OID_REFUTED)))
+        SearchFilterRequestDto empty = aPropertyEmptyFilter(FilterField.CBOM_ASSET_OID_REFUTED);
+        assertThatThrownBy(() -> search(empty)).isInstanceOf(ValidationException.class).hasMessageContaining("EMPTY");
+        SearchFilterRequestDto notEmpty = aPropertyNotEmptyFilter(FilterField.CBOM_ASSET_OID_REFUTED);
+        assertThatThrownBy(() -> search(notEmpty))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining("NOT_EMPTY");
+    }
+
+    /**
+     * The facet's value must be a scalar boolean. The platform's expectedValue path parses
+     * {@code getValue().toString()} with {@code Boolean.parseBoolean}, so a JSON-array value like ["true"] stringifies
+     * to "[true]", parses false, and silently INVERTS the predicate -- while the facet's mere presence disarms the
+     * refuted carve-outs for the whole request. The compound serves exclusively refuted rows to a caller whose intent
+     * was to exclude them. Anything but a scalar "true"/"false" is refused with a shaped 422.
+     */
+    @Test
+    void theRefutedFacetRefusesNonScalarAndNonBooleanValues() {
+        assetWriter
+                .upsertIdentity(
+                        new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ML-KEM-768",
+                                "2.16.840.1.101.3.4.4.2", "ml-kem", "kem", null, null, null, null, null),
+                        CryptoAssetIdentityGuard.REFUTED_OID);
+
+        SearchFilterRequestDto arrayValued = aPropertyFilter(FilterField.CBOM_ASSET_OID_REFUTED,
+                FilterConditionOperator.NOT_EQUALS, (Serializable) List.of("true"));
+        SearchFilterRequestDto freeText = aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT,
+                FilterConditionOperator.CONTAINS, "101.3.4.4");
+        assertThatThrownBy(() -> searchAll(List.of(freeText, arrayValued)))
+                .describedAs("an array-valued facet must be refused, never inverted into 'refuted rows only' with "
+                        + "the carve-outs disarmed")
+                .isInstanceOf(ValidationException.class);
+
+        SearchFilterRequestDto garbage = aPropertyEqualsFilter(FilterField.CBOM_ASSET_OID_REFUTED, "yes");
+        assertThatThrownBy(() -> search(garbage))
+                .describedAs("'yes' is not a boolean; parseBoolean would silently read it as false")
+                .isInstanceOf(ValidationException.class);
+    }
+
+    /** Free text is advertised as a single-value field; extra values are refused rather than silently dropped. */
+    @Test
+    void freeTextRefusesAMultiValuePayload() {
+        SearchFilterRequestDto multiValued = aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT,
+                FilterConditionOperator.CONTAINS, (Serializable) List.of("aes", "rsa"));
+        assertThatThrownBy(() -> search(multiValued)).isInstanceOf(ValidationException.class);
     }
 
     /**
@@ -314,13 +383,20 @@ class CryptoAssetSearchITest extends BaseSpringBootTest {
         assetWriter
                 .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "AESX128",
                         "oid-lookalike", null, null, null, null, null, null, null), null);
+        UUID percented = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "50% legacy",
+                        "oid-percent", null, null, null, null, null, null, null), null);
 
         assertThat(search(aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT, FilterConditionOperator.CONTAINS, "s_1")))
                 .describedAs("an underscore matches a literal underscore, not any character")
                 .containsExactly(underscored);
         assertThat(search(aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT, FilterConditionOperator.CONTAINS, "%")))
-                .describedAs("a lone percent matches rows containing a literal percent -- here, none")
-                .isEmpty();
+                .describedAs("the positive control: a lone percent matches exactly the row with a literal percent, "
+                        + "not the whole inventory")
+                .containsExactly(percented);
+        assertThat(search(aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT, FilterConditionOperator.CONTAINS, "0% l")))
+                .describedAs("a percent inside a longer literal still matches literally")
+                .containsExactly(percented);
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/search/CryptoAssetSearchITest.java
+++ b/src/test/java/com/otilm/core/integration/search/CryptoAssetSearchITest.java
@@ -1,5 +1,6 @@
 package com.otilm.core.integration.search;
 
+import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.certificate.SearchFilterRequestDto;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.cbom.CbomAssetSyncState;
@@ -12,8 +13,10 @@ import com.otilm.core.dao.entity.cbom.CryptoAsset;
 import com.otilm.core.dao.repository.CbomRepository;
 import com.otilm.core.dao.repository.cbom.CryptoAssetRepository;
 import com.otilm.core.enums.FilterField;
+import com.otilm.core.model.cbom.CryptoAssetIdentityGuard;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.writer.cbom.CbomAssetSyncStateWriter;
+import com.otilm.core.service.writer.cbom.CryptoAssetSourceWriter;
 import com.otilm.core.service.writer.cbom.CryptoAssetWriter;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.FilterPredicatesBuilder;
@@ -22,16 +25,19 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 
 import static com.otilm.core.util.builders.SearchFilterRequestDtoBuilder.aPropertyEmptyFilter;
 import static com.otilm.core.util.builders.SearchFilterRequestDtoBuilder.aPropertyEqualsFilter;
 import static com.otilm.core.util.builders.SearchFilterRequestDtoBuilder.aPropertyFilter;
 import static com.otilm.core.util.builders.SearchFilterRequestDtoBuilder.aPropertyNotEmptyFilter;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Every crypto-asset search field, exercised against real PostgreSQL for the three cases a nullable column makes
@@ -50,6 +56,9 @@ class CryptoAssetSearchITest extends BaseSpringBootTest {
 
     @Autowired
     private CryptoAssetWriter assetWriter;
+
+    @Autowired
+    private CryptoAssetSourceWriter sourceWriter;
 
     @Autowired
     private CbomRepository cbomRepository;
@@ -177,6 +186,159 @@ class CryptoAssetSearchITest extends BaseSpringBootTest {
                 .isEmpty();
     }
 
+    // ---- free text, refuted-OID and source-CBOM filters ----
+
+    @Test
+    void freeTextMatchesNameAndOidCaseInsensitively() {
+        assertThat(search(aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT, FilterConditionOperator.CONTAINS, "ECDSA")))
+                .describedAs("matches the name despite the case difference from the stored canonical spelling")
+                .containsExactly(populated);
+        assertThat(search(aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT, FilterConditionOperator.CONTAINS, "10045")))
+                .describedAs("matches the oid")
+                .containsExactly(populated);
+    }
+
+    /**
+     * The issue's acceptance criterion: a refuted OID is stored and auditable, but a default free-text search must
+     * never let it answer a query, while the row itself stays findable through every other property.
+     */
+    @Test
+    void freeTextNeverMatchesThroughARefutedOidWithoutTheOptIn() {
+        UUID refuted = assetWriter
+                .upsertIdentity(
+                        new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ML-KEM-768",
+                                "2.16.840.1.101.3.4.4.2", "ml-kem", "kem", null, null, null, null, null),
+                        CryptoAssetIdentityGuard.REFUTED_OID);
+
+        assertThat(search(
+                aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT, FilterConditionOperator.CONTAINS, "101.3.4.4")))
+                .describedAs("the refuted oid is the row's only match, so a default search must not surface it")
+                .isEmpty();
+        assertThat(
+                search(aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT, FilterConditionOperator.CONTAINS, "ml-kem")))
+                .describedAs("the row is not hidden -- only its refuted oid is neutralized, the name still matches")
+                .containsExactly(refuted);
+        assertThat(searchAll(List
+                .of(aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT, FilterConditionOperator.CONTAINS, "101.3.4.4"),
+                        aPropertyEqualsFilter(FilterField.CBOM_ASSET_OID_REFUTED, "true"))))
+                .describedAs("opting into the refuted-OID facet lets the neutralized value answer again")
+                .containsExactly(refuted);
+    }
+
+    @Test
+    void freeTextRefusesEveryOperatorExceptContains() {
+        assertThatThrownBy(() -> search(
+                aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT, FilterConditionOperator.EQUALS, "ecdsa")))
+                .isInstanceOf(ValidationException.class);
+    }
+
+    /**
+     * The same acceptance criterion as {@link #freeTextNeverMatchesThroughARefutedOidWithoutTheOptIn}, exercised
+     * directly against the OID field's own value predicates rather than through free text.
+     */
+    @Test
+    void oidValuePredicatesTreatARefutedOidAsAbsent() {
+        UUID refuted = assetWriter
+                .upsertIdentity(
+                        new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ML-KEM-768",
+                                "2.16.840.1.101.3.4.4.2", "ml-kem", "kem", null, null, null, null, null),
+                        CryptoAssetIdentityGuard.REFUTED_OID);
+
+        assertThat(search(aPropertyEqualsFilter(FilterField.CBOM_ASSET_OID, "2.16.840.1.101.3.4.4.2")))
+                .describedAs("a refuted oid must not answer an EQUALS predicate")
+                .isEmpty();
+        assertThat(searchAll(List
+                .of(aPropertyEqualsFilter(FilterField.CBOM_ASSET_OID, "2.16.840.1.101.3.4.4.2"),
+                        aPropertyEqualsFilter(FilterField.CBOM_ASSET_OID_REFUTED, "true"))))
+                .describedAs("opting into the refuted-OID facet lets the recorded value answer again")
+                .containsExactly(refuted);
+        assertThat(search(aPropertyFilter(FilterField.CBOM_ASSET_OID, FilterConditionOperator.CONTAINS, "101.3.4")))
+                .describedAs("a refuted oid must not answer a CONTAINS predicate")
+                .isEmpty();
+        assertThat(search(
+                aPropertyFilter(FilterField.CBOM_ASSET_OID, FilterConditionOperator.NOT_EQUALS, "1.2.840.10045.4.3.2")))
+                .describedAs("a NULL oid satisfies NOT_EQUALS for any value, and a refuted one must too")
+                .containsExactlyInAnyOrder(refuted, bare);
+        assertThat(search(aPropertyEmptyFilter(FilterField.CBOM_ASSET_OID)))
+                .describedAs("the refuted row HAS a recorded oid, so it is not EMPTY")
+                .containsExactly(bare);
+        assertThat(search(aPropertyNotEmptyFilter(FilterField.CBOM_ASSET_OID)))
+                .describedAs("the recorded value stays auditable under NOT_EMPTY")
+                .containsExactlyInAnyOrder(populated, refuted);
+    }
+
+    @Test
+    void theRefutedFacetSelectsRowsByRefutedness() {
+        UUID refuted = assetWriter
+                .upsertIdentity(
+                        new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ML-KEM-768",
+                                "2.16.840.1.101.3.4.4.2", "ml-kem", "kem", null, null, null, null, null),
+                        CryptoAssetIdentityGuard.REFUTED_OID);
+        UUID bareCn = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.CERTIFICATE, "some-cn", null, null,
+                        null, null, null, null, null, null), CryptoAssetIdentityGuard.BARE_CN_SUBJECT);
+
+        assertThat(search(aPropertyEqualsFilter(FilterField.CBOM_ASSET_OID_REFUTED, "true")))
+                .describedAs("only the refuted-OID row, not the BARE_CN_SUBJECT one")
+                .containsExactly(refuted);
+        assertThat(search(aPropertyEqualsFilter(FilterField.CBOM_ASSET_OID_REFUTED, "false")))
+                .describedAs("everything else, including a differently-guarded row")
+                .containsExactlyInAnyOrder(bareCn, bare, populated);
+    }
+
+    @Test
+    void theSourceCbomFilterMatchesThroughSourcesWithoutDuplicatingRows() {
+        Cbom alpha = newCbom("urn:uuid:alpha");
+        Cbom beta = newCbom("urn:uuid:beta");
+        UUID other = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "RSA", null, "rsa",
+                        "signature", null, null, null, null, null), null);
+        sourceWriter.upsertSource(populated, alpha.getUuid(), Map.of("k", "v"), List.of(), OffsetDateTime.now());
+        sourceWriter.upsertSource(populated, beta.getUuid(), Map.of("k", "v"), List.of(), OffsetDateTime.now());
+        sourceWriter.upsertSource(other, beta.getUuid(), Map.of("k", "v"), List.of(), OffsetDateTime.now());
+
+        assertThat(search(aPropertyEqualsFilter(FilterField.CBOM_ASSET_SOURCE_CBOM, "urn:uuid:alpha")))
+                .containsExactly(populated);
+        SearchFilterRequestDto matchesEitherSerial = aPropertyEqualsFilter(FilterField.CBOM_ASSET_SOURCE_CBOM,
+                (Serializable) List.of("urn:uuid:alpha", "urn:uuid:beta"));
+        assertThat(search(matchesEitherSerial))
+                .describedAs("populated has two matching sources; EQUALS matches through either")
+                .containsExactlyInAnyOrder(populated, other);
+        // findUsingSecurityFilter (used by search() above) runs its query through
+        // SecurityFilterRepositoryImpl#createCriteriaBuilder, which selects DISTINCT and would hide a
+        // join-based reimplementation of this predicate repeating populated's row. The uuid page query
+        // -- createCriteriaBuilderUuid, reached only through findUuidsUsingSecurityFilter -- carries no
+        // DISTINCT, so it is the path that actually proves the EXISTS design does not duplicate.
+        List<UUID> undistinctedUuidPage = assetRepository
+                .findUuidsUsingSecurityFilter(SecurityFilter.create(),
+                        (root, cb, cr) -> FilterPredicatesBuilder
+                                .getFiltersPredicate(cb, cr, root, List.of(matchesEitherSerial)),
+                        PageRequest.of(0, 10), (root, cb) -> cb.asc(root.get("uuid")));
+        assertThat(undistinctedUuidPage)
+                .describedAs("the undistincted uuid page must not repeat populated's row either")
+                .containsExactlyInAnyOrder(populated, other);
+        assertThat(search(aPropertyFilter(FilterField.CBOM_ASSET_SOURCE_CBOM, FilterConditionOperator.NOT_EQUALS,
+                "urn:uuid:alpha"))).describedAs("rows without an alpha source").containsExactlyInAnyOrder(other, bare);
+        assertThat(search(aPropertyEmptyFilter(FilterField.CBOM_ASSET_SOURCE_CBOM)))
+                .describedAs("the sourceless row")
+                .containsExactly(bare);
+        assertThat(search(aPropertyNotEmptyFilter(FilterField.CBOM_ASSET_SOURCE_CBOM)))
+                .describedAs("exactly the two sourced rows")
+                .containsExactlyInAnyOrder(populated, other);
+    }
+
+    @Test
+    void aFilterCombinesWithTheNewFields() {
+        Cbom alpha = newCbom("urn:uuid:alpha");
+        sourceWriter.upsertSource(populated, alpha.getUuid(), Map.of("k", "v"), List.of(), OffsetDateTime.now());
+
+        assertThat(searchAll(List
+                .of(aPropertyEqualsFilter(FilterField.CBOM_ASSET_TYPE, CryptographicAssetType.ALGORITHM.getCode()),
+                        aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT, FilterConditionOperator.CONTAINS, "ecdsa"),
+                        aPropertyEqualsFilter(FilterField.CBOM_ASSET_SOURCE_CBOM, "urn:uuid:alpha"))))
+                .containsExactly(populated);
+    }
+
     // ---- the CBOM-rooted asset-sync fields ----
 
     @Test
@@ -221,14 +383,24 @@ class CryptoAssetSearchITest extends BaseSpringBootTest {
                         FilterField.CBOM_ASSET_PARAMETER_SET, FilterField.CBOM_ASSET_CURVE, FilterField.CBOM_ASSET_MODE,
                         FilterField.CBOM_ASSET_PADDING, FilterField.CBOM_ASSET_VARIANT,
                         FilterField.CBOM_ASSET_PQC_VERDICT, FilterField.CBOM_ASSET_PQC_RULESET_VERSION,
-                        FilterField.CBOM_ASSET_RULESET_VERSION, FilterField.CBOM_ASSET_SOURCE_COUNT);
+                        FilterField.CBOM_ASSET_RULESET_VERSION, FilterField.CBOM_ASSET_SOURCE_COUNT,
+                        FilterField.CBOM_ASSET_OID_REFUTED);
         assertThat(cryptoAssetFields)
                 .describedAs("every crypto-asset field roots at the ratified CRYPTO_ASSET resource, so the inventory "
                         + "gets its own search surface rather than borrowing the CBOM one")
                 .allSatisfy(field -> assertThat(field.getRootResource()).isEqualTo(Resource.CRYPTO_ASSET));
+        // FREE_TEXT has no fieldAttribute and SOURCE_CBOM's declares on Cbom, not CryptoAsset, so neither is in
+        // cryptoAssetFields above; both still root at CRYPTO_ASSET and belong in its declared search surface.
         assertThat(FilterField.getEnumsForResource(Resource.CRYPTO_ASSET))
                 .describedAs("CRYPTO_ASSET serves the crypto-asset fields and nothing else")
-                .containsExactlyElementsOf(cryptoAssetFields);
+                .containsExactly(FilterField.CBOM_ASSET_TYPE, FilterField.CBOM_ASSET_NAME, FilterField.CBOM_ASSET_OID,
+                        FilterField.CBOM_ASSET_ALGORITHM_FAMILY, FilterField.CBOM_ASSET_PRIMITIVE,
+                        FilterField.CBOM_ASSET_PARAMETER_SET, FilterField.CBOM_ASSET_CURVE, FilterField.CBOM_ASSET_MODE,
+                        FilterField.CBOM_ASSET_PADDING, FilterField.CBOM_ASSET_VARIANT,
+                        FilterField.CBOM_ASSET_PQC_VERDICT, FilterField.CBOM_ASSET_PQC_RULESET_VERSION,
+                        FilterField.CBOM_ASSET_RULESET_VERSION, FilterField.CBOM_ASSET_SOURCE_COUNT,
+                        FilterField.CBOM_ASSET_FREE_TEXT, FilterField.CBOM_ASSET_OID_REFUTED,
+                        FilterField.CBOM_ASSET_SOURCE_CBOM);
 
         for (Resource resource : Resource.values()) {
             if (resource == Resource.CRYPTO_ASSET) {

--- a/src/test/java/com/otilm/core/integration/service/CryptographicAssetSearchableFieldsITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicAssetSearchableFieldsITest.java
@@ -71,14 +71,22 @@ class CryptographicAssetSearchableFieldsITest extends BaseSpringBootTest {
                                 "2.16.840.1.101.3.4.4.2", "ml-kem", "kem", null, null, null, null, null),
                         CryptoAssetIdentityGuard.REFUTED_OID);
 
-        Cbom cbom = new Cbom();
-        cbom.setSerialNumber(SEEDED_SERIAL);
-        cbom.setVersion(1);
-        cbom.setSpecVersion("1.7");
-        cbomRepository.save(cbom);
+        newCbom(SEEDED_SERIAL, 1);
+        // A second version of the same serial plus an earlier-sorting one: the value list must collapse the
+        // duplicate and come back sorted.
+        newCbom(SEEDED_SERIAL, 2);
+        newCbom("urn:uuid:aaa-first", 1);
 
         groups = cryptographicAssetService.getSearchableFieldInformationByGroup();
         fields = groups.get(0).getSearchFieldData();
+    }
+
+    private void newCbom(String serialNumber, int version) {
+        Cbom cbom = new Cbom();
+        cbom.setSerialNumber(serialNumber);
+        cbom.setVersion(version);
+        cbom.setSpecVersion("1.7");
+        cbomRepository.save(cbom);
     }
 
     /**
@@ -123,7 +131,8 @@ class CryptographicAssetSearchableFieldsITest extends BaseSpringBootTest {
         assertThat(refuted.getType()).isEqualTo(FilterFieldType.BOOLEAN);
 
         assertThat((List<String>) fieldFor(FilterField.CBOM_ASSET_SOURCE_CBOM).getValue())
-                .containsExactly(SEEDED_SERIAL);
+                .describedAs("scoped to the caller's CBOM access, duplicate serial collapsed, sorted")
+                .containsExactly("urn:uuid:aaa-first", SEEDED_SERIAL);
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/CryptographicAssetSearchableFieldsITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicAssetSearchableFieldsITest.java
@@ -57,8 +57,9 @@ class CryptographicAssetSearchableFieldsITest extends BaseSpringBootTest {
         assetWriter
                 .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ECDSA",
                         "1.2.840.10045.4.3.2", "ecdsa", "signature", "P-256", "SECP256R1", null, null, null), null);
-        // A second producer's spelling of the same curve, on a distinct row (different oid): findDistinctCurve()
-        // must still report the canonical spelling once, not twice.
+        // The same curve token in a second casing, on a distinct row (different oid): findDistinctCurve() must
+        // still report the stored normalized spelling once, not twice. Folding ALIASES of one curve (p-256 vs
+        // secp256r1) into one secg/* class representative is core#2072's ingest obligation, not this endpoint's.
         assetWriter
                 .upsertIdentity(
                         new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ECDSA-VARIANT",
@@ -94,7 +95,7 @@ class CryptographicAssetSearchableFieldsITest extends BaseSpringBootTest {
     }
 
     @Test
-    void theCurveFieldOffersTheCanonicalSpellingOnlyOnce() {
+    void theCurveFieldOffersTheStoredNormalizedSpellingOnlyOnce() {
         assertThat((List<String>) fieldFor(FilterField.CBOM_ASSET_CURVE).getValue())
                 .containsExactly("secp256r1")
                 .doesNotContainNull();

--- a/src/test/java/com/otilm/core/integration/service/CryptographicAssetSearchableFieldsITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicAssetSearchableFieldsITest.java
@@ -1,0 +1,143 @@
+package com.otilm.core.integration.service;
+
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetType;
+import com.otilm.api.model.core.search.FilterConditionOperator;
+import com.otilm.api.model.core.search.FilterFieldSource;
+import com.otilm.api.model.core.search.FilterFieldType;
+import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
+import com.otilm.api.model.core.search.SearchFieldDataDto;
+import com.otilm.core.cbom.asset.CryptoAssetIdentityFields;
+import com.otilm.core.dao.entity.Cbom;
+import com.otilm.core.dao.repository.CbomRepository;
+import com.otilm.core.enums.FilterField;
+import com.otilm.core.model.cbom.CryptoAssetIdentityGuard;
+import com.otilm.core.service.CryptographicAssetExternalService;
+import com.otilm.core.service.writer.cbom.CryptoAssetWriter;
+import com.otilm.core.util.BaseSpringBootTest;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link CryptographicAssetExternalService#getSearchableFieldInformationByGroup()}: the wire-level shape of the
+ * cryptographic asset search surface, including the two criteria the issue calls out explicitly -- the identity key is
+ * never offered as a field, and a producer-spelling difference does not show up twice in a value list.
+ */
+class CryptographicAssetSearchableFieldsITest extends BaseSpringBootTest {
+
+    private static final List<FilterField> EXPECTED_FIELDS = List
+            .of(FilterField.CBOM_ASSET_TYPE, FilterField.CBOM_ASSET_NAME, FilterField.CBOM_ASSET_OID,
+                    FilterField.CBOM_ASSET_ALGORITHM_FAMILY, FilterField.CBOM_ASSET_PRIMITIVE,
+                    FilterField.CBOM_ASSET_PARAMETER_SET, FilterField.CBOM_ASSET_CURVE, FilterField.CBOM_ASSET_MODE,
+                    FilterField.CBOM_ASSET_PADDING, FilterField.CBOM_ASSET_VARIANT, FilterField.CBOM_ASSET_PQC_VERDICT,
+                    FilterField.CBOM_ASSET_PQC_RULESET_VERSION, FilterField.CBOM_ASSET_RULESET_VERSION,
+                    FilterField.CBOM_ASSET_SOURCE_COUNT, FilterField.CBOM_ASSET_FREE_TEXT,
+                    FilterField.CBOM_ASSET_OID_REFUTED, FilterField.CBOM_ASSET_SOURCE_CBOM);
+
+    private static final String SEEDED_SERIAL = "urn:uuid:searchable-fields";
+
+    @Autowired
+    private CryptographicAssetExternalService cryptographicAssetService;
+
+    @Autowired
+    private CryptoAssetWriter assetWriter;
+
+    @Autowired
+    private CbomRepository cbomRepository;
+
+    private List<SearchFieldDataByGroupDto> groups;
+
+    private List<SearchFieldDataDto> fields;
+
+    @BeforeEach
+    void seedAssetsAndCbom() {
+        assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ECDSA",
+                        "1.2.840.10045.4.3.2", "ecdsa", "signature", "P-256", "SECP256R1", null, null, null), null);
+        // A second producer's spelling of the same curve, on a distinct row (different oid): findDistinctCurve()
+        // must still report the canonical spelling once, not twice.
+        assetWriter
+                .upsertIdentity(
+                        new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ECDSA-VARIANT",
+                                "1.2.840.10045.4.3.3", "ecdsa", "signature", "P-256", " secp256r1 ", null, null, null),
+                        null);
+        assetWriter
+                .upsertIdentity(
+                        new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ML-KEM-768",
+                                "2.16.840.1.101.3.4.4.2", "ml-kem", "kem", null, null, null, null, null),
+                        CryptoAssetIdentityGuard.REFUTED_OID);
+
+        Cbom cbom = new Cbom();
+        cbom.setSerialNumber(SEEDED_SERIAL);
+        cbom.setVersion(1);
+        cbom.setSpecVersion("1.7");
+        cbomRepository.save(cbom);
+
+        groups = cryptographicAssetService.getSearchableFieldInformationByGroup();
+        fields = groups.get(0).getSearchFieldData();
+    }
+
+    /**
+     * The wire-level "the identity key is not offered" criterion, pinned by exact enumeration: nothing besides the 17
+     * ratified crypto-asset fields is present.
+     */
+    @Test
+    void oneGroupOffersExactlyTheCryptoAssetFields() {
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get(0).getFilterFieldSource()).isEqualTo(FilterFieldSource.PROPERTY);
+        assertThat(fields)
+                .extracting(SearchFieldDataDto::getFieldIdentifier)
+                .containsExactlyInAnyOrderElementsOf(EXPECTED_FIELDS.stream().map(FilterField::name).toList());
+    }
+
+    @Test
+    void theCurveFieldOffersTheCanonicalSpellingOnlyOnce() {
+        assertThat((List<String>) fieldFor(FilterField.CBOM_ASSET_CURVE).getValue())
+                .containsExactly("secp256r1")
+                .doesNotContainNull();
+    }
+
+    @Test
+    void enumBackedFieldsCarryThePlatformEnumAndTheContractCodes() {
+        SearchFieldDataDto type = fieldFor(FilterField.CBOM_ASSET_TYPE);
+        assertThat(type.getPlatformEnum()).isNotNull();
+        assertThat((List<String>) type.getValue()).contains("algorithm");
+
+        SearchFieldDataDto verdict = fieldFor(FilterField.CBOM_ASSET_PQC_VERDICT);
+        assertThat(verdict.getPlatformEnum()).isNotNull();
+        assertThat((List<String>) verdict.getValue()).contains("notReady");
+    }
+
+    @Test
+    void freeTextAndTheRefutedFacetOfferTheirOwnConditionsAndTypes() {
+        assertThat(fieldFor(FilterField.CBOM_ASSET_FREE_TEXT).getConditions())
+                .containsExactly(FilterConditionOperator.CONTAINS);
+
+        SearchFieldDataDto refuted = fieldFor(FilterField.CBOM_ASSET_OID_REFUTED);
+        assertThat(refuted.getConditions())
+                .containsExactly(FilterConditionOperator.EQUALS, FilterConditionOperator.NOT_EQUALS);
+        assertThat(refuted.getType()).isEqualTo(FilterFieldType.BOOLEAN);
+
+        assertThat((List<String>) fieldFor(FilterField.CBOM_ASSET_SOURCE_CBOM).getValue())
+                .containsExactly(SEEDED_SERIAL);
+    }
+
+    @Test
+    void noFieldReportsSortable() {
+        assertThat(fields)
+                .describedAs(
+                        "the list's order is fixed and the contract allows sorting only on fields marked " + "sortable")
+                .allSatisfy(field -> assertThat(Boolean.TRUE.equals(field.getSortable())).isFalse());
+    }
+
+    private SearchFieldDataDto fieldFor(FilterField field) {
+        return fields
+                .stream()
+                .filter(candidate -> candidate.getFieldIdentifier().equals(field.name()))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/src/test/java/com/otilm/core/integration/service/CryptographicAssetServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicAssetServiceITest.java
@@ -116,6 +116,21 @@ class CryptographicAssetServiceITest extends BaseSpringBootTest {
                 .setSort(new SearchSortRequestDto(FilterFieldSource.PROPERTY, FilterField.CBOM_ASSET_NAME.name(),
                         SortDirection.ASC));
         assertThatThrownBy(() -> list(sorted)).isInstanceOf(ValidationException.class).hasMessageContaining("Sorting");
+
+        // (pageNumber - 1) * itemsPerPage must fit an int: the JPA offset is an int, so an unchecked product either
+        // throws deep in Hibernate (a 400, not the shaped 422) or -- worse -- wraps positive and silently serves the
+        // wrong page while echoing the requested number.
+        SearchRequestDto wrapping = new SearchRequestDto();
+        wrapping.setPageNumber(4294969);
+        wrapping.setItemsPerPage(1000);
+        assertThatThrownBy(() -> list(wrapping))
+                .describedAs("offset 4,294,968,000 wraps to +704 -- must be refused, not served")
+                .isInstanceOf(ValidationException.class);
+
+        SearchRequestDto overflowing = new SearchRequestDto();
+        overflowing.setPageNumber(2147485);
+        overflowing.setItemsPerPage(1000);
+        assertThatThrownBy(() -> list(overflowing)).isInstanceOf(ValidationException.class);
     }
 
     @Test
@@ -135,6 +150,11 @@ class CryptographicAssetServiceITest extends BaseSpringBootTest {
         UUID guarded = assetWriter
                 .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.CERTIFICATE, "some-cn", null, null,
                         null, null, null, null, null, null), CryptoAssetIdentityGuard.BARE_CN_SUBJECT);
+        UUID contradicted = assetWriter
+                .upsertIdentity(
+                        new CryptoAssetIdentityFields(CryptographicAssetType.CERTIFICATE, "contradicted-cert", null,
+                                null, null, null, null, null, null, null),
+                        CryptoAssetIdentityGuard.REFUTED_CERTIFICATE_DIGEST);
 
         UUID neverEvaluated = seedNamed(CryptographicAssetType.ALGORITHM, "RSA", "oid-never-evaluated");
 
@@ -151,12 +171,67 @@ class CryptographicAssetServiceITest extends BaseSpringBootTest {
         assertThat(sourcedDto.getUuid()).isEqualTo(sourced);
 
         CryptographicAssetDto guardedDto = dtoFor(page, guarded);
-        assertThat(guardedDto.isQuarantined()).isTrue();
+        assertThat(guardedDto.isQuarantined())
+                .describedAs("BARE_CN_SUBJECT is a permanent DN-scope split with no reconciliation path -- not the "
+                        + "contract's 'contradicting claims quarantined pending reconciliation'")
+                .isFalse();
+
+        CryptographicAssetDto contradictedDto = dtoFor(page, contradicted);
+        assertThat(contradictedDto.isQuarantined())
+                .describedAs("REFUTED_CERTIFICATE_DIGEST is the one guard the contract sentence describes: "
+                        + "contradicting claims, pending reconciliation")
+                .isTrue();
 
         CryptographicAssetDto neverEvaluatedDto = dtoFor(page, neverEvaluated);
         assertThat(neverEvaluatedDto.getPqcVerdict())
                 .describedAs("never evaluated -> UNKNOWN, not null")
                 .isEqualTo(PqcVerdict.UNKNOWN);
+    }
+
+    /**
+     * The contract orders rows "by name ascending", and the only name it defines is the served display field -- for a
+     * nameless row, its OID fallback. Sorting the bare column instead would put every nameless row last (NULL sorts
+     * last under ASC), serving ["zzz-cipher", "0.aaa"]: descending on the wire.
+     */
+    @Test
+    void ordersByTheServedNameNotTheBareColumn() {
+        UUID named = seedNamed(CryptographicAssetType.ALGORITHM, "zzz-cipher", "9.9.9");
+        UUID oidServed = seedNamed(CryptographicAssetType.CERTIFICATE, null, "0.aaa");
+
+        PaginationResponseDto<CryptographicAssetDto> page = list(new SearchRequestDto());
+        assertThat(page.getItems()).extracting(CryptographicAssetDto::getUuid).containsExactly(oidServed, named);
+        assertThat(page.getItems()).extracting(CryptographicAssetDto::getName).containsExactly("0.aaa", "zzz-cipher");
+    }
+
+    /**
+     * A refuted OID must not be served as the display name: the contract's principle for refuted identifiers (stated on
+     * the detail contract's per-OID flag) is that a client labels them instead of presenting them as fact, and the list
+     * DTO carries no such flag. The row serves no name at all -- the interfaces-owned both-null residual -- and sorts
+     * with the nameless rows, consistently with the search that refuses to match the same string.
+     */
+    @Test
+    void aRefutedOidIsNotServedAsTheName() {
+        UUID refutedNameless = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, null, "0.0.1", "ml-kem",
+                        null, null, null, null, null, null), CryptoAssetIdentityGuard.REFUTED_OID);
+        UUID named = seedNamed(CryptographicAssetType.ALGORITHM, "aes", "1.2.3");
+
+        PaginationResponseDto<CryptographicAssetDto> page = list(new SearchRequestDto());
+        assertThat(dtoFor(page, refutedNameless).getName()).isNull();
+        assertThat(page.getItems())
+                .extracting(CryptographicAssetDto::getUuid)
+                .describedAs("serves no name -> sorts after named rows even though '0.0.1' < 'aes'")
+                .containsExactly(named, refutedNameless);
+    }
+
+    @Test
+    void aRowWithNeitherNameNorOidServesNoName() {
+        UUID bare = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.CERTIFICATE, null, null, null,
+                        null, null, null, null, null, null), null);
+        assertThat(dtoFor(list(new SearchRequestDto()), bare).getName())
+                .describedAs("interfaces-owned residual: the REQUIRED name has no value to serve")
+                .isNull();
     }
 
     /**
@@ -212,8 +287,9 @@ class CryptographicAssetServiceITest extends BaseSpringBootTest {
         PaginationResponseDto<CryptographicAssetDto> withOptInResult = list(withOptIn);
         assertThat(withOptInResult.getItems()).extracting(CryptographicAssetDto::getUuid).containsExactly(refuted);
         assertThat(withOptInResult.getItems().getFirst().isQuarantined())
-                .describedAs("the opted-in row is served flagged as quarantined, not laundered")
-                .isTrue();
+                .describedAs("REFUTED_OID is one component contradicting itself, not 'sources making contradicting "
+                        + "claims pending reconciliation' -- served unflagged")
+                .isFalse();
     }
 
     /**
@@ -262,6 +338,11 @@ class CryptographicAssetServiceITest extends BaseSpringBootTest {
                 .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.CERTIFICATE, null, "oid-bare-only",
                         null, null, null, null, null, null, null), null);
 
+        UUID refutedNameless = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, null,
+                        "oid-refuted-label", "ml-kem", null, null, null, null, null, null),
+                        CryptoAssetIdentityGuard.REFUTED_OID);
+
         List<NameAndUuidDto> objects = resourceExtension().listResourceObjects(SecurityFilter.create(), null, null);
 
         assertThat(nameFor(objects, named))
@@ -270,6 +351,26 @@ class CryptographicAssetServiceITest extends BaseSpringBootTest {
         assertThat(nameFor(objects, bare))
                 .describedAs("a name-less row falls back to its oid")
                 .isEqualTo("oid-bare-only");
+        assertThat(nameFor(objects, refutedNameless))
+                .describedAs("a refuted OID is never presented as a label -- the picker shows no name rather than a "
+                        + "value the refuted ruling calls a false fact")
+                .isNull();
+    }
+
+    @Test
+    void listResourceObjectsHonoursPickerFilters() {
+        UUID aes = seedNamed(CryptographicAssetType.ALGORITHM, "AES", "oid-picker-aes");
+        seedNamed(CryptographicAssetType.ALGORITHM, "RSA", "oid-picker-rsa");
+
+        List<NameAndUuidDto> filtered = resourceExtension()
+                .listResourceObjects(SecurityFilter.create(),
+                        List.of(aPropertyEqualsFilter(FilterField.CBOM_ASSET_NAME, "aes")), null);
+
+        assertThat(filtered)
+                .describedAs("a search typed into the role editor's picker narrows the objects, like the "
+                        + "entity-instance precedent")
+                .extracting(NameAndUuidDto::getUuid)
+                .containsExactly(aes.toString());
     }
 
     @Test
@@ -281,8 +382,8 @@ class CryptographicAssetServiceITest extends BaseSpringBootTest {
         assertThat(found.getName()).isEqualTo("aes");
 
         UUID missing = UUID.randomUUID();
-        assertThatThrownBy(() -> resourceExtension().getResourceObjectInternal(missing))
-                .isInstanceOf(NotFoundException.class);
+        ResourceExtensionService extension = resourceExtension();
+        assertThatThrownBy(() -> extension.getResourceObjectInternal(missing)).isInstanceOf(NotFoundException.class);
     }
 
     @Test
@@ -294,7 +395,9 @@ class CryptographicAssetServiceITest extends BaseSpringBootTest {
         assertThat(found.getName()).isEqualTo("aes");
 
         UUID missing = UUID.randomUUID();
-        assertThatThrownBy(() -> resourceExtension().getResourceObjectExternal(SecuredUUID.fromUUID(missing)))
+        SecuredUUID missingUuid = SecuredUUID.fromUUID(missing);
+        ResourceExtensionService extension = resourceExtension();
+        assertThatThrownBy(() -> extension.getResourceObjectExternal(missingUuid))
                 .isInstanceOf(NotFoundException.class);
     }
 
@@ -304,8 +407,9 @@ class CryptographicAssetServiceITest extends BaseSpringBootTest {
         resourceExtension().evaluatePermissionChain(SecuredUUID.fromUUID(existing));
 
         UUID missing = UUID.randomUUID();
-        assertThatThrownBy(() -> resourceExtension().evaluatePermissionChain(SecuredUUID.fromUUID(missing)))
-                .isInstanceOf(NotFoundException.class);
+        SecuredUUID missingUuid = SecuredUUID.fromUUID(missing);
+        ResourceExtensionService extension = resourceExtension();
+        assertThatThrownBy(() -> extension.evaluatePermissionChain(missingUuid)).isInstanceOf(NotFoundException.class);
     }
 
     // ---- helpers ----

--- a/src/test/java/com/otilm/core/integration/service/CryptographicAssetServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicAssetServiceITest.java
@@ -1,8 +1,10 @@
 package com.otilm.core.integration.service;
 
+import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.certificate.SearchRequestDto;
 import com.otilm.api.model.client.certificate.SearchSortRequestDto;
+import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.common.PaginationResponseDto;
 import com.otilm.api.model.core.cryptoasset.CryptographicAssetDto;
 import com.otilm.api.model.core.cryptoasset.CryptographicAssetType;
@@ -15,8 +17,10 @@ import com.otilm.core.dao.entity.Cbom;
 import com.otilm.core.dao.repository.CbomRepository;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.model.cbom.CryptoAssetIdentityGuard;
+import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.CryptographicAssetExternalService;
+import com.otilm.core.service.ResourceExtensionService;
 import com.otilm.core.service.writer.cbom.CryptoAssetSourceWriter;
 import com.otilm.core.service.writer.cbom.CryptoAssetWriter;
 import com.otilm.core.util.BaseSpringBootTest;
@@ -231,6 +235,61 @@ class CryptographicAssetServiceITest extends BaseSpringBootTest {
         assertThat(page2.getTotalItems()).isEqualTo(3);
     }
 
+    // ---- the auth service's per-object listing (ResourceExtensionService) ----
+
+    @Test
+    void listResourceObjectsLabelsByNameOrFallsBackToOid() {
+        UUID named = seedNamed(CryptographicAssetType.ALGORITHM, "AES", "oid-named");
+        UUID bare = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.CERTIFICATE, null, "oid-bare-only",
+                        null, null, null, null, null, null, null), null);
+
+        List<NameAndUuidDto> objects = resourceExtension().listResourceObjects(SecurityFilter.create(), null, null);
+
+        assertThat(nameFor(objects, named))
+                .describedAs("a named row is labeled by its canonical name")
+                .isEqualTo("aes");
+        assertThat(nameFor(objects, bare))
+                .describedAs("a name-less row falls back to its oid")
+                .isEqualTo("oid-bare-only");
+    }
+
+    @Test
+    void getResourceObjectInternalReturnsNameAndUuidOrThrowsNotFound() throws NotFoundException {
+        UUID named = seedNamed(CryptographicAssetType.ALGORITHM, "AES", "oid-internal");
+
+        NameAndUuidDto found = resourceExtension().getResourceObjectInternal(named);
+        assertThat(found.getUuid()).isEqualTo(named.toString());
+        assertThat(found.getName()).isEqualTo("aes");
+
+        UUID missing = UUID.randomUUID();
+        assertThatThrownBy(() -> resourceExtension().getResourceObjectInternal(missing))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    void getResourceObjectExternalReturnsNameAndUuidOrThrowsNotFound() throws NotFoundException {
+        UUID named = seedNamed(CryptographicAssetType.ALGORITHM, "AES", "oid-external");
+
+        NameAndUuidDto found = resourceExtension().getResourceObjectExternal(SecuredUUID.fromUUID(named));
+        assertThat(found.getUuid()).isEqualTo(named.toString());
+        assertThat(found.getName()).isEqualTo("aes");
+
+        UUID missing = UUID.randomUUID();
+        assertThatThrownBy(() -> resourceExtension().getResourceObjectExternal(SecuredUUID.fromUUID(missing)))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    void evaluatePermissionChainThrowsNotFoundForAMissingUuidAndPassesForAnExistingOne() throws NotFoundException {
+        UUID existing = seedNamed(CryptographicAssetType.ALGORITHM, "AES", "oid-chain");
+        resourceExtension().evaluatePermissionChain(SecuredUUID.fromUUID(existing));
+
+        UUID missing = UUID.randomUUID();
+        assertThatThrownBy(() -> resourceExtension().evaluatePermissionChain(SecuredUUID.fromUUID(missing)))
+                .isInstanceOf(NotFoundException.class);
+    }
+
     // ---- helpers ----
 
     private PaginationResponseDto<CryptographicAssetDto> list(SearchRequestDto request) {
@@ -259,6 +318,21 @@ class CryptographicAssetServiceITest extends BaseSpringBootTest {
 
     private static CryptographicAssetDto dtoFor(PaginationResponseDto<CryptographicAssetDto> page, UUID uuid) {
         return page.getItems().stream().filter(dto -> dto.getUuid().equals(uuid)).findFirst().orElseThrow();
+    }
+
+    // CryptographicAssetServiceImpl implements both CryptographicAssetExternalService and ResourceExtensionService
+    // on the one bean; casting the already-autowired proxy reaches the same instance under the second interface.
+    private ResourceExtensionService resourceExtension() {
+        return (ResourceExtensionService) cryptographicAssetService;
+    }
+
+    private static String nameFor(List<NameAndUuidDto> objects, UUID uuid) {
+        return objects
+                .stream()
+                .filter(object -> object.getUuid().equals(uuid.toString()))
+                .findFirst()
+                .orElseThrow()
+                .getName();
     }
 
     /**

--- a/src/test/java/com/otilm/core/integration/service/CryptographicAssetServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicAssetServiceITest.java
@@ -1,0 +1,272 @@
+package com.otilm.core.integration.service;
+
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.client.certificate.SearchRequestDto;
+import com.otilm.api.model.client.certificate.SearchSortRequestDto;
+import com.otilm.api.model.common.PaginationResponseDto;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetDto;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetType;
+import com.otilm.api.model.core.cryptoasset.PqcVerdict;
+import com.otilm.api.model.core.search.FilterConditionOperator;
+import com.otilm.api.model.core.search.FilterFieldSource;
+import com.otilm.api.model.core.search.SortDirection;
+import com.otilm.core.cbom.asset.CryptoAssetIdentityFields;
+import com.otilm.core.dao.entity.Cbom;
+import com.otilm.core.dao.repository.CbomRepository;
+import com.otilm.core.enums.FilterField;
+import com.otilm.core.model.cbom.CryptoAssetIdentityGuard;
+import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.service.CryptographicAssetExternalService;
+import com.otilm.core.service.writer.cbom.CryptoAssetSourceWriter;
+import com.otilm.core.service.writer.cbom.CryptoAssetWriter;
+import com.otilm.core.util.BaseSpringBootTest;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.otilm.core.util.builders.SearchFilterRequestDtoBuilder.aPropertyEqualsFilter;
+import static com.otilm.core.util.builders.SearchFilterRequestDtoBuilder.aPropertyFilter;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The list operation ({@link CryptographicAssetExternalService#listCryptographicAssets}) end to end, through the
+ * service interface rather than the repository directly: ordering and paging determinism, the 1000-item clamp and
+ * paging refusals, the list-row-to-DTO mapping, and the acceptance criteria from the issue itself -- filters that
+ * answer across asset types, and a refuted OID that stays out of a default free-text search until the caller opts into
+ * the facet.
+ */
+class CryptographicAssetServiceITest extends BaseSpringBootTest {
+
+    @Autowired
+    private CryptographicAssetExternalService cryptographicAssetService;
+
+    @Autowired
+    private CryptoAssetWriter assetWriter;
+
+    @Autowired
+    private CryptoAssetSourceWriter sourceWriter;
+
+    @Autowired
+    private CbomRepository cbomRepository;
+
+    @Test
+    void ordersByNameThenUuidAndPagesDeterministically() {
+        UUID aesA = seedNamed(CryptographicAssetType.ALGORITHM, "AES", "oid-aes-a");
+        UUID aesB = seedNamed(CryptographicAssetType.ALGORITHM, "  aes  ", "oid-aes-b");
+        UUID ecdsa = seedNamed(CryptographicAssetType.ALGORITHM, "ECDSA", "oid-ecdsa");
+        UUID nullNamed = seedNamed(CryptographicAssetType.CERTIFICATE, null, "oid-null-name");
+
+        List<UUID> aesByUuidAscending = sortedByUuidString(aesA, aesB);
+        UUID aesFirst = aesByUuidAscending.get(0);
+        UUID aesSecond = aesByUuidAscending.get(1);
+
+        PaginationResponseDto<CryptographicAssetDto> defaultPage = list(new SearchRequestDto());
+        assertThat(defaultPage.getItems())
+                .extracting(CryptographicAssetDto::getUuid)
+                .containsExactly(aesFirst, aesSecond, ecdsa, nullNamed);
+        assertThat(defaultPage.getPageNumber()).isEqualTo(1);
+        assertThat(defaultPage.getItemsPerPage()).isEqualTo(10);
+        assertThat(defaultPage.getTotalItems()).isEqualTo(4);
+        assertThat(defaultPage.getTotalPages()).isEqualTo(1);
+
+        SearchRequestDto firstOfTwo = new SearchRequestDto();
+        firstOfTwo.setItemsPerPage(2);
+        firstOfTwo.setPageNumber(1);
+        PaginationResponseDto<CryptographicAssetDto> page1 = list(firstOfTwo);
+        assertThat(page1.getItems()).extracting(CryptographicAssetDto::getUuid).containsExactly(aesFirst, aesSecond);
+        assertThat(page1.getTotalPages()).isEqualTo(2);
+
+        SearchRequestDto secondOfTwo = new SearchRequestDto();
+        secondOfTwo.setItemsPerPage(2);
+        secondOfTwo.setPageNumber(2);
+        PaginationResponseDto<CryptographicAssetDto> page2 = list(secondOfTwo);
+        assertThat(page2.getItems())
+                .describedAs("page 1's boundary falls inside the tied 'aes' name group -- the uuid tiebreak makes "
+                        + "it deterministic")
+                .extracting(CryptographicAssetDto::getUuid)
+                .containsExactly(ecdsa, nullNamed);
+    }
+
+    @Test
+    void clampsOversizedPageAndRefusesInvalidPagingOrSort() {
+        SearchRequestDto oversized = new SearchRequestDto();
+        oversized.setItemsPerPage(5000);
+        assertThat(list(oversized).getItemsPerPage()).isEqualTo(1000);
+
+        SearchRequestDto zeroPage = new SearchRequestDto();
+        zeroPage.setPageNumber(0);
+        assertThatThrownBy(() -> list(zeroPage)).isInstanceOf(ValidationException.class);
+
+        SearchRequestDto zeroItems = new SearchRequestDto();
+        zeroItems.setItemsPerPage(0);
+        assertThatThrownBy(() -> list(zeroItems)).isInstanceOf(ValidationException.class);
+
+        SearchRequestDto sorted = new SearchRequestDto();
+        sorted
+                .setSort(new SearchSortRequestDto(FilterFieldSource.PROPERTY, FilterField.CBOM_ASSET_NAME.name(),
+                        SortDirection.ASC));
+        assertThatThrownBy(() -> list(sorted)).isInstanceOf(ValidationException.class).hasMessageContaining("Sorting");
+    }
+
+    @Test
+    void mapsListRowsToDtos() {
+        UUID sourced = seedNamed(CryptographicAssetType.ALGORITHM, "AES", "oid-sourced");
+        Cbom cbomOne = newCbom("urn:uuid:svc-one");
+        Cbom cbomTwo = newCbom("urn:uuid:svc-two");
+        sourceWriter
+                .upsertSource(sourced, cbomOne.getUuid(), Map.of("k", "v"),
+                        List.of(Map.of("location", "a"), Map.of("location", "b"), Map.of("location", "c")),
+                        OffsetDateTime.now());
+        sourceWriter
+                .upsertSource(sourced, cbomTwo.getUuid(), Map.of("k", "v"),
+                        List.of(Map.of("location", "d"), Map.of("location", "e")), OffsetDateTime.now());
+        assetWriter.applyPqcVerdict(sourced, PqcVerdict.NOT_READY, "rule", "reason", 3, Map.of());
+
+        UUID guarded = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.CERTIFICATE, "some-cn", null, null,
+                        null, null, null, null, null, null), CryptoAssetIdentityGuard.BARE_CN_SUBJECT);
+
+        UUID neverEvaluated = seedNamed(CryptographicAssetType.ALGORITHM, "RSA", "oid-never-evaluated");
+
+        PaginationResponseDto<CryptographicAssetDto> page = list(new SearchRequestDto());
+
+        CryptographicAssetDto sourcedDto = dtoFor(page, sourced);
+        assertThat(sourcedDto.getSourceCbomCount()).isEqualTo(2);
+        assertThat(sourcedDto.getOccurrenceCount())
+                .describedAs("occurrences summed across both sources: 3 + 2")
+                .isEqualTo(5);
+        assertThat(sourcedDto.getPqcVerdict()).isEqualTo(PqcVerdict.NOT_READY);
+        assertThat(sourcedDto.isQuarantined()).isFalse();
+        assertThat(sourcedDto.getName()).describedAs("canonical spelling, not the seeded case").isEqualTo("aes");
+        assertThat(sourcedDto.getUuid()).isEqualTo(sourced);
+
+        CryptographicAssetDto guardedDto = dtoFor(page, guarded);
+        assertThat(guardedDto.isQuarantined()).isTrue();
+
+        CryptographicAssetDto neverEvaluatedDto = dtoFor(page, neverEvaluated);
+        assertThat(neverEvaluatedDto.getPqcVerdict())
+                .describedAs("never evaluated -> UNKNOWN, not null")
+                .isEqualTo(PqcVerdict.UNKNOWN);
+    }
+
+    /**
+     * The issue's "normalized fields answer for every asset type" criterion: one filter value on a shared field returns
+     * rows of different {@link CryptographicAssetType}s, and the reported total tracks the filtered count.
+     */
+    @Test
+    void filtersNarrowResultsAcrossAssetTypes() {
+        UUID algorithmRow = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ECDSA", null, "ecdsa",
+                        "signature", "P-256", "secp256r1", null, null, null), null);
+        UUID certificateRow = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.CERTIFICATE, "some-cert", null,
+                        null, null, null, "secp256r1", null, null, null), null);
+        seedNamed(CryptographicAssetType.ALGORITHM, "RSA", "oid-unrelated");
+
+        SearchRequestDto request = new SearchRequestDto();
+        request.setFilters(List.of(aPropertyEqualsFilter(FilterField.CBOM_ASSET_CURVE, "secp256r1")));
+        PaginationResponseDto<CryptographicAssetDto> page = list(request);
+
+        assertThat(page.getItems())
+                .extracting(CryptographicAssetDto::getUuid)
+                .containsExactlyInAnyOrder(algorithmRow, certificateRow);
+        assertThat(page.getTotalItems()).describedAs("the filtered count, not the whole table").isEqualTo(2);
+    }
+
+    /**
+     * The issue's own acceptance criterion, end to end through the service: a refuted OID must never let a default
+     * free-text search surface the row, but opting into the refuted-OID facet lets it answer again.
+     */
+    @Test
+    void freeTextRefusesARefutedOidUntilTheRefutedFacetOptsIn() {
+        UUID refuted = assetWriter
+                .upsertIdentity(
+                        new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ML-KEM-768",
+                                "2.16.840.1.101.3.4.4.2", "ml-kem", "kem", null, null, null, null, null),
+                        CryptoAssetIdentityGuard.REFUTED_OID);
+
+        SearchRequestDto freeTextOnly = new SearchRequestDto();
+        freeTextOnly
+                .setFilters(List
+                        .of(aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT, FilterConditionOperator.CONTAINS,
+                                "101.3.4.4")));
+        PaginationResponseDto<CryptographicAssetDto> withoutOptIn = list(freeTextOnly);
+        assertThat(withoutOptIn.getItems()).isEmpty();
+        assertThat(withoutOptIn.getTotalItems()).isZero();
+
+        SearchRequestDto withOptIn = new SearchRequestDto();
+        withOptIn
+                .setFilters(List
+                        .of(aPropertyFilter(FilterField.CBOM_ASSET_FREE_TEXT, FilterConditionOperator.CONTAINS,
+                                "101.3.4.4"), aPropertyEqualsFilter(FilterField.CBOM_ASSET_OID_REFUTED, "true")));
+        PaginationResponseDto<CryptographicAssetDto> withOptInResult = list(withOptIn);
+        assertThat(withOptInResult.getItems()).extracting(CryptographicAssetDto::getUuid).containsExactly(refuted);
+    }
+
+    @Test
+    void totalPagesReflectsFilteredCountAcrossPages() {
+        seedFamily("AES-1", "aes");
+        seedFamily("AES-2", "aes");
+        seedFamily("AES-3", "aes");
+        seedFamily("RSA-1", "rsa");
+
+        SearchRequestDto request = new SearchRequestDto();
+        request.setItemsPerPage(2);
+        request.setPageNumber(1);
+        request.setFilters(List.of(aPropertyEqualsFilter(FilterField.CBOM_ASSET_ALGORITHM_FAMILY, "aes")));
+        PaginationResponseDto<CryptographicAssetDto> page1 = list(request);
+        assertThat(page1.getItems()).hasSize(2);
+        assertThat(page1.getTotalItems()).isEqualTo(3);
+        assertThat(page1.getTotalPages()).isEqualTo(2);
+
+        request.setPageNumber(2);
+        PaginationResponseDto<CryptographicAssetDto> page2 = list(request);
+        assertThat(page2.getItems()).hasSize(1);
+        assertThat(page2.getTotalItems()).isEqualTo(3);
+    }
+
+    // ---- helpers ----
+
+    private PaginationResponseDto<CryptographicAssetDto> list(SearchRequestDto request) {
+        return cryptographicAssetService.listCryptographicAssets(SecurityFilter.create(), request);
+    }
+
+    private UUID seedNamed(CryptographicAssetType type, String name, String oid) {
+        return assetWriter
+                .upsertIdentity(
+                        new CryptoAssetIdentityFields(type, name, oid, null, null, null, null, null, null, null), null);
+    }
+
+    private UUID seedFamily(String name, String family) {
+        return assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, name, null, family,
+                        null, null, null, null, null, null), null);
+    }
+
+    private Cbom newCbom(String serialNumber) {
+        Cbom cbom = new Cbom();
+        cbom.setSerialNumber(serialNumber);
+        cbom.setVersion(1);
+        cbom.setSpecVersion("1.7");
+        return cbomRepository.save(cbom);
+    }
+
+    private static CryptographicAssetDto dtoFor(PaginationResponseDto<CryptographicAssetDto> page, UUID uuid) {
+        return page.getItems().stream().filter(dto -> dto.getUuid().equals(uuid)).findFirst().orElseThrow();
+    }
+
+    /**
+     * The given UUIDs, ascending in Postgres's own {@code uuid} order -- see
+     * {@code CryptoAssetListQueryITest#sortedByUuidString} for why {@link UUID#toString()} order, not
+     * {@link UUID#compareTo}, is what Postgres actually applies.
+     */
+    private static List<UUID> sortedByUuidString(UUID... uuids) {
+        return Arrays.stream(uuids).sorted(Comparator.comparing(UUID::toString)).toList();
+    }
+}

--- a/src/test/java/com/otilm/core/integration/service/CryptographicAssetServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicAssetServiceITest.java
@@ -211,6 +211,24 @@ class CryptographicAssetServiceITest extends BaseSpringBootTest {
                                 "101.3.4.4"), aPropertyEqualsFilter(FilterField.CBOM_ASSET_OID_REFUTED, "true")));
         PaginationResponseDto<CryptographicAssetDto> withOptInResult = list(withOptIn);
         assertThat(withOptInResult.getItems()).extracting(CryptographicAssetDto::getUuid).containsExactly(refuted);
+        assertThat(withOptInResult.getItems().getFirst().isQuarantined())
+                .describedAs("the opted-in row is served flagged as quarantined, not laundered")
+                .isTrue();
+    }
+
+    /**
+     * The contract marks {@code name} REQUIRED and the wire mapper drops nulls, so a row that has no producer name must
+     * serve its next-best stable label -- the recorded OID, the same fallback the object picker's display label uses. A
+     * row with neither name nor OID remains a documented contract friction for interfaces to settle.
+     */
+    @Test
+    void aNamelessRowServesItsOidAsTheRequiredName() {
+        UUID nameless = assetWriter
+                .upsertIdentity(new CryptoAssetIdentityFields(CryptographicAssetType.CERTIFICATE, null, "oid-only-row",
+                        null, null, null, null, null, null, null), null);
+
+        CryptographicAssetDto dto = dtoFor(list(new SearchRequestDto()), nameless);
+        assertThat(dto.getName()).isEqualTo("oid-only-row");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/util/BaseSpringBootTest.java
+++ b/src/test/java/com/otilm/core/util/BaseSpringBootTest.java
@@ -105,6 +105,27 @@ public class BaseSpringBootTest {
     }
 
     /**
+     * Denies the OBJECT-access vote for one resource+action -- the vote {@code ObjectFilterAspect} turns into a
+     * security filter -- while {@link #denyResourceAccess} denies the method-security resource vote. A path that scopes
+     * data by a populated filter (rather than refusing the call) is exercised through this one: the filter comes back
+     * "only specific objects, none allowed", so the scoped query returns nothing instead of everything.
+     */
+    protected void denyObjectAccess(Resource resource, ResourceAction action) {
+        OpaObjectAccessResult noObjects = new OpaObjectAccessResult();
+        noObjects.setActionAllowedForGroupOfObjects(false);
+        noObjects.setAllowedObjects(List.of());
+        noObjects.setForbiddenObjects(List.of());
+        when(opaClient
+                .checkObjectAccess(Mockito.any(),
+                        Mockito
+                                .argThat(req -> req != null && req.getProperties() != null
+                                        && resource.getCode().equals(req.getProperties().get("name"))
+                                        && action.getCode().equals(req.getProperties().get("action"))),
+                        Mockito.any(), Mockito.any()))
+                .thenReturn(noObjects);
+    }
+
+    /**
      * Every resource-access request submitted to OPA so far, in submission order.
      */
     protected List<OpaRequestedResource> captureOpaRequests() {


### PR DESCRIPTION
Implements OmniTrustILM/core#2074: the list and searchable-fields operations of the cryptographic asset inventory contract (OmniTrustILM/interfaces#874), on top of the OmniTrustILM/core#2071 / OmniTrustILM/core#2146 data model. The last three commits answer the review on this PR; every inline thread carries its resolution.

## What it does

- **List** (`POST /v1/cryptoAssets`): every AC5 filter (asset type, algorithm family, primitive, parameter set, curve, PQC verdict, source CBOM), combinable, plus free-text as a case-insensitive OR over `lower(name)`/`lower(oid)` — LIKE wildcards escaped, the pattern bound (never inlined into statement text), multi-value payloads refused. Deterministic order by the **served label** (name, else unrefuted OID; the contract's "ordered by name ascending" names the served field) with the repository's uuid tie-break (OmniTrustILM/core#2157's `SortOrderBuilder`). Real runtime clamp at the schema's 1000; page offset guarded against int overflow (422, never a wrapped page).
- **Refuted OIDs** answer no default value predicate and no free-text query — the row stays findable by name, the value stays stored and auditable (EMPTY/NOT_EMPTY untouched), an explicit facet filter opts the request in, and the facet refuses unadvertised conditions and non-scalar/non-boolean values (422, never an inverted predicate). A refuted OID is also never served as a display name — not in the list, the object picker, or the sort key.
- **`quarantined`** fires only for `REFUTED_CERTIFICATE_DIGEST` — the one guard the contract sentence ("sources make contradicting claims … quarantined pending reconciliation") describes. The other guards are permanent-by-design splits; flagging them would advertise a queue that can never drain.
- **Searchable fields** (`GET /v1/cryptoAssets/search`): 17 fields, PROPERTY group only, value lists as recursive-CTE loose index scans over the existing btrees (milliseconds instead of eight parallel seq scans per filter-panel open); the source-CBOM list is scoped by the caller's own `cboms:list` object access — the platform's first cross-resource value list is not served platform-wide. Identity key in no field, no value list, no response: fence arch tests plus wire-level assertions including a recomputed exact-key check.
- **Counting**: `totalItems` uses a plain-count variant — `count(DISTINCT)` is unparallelizable and measured seconds-vs-milliseconds at 5M rows; a test pins plain == distinct through the only predicate shape that could differ.
- **Auth**: `@ExternalAuthorization(CRYPTO_ASSET, LIST)` on both operations (403 tested over HTTP), `@AuthEndpoint` + `ResourceExtensionService` bean for the role editor's object picker — which honours its filters. Detail/statistics stay 501 (OmniTrustILM/core#2145's scope).

## Review resolution map

- 🔴 quarantined contract mismatch, sort-vs-served-name, offset overflow, refuted-OID-as-name, picker filters, fence-test hardening → commit `eadc62c2`.
- 🔴 facet array-value inversion (+ carve-out disarm compound), free-text multi-value, literal-vs-bound pattern, migration-premise javadoc, `%` positive control, untested carve-out branches → commit `ef9177a6`.
- 🟡 `count(DISTINCT)` and the eight unbounded `SELECT DISTINCT` value scans → commit `da770563`.
- 🟡 cross-resource CBOM serial list → scoped in `eadc62c2`; **size** remains unbounded for a permitted caller — a cap is a contract change, sign-off still requested.
- 🟡 `hasObjectAccess` → OmniTrustILM/interfaces#924 (lock-step release is its AC). `@AuthEndpoint` stays: the ticket text mandates the synced listing endpoint; until the flag ships, `/v1/resources` errs on the hidden side.
- Both-null / refuted-nameless `name` residual → OmniTrustILM/interfaces#925 (nullable name, guaranteed fallback, or per-row refuted flag — one to ratify).
- Deep-offset paging → OmniTrustILM/core#2169 (keyset story, with the review's measurements).
- Curve class representatives → deferral adjudicated on the thread; OmniTrustILM/core#2166 extended (folding landing spot, saved-view JSONB rot, re-key consequence). **Asking the ticket owner to move that AC checkbox from OmniTrustILM/core#2074 to OmniTrustILM/core#2166 so #2074 can close honestly.**
- OmniTrustILM/core#2165 occurrence-triple coupling → noted on that ticket (`occurrenceCount` is now client-facing).
- **Pushback, one item**: withholding `CBOM_ASSET_RULESET_VERSION` until the stored-int-vs-string ruling — OmniTrustILM/core#2071's AC reads "ruleset_version is written on every insert and update; **a row keyed under an older ruleset is findable by query**", so the field stays served. The R3 ripple (NUMBER→STRING would change the advertised operator set and rot saved numeric conditions) stands as this PR's known coupling.
- Sonar's clustered `S5778` lambdas restructured (single throwing invocation per assertion) across the flagged tests.

## Review notes that remain decisions

1. **Migration comment drift:** `V202608271000`'s "never emits lower()" premise is superseded — correction now lives in the free-text predicate's javadoc (with the review's prefix-LIKE finding: a future index story needs trigram GIN for infix AND `text_pattern_ops` for prefix). The applied file stays untouched (Flyway checksum).
2. **Sort refused with 422 by ratified v1 design**; OmniTrustILM/core#2157 landed the mechanism with no service wired yet. Related platform trap (unchanged here): OmniTrustILM/core#2158 saved views validate sort by catalogue membership only, so a view can persist a sort this endpoint refuses — needs a platform decision (view-save learns sortability, or listings accept sort).
3. **Serial value list size** (see resolution map) — sign-off requested.
4. **`ruleset_version` NUMBER filter** — kept per OmniTrustILM/core#2071 AC; R3 ripple documented.

## Validation

- All six changed/new integration suites green at final HEAD, including the review-driven regression tests (facet inversion compound, served-name ordering, per-guard quarantined, offset wrap, scoped serial list over HTTP both ways, exact-key wire fence).
- Full `-Ptest-non-integration` group at final HEAD: green apart from the two known environmental `ProxyPropertiesTest` hostname failures on the dev machine (`mezeq` unresolvable).
- spotless + checkstyle clean; ContextSignatureGuard baseline unchanged; NativeQuerySchemaArchTest green over the new native value queries.
- CI on the PR: all checks green including Sonar (96.6% new-code coverage before this round; gate re-runs on push).

Link: OmniTrustILM/core#2074

🤖 Generated with [Claude Code](https://claude.com/claude-code)
