### PR TITLE
Repair the primitive identity helpers for core#2165 (1 of 2, must land before core#2170)

### DIFF
--- a/src/main/java/com/otilm/core/cbom/asset/identity/AsciiText.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/AsciiText.java
@@ -30,7 +30,29 @@ import java.util.regex.Pattern;
  */
 public final class AsciiText {
 
-    private static final Pattern LOOKUP_SEPARATORS = Pattern.compile("[\\s_\\-/]+");
+    /**
+     * The whitespace the reference strips and collapses, which is not the whitespace Java strips.
+     *
+     * <p>
+     * Measured over the whole BMP, the two definitions disagree on exactly four code points, all in one direction:
+     * {@code U+0085 NEXT LINE}, {@code U+00A0 NO-BREAK SPACE}, {@code U+2007 FIGURE SPACE} and
+     * {@code U+202F NARROW NO-BREAK SPACE} are whitespace to the reference and are not whitespace to
+     * {@link Character#isWhitespace}, which is what {@link String#strip()} consults. Nothing runs the other way --
+     * every character the JDK calls whitespace is in this set -- so substituting {@link #strip} for the JDK's is always
+     * safe. {@code U+200B ZERO WIDTH SPACE} is correctly whitespace to neither.
+     *
+     * <p>
+     * The no-break spaces are exactly the ones that occur in producer text pasted out of documents. A trailing one
+     * survives {@code String.strip()}, and NFKC then turns it into an ordinary trailing space, keying {@code "RSA "}
+     * apart from {@code "RSA"}: a silent inventory split on a formatting accident.
+     */
+    private static final String PYTHON_WHITESPACE = " \t\n\u000B\f\r\u001C\u001D\u001E\u001F\u0085\u00A0"
+            + "\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u2029"
+            + "\u202F\u205F\u3000";
+
+    private static final Pattern LOOKUP_SEPARATORS = Pattern.compile("[" + PYTHON_WHITESPACE + "_\\-/]+");
+
+    private static final Pattern WHITESPACE_RUN = Pattern.compile("[" + PYTHON_WHITESPACE + "]+");
 
     private AsciiText() {
     }
@@ -98,28 +120,6 @@ public final class AsciiText {
         }
         return true;
     }
-
-    /**
-     * The whitespace the reference strips and collapses, which is not the whitespace Java strips.
-     *
-     * <p>
-     * Measured over the whole BMP, the two definitions disagree on exactly four code points, all in one direction:
-     * {@code U+0085 NEXT LINE}, {@code U+00A0 NO-BREAK SPACE}, {@code U+2007 FIGURE SPACE} and
-     * {@code U+202F NARROW NO-BREAK SPACE} are whitespace to the reference and are not whitespace to
-     * {@link Character#isWhitespace}, which is what {@link String#strip()} consults. Nothing runs the other way --
-     * every character the JDK calls whitespace is in this set -- so substituting {@link #strip} for the JDK's is always
-     * safe. {@code U+200B ZERO WIDTH SPACE} is correctly whitespace to neither.
-     *
-     * <p>
-     * Two of the three -- the no-break spaces -- are exactly the ones that occur in producer text pasted out of
-     * documents. A trailing one survives {@code String.strip()}, and NFKC then turns it into an ordinary trailing
-     * space, keying {@code "RSA "} apart from {@code "RSA"}: a silent inventory split on a formatting accident.
-     */
-    private static final String PYTHON_WHITESPACE = " \t\n\u000B\f\r\u001C\u001D\u001E\u001F\u0085\u00A0"
-            + "\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u2029"
-            + "\u202F\u205F\u3000";
-
-    private static final Pattern WHITESPACE_RUN = Pattern.compile("[" + PYTHON_WHITESPACE + "]+");
 
     /** Strips leading and trailing whitespace as the reference defines it, not as the JDK defines it. */
     public static String strip(String text) {

--- a/src/main/java/com/otilm/core/cbom/asset/identity/AsciiText.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/AsciiText.java
@@ -1,5 +1,6 @@
 package com.otilm.core.cbom.asset.identity;
 
+import java.util.Comparator;
 import java.util.regex.Pattern;
 
 /**
@@ -53,6 +54,35 @@ public final class AsciiText {
     private static final Pattern LOOKUP_SEPARATORS = Pattern.compile("[" + PYTHON_WHITESPACE + "_\\-/]+");
 
     private static final Pattern WHITESPACE_RUN = Pattern.compile("[" + PYTHON_WHITESPACE + "]+");
+
+    /**
+     * Orders by code point, so an astral character sorts above every basic-plane one, as the reference does.
+     *
+     * <p>
+     * Java's natural {@code String} order compares UTF-16 units, which sorts a supplementary character <em>below</em>
+     * {@code U+E000}-{@code U+FFFF}, because its high surrogate is {@code U+D800}-{@code U+DBFF}. Every sorted sequence
+     * that reaches a pre-image or a canonical rendering has to use this instead of {@code compareTo} or a bare
+     * {@code TreeSet}.
+     *
+     * <p>
+     * It lives here rather than in any one of its callers because all of them are load-bearing for byte-exactness, so a
+     * correction has to land in one place. Three sequences depend on it today: canonical object member order, the
+     * occurrence triples, and the cipher-suite tokens.
+     */
+    public static final Comparator<String> BY_CODE_POINT = (left, right) -> {
+        int leftIndex = 0;
+        int rightIndex = 0;
+        while (leftIndex < left.length() && rightIndex < right.length()) {
+            int leftPoint = left.codePointAt(leftIndex);
+            int rightPoint = right.codePointAt(rightIndex);
+            if (leftPoint != rightPoint) {
+                return Integer.compare(leftPoint, rightPoint);
+            }
+            leftIndex += Character.charCount(leftPoint);
+            rightIndex += Character.charCount(rightPoint);
+        }
+        return Integer.compare(left.length() - leftIndex, right.length() - rightIndex);
+    };
 
     private AsciiText() {
     }

--- a/src/main/java/com/otilm/core/cbom/asset/identity/CanonicalJson.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/CanonicalJson.java
@@ -8,7 +8,6 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -50,22 +49,6 @@ public final class CanonicalJson {
     private static final Set<String> REFERENCE_FIELDS = Set
             .of("algorithmRef", "signatureAlgorithmRef", "subjectPublicKeyRef", "cryptoRefArray",
                     "relatedCryptographicAssets", "relatedCryptographicAsset");
-
-    /** Compares by code point, so an astral character sorts above every basic-plane one, as the reference does. */
-    private static final Comparator<String> BY_CODE_POINT = (left, right) -> {
-        int leftIndex = 0;
-        int rightIndex = 0;
-        while (leftIndex < left.length() && rightIndex < right.length()) {
-            int leftPoint = left.codePointAt(leftIndex);
-            int rightPoint = right.codePointAt(rightIndex);
-            if (leftPoint != rightPoint) {
-                return Integer.compare(leftPoint, rightPoint);
-            }
-            leftIndex += Character.charCount(leftPoint);
-            rightIndex += Character.charCount(rightPoint);
-        }
-        return Integer.compare(left.length() - leftIndex, right.length() - rightIndex);
-    };
 
     private CanonicalJson() {
     }
@@ -142,7 +125,7 @@ public final class CanonicalJson {
         if (node.isObject()) {
             List<String> names = new ArrayList<>(node.properties().size());
             node.properties().forEach(field -> names.add(field.getKey()));
-            names.sort(BY_CODE_POINT);
+            names.sort(AsciiText.BY_CODE_POINT);
             out.append('{');
             for (int index = 0; index < names.size(); index++) {
                 if (index > 0) {

--- a/src/main/java/com/otilm/core/cbom/asset/identity/CertificateDigests.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/CertificateDigests.java
@@ -75,26 +75,8 @@ public final class CertificateDigests {
         if (hashes == null || !hashes.isArray()) {
             return null;
         }
-        Map<String, String> byAlgorithm = new LinkedHashMap<>();
         Set<String> contradicted = new HashSet<>();
-        for (JsonNode hash : hashes) {
-            if (!hash.isObject()) {
-                continue;
-            }
-            JsonNode algorithm = hash.get("alg");
-            JsonNode content = hash.get("content");
-            String normalizedAlgorithm = AsciiText
-                    .upper(AsciiText.strip(algorithm == null || algorithm.isNull() ? "" : algorithm.asText()));
-            String normalizedContent = AsciiText
-                    .fold(AsciiText.strip(content == null || content.isNull() ? "" : content.asText()));
-            if (normalizedContent.isEmpty()) {
-                continue;
-            }
-            String existing = byAlgorithm.putIfAbsent(normalizedAlgorithm, normalizedContent);
-            if (existing != null && !existing.equals(normalizedContent)) {
-                contradicted.add(normalizedAlgorithm);
-            }
-        }
+        Map<String, String> byAlgorithm = collectHashes(hashes, contradicted);
         for (String algorithm : PREFERENCE) {
             String content = byAlgorithm.get(algorithm);
             if (content != null && !contradicted.contains(algorithm)) {
@@ -102,6 +84,45 @@ public final class CertificateDigests {
             }
         }
         return null;
+    }
+
+    /**
+     * The first non-empty content each algorithm claims, recording into {@code contradicted} any algorithm that claimed
+     * two different ones.
+     *
+     * <p>
+     * An entry with no content does not decide and does not shadow one that does, so a trailing empty entry cannot
+     * demote an algorithm to the next preference and a leading one cannot suppress the real digest behind it. Empty is
+     * not a contradiction either: a producer that said nothing has not said something different.
+     */
+    private static Map<String, String> collectHashes(JsonNode hashes, Set<String> contradicted) {
+        Map<String, String> byAlgorithm = new LinkedHashMap<>();
+        for (JsonNode hash : hashes) {
+            String normalizedContent = normalized(hash, "content", false);
+            if (normalizedContent == null || normalizedContent.isEmpty()) {
+                continue;
+            }
+            String normalizedAlgorithm = normalized(hash, "alg", true);
+            String existing = byAlgorithm.putIfAbsent(normalizedAlgorithm, normalizedContent);
+            if (existing != null && !existing.equals(normalizedContent)) {
+                contradicted.add(normalizedAlgorithm);
+            }
+        }
+        return byAlgorithm;
+    }
+
+    /**
+     * One field of a hash entry, stripped and then cased, or {@code null} when the entry is not an object.
+     *
+     * @param upper {@code true} for the algorithm, which is enum-shaped, {@code false} for content, which is hex
+     */
+    private static String normalized(JsonNode hash, String field, boolean upper) {
+        if (!hash.isObject()) {
+            return null;
+        }
+        JsonNode value = hash.get(field);
+        String text = AsciiText.strip(value == null || value.isNull() ? "" : value.asText());
+        return upper ? AsciiText.upper(text) : AsciiText.fold(text);
     }
 
     /**

--- a/src/main/java/com/otilm/core/cbom/asset/identity/CertificateDigests.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/CertificateDigests.java
@@ -2,9 +2,11 @@ package com.otilm.core.cbom.asset.identity;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /** The content digests a certificate claims, in preference order, reduced to one spelling. */
 public final class CertificateDigests {
@@ -33,8 +35,8 @@ public final class CertificateDigests {
         }
         JsonNode algorithm = fingerprint.get("alg");
         String label = algorithm != null && !algorithm.isNull() ? algorithm.asText() : "sha-256";
-        return AsciiText.fold(AsciiText.strip(label)) + ":"
-                + AsciiText.fold(AsciiText.strip(fingerprint.get(CbomNames.CONTENT).asText()));
+        return claim(AsciiText.fold(AsciiText.strip(label)),
+                AsciiText.fold(AsciiText.strip(fingerprint.get(CbomNames.CONTENT).asText())));
     }
 
     /**
@@ -72,23 +74,59 @@ public final class CertificateDigests {
             return null;
         }
         Map<String, String> byAlgorithm = new LinkedHashMap<>();
+        Set<String> contradicted = new HashSet<>();
         for (JsonNode hash : hashes) {
             if (!hash.isObject()) {
                 continue;
             }
             JsonNode algorithm = hash.get("alg");
             JsonNode content = hash.get("content");
-            byAlgorithm
-                    .put(AsciiText.upper(algorithm == null || algorithm.isNull() ? "" : algorithm.asText()),
-                            AsciiText.fold(content == null || content.isNull() ? "" : content.asText()));
+            String normalizedAlgorithm = AsciiText
+                    .upper(AsciiText.strip(algorithm == null || algorithm.isNull() ? "" : algorithm.asText()));
+            String normalizedContent = AsciiText
+                    .fold(AsciiText.strip(content == null || content.isNull() ? "" : content.asText()));
+            if (normalizedContent.isEmpty()) {
+                continue;
+            }
+            String existing = byAlgorithm.putIfAbsent(normalizedAlgorithm, normalizedContent);
+            if (existing != null && !existing.equals(normalizedContent)) {
+                contradicted.add(normalizedAlgorithm);
+            }
         }
         for (String algorithm : PREFERENCE) {
             String content = byAlgorithm.get(algorithm);
-            if (content != null && !content.isEmpty()) {
-                return AsciiText.fold(algorithm) + ":" + content;
+            if (content != null && !contradicted.contains(algorithm)) {
+                return claim(AsciiText.fold(algorithm), content);
             }
         }
         return null;
+    }
+
+    private static String claim(String algorithm, String content) {
+        return digestPart(algorithm) + ":" + digestPart(content);
+    }
+
+    private static String digestPart(String value) {
+        StringBuilder escaped = null;
+        for (int index = 0; index < value.length(); index++) {
+            char character = value.charAt(index);
+            String replacement = switch (character) {
+                case '%' -> "%25";
+                case ':' -> "%3A";
+                default -> null;
+            };
+            if (replacement == null) {
+                if (escaped != null) {
+                    escaped.append(character);
+                }
+                continue;
+            }
+            if (escaped == null) {
+                escaped = new StringBuilder(value.length() + 8).append(value, 0, index);
+            }
+            escaped.append(replacement);
+        }
+        return escaped == null ? value : escaped.toString();
     }
 
     static boolean isPresent(JsonNode node) {

--- a/src/main/java/com/otilm/core/cbom/asset/identity/CertificateDigests.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/CertificateDigests.java
@@ -37,10 +37,10 @@ public final class CertificateDigests {
         }
         JsonNode contentNode = fingerprint.get(CbomNames.CONTENT);
         if (contentNode == null || !contentNode.isTextual()) {
-            // Textual only, and blank-checked after the strip rather than before it. isPresent tests asText() on the
-            // raw node, so " " passed it and rendered the claim "sha-256:" -- and two unrelated certificates then
-            // shared that first preference-order claim and merged onto one content-digest tier. A boolean or numeric
-            // content passed it too, keying on "true".
+            // Textual only, and blank-checked after the strip rather than before it. The predecessor tested asText()
+            // on the raw node, so " " passed it and rendered the claim "sha-256:" -- and two unrelated certificates
+            // then shared that first preference-order claim and merged onto one content-digest tier. A boolean or
+            // numeric content passed it too, keying on "true".
             return null;
         }
         String content = AsciiText.fold(AsciiText.strip(contentNode.textValue()));
@@ -186,7 +186,4 @@ public final class CertificateDigests {
         };
     }
 
-    static boolean isPresent(JsonNode node) {
-        return node != null && !node.isNull() && !node.asText().isEmpty();
-    }
 }

--- a/src/main/java/com/otilm/core/cbom/asset/identity/CertificateDigests.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/CertificateDigests.java
@@ -134,10 +134,7 @@ public final class CertificateDigests {
     private static Map<String, String> collectHashes(JsonNode hashes, Set<String> contradicted) {
         Map<String, String> byAlgorithm = new LinkedHashMap<>();
         for (JsonNode hash : hashes) {
-            if (!hash.isObject()) {
-                continue;
-            }
-            String content = textual(hash.get("content"));
+            String content = hash.isObject() ? textual(hash.get("content")) : "";
             if (content.isEmpty()) {
                 continue;
             }

--- a/src/main/java/com/otilm/core/cbom/asset/identity/CertificateDigests.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/CertificateDigests.java
@@ -12,7 +12,9 @@ import java.util.Set;
 public final class CertificateDigests {
 
     /**
-     * Strongest first. SHA-1 is last but still accepted: a weak digest still identifies, and refusing it loses a row.
+     * Preferred first, which is not strongest first: {@code SHA-256} leads because it is what producers actually emit,
+     * and reordering would re-key every certificate claiming more than one digest. SHA-1 is last but still accepted --
+     * a weak digest still identifies, and refusing it loses a row.
      */
     private static final List<String> PREFERENCE = List.of("SHA-256", "SHA-384", "SHA-512", "SHA-1");
 
@@ -102,31 +104,30 @@ public final class CertificateDigests {
         return null;
     }
 
+    /**
+     * Joins an algorithm to its content so neither half can forge the boundary between them.
+     *
+     * <p>
+     * {@code alg} is producer-controlled, so a bare join let {@code {"alg":"sha-256:aabbcc","content":"dd"}} and
+     * {@code {"alg":"sha-256","content":"aabbcc:dd"}} render one string and collapse two certificates onto one key.
+     *
+     * <p>
+     * The {@code :} belongs to this layer and not to {@link PreImageSlot}: the claim later enters a {@code |}-delimited
+     * outer slot through {@link PreImageSlot#of}, and teaching that the {@code :} would escape this separator too,
+     * erasing the distinction it exists to draw. The consequence is that the pre-image carries the doubly-escaped
+     * spelling {@code %253A} rather than {@code %3A} -- see {@link PreImageSlot#escape}.
+     */
     private static String claim(String algorithm, String content) {
-        return digestPart(algorithm) + ":" + digestPart(content);
+        return PreImageSlot.escape(algorithm, CertificateDigests::digestEscapeFor) + ":"
+                + PreImageSlot.escape(content, CertificateDigests::digestEscapeFor);
     }
 
-    private static String digestPart(String value) {
-        StringBuilder escaped = null;
-        for (int index = 0; index < value.length(); index++) {
-            char character = value.charAt(index);
-            String replacement = switch (character) {
-                case '%' -> "%25";
-                case ':' -> "%3A";
-                default -> null;
-            };
-            if (replacement == null) {
-                if (escaped != null) {
-                    escaped.append(character);
-                }
-                continue;
-            }
-            if (escaped == null) {
-                escaped = new StringBuilder(value.length() + 8).append(value, 0, index);
-            }
-            escaped.append(replacement);
-        }
-        return escaped == null ? value : escaped.toString();
+    private static String digestEscapeFor(char character) {
+        return switch (character) {
+            case '%' -> "%25";
+            case ':' -> "%3A";
+            default -> null;
+        };
     }
 
     static boolean isPresent(JsonNode node) {

--- a/src/main/java/com/otilm/core/cbom/asset/identity/CertificateDigests.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/CertificateDigests.java
@@ -32,13 +32,46 @@ public final class CertificateDigests {
      */
     public static String fingerprintDigest(JsonNode certificateProperties) {
         JsonNode fingerprint = certificateProperties == null ? null : certificateProperties.get("fingerprint");
-        if (fingerprint == null || !fingerprint.isObject() || !isPresent(fingerprint.get(CbomNames.CONTENT))) {
+        if (fingerprint == null || !fingerprint.isObject()) {
             return null;
         }
+        JsonNode contentNode = fingerprint.get(CbomNames.CONTENT);
+        if (contentNode == null || !contentNode.isTextual()) {
+            // Textual only, and blank-checked after the strip rather than before it. isPresent tests asText() on the
+            // raw node, so " " passed it and rendered the claim "sha-256:" -- and two unrelated certificates then
+            // shared that first preference-order claim and merged onto one content-digest tier. A boolean or numeric
+            // content passed it too, keying on "true".
+            return null;
+        }
+        String content = AsciiText.fold(AsciiText.strip(contentNode.textValue()));
+        if (content.isEmpty()) {
+            return null;
+        }
+        // A container alg made the "sha-256" default unreachable and rendered the claim ":aa", because asText() on an
+        // object or array yields the empty string rather than null.
         JsonNode algorithm = fingerprint.get("alg");
-        String label = algorithm != null && !algorithm.isNull() ? algorithm.asText() : "sha-256";
-        return claim(AsciiText.fold(AsciiText.strip(label)),
-                AsciiText.fold(AsciiText.strip(fingerprint.get(CbomNames.CONTENT).asText())));
+        String label = algorithm != null && algorithm.isTextual() ? algorithm.textValue() : "sha-256";
+        return claim(canonicalLabel(label), content);
+    }
+
+    /**
+     * The {@link #PREFERENCE} spelling of a digest label, or the producer's own folded spelling when it names no known
+     * algorithm.
+     *
+     * <p>
+     * Both channels route through here so one certificate cannot fork on how its label was written. A 1.7 producer
+     * emitting {@code alg: "SHA256"} and a 1.6 producer emitting {@code alg: "SHA-256"} over the same certificate bytes
+     * were keying two different assets, and an alias spelling inside {@code hashes[]} yielded no digest tier at all
+     * because {@code PREFERENCE} holds only the canonical spellings.
+     */
+    private static String canonicalLabel(String label) {
+        String lookup = AsciiText.lookupKey(label);
+        for (String preferred : PREFERENCE) {
+            if (AsciiText.lookupKey(preferred).equals(lookup)) {
+                return AsciiText.fold(preferred);
+            }
+        }
+        return AsciiText.fold(AsciiText.strip(label));
     }
 
     /**
@@ -98,31 +131,33 @@ public final class CertificateDigests {
     private static Map<String, String> collectHashes(JsonNode hashes, Set<String> contradicted) {
         Map<String, String> byAlgorithm = new LinkedHashMap<>();
         for (JsonNode hash : hashes) {
-            String normalizedContent = normalized(hash, "content", false);
-            if (normalizedContent == null || normalizedContent.isEmpty()) {
+            if (!hash.isObject()) {
                 continue;
             }
-            String normalizedAlgorithm = normalized(hash, "alg", true);
-            String existing = byAlgorithm.putIfAbsent(normalizedAlgorithm, normalizedContent);
-            if (existing != null && !existing.equals(normalizedContent)) {
-                contradicted.add(normalizedAlgorithm);
+            String content = textual(hash.get("content"));
+            if (content.isEmpty()) {
+                continue;
+            }
+            String algorithm = AsciiText.upper(canonicalLabel(textual(hash.get("alg"))));
+            String existing = byAlgorithm.putIfAbsent(algorithm, content);
+            if (existing != null && !existing.equals(content)) {
+                contradicted.add(algorithm);
             }
         }
         return byAlgorithm;
     }
 
     /**
-     * One field of a hash entry, stripped and then cased, or {@code null} when the entry is not an object.
+     * One textual field of a hash entry, stripped and ASCII-folded, or the empty string when it is absent or not text.
      *
-     * @param upper {@code true} for the algorithm, which is enum-shaped, {@code false} for content, which is hex
+     * <p>
+     * The algorithm is keyed through {@link #canonicalLabel} rather than on its own spelling. Keying it on
+     * {@code upper(strip(alg))} let an alias escape the contradiction guard entirely: a certificate stating
+     * {@code SHA256:aa} and {@code SHA-256:bb} produced two different map entries, so neither was recorded as
+     * contradicted and the second silently won -- the exact case the guard exists to refuse.
      */
-    private static String normalized(JsonNode hash, String field, boolean upper) {
-        if (!hash.isObject()) {
-            return null;
-        }
-        JsonNode value = hash.get(field);
-        String text = AsciiText.strip(value == null || value.isNull() ? "" : value.asText());
-        return upper ? AsciiText.upper(text) : AsciiText.fold(text);
+    private static String textual(JsonNode value) {
+        return value == null || !value.isTextual() ? "" : AsciiText.fold(AsciiText.strip(value.textValue()));
     }
 
     /**

--- a/src/main/java/com/otilm/core/cbom/asset/identity/CertificateDigests.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/CertificateDigests.java
@@ -48,10 +48,13 @@ public final class CertificateDigests {
             return null;
         }
         // A container alg made the "sha-256" default unreachable and rendered the claim ":aa", because asText() on an
-        // object or array yields the empty string rather than null.
+        // object or array yields the empty string rather than null. A blank textual alg reached the same claim by the
+        // other side: isTextual() is true, so the default was skipped and the label folded to "" -- and one
+        // certificate then forked between ":aa" and "sha-256:aa" on whether its alg was blank or absent, which are two
+        // spellings of the same silence. Blank-checked after the fold, the way the content is twelve lines up.
         JsonNode algorithm = fingerprint.get("alg");
-        String label = algorithm != null && algorithm.isTextual() ? algorithm.textValue() : "sha-256";
-        return claim(canonicalLabel(label), content);
+        String label = algorithm != null && algorithm.isTextual() ? canonicalLabel(algorithm.textValue()) : "";
+        return claim(label.isEmpty() ? AsciiText.fold("sha-256") : label, content);
     }
 
     /**

--- a/src/main/java/com/otilm/core/cbom/asset/identity/CipherSuites.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/CipherSuites.java
@@ -3,6 +3,7 @@ package com.otilm.core.cbom.asset.identity;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Pattern;
 
 /**
  * Cipher-suite identifiers, reduced to IANA codes -- never bom-refs, never raw suite names.
@@ -15,6 +16,10 @@ import java.util.TreeSet;
  * identifiers are the code bytes, so they are stable.
  */
 public final class CipherSuites {
+
+    private static final Pattern HEX_DIGITS = Pattern.compile("[0-9a-f]+");
+
+    private static final int MAX_CODE_UNIT = 0xFFFF;
 
     private CipherSuites() {
     }
@@ -47,9 +52,21 @@ public final class CipherSuites {
                 if (trimmed.isEmpty()) {
                     continue;
                 }
-                String digits = AsciiText.fold(trimmed).startsWith("0x") ? trimmed.substring(2) : trimmed;
+                String folded = AsciiText.fold(trimmed);
+                if (folded.startsWith("+") || folded.startsWith("-")) {
+                    return null;
+                }
+                String digits = folded.startsWith("0x") ? folded.substring(2) : folded;
+                if (!HEX_DIGITS.matcher(digits).matches()) {
+                    return null;
+                }
                 try {
-                    octets.append(String.format("%02x", Integer.parseInt(digits, 16)));
+                    int value = Integer.parseInt(digits, 16);
+                    if (value > MAX_CODE_UNIT) {
+                        return null;
+                    }
+                    String hex = Integer.toHexString(value);
+                    octets.append(hex.length() % 2 == 0 ? hex : "0" + hex);
                 } catch (NumberFormatException e) {
                     // A list this implementation cannot read yields no code at all rather than a partial one. The
                     // caller falls back to the suite name, which is what keeps "we know it has suites and cannot read

--- a/src/main/java/com/otilm/core/cbom/asset/identity/CipherSuites.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/CipherSuites.java
@@ -41,10 +41,15 @@ public final class CipherSuites {
      *
      * <p>
      * <b>The join is not injective for odd-width tokens, and cannot be made so here.</b> Even-width padding is what
-     * merges {@code ["0x13", "0x1"]} with {@code ["0x1301"]}; the price is that {@code ["0x131", "0x1"]} and
-     * {@code ["0x01", "0x3101"]} both render {@code 013101}. Nothing in the token stream says whether a token is one
-     * byte or a whole code, so no rendering separates those two without breaking the merge this exists for. No such
-     * list occurs in the 2026-08-31 corpus; a document that emits one keys two suite sets alike.
+     * merges {@code ["0x13", "0x1"]} with {@code ["0x1301"]}.
+     *
+     * <p>
+     * <b>Grouping is not identity.</b> Because every token renders to a whole number of octets, the result is the
+     * declaration's <em>byte stream</em> and nothing else: {@code ["0x131", "0x1"]} and {@code ["0x01", "0x3101"]} both
+     * render {@code 013101} because both state the bytes {@code 01 31 01}. That is the same equivalence that merges the
+     * four spellings above, not a collision beside it -- two lists keying alike means they said the same bytes. What
+     * would be a defect is a token rendering to half an octet, which is what the unpadded {@code %02x} did to
+     * {@code 0x131}: {@code 131} is not a byte stream at all, so the concatenation stopped meaning anything.
      */
     public static String code(JsonNode identifiers) {
         if (identifiers == null || !identifiers.isArray()) {
@@ -57,35 +62,57 @@ public final class CipherSuites {
                 // so a malformed list impersonated a real suite. All-or-nothing means the malformed element decides.
                 return null;
             }
-            for (String token : element.textValue().split(",")) {
-                String trimmed = AsciiText.strip(token);
-                if (trimmed.isEmpty()) {
-                    continue;
-                }
-                String folded = AsciiText.fold(trimmed);
-                if (folded.startsWith("+") || folded.startsWith("-")) {
-                    return null;
-                }
-                String digits = folded.startsWith("0x") ? folded.substring(2) : folded;
-                if (!HEX_DIGITS.matcher(digits).matches()) {
-                    return null;
-                }
-                try {
-                    int value = Integer.parseInt(digits, 16);
-                    if (value > MAX_CODE_UNIT) {
-                        return null;
-                    }
-                    String hex = Integer.toHexString(value);
-                    octets.append(hex.length() % 2 == 0 ? hex : "0" + hex);
-                } catch (NumberFormatException e) {
-                    // A list this implementation cannot read yields no code at all rather than a partial one. The
-                    // caller falls back to the suite name, which is what keeps "we know it has suites and cannot read
-                    // them" apart from "nothing was said".
-                    return null;
-                }
+            if (!appendOctets(element.textValue(), octets)) {
+                return null;
             }
         }
         return octets.isEmpty() ? null : octets.toString();
+    }
+
+    /** Appends every token of one element, or returns {@code false} for a list this implementation cannot read. */
+    private static boolean appendOctets(String element, StringBuilder octets) {
+        for (String token : element.split(",")) {
+            String trimmed = AsciiText.strip(token);
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            String hex = octetsOf(trimmed);
+            if (hex == null) {
+                return false;
+            }
+            octets.append(hex);
+        }
+        return true;
+    }
+
+    /**
+     * One token as an even number of lowercase hex digits, or {@code null} when it is not a readable code unit.
+     *
+     * <p>
+     * A token this implementation cannot read yields no code for the whole list rather than a partial one. The caller
+     * falls back to the suite name, which is what keeps "we know it has suites and cannot read them" apart from
+     * "nothing was said".
+     */
+    private static String octetsOf(String token) {
+        String folded = AsciiText.fold(token);
+        if (folded.startsWith("+") || folded.startsWith("-")) {
+            return null;
+        }
+        String digits = folded.startsWith("0x") ? folded.substring(2) : folded;
+        if (!HEX_DIGITS.matcher(digits).matches()) {
+            return null;
+        }
+        try {
+            int value = Integer.parseInt(digits, 16);
+            if (value > MAX_CODE_UNIT) {
+                return null;
+            }
+            String hex = Integer.toHexString(value);
+            return hex.length() % 2 == 0 ? hex : "0" + hex;
+        } catch (NumberFormatException e) {
+            // More hex digits than an int holds. HEX_DIGITS already passed, so this is length alone.
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/com/otilm/core/cbom/asset/identity/CipherSuites.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/CipherSuites.java
@@ -28,13 +28,23 @@ public final class CipherSuites {
      * Normalizes an identifier list to its IANA code as lowercase hex, or {@code null}.
      *
      * <p>
-     * Three encodings occur in real documents and all three must land on the same code: one element per byte unpadded
-     * ({@code ["0x13", "0x1"]}), one element per byte padded ({@code ["0xC0", "0x30"]}), and both bytes comma-packed
-     * into a single element ({@code "0x13,0x02"}).
+     * Four encodings occur in real documents and all four must land on the same code: one element per byte unpadded
+     * ({@code ["0x13", "0x1"]}), one element per byte padded ({@code ["0xC0", "0x30"]}), both bytes comma-packed into a
+     * single element ({@code "0x13,0x02"}), and the whole two-byte code in one token ({@code ["0x1301"]}, which
+     * CycloneDX's own {@code valid-cryptography-full-1.7} conformance fixture emits). Rendering each token to an even
+     * hex width is what merges them; a one-octet parser splits that fixture's TLS 1.3 suite from every per-byte
+     * spelling of it.
      *
      * <p>
      * Bytes are joined in <b>array order, before any sorting</b>, because flattening across suites collides:
      * {@code {0xC02B, 0x1301}} and {@code {0xC001, 0x132B}} share a byte multiset and would otherwise hash alike.
+     *
+     * <p>
+     * <b>The join is not injective for odd-width tokens, and cannot be made so here.</b> Even-width padding is what
+     * merges {@code ["0x13", "0x1"]} with {@code ["0x1301"]}; the price is that {@code ["0x131", "0x1"]} and
+     * {@code ["0x01", "0x3101"]} both render {@code 013101}. Nothing in the token stream says whether a token is one
+     * byte or a whole code, so no rendering separates those two without breaking the merge this exists for. No such
+     * list occurs in the 2026-08-31 corpus; a document that emits one keys two suite sets alike.
      */
     public static String code(JsonNode identifiers) {
         if (identifiers == null || !identifiers.isArray()) {

--- a/src/main/java/com/otilm/core/cbom/asset/identity/CipherSuites.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/CipherSuites.java
@@ -40,10 +40,6 @@ public final class CipherSuites {
      * {@code {0xC02B, 0x1301}} and {@code {0xC001, 0x132B}} share a byte multiset and would otherwise hash alike.
      *
      * <p>
-     * <b>The join is not injective for odd-width tokens, and cannot be made so here.</b> Even-width padding is what
-     * merges {@code ["0x13", "0x1"]} with {@code ["0x1301"]}.
-     *
-     * <p>
      * <b>Grouping is not identity.</b> Because every token renders to a whole number of octets, the result is the
      * declaration's <em>byte stream</em> and nothing else: {@code ["0x131", "0x1"]} and {@code ["0x01", "0x3101"]} both
      * render {@code 013101} because both state the bytes {@code 01 31 01}. That is the same equivalence that merges the
@@ -76,7 +72,7 @@ public final class CipherSuites {
             if (trimmed.isEmpty()) {
                 continue;
             }
-            String hex = octetsOf(trimmed);
+            String hex = octetsOf(AsciiText.fold(trimmed));
             if (hex == null) {
                 return false;
             }
@@ -86,15 +82,17 @@ public final class CipherSuites {
     }
 
     /**
-     * One token as an even number of lowercase hex digits, or {@code null} when it is not a readable code unit.
+     * One folded token as an even number of lowercase hex digits, or {@code null} when it is not a readable code unit.
      *
      * <p>
      * A token this implementation cannot read yields no code for the whole list rather than a partial one. The caller
      * falls back to the suite name, which is what keeps "we know it has suites and cannot read them" apart from
      * "nothing was said".
+     *
+     * @param folded a non-empty token, already ASCII-folded by the caller -- the case fold stays there because that is
+     * where the token is known to be present, and this method is about hex rather than about case
      */
-    private static String octetsOf(String token) {
-        String folded = AsciiText.fold(token);
+    private static String octetsOf(String folded) {
         if (folded.startsWith("+") || folded.startsWith("-")) {
             return null;
         }

--- a/src/main/java/com/otilm/core/cbom/asset/identity/CipherSuites.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/CipherSuites.java
@@ -36,6 +36,14 @@ public final class CipherSuites {
      * spelling of it.
      *
      * <p>
+     * The width is the <b>producer's</b>, rounded up to a whole octet -- never the width of the parsed value.
+     * {@code Integer.toHexString} drops leading zeros, so padding its output restored a nibble instead of an octet and
+     * the merge held only for a non-zero high byte: {@code ["0x002F"]} rendered {@code 2f} where
+     * {@code ["0x00", "0x2F"]} rendered {@code 002f}. That forked every suite in {@code 0x0000}-{@code 0x00FF} between
+     * its two spellings -- the classic TLS block, {@code 0x002F} {@code TLS_RSA_WITH_AES_128_CBC_SHA} among them -- and
+     * also let a packed {@code 0x002F} collide with a malformed one-byte {@code ["0x2F"]}.
+     *
+     * <p>
      * Bytes are joined in <b>array order, before any sorting</b>, because flattening across suites collides:
      * {@code {0xC02B, 0x1301}} and {@code {0xC001, 0x132B}} share a byte multiset and would otherwise hash alike.
      *
@@ -67,10 +75,15 @@ public final class CipherSuites {
 
     /** Appends every token of one element, or returns {@code false} for a list this implementation cannot read. */
     private static boolean appendOctets(String element, StringBuilder octets) {
-        for (String token : element.split(",")) {
+        // Limit -1 keeps trailing empty tokens, which the default drops: "," split with the default yields no tokens
+        // at all, so the blank check below never saw it and the element contributed nothing silently.
+        for (String token : element.split(",", -1)) {
             String trimmed = AsciiText.strip(token);
             if (trimmed.isEmpty()) {
-                continue;
+                // Skipped, a blank token made ["0x13","","0x01"] render byte-identically to the well-formed
+                // ["0x13","0x01"], which is the impersonation the non-textual branch above refuses. The two rules
+                // now agree: anything in the list this implementation cannot read costs the whole code.
+                return false;
             }
             String hex = octetsOf(AsciiText.fold(trimmed));
             if (hex == null) {
@@ -105,8 +118,13 @@ public final class CipherSuites {
             if (value > MAX_CODE_UNIT) {
                 return null;
             }
+            // The producer's own width, rounded up to a whole octet -- not the width of the parsed value.
+            // Integer.toHexString drops leading zeros, so padding its result restored a nibble rather than an
+            // octet: ["0x002F"] rendered 2f where ["0x00","0x2F"] rendered 002f, forking every suite in
+            // 0x0000-0x00FF -- the classic TLS block -- between its packed and per-byte spellings.
+            int width = digits.length() + (digits.length() & 1);
             String hex = Integer.toHexString(value);
-            return hex.length() % 2 == 0 ? hex : "0" + hex;
+            return "0".repeat(width - hex.length()) + hex;
         } catch (NumberFormatException e) {
             // More hex digits than an int holds. HEX_DIGITS already passed, so this is length alone.
             return null;
@@ -130,7 +148,9 @@ public final class CipherSuites {
         if (suites == null || !suites.isArray()) {
             return null;
         }
-        TreeSet<String> tokens = new TreeSet<>();
+        // Code-point order, not Java's UTF-16 order: this set is hashed into the protocol tier, and a bare TreeSet
+        // sorted two suite names with astral characters opposite to the way the occurrence triples sort them.
+        TreeSet<String> tokens = new TreeSet<>(AsciiText.BY_CODE_POINT);
         for (JsonNode suite : suites) {
             if (!suite.isObject()) {
                 continue;

--- a/src/main/java/com/otilm/core/cbom/asset/identity/CipherSuites.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/CipherSuites.java
@@ -83,6 +83,13 @@ public final class CipherSuites {
                 // Skipped, a blank token made ["0x13","","0x01"] render byte-identically to the well-formed
                 // ["0x13","0x01"], which is the impersonation the non-textual branch above refuses. The two rules
                 // now agree: anything in the list this implementation cannot read costs the whole code.
+                //
+                // That doctrine is deliberate and it has a cost worth stating: a merely sloppy list pays the same
+                // price as an unreadable one, so ["0x13,"] -- one unambiguous octet with a trailing comma -- yields no
+                // code, and tokens() falls back from c:13 to n:<NAME>, re-keying the protocol tier. Exempting a
+                // leading or trailing empty token would rescue it, at the price of a rule with two halves: an empty
+                // token is either readable or it is not, and deciding by position is a guess about producer intent.
+                // One rule, uniformly fail-closed, is the arm chosen here.
                 return false;
             }
             String hex = octetsOf(AsciiText.fold(trimmed));

--- a/src/main/java/com/otilm/core/cbom/asset/identity/MaterialRedaction.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/MaterialRedaction.java
@@ -116,9 +116,10 @@ public final class MaterialRedaction {
         redacted.put("length", length);
         String publishedDigest = digestPublishable(materialType) ? identityDigest : null;
         if (publishedDigest == null) {
-            // No digest at all. An unsalted SHA-256 of a password or a token is rainbow-table reversible, so
-            // publishing it is the same leak one step removed -- and producers really do emit generic-password and
-            // jwt-token material. Identity falls through to the occurrence tier, which the chain already has.
+            // The envelope carries no digest for any type, so this gate no longer decides what is stored -- it decides
+            // what publishedDigest() may hand an internal caller. An unsalted SHA-256 of a password or a token is
+            // rainbow-table reversible, so a caller that put one on an API would leak it one step removed, and
+            // producers really do emit generic-password and jwt-token material.
             findings.add("digest withheld: " + materialType + " is low-entropy material");
         }
         materialNode.set(CbomNames.VALUE, redacted);

--- a/src/main/java/com/otilm/core/cbom/asset/identity/MaterialRedaction.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/MaterialRedaction.java
@@ -87,7 +87,7 @@ public final class MaterialRedaction {
         // Before the value branch, and independent of it. A scanner that fingerprints a detected secret to dedupe its
         // findings emits the same unsalted digest the withhold rule below refuses to publish -- and it does so in a
         // sibling member that the value redaction never touches, on a block that may carry no inlined value at all.
-        withholdFingerprint(materialNode, materialType, findings);
+        dropUncontractedMembers(materialNode, materialType, findings);
 
         if (!materialNode.has(CbomNames.VALUE)) {
             return new MaterialRedaction(payload, materialType, null, null, null, List.copyOf(findings));
@@ -146,47 +146,52 @@ public final class MaterialRedaction {
     }
 
     /**
-     * Removes a fingerprint digest of low-entropy material. {@code value} is not the only member that can carry the
-     * plaintext's digest: a secret scanner fingerprints what it found so it can dedupe findings across runs, and that
-     * digest is exactly as reversible as the one {@link #digestPublishable} refuses to publish.
+     * The members of {@code relatedCryptoMaterialProperties} this pipeline contracts for.
+     *
+     * <p>
+     * Everything else is a producer extension. For low-entropy material the extensions are dropped rather than
+     * enumerated, because {@code value} is not the only member that can carry the plaintext's digest and the set of
+     * names that can is open: a secret scanner fingerprints what it found so it can dedupe findings across runs, and
+     * that digest is exactly as reversible as the one {@link #digestPublishable} refuses to publish.
      */
-    private static void withholdFingerprint(ObjectNode materialNode, String materialType, List<String> findings) {
+    private static final Set<String> CONTRACTED_MEMBERS = Set
+            .of("type", "id", "state", "algorithmRef", "creationDate", "activationDate", "updateDate", "expirationDate",
+                    "value", "size", "format", "securedBy");
+
+    /**
+     * Drops every uncontracted member of low-entropy material, and says which.
+     *
+     * <p>
+     * <b>An allowlist, because the hazard is open-ended.</b> The predecessor named {@code fingerprint} and
+     * {@code digest} and withheld those two: {@code hash}, {@code hashes}, {@code sha256}, {@code checksum},
+     * {@code thumbprint}, {@code md5}, {@code fingerprints} and even {@code Fingerprint} -- the match was
+     * case-sensitive -- each carried an unsalted SHA-256 of a password into the served payload with no finding raised.
+     * None of those is a CycloneDX field, which is what makes enumeration the wrong shape of defence: the next scanner
+     * invents the eleventh name and it fails open again, silently, exactly as five of six spellings did before.
+     *
+     * <p>
+     * Inverting it costs a producer's harmless extensions on low-entropy material only, and costs them loudly -- the
+     * finding names every member removed, so nothing disappears without a record. This is the same instinct as dropping
+     * an unrecognised value <em>shape</em> rather than trusting it, applied to the member name.
+     */
+    private static void dropUncontractedMembers(ObjectNode materialNode, String materialType, List<String> findings) {
         if (digestPublishable(materialType)) {
             return;
         }
-        withholdDigestMember(materialNode, "fingerprint", materialType, findings);
-        withholdDigestMember(materialNode, "digest", materialType, findings);
-    }
-
-    /**
-     * Removes one digest-bearing member of low-entropy material, whatever shape the producer gave it.
-     *
-     * <p>
-     * <b>Fails closed on a shape it does not recognise.</b> Testing {@code isObject() && has("content")} and returning
-     * otherwise meant every other spelling passed straight through with no finding raised: a string
-     * {@code fingerprint: "sha256:5e8848..."}, an array of one, an object keyed {@code sha256} rather than
-     * {@code content}, and a nested {@code {"x": {"content": ...}}} all carried an unsalted SHA-256 of a password into
-     * the served payload. Only the one covered spelling was withheld.
-     *
-     * <p>
-     * Eighty lines up, a non-textual {@code value} is dropped rather than passed through for this same reason. Now that
-     * the envelope publishes no digest for any type, this is the only stored-payload enforcement of the low-entropy
-     * rule left, so an unrecognised shape is removed whole rather than trusted.
-     *
-     * <p>
-     * <b>The member goes whole, siblings included.</b> Removing only the recognised {@code content} and keeping the
-     * rest trusted the siblings: {@code {"alg": "sha-256", "content": "decoy", "x": {"content": <digest>}}} lost the
-     * decoy and stored the nested digest. An {@code alg} with no content states nothing worth keeping, so there is no
-     * shape whose recognised part is worth the risk of mis-recognising the rest.
-     */
-    private static void withholdDigestMember(ObjectNode materialNode, String member, String materialType,
-            List<String> findings) {
-        JsonNode node = materialNode.get(member);
-        if (node == null || node.isNull()) {
+        List<String> dropped = new ArrayList<>();
+        materialNode.fieldNames().forEachRemaining(name -> {
+            if (!CONTRACTED_MEMBERS.contains(name)) {
+                dropped.add(name);
+            }
+        });
+        if (dropped.isEmpty()) {
             return;
         }
-        materialNode.remove(member);
-        findings.add(member + " digest withheld: " + materialType + " is low-entropy material");
+        dropped.sort(AsciiText.BY_CODE_POINT);
+        dropped.forEach(materialNode::remove);
+        findings
+                .add("uncontracted members dropped for low-entropy material, any of which may carry a reversible "
+                        + "digest of the plaintext: " + String.join(", ", dropped));
     }
 
     /** The redacted properties. This is what may be stored, keyed, logged or served. */

--- a/src/main/java/com/otilm/core/cbom/asset/identity/MaterialRedaction.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/MaterialRedaction.java
@@ -7,21 +7,20 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Replaces inlined key material with a digest and a length, in one pass, before anything else reads the payload.
+ * Replaces inlined key material with the contracted redaction envelope, in one pass, before anything else reads the
+ * payload.
  *
  * <p>
  * <b>Ordering is the whole security property.</b> The digest is computed and the plaintext dropped before identity,
  * persistence, logging or metrics can observe the payload. The identity digest is carried out-of-band on the result so
- * the material identity chain can use it without any caller ever holding the plaintext, and the caller's input is never
- * mutated.
+ * the material identity chain can use it without any caller ever holding the plaintext. The stored payload carries no
+ * digest, and the caller's input is never mutated.
  *
  * <p>
  * The value is hashed verbatim -- no base64 decode, no trim. Normalizing first would make identity depend on the
  * normalizer.
  */
 public final class MaterialRedaction {
-
-    public static final String REDACTED_MARKER = "urn:otilm:redacted";
 
     /**
      * Material types whose plaintext is low-entropy enough that publishing {@code sha256(value)} would itself be an
@@ -113,17 +112,13 @@ public final class MaterialRedaction {
         String identityDigest = IdentityDigests.sha256Hex(value);
 
         ObjectNode redacted = materialNode.objectNode();
-        redacted.put("$redacted", REDACTED_MARKER);
-        String publishedDigest = null;
-        if (digestPublishable(materialType)) {
-            publishedDigest = identityDigest;
-            redacted.put("sha256", publishedDigest);
-            redacted.put("length", length);
-        } else {
+        redacted.put("redacted", true);
+        redacted.put("length", length);
+        String publishedDigest = digestPublishable(materialType) ? identityDigest : null;
+        if (publishedDigest == null) {
             // No digest at all. An unsalted SHA-256 of a password or a token is rainbow-table reversible, so
             // publishing it is the same leak one step removed -- and producers really do emit generic-password and
             // jwt-token material. Identity falls through to the occurrence tier, which the chain already has.
-            redacted.put("length", length);
             findings.add("digest withheld: " + materialType + " is low-entropy material");
         }
         materialNode.set(CbomNames.VALUE, redacted);
@@ -181,7 +176,7 @@ public final class MaterialRedaction {
         return identityDigest;
     }
 
-    /** The digest that may appear in the stored payload, or {@code null} for low-entropy material. */
+    /** The digest that may be used by internal callers, or {@code null} for low-entropy material. */
     public String publishedDigest() {
         return publishedDigest;
     }

--- a/src/main/java/com/otilm/core/cbom/asset/identity/MaterialRedaction.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/MaterialRedaction.java
@@ -172,6 +172,12 @@ public final class MaterialRedaction {
      * Eighty lines up, a non-textual {@code value} is dropped rather than passed through for this same reason. Now that
      * the envelope publishes no digest for any type, this is the only stored-payload enforcement of the low-entropy
      * rule left, so an unrecognised shape is removed whole rather than trusted.
+     *
+     * <p>
+     * <b>The member goes whole, siblings included.</b> Removing only the recognised {@code content} and keeping the
+     * rest trusted the siblings: {@code {"alg": "sha-256", "content": "decoy", "x": {"content": <digest>}}} lost the
+     * decoy and stored the nested digest. An {@code alg} with no content states nothing worth keeping, so there is no
+     * shape whose recognised part is worth the risk of mis-recognising the rest.
      */
     private static void withholdDigestMember(ObjectNode materialNode, String member, String materialType,
             List<String> findings) {
@@ -179,11 +185,7 @@ public final class MaterialRedaction {
         if (node == null || node.isNull()) {
             return;
         }
-        if (node.isObject() && node.has(CbomNames.CONTENT) && node.size() > 1) {
-            ((ObjectNode) node).remove(CbomNames.CONTENT);
-        } else {
-            materialNode.remove(member);
-        }
+        materialNode.remove(member);
         findings.add(member + " digest withheld: " + materialType + " is low-entropy material");
     }
 

--- a/src/main/java/com/otilm/core/cbom/asset/identity/MaterialRedaction.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/MaterialRedaction.java
@@ -151,13 +151,40 @@ public final class MaterialRedaction {
      * digest is exactly as reversible as the one {@link #digestPublishable} refuses to publish.
      */
     private static void withholdFingerprint(ObjectNode materialNode, String materialType, List<String> findings) {
-        JsonNode fingerprint = materialNode.get("fingerprint");
-        if (fingerprint == null || !fingerprint.isObject() || !fingerprint.has("content")
-                || digestPublishable(materialType)) {
+        if (digestPublishable(materialType)) {
             return;
         }
-        ((ObjectNode) fingerprint).remove("content");
-        findings.add("fingerprint digest withheld: " + materialType + " is low-entropy material");
+        withholdDigestMember(materialNode, "fingerprint", materialType, findings);
+        withholdDigestMember(materialNode, "digest", materialType, findings);
+    }
+
+    /**
+     * Removes one digest-bearing member of low-entropy material, whatever shape the producer gave it.
+     *
+     * <p>
+     * <b>Fails closed on a shape it does not recognise.</b> Testing {@code isObject() && has("content")} and returning
+     * otherwise meant every other spelling passed straight through with no finding raised: a string
+     * {@code fingerprint: "sha256:5e8848..."}, an array of one, an object keyed {@code sha256} rather than
+     * {@code content}, and a nested {@code {"x": {"content": ...}}} all carried an unsalted SHA-256 of a password into
+     * the served payload. Only the one covered spelling was withheld.
+     *
+     * <p>
+     * Eighty lines up, a non-textual {@code value} is dropped rather than passed through for this same reason. Now that
+     * the envelope publishes no digest for any type, this is the only stored-payload enforcement of the low-entropy
+     * rule left, so an unrecognised shape is removed whole rather than trusted.
+     */
+    private static void withholdDigestMember(ObjectNode materialNode, String member, String materialType,
+            List<String> findings) {
+        JsonNode node = materialNode.get(member);
+        if (node == null || node.isNull()) {
+            return;
+        }
+        if (node.isObject() && node.has(CbomNames.CONTENT) && node.size() > 1) {
+            ((ObjectNode) node).remove(CbomNames.CONTENT);
+        } else {
+            materialNode.remove(member);
+        }
+        findings.add(member + " digest withheld: " + materialType + " is low-entropy material");
     }
 
     /** The redacted properties. This is what may be stored, keyed, logged or served. */

--- a/src/main/java/com/otilm/core/cbom/asset/identity/Occurrences.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/Occurrences.java
@@ -2,8 +2,8 @@ package com.otilm.core.cbom.asset.identity;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
-import java.util.TreeSet;
 import java.util.regex.Pattern;
 
 /**
@@ -24,6 +24,8 @@ public final class Occurrences {
     private static final Pattern USERINFO = Pattern.compile("://[^/?#]*@");
 
     private static final int MAX_LOCATION_LENGTH = 1024;
+
+    private static final Comparator<String> CODE_POINT_ORDER = Occurrences::compareCodePoints;
 
     private Occurrences() {
     }
@@ -52,7 +54,6 @@ public final class Occurrences {
         if (occurrences == null || !occurrences.isArray()) {
             return null;
         }
-        TreeSet<String> sorted = new TreeSet<>();
         List<String> triples = new ArrayList<>();
         for (JsonNode occurrence : occurrences) {
             if (!occurrence.isObject()) {
@@ -65,8 +66,8 @@ public final class Occurrences {
         if (triples.isEmpty()) {
             return null;
         }
-        sorted.addAll(triples);
-        return String.join("\n", sorted);
+        triples.sort(CODE_POINT_ORDER);
+        return String.join("\n", triples);
     }
 
     /**
@@ -95,19 +96,16 @@ public final class Occurrences {
     }
 
     /**
-     * Where the length cap may cut, which is never between the halves of a surrogate pair.
+     * Where the length cap may cut, counting code points rather than UTF-16 code units.
      *
      * <p>
-     * The cap counts UTF-16 units, so a location of 1023 basic-plane characters followed by any astral character -- an
-     * emoji or a CJK extension character in a scanned path is enough -- left a lone high surrogate as the last char.
-     * That is well-formed input made malformed by the cap, and {@link IdentityDigests#sha256Hex} refuses it, so the
-     * component became a reported skip and vanished from the inventory with nothing an operator could act on. The same
-     * truncated string is written to stored evidence, where a lone surrogate has no valid UTF-8 encoding for a jsonb
-     * column.
+     * The specification and reference count characters, not Java storage units. Counting UTF-16 cut an astral-heavy URI
+     * early enough to drop the {@code @} separator before user-info stripping, leaving part of a credential behind.
      */
     private static int capBoundary(String text) {
-        int end = Math.min(text.length(), MAX_LOCATION_LENGTH);
-        return end > 0 && end < text.length() && Character.isHighSurrogate(text.charAt(end - 1)) ? end - 1 : end;
+        return text.codePointCount(0, text.length()) <= MAX_LOCATION_LENGTH
+                ? text.length()
+                : text.offsetByCodePoints(0, MAX_LOCATION_LENGTH);
     }
 
     /**
@@ -122,8 +120,23 @@ public final class Occurrences {
             return "";
         }
         if (value.isNumber()) {
-            return PreImageSlot.of(value.isIntegralNumber() ? value.bigIntegerValue().toString() : value.asText());
+            return value.isIntegralNumber() ? PreImageSlot.of(value.bigIntegerValue().toString()) : "";
         }
         return PreImageSlot.of(value.asText());
+    }
+
+    private static int compareCodePoints(String left, String right) {
+        int leftIndex = 0;
+        int rightIndex = 0;
+        while (leftIndex < left.length() && rightIndex < right.length()) {
+            int leftCodePoint = left.codePointAt(leftIndex);
+            int rightCodePoint = right.codePointAt(rightIndex);
+            if (leftCodePoint != rightCodePoint) {
+                return Integer.compare(leftCodePoint, rightCodePoint);
+            }
+            leftIndex += Character.charCount(leftCodePoint);
+            rightIndex += Character.charCount(rightCodePoint);
+        }
+        return Integer.compare(left.length() - leftIndex, right.length() - rightIndex);
     }
 }

--- a/src/main/java/com/otilm/core/cbom/asset/identity/Occurrences.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/Occurrences.java
@@ -99,8 +99,15 @@ public final class Occurrences {
      * Where the length cap may cut, counting code points rather than UTF-16 code units.
      *
      * <p>
-     * The specification and reference count characters, not Java storage units. Counting UTF-16 cut an astral-heavy URI
-     * early enough to drop the {@code @} separator before user-info stripping, leaving part of a credential behind.
+     * The specification and the reference count characters; Java's {@code length()} counts UTF-16 storage units. The
+     * two disagree from the first astral character onward, so a location of 1024 emoji was capped at 512 here and at
+     * 1024 by the reference -- one location, two keys. Cutting on a code-point boundary also makes the lone-surrogate
+     * case impossible rather than repaired: the old boundary check existed only because the unit count could land
+     * between the halves of a pair.
+     *
+     * <p>
+     * The cap is the last step of {@link #sanitizeLocation}, after the query, fragment and user-info have already gone,
+     * so it can neither expose nor preserve a credential -- only shorten a location that no longer carries one.
      */
     private static int capBoundary(String text) {
         return text.codePointCount(0, text.length()) <= MAX_LOCATION_LENGTH
@@ -109,18 +116,34 @@ public final class Occurrences {
     }
 
     /**
+     * A numeric position that names no line or offset, kept distinct from the empty slot.
+     *
+     * <p>
+     * {@code %3F} cannot arise from a producer value: {@link PreImageSlot} emits only {@code %25}, {@code %7C},
+     * {@code %20}, {@code %09}, {@code %0D} and {@code %0A}, and escapes any literal {@code %} to {@code %25} first.
+     * Rendering a refusal as the empty string instead would key {@code line: 1.5} identically to a stated-nothing
+     * occurrence, and the empty slot means absent everywhere else in the chain.
+     */
+    private static final String REFUSED_POSITION = "%3F";
+
+    /**
      * Renders a line or offset into its position of the triple.
      *
      * <p>
      * Escaped like any other slot value, because a producer controls it and a crafted string could otherwise forge a
      * triple boundary.
+     *
+     * <p>
+     * A non-integral number has no exact integer to render, so it is refused rather than rounded or spelled out --
+     * {@code JsonNode.asText()} on {@code 1.5} keys on the producer's serializer. Refusal is not absence, so it renders
+     * as {@link #REFUSED_POSITION}.
      */
     private static String slot(JsonNode value) {
         if (value == null || value.isNull() || value.isMissingNode()) {
             return "";
         }
         if (value.isNumber()) {
-            return value.isIntegralNumber() ? PreImageSlot.of(value.bigIntegerValue().toString()) : "";
+            return value.isIntegralNumber() ? PreImageSlot.of(value.bigIntegerValue().toString()) : REFUSED_POSITION;
         }
         return PreImageSlot.of(value.asText());
     }

--- a/src/main/java/com/otilm/core/cbom/asset/identity/Occurrences.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/Occurrences.java
@@ -107,14 +107,24 @@ public final class Occurrences {
         return sanitizeLocation(location.textValue());
     }
 
+    /**
+     * Sanitizes in an order the steps cannot undo for each other.
+     *
+     * <p>
+     * <b>The surrogate scrub goes first.</b> Removing a lone surrogate can <em>create</em> the {@code ://...@} shape
+     * that {@link #USERINFO} strips: {@code x:\uD800//user:pass@host} does not match the pattern, and scrubbing after
+     * the strip yields {@code x://user:pass@host} -- a well-formed, hashable location with the credential intact.
+     * Scrubbing first cannot have the mirror effect, because deleting a surrogate introduces no {@code ?}, {@code #},
+     * {@code @} or {@code :} for a later step to miss.
+     */
     public static String sanitizeLocation(String location) {
         if (AsciiText.isBlank(location)) {
             return "";
         }
         String text = AsciiText.strip(location);
+        text = UNPAIRED_SURROGATE.matcher(text).replaceAll("");
         text = withoutQueryOrFragment(text);
         text = USERINFO.matcher(text).replaceAll("://");
-        text = UNPAIRED_SURROGATE.matcher(text).replaceAll("");
         return text.substring(0, capBoundary(text));
     }
 
@@ -131,10 +141,22 @@ public final class Occurrences {
      * <p>
      * Such a location keeps its own text instead. It states something, and the query-and-fragment rule exists to drop a
      * <em>trailing</em> session token from a real path, not to erase a pointer that is the whole reference.
+     *
+     * <p>
+     * <b>Only a leading {@code #} earns that.</b> A pointer keeps its text but still loses a query of its own, and a
+     * location beginning with {@code ?} names no place at all -- it is a bare query string, so keeping it verbatim
+     * would store exactly the session token this rule exists to drop. That one renders as the empty location, which is
+     * what stating no location renders as, because it states no location.
      */
     private static String withoutQueryOrFragment(String text) {
         String[] halves = QUERY_OR_FRAGMENT.split(text, 2);
-        return halves[0].isEmpty() ? text : halves[0];
+        if (!halves[0].isEmpty()) {
+            return halves[0];
+        }
+        if (text.charAt(0) != '#') {
+            return "";
+        }
+        return "#" + QUERY_OR_FRAGMENT.split(text.substring(1), 2)[0];
     }
 
     /**
@@ -217,6 +239,11 @@ public final class Occurrences {
     private static String exactPosition(JsonNode value) {
         if (value.isIntegralNumber()) {
             return value.bigIntegerValue().toString();
+        }
+        if (value.isFloatingPointNumber() && !Double.isFinite(value.doubleValue())) {
+            // A JSON 1e999 parses to Infinity, and BigDecimal.valueOf(Infinity) throws. The sentinel exists so an
+            // unusable position is refused rather than fatal, so the overflow spelling has to reach it, not bypass it.
+            return null;
         }
         BigDecimal exact = value.decimalValue().stripTrailingZeros();
         return exact.scale() <= 0 ? exact.toPlainString() : null;

--- a/src/main/java/com/otilm/core/cbom/asset/identity/Occurrences.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/Occurrences.java
@@ -1,6 +1,7 @@
 package com.otilm.core.cbom.asset.identity;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -20,12 +21,33 @@ public final class Occurrences {
     /** Everything from the first {@code ?} or {@code #} onward: query strings and fragments carry session tokens. */
     private static final Pattern QUERY_OR_FRAGMENT = Pattern.compile("[?#]");
 
-    /** {@code scheme://user:pass@host} -- a real shape, and the reason a raw location must never be hashed. */
+    /**
+     * {@code scheme://user:pass@host} -- a real shape, and the reason a raw location must never be hashed.
+     *
+     * <p>
+     * Replaced <b>globally</b>, not once. One location can hold more than one URI: an archive scanner writes
+     * {@code jar:file://u:p@h/a.jar!/https://u2:p2@h2/b} and a Kafka bootstrap list is comma-separated. Because
+     * {@code [^/?#]*} cannot cross a {@code /}, a single replacement leaves every credential after the first standing
+     * -- and this is the one method in this package on the live path to the served {@code evidence} column, so what
+     * survives here is a stored, queryable secret.
+     */
     private static final Pattern USERINFO = Pattern.compile("://[^/?#]*@");
+
+    /**
+     * An unpaired surrogate, which is well-formed to Java and has no encoding at all in UTF-8.
+     *
+     * <p>
+     * {@link IdentityDigests#sha256Hex} refuses one, so a component carrying it becomes a reported skip and vanishes
+     * from the inventory; the same string also has no valid encoding for the {@code jsonb} evidence column. Scrubbing
+     * is unconditional rather than a cap-boundary repair, because a producer can put one anywhere in the string and
+     * only the cut position was ever guarded.
+     */
+    private static final Pattern UNPAIRED_SURROGATE = Pattern
+            .compile("[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])" + "|(?<![\\uD800-\\uDBFF])[\\uDC00-\\uDFFF]");
 
     private static final int MAX_LOCATION_LENGTH = 1024;
 
-    private static final Comparator<String> CODE_POINT_ORDER = Occurrences::compareCodePoints;
+    private static final Comparator<String> CODE_POINT_ORDER = AsciiText.BY_CODE_POINT;
 
     private Occurrences() {
     }
@@ -90,9 +112,29 @@ public final class Occurrences {
             return "";
         }
         String text = AsciiText.strip(location);
-        text = QUERY_OR_FRAGMENT.split(text, 2)[0];
-        text = USERINFO.matcher(text).replaceFirst("://");
+        text = withoutQueryOrFragment(text);
+        text = USERINFO.matcher(text).replaceAll("://");
+        text = UNPAIRED_SURROGATE.matcher(text).replaceAll("");
         return text.substring(0, capBoundary(text));
+    }
+
+    /**
+     * The location up to its first {@code ?} or {@code #}, unless the delimiter is the first character.
+     *
+     * <p>
+     * A location that <em>begins</em> with the delimiter is all fragment, and cutting at position zero rendered it as
+     * the empty string -- which is what an absent location renders as. A CycloneDX occurrence inside an OpenAPI or JSON
+     * document carries a JSON pointer, so {@code #/components/schemas/PrivateKey} and
+     * {@code #/components/schemas/PublicKey} both became the empty location and then shared one discriminator with each
+     * other and with every component that stated no location at all.
+     *
+     * <p>
+     * Such a location keeps its own text instead. It states something, and the query-and-fragment rule exists to drop a
+     * <em>trailing</em> session token from a real path, not to erase a pointer that is the whole reference.
+     */
+    private static String withoutQueryOrFragment(String text) {
+        String[] halves = QUERY_OR_FRAGMENT.split(text, 2);
+        return halves[0].isEmpty() ? text : halves[0];
     }
 
     /**
@@ -101,9 +143,13 @@ public final class Occurrences {
      * <p>
      * The specification and the reference count characters; Java's {@code length()} counts UTF-16 storage units. The
      * two disagree from the first astral character onward, so a location of 1024 emoji was capped at 512 here and at
-     * 1024 by the reference -- one location, two keys. Cutting on a code-point boundary also makes the lone-surrogate
-     * case impossible rather than repaired: the old boundary check existed only because the unit count could land
-     * between the halves of a pair.
+     * 1024 by the reference -- one location, two keys.
+     *
+     * <p>
+     * Cutting on a code-point boundary means the cap can no longer <em>create</em> a lone surrogate, which is the case
+     * the old positional guard was written for. It says nothing about one already present in the producer's text, which
+     * the cap can now carry through where the old boundary sometimes happened to trim it -- so
+     * {@link #UNPAIRED_SURROGATE} scrubs those explicitly rather than relying on where the cut lands.
      *
      * <p>
      * The cap is the last step of {@link #sanitizeLocation}, after the query, fragment and user-info have already gone,
@@ -130,36 +176,49 @@ public final class Occurrences {
      * Renders a line or offset into its position of the triple.
      *
      * <p>
-     * Escaped like any other slot value, because a producer controls it and a crafted string could otherwise forge a
-     * triple boundary.
+     * Escaped like any other slot value, because a producer controls it. Note what that does and does not buy:
+     * {@link PreImageSlot} escapes {@code %}, {@code |}, space, tab, CR and LF, but <b>not</b> {@code #}, which is this
+     * triple's own delimiter. So a textual position can still move the boundary between the line and offset fields --
+     * {@code line="1#2", offset="3"} and {@code line="1", offset="2#3"} both render {@code a#1#2#3}. The producer
+     * states all three fields either way, and the schema types line and offset as integers so a textual value is
+     * schema-invalid, but the escaping is not what prevents it.
      *
      * <p>
-     * A non-integral number has no exact integer to render, so it is refused rather than rounded or spelled out --
-     * {@code JsonNode.asText()} on {@code 1.5} keys on the producer's serializer. Refusal is not absence, so it renders
-     * as {@link #REFUSED_POSITION}.
+     * A number is rendered through its exact decimal value, so {@code 1.0} and {@code 2.0} stay apart and {@code 1e3}
+     * renders as the line {@code 1000} it names. {@code isIntegralNumber} was the wrong test: it asks Jackson's node
+     * type, not the value, so every double-serialized line collapsed onto one refusal -- and a producer whose JSON
+     * writer emits {@code 1.0} for an integer had its discriminator degraded to location-only.
+     *
+     * <p>
+     * Only a genuinely fractional position has no line to name, and that renders as {@link #REFUSED_POSITION} rather
+     * than as the empty slot, because refusal is not absence.
      */
     private static String slot(JsonNode value) {
         if (value == null || value.isNull() || value.isMissingNode()) {
             return "";
         }
         if (value.isNumber()) {
-            return value.isIntegralNumber() ? PreImageSlot.of(value.bigIntegerValue().toString()) : REFUSED_POSITION;
+            // The sentinel bypasses PreImageSlot deliberately. Escaping it would render it %253F, which is exactly
+            // what a producer spelling "%3F" renders as -- restoring the collision the sentinel exists to avoid.
+            String exact = exactPosition(value);
+            return exact == null ? REFUSED_POSITION : PreImageSlot.of(exact);
         }
         return PreImageSlot.of(value.asText());
     }
 
-    private static int compareCodePoints(String left, String right) {
-        int leftIndex = 0;
-        int rightIndex = 0;
-        while (leftIndex < left.length() && rightIndex < right.length()) {
-            int leftCodePoint = left.codePointAt(leftIndex);
-            int rightCodePoint = right.codePointAt(rightIndex);
-            if (leftCodePoint != rightCodePoint) {
-                return Integer.compare(leftCodePoint, rightCodePoint);
-            }
-            leftIndex += Character.charCount(leftCodePoint);
-            rightIndex += Character.charCount(rightCodePoint);
+    /**
+     * A numeric position as an exact integer, or {@code null} when it names no integer at all.
+     *
+     * <p>
+     * {@code stripTrailingZeros().toPlainString()} is exact and JDK-stable, which {@code asText()} is not:
+     * {@code JsonNode.asText()} on a large integral node can yield exponent notation, keying one line two ways
+     * depending on how the producer serialized it.
+     */
+    private static String exactPosition(JsonNode value) {
+        if (value.isIntegralNumber()) {
+            return value.bigIntegerValue().toString();
         }
-        return Integer.compare(left.length() - leftIndex, right.length() - rightIndex);
+        BigDecimal exact = value.decimalValue().stripTrailingZeros();
+        return exact.scale() <= 0 ? exact.toPlainString() : null;
     }
 }

--- a/src/main/java/com/otilm/core/cbom/asset/identity/Occurrences.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/Occurrences.java
@@ -18,7 +18,13 @@ import java.util.regex.Pattern;
  */
 public final class Occurrences {
 
-    /** Everything from the first {@code ?} or {@code #} onward: query strings and fragments carry session tokens. */
+    /**
+     * Everything from the first {@code ?} or {@code #} onward: query strings and fragments carry session tokens.
+     *
+     * <p>
+     * A match at position zero is the one case where the text before the delimiter is not the answer -- see
+     * {@link #withoutQueryOrFragment}, which keeps a leading fragment's <em>text</em> without keeping its delimiter.
+     */
     private static final Pattern QUERY_OR_FRAGMENT = Pattern.compile("[?#]");
 
     /**
@@ -30,8 +36,20 @@ public final class Occurrences {
      * {@code [^/?#]*} cannot cross a {@code /}, a single replacement leaves every credential after the first standing
      * -- and this is the one method in this package on the live path to the served {@code evidence} column, so what
      * survives here is a stored, queryable secret.
+     *
+     * <p>
+     * <b>The authority, not the scheme delimiter.</b> Anchoring on a literal {@code ://} missed a network-path
+     * reference: {@code //user:secret@host/x} is a well-formed URI reference that {@link java.net.URI} parses with
+     * {@code userInfo=user:secret}, and it is what a scanner emits for a protocol-relative URL. The alternation keeps
+     * the matched prefix so both spellings survive the replacement intact.
+     *
+     * <p>
+     * {@code [^/?#]*} stays <b>greedy</b> on purpose. A comma-separated multi-host authority --
+     * {@code mongodb://u1:p1@h1,u2:p2@h2/db} -- carries two credentials under one {@code //}, and a lazy quantifier
+     * stops at the first {@code @} and leaves the second standing. Greedy costs the first host, which is fidelity; lazy
+     * costs a credential, which is the thing this pattern exists for.
      */
-    private static final Pattern USERINFO = Pattern.compile("://[^/?#]*@");
+    private static final Pattern USERINFO = Pattern.compile("(^//|://)[^/?#]*@");
 
     /**
      * An unpaired surrogate, which is well-formed to Java and has no encoding at all in UTF-8.
@@ -98,7 +116,9 @@ public final class Occurrences {
      * <p>
      * {@code tcp://user:pass@host:443} is a real shape, and the location feeds the identity key for version-less
      * protocols and identity-less material -- so unsanitized, a password would be hashed into the key and stored in the
-     * evidence payload. The query and fragment go too: they carry session tokens and do not identify a location.
+     * evidence payload. A query string goes too, wherever it sits: it carries session tokens and identifies no
+     * location. A fragment goes with it, except when the location <em>is</em> the fragment -- a JSON pointer states a
+     * place, and {@link #withoutQueryOrFragment} keeps its text without its delimiter.
      */
     public static String sanitizeLocation(JsonNode location) {
         if (location == null || !location.isTextual() || AsciiText.isBlank(location.textValue())) {
@@ -124,7 +144,7 @@ public final class Occurrences {
         String text = AsciiText.strip(location);
         text = UNPAIRED_SURROGATE.matcher(text).replaceAll("");
         text = withoutQueryOrFragment(text);
-        text = USERINFO.matcher(text).replaceAll("://");
+        text = USERINFO.matcher(text).replaceAll("$1");
         return text.substring(0, capBoundary(text));
     }
 
@@ -139,14 +159,24 @@ public final class Occurrences {
      * other and with every component that stated no location at all.
      *
      * <p>
-     * Such a location keeps its own text instead. It states something, and the query-and-fragment rule exists to drop a
-     * <em>trailing</em> session token from a real path, not to erase a pointer that is the whole reference.
+     * Such a location keeps its own <em>text</em> instead, without its delimiter. It states something, and the
+     * query-and-fragment rule exists to drop a <em>trailing</em> session token from a real path, not to erase a pointer
+     * that is the whole reference.
      *
      * <p>
-     * <b>Only a leading {@code #} earns that.</b> A pointer keeps its text but still loses a query of its own, and a
-     * location beginning with {@code ?} names no place at all -- it is a bare query string, so keeping it verbatim
-     * would store exactly the session token this rule exists to drop. That one renders as the empty location, which is
-     * what stating no location renders as, because it states no location.
+     * <b>The delimiter itself does not come back.</b> {@code #} is the separator of the occurrence triple and the
+     * location slot is the one slot {@link PreImageSlot} does not escape, so a location that carries a {@code #} can
+     * forge a triple: with a newline in the same string, one occurrence renders as two triple lines. Returning the text
+     * whole re-opened that -- 234 colliding one-occurrence-against-two pairs over <code>{#, ?, \n, a, b, 1, 2}</code>,
+     * none before. Cutting after the delimiter keeps the pointer distinct and restores the invariant that made a
+     * newline harmless, without opening the escape set and re-keying every row.
+     *
+     * <p>
+     * <b>Only a leading {@code #} earns retention at all.</b> A pointer states a place; a location beginning with
+     * {@code ?} is a bare query string -- {@code ?X-Amz-Signature=}, {@code ?sig=}, {@code ?token=} are the shapes this
+     * rule was written for -- so keeping it verbatim would store exactly the session token the rule drops. It renders
+     * as the empty location. A sentinel distinguishable from absence would be better, as it is for a refused position,
+     * but this slot is unescaped: any sentinel a location could carry, a producer can also spell.
      */
     private static String withoutQueryOrFragment(String text) {
         String[] halves = QUERY_OR_FRAGMENT.split(text, 2);
@@ -156,7 +186,7 @@ public final class Occurrences {
         if (text.charAt(0) != '#') {
             return "";
         }
-        return "#" + QUERY_OR_FRAGMENT.split(text.substring(1), 2)[0];
+        return QUERY_OR_FRAGMENT.split(text.substring(1), 2)[0];
     }
 
     /**
@@ -206,10 +236,10 @@ public final class Occurrences {
      * schema-invalid, but the escaping is not what prevents it.
      *
      * <p>
-     * A number is rendered through its exact decimal value, so {@code 1.0} and {@code 2.0} stay apart and {@code 1e3}
-     * renders as the line {@code 1000} it names. {@code isIntegralNumber} was the wrong test: it asks Jackson's node
-     * type, not the value, so every double-serialized line collapsed onto one refusal -- and a producer whose JSON
-     * writer emits {@code 1.0} for an integer had its discriminator degraded to location-only.
+     * A number is rendered through its value rather than its spelling, so {@code 1.0} and {@code 2.0} stay apart and
+     * {@code 1e3} renders as the line {@code 1000} it names. {@code isIntegralNumber} was the wrong test: it asks
+     * Jackson's node type, not the value, so every double-serialized line collapsed onto one refusal -- and a producer
+     * whose JSON writer emits {@code 1.0} for an integer had its discriminator degraded to location-only.
      *
      * <p>
      * Only a genuinely fractional position has no line to name, and that renders as {@link #REFUSED_POSITION} rather
@@ -232,9 +262,18 @@ public final class Occurrences {
      * A numeric position as an exact integer, or {@code null} when it names no integer at all.
      *
      * <p>
-     * {@code stripTrailingZeros().toPlainString()} is exact and JDK-stable, which {@code asText()} is not:
-     * {@code JsonNode.asText()} on a large integral node can yield exponent notation, keying one line two ways
-     * depending on how the producer serialized it.
+     * <b>What the rendered string is.</b> {@code decimalValue()} on a double node is {@code BigDecimal.valueOf}, whose
+     * contract is {@code new BigDecimal(Double.toString(d))} -- so the keyed string is the shortest decimal that round
+     * trips, zero-expanded, not the value's exact binary expansion: {@code 1e23} keys as
+     * {@code 100000000000000000000000} while the double it names is {@code 99999999999999991611392}. That is a narrower
+     * dependency than {@code asText()}'s, which yielded exponent notation for a large integral node and keyed one line
+     * two ways on the producer's serializer, but it is not none: {@code Double.toString}'s algorithm was rewritten in
+     * JDK 19 (JDK-4511638). Using {@code new BigDecimal(double)} would remove it entirely at the cost of diverging from
+     * the reference kernel's rendering, so the dependency is recorded rather than closed.
+     *
+     * <p>
+     * A position that underflows to zero -- {@code 1e-1000} -- keys as the line {@code 0}, because it parses to the
+     * double {@code 0.0} before this method sees it and nothing downstream can tell the two apart.
      */
     private static String exactPosition(JsonNode value) {
         if (value.isIntegralNumber()) {

--- a/src/main/java/com/otilm/core/cbom/asset/identity/Occurrences.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/Occurrences.java
@@ -40,8 +40,8 @@ public final class Occurrences {
      * <p>
      * <b>The authority, not the scheme delimiter.</b> Anchoring on a literal {@code ://} missed a network-path
      * reference: {@code //user:secret@host/x} is a well-formed URI reference that {@link java.net.URI} parses with
-     * {@code userInfo=user:secret}, and it is what a scanner emits for a protocol-relative URL. The alternation keeps
-     * the matched prefix so both spellings survive the replacement intact.
+     * {@code userInfo=user:secret}, and it is what a scanner emits for a protocol-relative URL. The captured group is
+     * the scheme's colon or nothing at all, so both spellings survive the replacement with their prefix intact.
      *
      * <p>
      * {@code [^/?#]*} stays <b>greedy</b> on purpose. A comma-separated multi-host authority --
@@ -49,7 +49,7 @@ public final class Occurrences {
      * stops at the first {@code @} and leaves the second standing. Greedy costs the first host, which is fidelity; lazy
      * costs a credential, which is the thing this pattern exists for.
      */
-    private static final Pattern USERINFO = Pattern.compile("(^//|://)[^/?#]*@");
+    private static final Pattern USERINFO = Pattern.compile("(^|:)//[^/?#]*@");
 
     /**
      * An unpaired surrogate, which is well-formed to Java and has no encoding at all in UTF-8.
@@ -61,7 +61,7 @@ public final class Occurrences {
      * only the cut position was ever guarded.
      */
     private static final Pattern UNPAIRED_SURROGATE = Pattern
-            .compile("[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])" + "|(?<![\\uD800-\\uDBFF])[\\uDC00-\\uDFFF]");
+            .compile("(?:[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF]))" + "|(?:(?<![\\uD800-\\uDBFF])[\\uDC00-\\uDFFF])");
 
     private static final int MAX_LOCATION_LENGTH = 1024;
 
@@ -144,7 +144,7 @@ public final class Occurrences {
         String text = AsciiText.strip(location);
         text = UNPAIRED_SURROGATE.matcher(text).replaceAll("");
         text = withoutQueryOrFragment(text);
-        text = USERINFO.matcher(text).replaceAll("$1");
+        text = USERINFO.matcher(text).replaceAll("$1//");
         return text.substring(0, capBoundary(text));
     }
 

--- a/src/main/java/com/otilm/core/cbom/asset/identity/PreImageSlot.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/PreImageSlot.java
@@ -18,11 +18,13 @@ package com.otilm.core.cbom.asset.identity;
  *
  * <p>
  * <b>{@code #} is deliberately not in the set.</b> It is the separator of the occurrence triple, owned by
- * {@link Occurrences#slot} rather than by this class, and a triple can only be forged through it by a <em>textual</em>
- * line or offset -- which the schema types as an integer and the upload gate refuses before this code runs. Adding it
- * here would re-key every occurrence-bearing row to close a case that is already rejected upstream, so the separator is
- * documented rather than escaped. A reader asking "why is {@code #} missing?" should find the answer here; if the
- * upload gate ever stops refusing a textual position, this is the paragraph that has to change with it.
+ * {@link Occurrences#slot} rather than by this class, and a triple can be forged through it by a <em>textual</em> line
+ * or offset: {@code {"line": "1#2", "offset": "3"}} and {@code {"line": "1", "offset": "2#3"}} render one slot. What
+ * keeps that out is the CycloneDX schema typing both as integers, not this escape set and not any check in core --
+ * {@code Occurrences.slot} renders a textual position without complaint if one arrives. Adding {@code #} here would
+ * re-key every occurrence-bearing row, so the exposure is documented rather than escaped, and it is an argument about
+ * cost, not a claim that the case is impossible. A reader asking "why is {@code #} missing?" should find the answer
+ * here; if a textual position ever becomes reachable, this is the paragraph that has to change with it.
  */
 public final class PreImageSlot {
 

--- a/src/main/java/com/otilm/core/cbom/asset/identity/PreImageSlot.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/PreImageSlot.java
@@ -23,12 +23,40 @@ public final class PreImageSlot {
 
     /** An absent value renders as the empty slot, which is distinct from every present value. */
     public static String of(String value) {
-        if (value == null) {
-            return "";
-        }
+        return value == null ? "" : escape(value, PreImageSlot::escapeFor);
+    }
+
+    public static String of(Integer value) {
+        return value == null ? "" : value.toString();
+    }
+
+    /**
+     * The escape set a caller applies to its own delimiter.
+     *
+     * <p>
+     * A nested pre-image has a delimiter of its own that this class does not escape -- the {@code alg:content} digest
+     * claim is the worked example -- so the escape set is the caller's, while the walk stays here.
+     */
+    interface EscapeSet {
+
+        /** The replacement for {@code character}, or {@code null} when it passes through unchanged. */
+        String replacementFor(char character);
+    }
+
+    /**
+     * Applies an escape set, allocating only once something actually escapes.
+     *
+     * <p>
+     * <b>Escapes compose, and the outer layer wins twice.</b> A value escaped by an inner set and then passed to
+     * {@link #of} carries its {@code %} escaped again: an {@code alg} of {@code sha-256:x} becomes {@code sha-256%3Ax}
+     * from the digest set and then {@code sha-256%253Ax} in the outer slot. Composing injective escapers stays
+     * injective, so nothing collides -- but a conformance vector must pin the doubly-escaped spelling, because that is
+     * what reaches the pre-image.
+     */
+    static String escape(String value, EscapeSet escapes) {
         StringBuilder escaped = null;
         for (int index = 0; index < value.length(); index++) {
-            String replacement = escapeFor(value.charAt(index));
+            String replacement = escapes.replacementFor(value.charAt(index));
             if (replacement == null) {
                 if (escaped != null) {
                     escaped.append(value.charAt(index));
@@ -41,10 +69,6 @@ public final class PreImageSlot {
             escaped.append(replacement);
         }
         return escaped == null ? value : escaped.toString();
-    }
-
-    public static String of(Integer value) {
-        return value == null ? "" : value.toString();
     }
 
     private static String escapeFor(char character) {

--- a/src/main/java/com/otilm/core/cbom/asset/identity/PreImageSlot.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/PreImageSlot.java
@@ -15,6 +15,14 @@ package com.otilm.core.cbom.asset.identity;
  * composite is the worked example: {@code CRT|S|v1|...} carries {@code 2.5.4.3=example%20ca} because that DN sits in an
  * outer slot, while the composite's inner pre-image carries {@code 2.5.4.3=vector ca} with the space intact, because
  * only its SHA-256 enters a slot. Getting this backwards re-keys every certificate.
+ *
+ * <p>
+ * <b>{@code #} is deliberately not in the set.</b> It is the separator of the occurrence triple, owned by
+ * {@link Occurrences#slot} rather than by this class, and a triple can only be forged through it by a <em>textual</em>
+ * line or offset -- which the schema types as an integer and the upload gate refuses before this code runs. Adding it
+ * here would re-key every occurrence-bearing row to close a case that is already rejected upstream, so the separator is
+ * documented rather than escaped. A reader asking "why is {@code #} missing?" should find the answer here; if the
+ * upload gate ever stops refusing a textual position, this is the paragraph that has to change with it.
  */
 public final class PreImageSlot {
 

--- a/src/main/java/com/otilm/core/cbom/asset/identity/ValidityTimestamps.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/ValidityTimestamps.java
@@ -26,7 +26,16 @@ import java.util.regex.Pattern;
  */
 public final class ValidityTimestamps {
 
-    private static final Pattern FRACTION = Pattern.compile("([Tt]\\d{2}:\\d{2}:\\d{2})\\.\\d+");
+    /**
+     * A fractional second, and nothing else that happens to contain a dot.
+     *
+     * <p>
+     * Anchored to a time of day so a version-shaped value keeps its own spelling: an unanchored {@code \.\d+} turned
+     * {@code v1.2.3} into {@code v1} and {@code release.1} into {@code release}, merging values that name different
+     * things. Both spellings this class accepts are anchored -- the extended {@code T15:16:00} form and the basic
+     * fourteen-digit one -- because {@code uuuuMMddHHmmss'Z'} is GeneralizedTime, where a fraction is legal.
+     */
+    private static final Pattern FRACTION = Pattern.compile("([Tt]\\d{2}:\\d{2}:\\d{2}|\\d{14})\\.\\d+");
 
     /**
      * Parsed case-insensitively, because the reference's parser is. RFC 3339 permits a lowercase {@code t} separator

--- a/src/main/java/com/otilm/core/cbom/asset/identity/ValidityTimestamps.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/ValidityTimestamps.java
@@ -83,8 +83,19 @@ public final class ValidityTimestamps {
      * advertises -- that sub-second precision carries no identity, and that a spelling cannot key a value -- hold for
      * the set of values that parse and not beyond it. {@code 2025-02-30T00:00:00Z}, {@code 2025-02-30T00:00:00.000Z}
      * and {@code 2025-02-30t00:00:00z} are one calendar-invalid date in three spellings, and they key three ways.
-     * Normalizing the fallback instead would put {@code release.1} back on the path that turned it into
-     * {@code release}, which is the defect the anchored pattern exists to prevent.
+     *
+     * <p>
+     * Returning {@code parseCandidate} instead would put the unconditional {@code z -> Z} fold back on every
+     * unparseable value: {@code zebra-2025} keys as {@code Zebra-2025} and {@code cert-z-serial} as
+     * {@code cert-Z-serial}, which is the {@code main} defect the previous round closed. The anchored {@link #FRACTION}
+     * already protects {@code release.1} and {@code v1.2.3} -- measured directly at this head, both are returned
+     * untouched -- so it is the zone fold, not the fraction strip, that puts the two arms in tension.
+     *
+     * <p>
+     * A third arm exists: strip the fraction on the fallback and do <em>not</em> fold the zone case. That folds
+     * {@code .000Z} onto {@code Z}, leaves {@code zebra-2025} alone, and leaves only the lowercase spelling keying
+     * apart. It is a real option, declined because "returned exactly as written" is a contract a reader can hold in one
+     * sentence and "fraction stripped, case kept" is not, and because the corpus carries zero rows either way.
      */
     public static String normalize(String raw) {
         if (raw == null || AsciiText.isBlank(raw)) {

--- a/src/main/java/com/otilm/core/cbom/asset/identity/ValidityTimestamps.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/ValidityTimestamps.java
@@ -76,6 +76,15 @@ public final class ValidityTimestamps {
      * An unparseable value is returned rather than discarded: it is still a fact the producer stated, and two
      * certificates differing only in an unparseable validity must not merge. The empty string means absent, which is
      * distinct from every present value.
+     *
+     * <p>
+     * <b>An unparseable value is returned exactly as written</b>, stripped of surrounding whitespace and nothing else.
+     * The fraction-stripping and zone-case folding apply only to the parse attempt, so the two guarantees this class
+     * advertises -- that sub-second precision carries no identity, and that a spelling cannot key a value -- hold for
+     * the set of values that parse and not beyond it. {@code 2025-02-30T00:00:00Z}, {@code 2025-02-30T00:00:00.000Z}
+     * and {@code 2025-02-30t00:00:00z} are one calendar-invalid date in three spellings, and they key three ways.
+     * Normalizing the fallback instead would put {@code release.1} back on the path that turned it into
+     * {@code release}, which is the defect the anchored pattern exists to prevent.
      */
     public static String normalize(String raw) {
         if (raw == null || AsciiText.isBlank(raw)) {

--- a/src/main/java/com/otilm/core/cbom/asset/identity/ValidityTimestamps.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/ValidityTimestamps.java
@@ -7,6 +7,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -25,7 +26,7 @@ import java.util.regex.Pattern;
  */
 public final class ValidityTimestamps {
 
-    private static final Pattern FRACTION = Pattern.compile("\\.\\d+");
+    private static final Pattern FRACTION = Pattern.compile("([Tt]\\d{2}:\\d{2}:\\d{2})\\.\\d+");
 
     /**
      * Parsed case-insensitively, because the reference's parser is. RFC 3339 permits a lowercase {@code t} separator
@@ -34,21 +35,26 @@ public final class ValidityTimestamps {
      * {@code 2025-01-01t00:00:00z} unparsed, keying it on its spelling instead of on its instant.
      */
     private static final List<DateTimeFormatter> OFFSET_FORMATS = List
-            .of(caseInsensitiveOffset("+HH:MM"), caseInsensitive("yyyy-MM-dd'T'HH:mm:ssZ"));
+            .of(caseInsensitiveOffset("+HH:MM"), caseInsensitive("uuuu-MM-dd'T'HH:mm:ssZ"));
 
     private static final List<DateTimeFormatter> LOCAL_FORMATS = List
-            .of(caseInsensitive("yyyy-MM-dd'T'HH:mm:ss'Z'"), caseInsensitive("yyyyMMddHHmmss'Z'"));
+            .of(caseInsensitive("uuuu-MM-dd'T'HH:mm:ss'Z'"), caseInsensitive("uuuuMMddHHmmss'Z'"));
 
     private static DateTimeFormatter caseInsensitive(String pattern) {
-        return new DateTimeFormatterBuilder().parseCaseInsensitive().appendPattern(pattern).toFormatter();
+        return new DateTimeFormatterBuilder()
+                .parseCaseInsensitive()
+                .appendPattern(pattern)
+                .toFormatter()
+                .withResolverStyle(ResolverStyle.STRICT);
     }
 
     private static DateTimeFormatter caseInsensitiveOffset(String offsetPattern) {
         return new DateTimeFormatterBuilder()
                 .parseCaseInsensitive()
-                .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+                .appendPattern("uuuu-MM-dd'T'HH:mm:ss")
                 .appendOffset(offsetPattern, "Z")
-                .toFormatter();
+                .toFormatter()
+                .withResolverStyle(ResolverStyle.STRICT);
     }
 
     private ValidityTimestamps() {
@@ -66,10 +72,11 @@ public final class ValidityTimestamps {
         if (raw == null || AsciiText.isBlank(raw)) {
             return "";
         }
-        String cleaned = FRACTION.matcher(AsciiText.strip(raw)).replaceAll("").replace("z", "Z");
+        String cleaned = AsciiText.strip(raw);
+        String parseCandidate = FRACTION.matcher(cleaned).replaceAll("$1").replace("z", "Z");
         for (DateTimeFormatter format : OFFSET_FORMATS) {
             try {
-                return Long.toString(OffsetDateTime.parse(cleaned, format).toEpochSecond());
+                return Long.toString(OffsetDateTime.parse(parseCandidate, format).toEpochSecond());
             } catch (DateTimeParseException e) {
                 // Not this offset spelling. The local spellings are tried below, and a value matching none is returned
                 // cleaned rather than dropped.
@@ -77,7 +84,9 @@ public final class ValidityTimestamps {
         }
         for (DateTimeFormatter format : LOCAL_FORMATS) {
             try {
-                return Long.toString(LocalDateTime.parse(cleaned, format).toInstant(ZoneOffset.UTC).getEpochSecond());
+                return Long
+                        .toString(
+                                LocalDateTime.parse(parseCandidate, format).toInstant(ZoneOffset.UTC).getEpochSecond());
             } catch (DateTimeParseException e) {
                 // As above.
             }

--- a/src/main/java/com/otilm/core/cbom/asset/identity/package-info.java
+++ b/src/main/java/com/otilm/core/cbom/asset/identity/package-info.java
@@ -38,8 +38,7 @@
  *
  * <p>
  * The package stays flat on purpose. Splitting it by layer would force
- * {@link com.otilm.core.cbom.asset.identity.CbomNames} and {@code CertificateDigests.isPresent} to widen from
- * package-private, and that encapsulation is what keeps the pipeline's vocabulary out of reach of the rest of the
- * platform.
+ * {@link com.otilm.core.cbom.asset.identity.CbomNames} and the digest-claim helpers to widen from package-private, and
+ * that encapsulation is what keeps the pipeline's vocabulary out of reach of the rest of the platform.
  */
 package com.otilm.core.cbom.asset.identity;

--- a/src/test/java/com/otilm/core/cbom/asset/identity/ContentDigestTest.java
+++ b/src/test/java/com/otilm/core/cbom/asset/identity/ContentDigestTest.java
@@ -475,4 +475,24 @@ class ContentDigestTest {
             throw new IllegalArgumentException("test fixture is not JSON: " + json, e);
         }
     }
+
+    /**
+     * A blank algorithm label is the same silence as an absent one.
+     *
+     * <p>
+     * {@code isTextual()} is true for {@code "  "}, so the default was skipped and the label folded to the empty
+     * string: one certificate forked between {@code :aa} and {@code sha-256:aa} on whether its producer wrote a blank
+     * alg or none.
+     */
+    @Test
+    void aBlankAlgorithmLabelTakesTheDefault() {
+        String absent = CertificateDigests.fingerprintDigest(read("{\"fingerprint\":{\"content\":\"aa\"}}"));
+
+        assertThat(CertificateDigests.fingerprintDigest(read("{\"fingerprint\":{\"alg\":\"  \",\"content\":\"aa\"}}")))
+                .isEqualTo(absent);
+        assertThat(CertificateDigests.fingerprintDigest(read("{\"fingerprint\":{\"alg\":\"\",\"content\":\"aa\"}}")))
+                .isEqualTo(absent);
+        assertThat(absent).doesNotStartWith(":");
+    }
+
 }

--- a/src/test/java/com/otilm/core/cbom/asset/identity/ContentDigestTest.java
+++ b/src/test/java/com/otilm/core/cbom/asset/identity/ContentDigestTest.java
@@ -156,6 +156,53 @@ class ContentDigestTest {
      * the next preference and a leading one cannot suppress the real digest behind it. Empty is not a contradiction
      * either -- a producer that says nothing has not said something different.
      */
+    /**
+     * An alias spelling cannot escape the contradiction guard.
+     *
+     * <p>
+     * Keying the map on {@code upper(strip(alg))} put {@code SHA256} and {@code SHA-256} in two entries, so a
+     * certificate stating two different SHA-256 digests recorded no contradiction and the second silently won. An alias
+     * spelling alone also yielded no digest tier at all, because {@code PREFERENCE} holds only canonical spellings.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"SHA256", "sha_256", "SHA 256", "sha-256", "SHA-256"})
+    void anAliasSpellingIsTheSameAlgorithmForContradictionAndForPreference(String alias) {
+        assertThat(CertificateDigests
+                .componentHash(read("{\"hashes\":[{\"alg\":\"" + alias + "\",\"content\":\"aa\"},"
+                        + "{\"alg\":\"SHA-256\",\"content\":\"bb\"}]}")))
+                .describedAs("two different SHA-256 digests are a contradiction however they are spelled")
+                .isNull();
+        assertThat(
+                CertificateDigests.componentHash(read("{\"hashes\":[{\"alg\":\"" + alias + "\",\"content\":\"aa\"}]}")))
+                .describedAs("an alias alone still names SHA-256")
+                .isEqualTo("sha-256:aa");
+    }
+
+    /** Both channels render the canonical label, so one certificate cannot fork on how its algorithm was written. */
+    @Test
+    void bothDigestChannelsCanonicalizeTheLabel() {
+        assertThat(
+                CertificateDigests.fingerprintDigest(read("{\"fingerprint\":{\"alg\":\"SHA256\",\"content\":\"aa\"}}")))
+                .isEqualTo("sha-256:aa")
+                .isEqualTo(CertificateDigests
+                        .componentHash(read("{\"hashes\":[{\"alg\":\"SHA-256\"," + "\"content\":\"aa\"}]}")));
+    }
+
+    /** The fingerprint channel refuses a blank or non-textual claim, as the hashes channel does. */
+    @Test
+    void aFingerprintClaimingNothingUsableIsNoClaim() {
+        assertThat(CertificateDigests
+                .fingerprintDigest(read("{\"fingerprint\":{\"alg\":\"sha-256\"," + "\"content\":\"   \"}}"))).isNull();
+        assertThat(CertificateDigests
+                .fingerprintDigest(read("{\"fingerprint\":{\"alg\":\"sha-256\"," + "\"content\":true}}"))).isNull();
+        assertThat(CertificateDigests
+                .fingerprintDigest(read("{\"fingerprint\":{\"alg\":{\"x\":1}," + "\"content\":\"aa\"}}")))
+                .describedAs("a container alg falls back to the documented default rather than rendering \":aa\"")
+                .isEqualTo("sha-256:aa");
+        assertThat(CertificateDigests.fingerprintDigest(read("{\"fingerprint\":{\"alg\":[],\"content\":\"aa\"}}")))
+                .isEqualTo("sha-256:aa");
+    }
+
     @Test
     void anEmptyContentNeitherWinsNorShadows() {
         assertThat(CertificateDigests
@@ -267,6 +314,47 @@ class ContentDigestTest {
     void oddNibbleTokensAreEvenPaddedIndividually() {
         assertThat(CipherSuites.code(read("[\"0x131\",\"0x1\"]"))).isEqualTo("013101");
         assertThat(CipherSuites.code(read("[\"0x13\",\"0x101\"]"))).isEqualTo("130101");
+    }
+
+    /**
+     * The pad restores a whole octet, at the width the producer wrote.
+     *
+     * <p>
+     * {@code Integer.toHexString} drops leading zeros, so padding its result restored a nibble and the four-encoding
+     * merge held only for a non-zero high byte. Every suite in {@code 0x0000}-{@code 0x00FF} -- the classic TLS block
+     * -- forked between its packed and per-byte spellings, and a packed {@code 0x002F} also collided with a malformed
+     * one-byte {@code ["0x2F"]}.
+     */
+    @ParameterizedTest
+    @CsvSource({
+            "'[\"0x002F\"]', 002f",
+            "'[\"0x00\",\"0x2F\"]', 002f",
+            "'[\"0x0035\"]', 0035",
+            "'[\"0x00\",\"0x35\"]', 0035",
+            "'[\"0x009C\"]', 009c",
+            "'[\"0x000A\"]', 000a",
+            "'[\"0x0000\"]', 0000",
+            "'[\"0x00\",\"0x00\"]', 0000",
+            "'[\"0x2F\"]', 2f",
+            "'[\"0x00\"]', 00"})
+    void aZeroHighByteSurvivesThePad(String identifiers, String expected) {
+        assertThat(CipherSuites.code(read(identifiers))).isEqualTo(expected);
+    }
+
+    /** A packed two-octet code must not collide with a malformed one-octet spelling of its low byte. */
+    @Test
+    void aPackedCodeKeepsItsWidthAgainstAOneByteToken() {
+        assertThat(CipherSuites.code(read("[\"0x002F\"]"))).isNotEqualTo(CipherSuites.code(read("[\"0x2F\"]")));
+        assertThat(CipherSuites.code(read("[\"0x0000\"]"))).isNotEqualTo(CipherSuites.code(read("[\"0x00\"]")));
+    }
+
+    /** A blank token states nothing, and a list carrying one must not impersonate the well-formed list. */
+    @Test
+    void aBlankTokenCostsTheWholeCode() {
+        assertThat(CipherSuites.code(read("[\"0x13\",\"\",\"0x01\"]"))).isNull();
+        assertThat(CipherSuites.code(read("[\"0x13\",\"  \",\"0x01\"]"))).isNull();
+        assertThat(CipherSuites.code(read("[\"0x13\",\",\",\"0x01\"]"))).isNull();
+        assertThat(CipherSuites.code(read("[\"0x13\",\"0x01\"]"))).isEqualTo("1301");
     }
 
     /**

--- a/src/test/java/com/otilm/core/cbom/asset/identity/ContentDigestTest.java
+++ b/src/test/java/com/otilm/core/cbom/asset/identity/ContentDigestTest.java
@@ -148,6 +148,31 @@ class ContentDigestTest {
                 .isNull();
     }
 
+    /**
+     * An entry carrying no content does not decide, and does not shadow one that does.
+     *
+     * <p>
+     * The map keeps the first non-empty content per algorithm, so a trailing empty entry cannot demote an algorithm to
+     * the next preference and a leading one cannot suppress the real digest behind it. Empty is not a contradiction
+     * either -- a producer that says nothing has not said something different.
+     */
+    @Test
+    void anEmptyContentNeitherWinsNorShadows() {
+        assertThat(CertificateDigests
+                .componentHash(read("{\"hashes\":[" + "{\"alg\":\"SHA-256\",\"content\":\"aa\"},"
+                        + "{\"alg\":\"SHA-256\",\"content\":\"\"}]}")))
+                .isEqualTo("sha-256:aa");
+        assertThat(CertificateDigests
+                .componentHash(read("{\"hashes\":[" + "{\"alg\":\"SHA-256\",\"content\":\"\"},"
+                        + "{\"alg\":\"SHA-256\",\"content\":\"aa\"}]}")))
+                .isEqualTo("sha-256:aa");
+        assertThat(CertificateDigests
+                .componentHash(read("{\"hashes\":[" + "{\"alg\":\"SHA-256\",\"content\":\"\"},"
+                        + "{\"alg\":\"SHA-384\",\"content\":\"cc\"}]}")))
+                .describedAs("an algorithm that claimed nothing falls through to the next preference")
+                .isEqualTo("sha-384:cc");
+    }
+
     @Test
     void digestClaimPartsCannotForgeAColonBoundary() {
         assertThat(CertificateDigests
@@ -161,6 +186,36 @@ class ContentDigestTest {
         assertThat(CertificateDigests
                 .fingerprintDigest(read("{\"fingerprint\":" + "{\"alg\":\"sha-256\",\"content\":\"aabbcc:dd\"}}")))
                 .isEqualTo("sha-256:aabbcc%3Add");
+        assertThat(CertificateDigests
+                .fingerprintDigest(read("{\"fingerprint\":" + "{\"alg\":\"sha-256%3Aaabbcc\",\"content\":\"dd\"}}")))
+                .describedAs("escaping the escape character is what makes the encoding injective; the producer's own"
+                        + " %3A is ASCII-folded before it is escaped, so it lands lowercase")
+                .isEqualTo("sha-256%253aaabbcc:dd")
+                .isNotEqualTo(CertificateDigests
+                        .fingerprintDigest(
+                                read("{\"fingerprint\":" + "{\"alg\":\"sha-256:aabbcc\",\"content\":\"dd\"}}")));
+    }
+
+    /**
+     * What the pre-image carries, which is not what {@link CertificateDigests} returns.
+     *
+     * <p>
+     * The claim enters a {@code |}-delimited outer slot through {@link PreImageSlot#of}, which escapes the {@code %}
+     * this layer already emitted. A conformance vector cut on the return value alone would pin {@code %3A} and miss the
+     * {@code %253A} that actually reaches the key.
+     */
+    @Test
+    void theOuterSlotEscapesTheDigestEscapeAgain() {
+        String claim = CertificateDigests
+                .fingerprintDigest(read("{\"fingerprint\":" + "{\"alg\":\"sha-256:x\",\"content\":\"dd\"}}"));
+
+        assertThat(claim).isEqualTo("sha-256%3Ax:dd");
+        assertThat(PreImageSlot.of(claim)).isEqualTo("sha-256%253Ax:dd");
+        assertThat(PreImageSlot
+                .of(CertificateDigests
+                        .fingerprintDigest(read("{\"fingerprint\":" + "{\"alg\":\"sha-256\",\"content\":\"x:dd\"}}"))))
+                .describedAs("the two spellings stay apart through both layers")
+                .isNotEqualTo(PreImageSlot.of(claim));
     }
 
     /**

--- a/src/test/java/com/otilm/core/cbom/asset/identity/ContentDigestTest.java
+++ b/src/test/java/com/otilm/core/cbom/asset/identity/ContentDigestTest.java
@@ -136,6 +136,33 @@ class ContentDigestTest {
                 .isEqualTo("sha-256:aabb");
     }
 
+    @Test
+    void aSelfContradictoryDigestAlgorithmIsNotUsedForIdentity() {
+        assertThat(CertificateDigests
+                .componentHash(read("{\"hashes\":[" + "{\"alg\":\"SHA-256\",\"content\":\"aa\"},"
+                        + "{\"alg\":\"SHA-384\",\"content\":\"cc\"}," + "{\"alg\":\"SHA-256\",\"content\":\"bb\"}]}")))
+                .isEqualTo("sha-384:cc");
+        assertThat(CertificateDigests
+                .componentHash(read("{\"hashes\":[" + "{\"alg\":\"SHA-256\",\"content\":\"aa\"},"
+                        + "{\"alg\":\"SHA-256\",\"content\":\"bb\"}]}")))
+                .isNull();
+    }
+
+    @Test
+    void digestClaimPartsCannotForgeAColonBoundary() {
+        assertThat(CertificateDigests
+                .fingerprintDigest(read("{\"fingerprint\":" + "{\"alg\":\"sha-256:aabbcc\",\"content\":\"dd\"}}")))
+                .isNotEqualTo(CertificateDigests
+                        .fingerprintDigest(
+                                read("{\"fingerprint\":" + "{\"alg\":\"sha-256\",\"content\":\"aabbcc:dd\"}}")));
+        assertThat(CertificateDigests
+                .fingerprintDigest(read("{\"fingerprint\":" + "{\"alg\":\"sha-256:aabbcc\",\"content\":\"dd\"}}")))
+                .isEqualTo("sha-256%3Aaabbcc:dd");
+        assertThat(CertificateDigests
+                .fingerprintDigest(read("{\"fingerprint\":" + "{\"alg\":\"sha-256\",\"content\":\"aabbcc:dd\"}}")))
+                .isEqualTo("sha-256:aabbcc%3Add");
+    }
+
     /**
      * The 1.7 fingerprint field and an identical component hash produce the same tier, in a fixed order.
      *
@@ -173,10 +200,18 @@ class ContentDigestTest {
     @CsvSource({
             "'[\"0x13\",\"0x1\"]', 1301",
             "'[\"0x13\",\"0x01\"]', 1301",
+            "'[\"0x1301\"]', 1301",
             "'[\"0x13,0x01\"]', 1301",
-            "'[\"0xC0\",\"0x30\"]', c030"})
+            "'[\"0xC0\",\"0x30\"]', c030",
+            "'[\"0x100\",\"0x1\"]', 010001"})
     void everyEncodingOfOneSuiteYieldsOneCode(String identifiers, String expected) {
         assertThat(CipherSuites.code(read(identifiers))).isEqualTo(expected);
+    }
+
+    @Test
+    void oddNibbleTokensAreEvenPaddedIndividually() {
+        assertThat(CipherSuites.code(read("[\"0x131\",\"0x1\"]"))).isEqualTo("013101");
+        assertThat(CipherSuites.code(read("[\"0x13\",\"0x101\"]"))).isEqualTo("130101");
     }
 
     /**
@@ -195,6 +230,13 @@ class ContentDigestTest {
     @Test
     void anUnreadableIdentifierListYieldsNoCode() {
         assertThat(CipherSuites.code(read("[\"nonsense\"]"))).isNull();
+        assertThat(CipherSuites.code(read("[\"0x10000\"]"))).isNull();
+        assertThat(CipherSuites.code(read("[\"0x100000000\"]"))).isNull();
+        assertThat(CipherSuites.code(read("[\"-1\"]"))).isNull();
+        assertThat(CipherSuites.code(read("[\"+0x1\"]"))).isNull();
+        assertThat(CipherSuites.code(read("[\"1_3\"]"))).isNull();
+        assertThat(CipherSuites.code(read("[\"0x1_3\"]"))).isNull();
+        assertThat(CipherSuites.code(read("[\"0x-5\"]"))).isNull();
         assertThat(CipherSuites.code(read("[]"))).isNull();
         assertThat(CipherSuites.code(read("\"not-an-array\""))).isNull();
         assertThat(CipherSuites.code(null)).isNull();

--- a/src/test/java/com/otilm/core/cbom/asset/identity/ContentDigestTest.java
+++ b/src/test/java/com/otilm/core/cbom/asset/identity/ContentDigestTest.java
@@ -149,14 +149,6 @@ class ContentDigestTest {
     }
 
     /**
-     * An entry carrying no content does not decide, and does not shadow one that does.
-     *
-     * <p>
-     * The map keeps the first non-empty content per algorithm, so a trailing empty entry cannot demote an algorithm to
-     * the next preference and a leading one cannot suppress the real digest behind it. Empty is not a contradiction
-     * either -- a producer that says nothing has not said something different.
-     */
-    /**
      * An alias spelling cannot escape the contradiction guard.
      *
      * <p>
@@ -203,6 +195,14 @@ class ContentDigestTest {
                 .isEqualTo("sha-256:aa");
     }
 
+    /**
+     * An entry carrying no content does not decide, and does not shadow one that does.
+     *
+     * <p>
+     * The map keeps the first non-empty content per algorithm, so a trailing empty entry cannot demote an algorithm to
+     * the next preference and a leading one cannot suppress the real digest behind it. Empty is not a contradiction
+     * either -- a producer that says nothing has not said something different.
+     */
     @Test
     void anEmptyContentNeitherWinsNorShadows() {
         assertThat(CertificateDigests

--- a/src/test/java/com/otilm/core/cbom/asset/identity/MaterialRedactionTest.java
+++ b/src/test/java/com/otilm/core/cbom/asset/identity/MaterialRedactionTest.java
@@ -173,6 +173,23 @@ class MaterialRedactionTest {
         assertThat(redaction.findings()).anySatisfy(finding -> assertThat(finding).contains("digest withheld"));
     }
 
+    /**
+     * The withheld member goes whole, so a sibling cannot carry the digest through.
+     *
+     * <p>
+     * Removing only the recognised {@code content} trusted whatever sat beside it: the decoy went and the nested digest
+     * was stored.
+     */
+    @Test
+    void aSiblingCannotCarryTheWithheldDigestThrough() {
+        MaterialRedaction redaction = MaterialRedaction
+                .of(read("{\"relatedCryptoMaterialProperties\":{\"type\":\"password\",\"fingerprint\":"
+                        + "{\"alg\":\"sha-256\",\"content\":\"decoy\",\"x\":{\"content\":\"5e884898da280471\"}}}}"));
+
+        assertThat(redaction.payload().toString()).doesNotContain("5e884898da280471").doesNotContain("decoy");
+        assertThat(redaction.payload().at("/relatedCryptoMaterialProperties/fingerprint").isMissingNode()).isTrue();
+    }
+
     /** The sibling {@code digest} member carries the same hazard and the same rule. */
     @Test
     void aBareDigestMemberIsWithheldToo() {

--- a/src/test/java/com/otilm/core/cbom/asset/identity/MaterialRedactionTest.java
+++ b/src/test/java/com/otilm/core/cbom/asset/identity/MaterialRedactionTest.java
@@ -59,8 +59,9 @@ class MaterialRedactionTest {
 
         assertThat(redaction.publishedDigest()).isNull();
         assertThat(redaction.identityDigest()).isNotNull().hasSize(64);
-        assertThat(redaction.payload().at("/relatedCryptoMaterialProperties/value/sha256").isMissingNode()).isTrue();
         assertThat(redaction.payload().at("/relatedCryptoMaterialProperties/value/length").asInt()).isEqualTo(7);
+        assertThat(redaction.payload().at("/relatedCryptoMaterialProperties/value/redacted").asBoolean()).isTrue();
+        assertThat(redaction.payload().at("/relatedCryptoMaterialProperties/value/sha256").isMissingNode()).isTrue();
         assertThat(redaction.findings()).anySatisfy(finding -> assertThat(finding).contains("digest withheld"));
     }
 
@@ -70,14 +71,14 @@ class MaterialRedactionTest {
     }
 
     @Test
-    void publishableMaterialCarriesItsDigestAndLength() {
+    void publishableMaterialCarriesTheContractedRedactionEnvelope() {
         MaterialRedaction redaction = redact("public-key", "QUJDRA==");
 
         assertThat(redaction.publishedDigest()).isEqualTo(redaction.identityDigest());
-        assertThat(redaction.payload().at("/relatedCryptoMaterialProperties/value/sha256").asText())
-                .isEqualTo(redaction.publishedDigest());
-        assertThat(redaction.payload().at("/relatedCryptoMaterialProperties/value/$redacted").asText())
-                .isEqualTo(MaterialRedaction.REDACTED_MARKER);
+        assertThat(redaction.payload().at("/relatedCryptoMaterialProperties/value/redacted").asBoolean()).isTrue();
+        assertThat(redaction.payload().at("/relatedCryptoMaterialProperties/value/length").asInt()).isEqualTo(8);
+        assertThat(redaction.payload().at("/relatedCryptoMaterialProperties/value/sha256").isMissingNode()).isTrue();
+        assertThat(redaction.payload().at("/relatedCryptoMaterialProperties/value/$redacted").isMissingNode()).isTrue();
     }
 
     /** Fails closed: guessing wrong on an unknown type would publish a reversible digest. */

--- a/src/test/java/com/otilm/core/cbom/asset/identity/MaterialRedactionTest.java
+++ b/src/test/java/com/otilm/core/cbom/asset/identity/MaterialRedactionTest.java
@@ -148,6 +148,61 @@ class MaterialRedactionTest {
         assertThat(redaction.identityDigest()).isNull();
     }
 
+    /**
+     * Every shape of a digest-bearing member goes for low-entropy material, not only the one covered shape.
+     *
+     * <p>
+     * A secret scanner fingerprints what it found so it can dedupe findings across runs, and that digest is exactly as
+     * reversible as the one the envelope withholds. Testing {@code isObject() && has("content")} and returning
+     * otherwise let a string, an array, an object keyed {@code sha256} and a nested object each carry an unsalted
+     * SHA-256 of a password into the served payload with no finding raised.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "\"sha256:5e884898da280471\"",
+            "[\"sha256:5e884898da280471\"]",
+            "{\"sha256\":\"5e884898da280471\"}",
+            "{\"x\":{\"content\":\"5e884898da280471\"}}",
+            "{\"content\":\"5e884898da280471\"}"})
+    void everyFingerprintShapeIsWithheldForLowEntropyMaterial(String fingerprint) {
+        MaterialRedaction redaction = MaterialRedaction
+                .of(read("{\"relatedCryptoMaterialProperties\":{\"type\":\"password\",\"fingerprint\":" + fingerprint
+                        + "}}"));
+
+        assertThat(redaction.payload().toString()).doesNotContain("5e884898da280471");
+        assertThat(redaction.findings()).anySatisfy(finding -> assertThat(finding).contains("digest withheld"));
+    }
+
+    /** The sibling {@code digest} member carries the same hazard and the same rule. */
+    @Test
+    void aBareDigestMemberIsWithheldToo() {
+        MaterialRedaction redaction = MaterialRedaction
+                .of(read("{\"relatedCryptoMaterialProperties\":{\"type\":\"password\","
+                        + "\"digest\":\"5e884898da280471\"}}"));
+
+        assertThat(redaction.payload().toString()).doesNotContain("5e884898da280471");
+        assertThat(redaction.findings()).anySatisfy(finding -> assertThat(finding).contains("digest withheld"));
+    }
+
+    /** Publishable material keeps its fingerprint: the withhold rule is about low-entropy types only. */
+    @Test
+    void aPublishableTypeKeepsItsFingerprint() {
+        MaterialRedaction redaction = MaterialRedaction
+                .of(read("{\"relatedCryptoMaterialProperties\":{\"type\":\"public-key\","
+                        + "\"fingerprint\":{\"content\":\"aabb\"}}}"));
+
+        assertThat(redaction.payload().toString()).contains("aabb");
+    }
+
+    /** An absent fingerprint raises nothing, so the finding list stays a signal rather than noise. */
+    @Test
+    void anAbsentFingerprintRaisesNoFinding() {
+        MaterialRedaction redaction = redact("password", "hunter2");
+
+        assertThat(redaction.findings())
+                .noneSatisfy(finding -> assertThat(finding).contains("fingerprint digest withheld"));
+    }
+
     private static MaterialRedaction redact(String type, String value) {
         return MaterialRedaction
                 .of(read("{\"relatedCryptoMaterialProperties\":{\"type\":\"" + type + "\",\"value\":" + quote(value)

--- a/src/test/java/com/otilm/core/cbom/asset/identity/MaterialRedactionTest.java
+++ b/src/test/java/com/otilm/core/cbom/asset/identity/MaterialRedactionTest.java
@@ -170,7 +170,52 @@ class MaterialRedactionTest {
                         + "}}"));
 
         assertThat(redaction.payload().toString()).doesNotContain("5e884898da280471");
-        assertThat(redaction.findings()).anySatisfy(finding -> assertThat(finding).contains("digest withheld"));
+        assertThat(redaction.findings()).anySatisfy(finding -> assertThat(finding).contains("fingerprint"));
+    }
+
+    /**
+     * The member name is not enumerable, so the rule is an allowlist.
+     *
+     * <p>
+     * None of these is a CycloneDX field -- they are all producer extensions, and a two-name withhold list let eight of
+     * ten carry an unsalted SHA-256 of a password into the served payload with no finding at all.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "hash",
+            "hashes",
+            "sha256",
+            "checksum",
+            "thumbprint",
+            "md5",
+            "fingerprints",
+            "Fingerprint",
+            "fingerprint",
+            "digest"})
+    void anyUncontractedMemberIsDroppedForLowEntropyMaterial(String member) {
+        MaterialRedaction redaction = MaterialRedaction
+                .of(read("{\"relatedCryptoMaterialProperties\":{\"type\":\"password\",\"" + member
+                        + "\":\"5e884898da280471\"}}"));
+
+        assertThat(redaction.payload().toString()).doesNotContain("5e884898da280471");
+        assertThat(redaction.findings())
+                .anySatisfy(finding -> assertThat(finding).contains("uncontracted members dropped").contains(member));
+    }
+
+    /** A contracted member is not an extension: the allowlist must not eat the pipeline's own fields. */
+    @Test
+    void everyContractedMemberSurvivesLowEntropyMaterial() {
+        MaterialRedaction redaction = MaterialRedaction
+                .of(read("{\"relatedCryptoMaterialProperties\":{\"type\":\"password\",\"id\":\"k1\","
+                        + "\"state\":\"active\",\"format\":\"raw\",\"size\":256,\"securedBy\":{\"mechanism\":\"HSM\"},"
+                        + "\"algorithmRef\":\"a1\",\"creationDate\":\"2026-01-01T00:00:00Z\"}}"));
+
+        assertThat(redaction.payload().at("/relatedCryptoMaterialProperties/id").asText()).isEqualTo("k1");
+        assertThat(redaction.payload().at("/relatedCryptoMaterialProperties/size").asInt()).isEqualTo(256);
+        assertThat(redaction.payload().at("/relatedCryptoMaterialProperties/securedBy/mechanism").asText())
+                .isEqualTo("HSM");
+        assertThat(redaction.findings())
+                .noneSatisfy(finding -> assertThat(finding).contains("uncontracted members dropped"));
     }
 
     /**
@@ -198,7 +243,7 @@ class MaterialRedactionTest {
                         + "\"digest\":\"5e884898da280471\"}}"));
 
         assertThat(redaction.payload().toString()).doesNotContain("5e884898da280471");
-        assertThat(redaction.findings()).anySatisfy(finding -> assertThat(finding).contains("digest withheld"));
+        assertThat(redaction.findings()).anySatisfy(finding -> assertThat(finding).contains("digest"));
     }
 
     /** Publishable material keeps its fingerprint: the withhold rule is about low-entropy types only. */
@@ -211,13 +256,15 @@ class MaterialRedactionTest {
         assertThat(redaction.payload().toString()).contains("aabb");
     }
 
-    /** An absent fingerprint raises nothing, so the finding list stays a signal rather than noise. */
+    /**
+     * A block carrying only contracted members raises nothing, so the finding list stays a signal rather than noise.
+     */
     @Test
     void anAbsentFingerprintRaisesNoFinding() {
         MaterialRedaction redaction = redact("password", "hunter2");
 
         assertThat(redaction.findings())
-                .noneSatisfy(finding -> assertThat(finding).contains("fingerprint digest withheld"));
+                .noneSatisfy(finding -> assertThat(finding).contains("uncontracted members dropped"));
     }
 
     private static MaterialRedaction redact(String type, String value) {

--- a/src/test/java/com/otilm/core/cbom/asset/identity/TextNormalizationTest.java
+++ b/src/test/java/com/otilm/core/cbom/asset/identity/TextNormalizationTest.java
@@ -445,8 +445,37 @@ class TextNormalizationTest {
         assertThat(sanitize("#/components/schemas/PrivateKey"))
                 .isNotEqualTo(sanitize("#/components/schemas/PublicKey"));
         assertThat(sanitize("#L42")).isEqualTo("#L42");
-        assertThat(sanitize("?path=/etc/ssl/private/a.key")).isEqualTo("?path=/etc/ssl/private/a.key");
         assertThat(sanitize("a.py#L42")).describedAs("a trailing fragment on a real path still goes").isEqualTo("a.py");
+    }
+
+    /**
+     * The kept pointer is a fragment, not a licence to keep a query.
+     *
+     * <p>
+     * A location beginning with {@code ?} is a bare query string naming no place, so keeping it verbatim stored the
+     * session token the query rule exists to drop -- and a pointer with a query of its own kept that token too.
+     */
+    @Test
+    void aLeadingDelimiterNeverKeepsAQueryString() {
+        assertThat(sanitize("?session=SECRETTOKEN&sig=HMACSECRET")).isEmpty();
+        assertThat(sanitize("#/components/schemas/PrivateKey?session=SECRETTOKEN"))
+                .isEqualTo("#/components/schemas/PrivateKey");
+        assertThat(sanitize("#frag?session=SECRETTOKEN")).isEqualTo("#frag");
+    }
+
+    /**
+     * The surrogate scrub runs before the credential strip, because removal can create what the strip looks for.
+     *
+     * <p>
+     * {@code x:\uD800//user:pass@host} does not match the user-info pattern. Scrubbing after the strip rendered
+     * {@code x://user:pass@host} -- a well-formed location carrying the credential into the digest and the evidence
+     * column, where the retained surrogate had previously made the whole string unhashable.
+     */
+    @Test
+    void aSurrogateCannotSmuggleACredentialPastTheStrip() {
+        assertThat(sanitize("x:\uD800//user:pass@host")).isEqualTo("x://host");
+        assertThat(sanitize(":/\uD800/user:pass@host")).isEqualTo("://host");
+        assertThat(sanitize("x://user:pass@host")).isEqualTo("x://host");
     }
 
     /** An unpaired surrogate has no UTF-8 encoding, so it reaches neither the digest nor the jsonb column. */
@@ -554,6 +583,20 @@ class TextNormalizationTest {
         assertThat(Occurrences.triples(occurrences("[{\"location\": \"a\", \"line\": -1.5}]")))
                 .describedAs("only a genuinely fractional position names no line")
                 .isEqualTo("a#%3F#");
+    }
+
+    /**
+     * An overflowing position is refused, not fatal.
+     *
+     * <p>
+     * A JSON {@code 1e999} parses to {@code Infinity}, and {@code BigDecimal.valueOf(Infinity)} throws -- so rendering
+     * the exact value threw {@code NumberFormatException} out of the reducer on a producer-controlled number. The
+     * sentinel exists precisely so an unusable position cannot key as absent; it has to catch this one too.
+     */
+    @Test
+    void anOverflowingPositionReachesTheSentinelRatherThanThrowing() {
+        assertThat(Occurrences.triples(occurrences("[{\"location\": \"a\", \"line\": 1e999}]"))).isEqualTo("a#%3F#");
+        assertThat(Occurrences.triples(occurrences("[{\"location\": \"a\", \"line\": -1e999}]"))).isEqualTo("a#%3F#");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/cbom/asset/identity/TextNormalizationTest.java
+++ b/src/test/java/com/otilm/core/cbom/asset/identity/TextNormalizationTest.java
@@ -79,14 +79,8 @@ class TextNormalizationTest {
     // ---------------------------------------------------------------- whitespace
 
     /**
-     * The whitespace stripped is the reference's, not the JDK's.
-     *
-     * <p>
-     * Measured, the two definitions disagree on exactly these four code points, and {@link String#strip()} misses all
-     * four because it consults {@link Character#isWhitespace}. The no-break spaces are the ones that occur in producer
-     * text pasted out of documents: a trailing one survives {@code strip()}, NFKC then turns it into an ordinary
-     * trailing space, and {@code "RSA "} keys apart from {@code "RSA"} -- a silent inventory split on a formatting
-     * accident.
+     * The whitespace stripped is the reference's, not the JDK's. These are the code points the two disagree on, and
+     * {@code AsciiText.PYTHON_WHITESPACE} carries the measurement and the reason.
      */
     @ParameterizedTest
     @ValueSource(ints = {0x0085, 0x00A0, 0x2007, 0x202F})
@@ -291,6 +285,21 @@ class TextNormalizationTest {
         assertThat(ValidityTimestamps.normalize(null)).isEmpty();
     }
 
+    /**
+     * A fraction is stripped from both accepted spellings, not only the extended one.
+     *
+     * <p>
+     * {@code uuuuMMddHHmmss'Z'} is GeneralizedTime, where a fractional second is legal, so anchoring the fraction
+     * pattern to the extended form alone left {@code 20250101000000.123Z} unparsed and keyed on its spelling -- the
+     * split this class exists to prevent, reintroduced for the one format the corpus does not yet witness.
+     */
+    @Test
+    void aFractionIsStrippedFromTheBasicSpellingToo() {
+        assertThat(ValidityTimestamps.normalize("20250101000000.123Z")).isEqualTo("1735689600");
+        assertThat(ValidityTimestamps.normalize("20250101000000Z")).isEqualTo("1735689600");
+        assertThat(ValidityTimestamps.normalize("2025-01-01T00:00:00.123Z")).isEqualTo("1735689600");
+    }
+
     @Test
     void calendarInvalidTimestampsStayLiteral() {
         assertThat(ValidityTimestamps.normalize("2025-02-28T00:00:00Z")).isEqualTo("1740700800");
@@ -381,19 +390,21 @@ class TextNormalizationTest {
      * The cap counts code points rather than UTF-16 units.
      *
      * <p>
-     * Counting storage units caps an astral-heavy URI before the user-info delimiter is even visible, so a credential
-     * can survive the sanitization step that should have removed it.
+     * The reference counts characters, so an astral-heavy location was capped at 512 characters here and at 1024 there
+     * -- one location, two keys. A location of 1024 astral characters is the shortest input that shows it.
      */
     @Test
     void theLocationLengthCapCountsCodePoints() {
         String astral = Character.toString(0x1F5DD);
 
         assertThat(sanitize("a".repeat(1023) + astral + "b")).isEqualTo("a".repeat(1023) + astral);
+        assertThat(sanitize(astral.repeat(1024) + "b")).isEqualTo(astral.repeat(1024));
         assertThat(sanitize("a".repeat(2000))).hasSize(1024);
     }
 
+    /** The cap is the last step, so no length of location can leave a credential behind it. */
     @Test
-    void userInfoIsStrippedBeforeTheLocationIsCapped() {
+    void userInfoIsStrippedWhateverTheCapCounts() {
         String astral = Character.toString(0x1F5DD);
         String location = "tcp://" + astral.repeat(611) + ":SuperSecretPassword123@host:443/path";
 
@@ -452,7 +463,25 @@ class TextNormalizationTest {
                 .isEqualTo("a#10000000000#");
         assertThat(Occurrences.triples(occurrences("[{\"location\": \"a\", \"line\": 1.5}]")))
                 .describedAs("no exact integer exists, so the numeric value is refused")
-                .isEqualTo("a##");
+                .isEqualTo("a#%3F#");
+    }
+
+    /**
+     * A refused position is not an absent one.
+     *
+     * <p>
+     * Rendering both as the empty slot would key an occurrence that stated an unusable line identically to one that
+     * stated no line at all, and the empty slot means absent everywhere else in the chain. The sentinel cannot collide
+     * with a producer value because {@link PreImageSlot} escapes a literal {@code %} before anything else.
+     */
+    @Test
+    void aRefusedPositionKeysApartFromAnAbsentOne() {
+        assertThat(Occurrences.triples(occurrences("[{\"location\": \"a\", \"line\": 1.5}]")))
+                .isNotEqualTo(Occurrences.triples(occurrences("[{\"location\": \"a\"}]")));
+        assertThat(Occurrences.triples(occurrences("[{\"location\": \"a\"}]"))).isEqualTo("a##");
+        assertThat(Occurrences.triples(occurrences("[{\"location\": \"a\", \"line\": \"%3F\"}]")))
+                .describedAs("a producer spelling the sentinel is escaped, so it cannot impersonate a refusal")
+                .isEqualTo("a#%253F#");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/cbom/asset/identity/TextNormalizationTest.java
+++ b/src/test/java/com/otilm/core/cbom/asset/identity/TextNormalizationTest.java
@@ -411,6 +411,55 @@ class TextNormalizationTest {
         assertThat(sanitize(location)).doesNotContain("SuperSecret").isEqualTo("tcp://host:443/path");
     }
 
+    /**
+     * Every user-info goes, not only the first.
+     *
+     * <p>
+     * One location can hold more than one URI, and {@code [^/?#]*} cannot cross a {@code /}, so a single replacement
+     * left every credential after the first standing. This is the live path to the served {@code evidence} column, so
+     * what survives is a stored, queryable secret.
+     */
+    @Test
+    void everyUserInfoIsStrippedNotOnlyTheFirst() {
+        assertThat(sanitize("jar:file://u1:p1@h1/a.jar!/https://u2:SECRET2@h2/b"))
+                .isEqualTo("jar:file://h1/a.jar!/https://h2/b");
+        assertThat(sanitize("kafka://u1:p1@b1:9092,kafka://u2:p2@b2:9092"))
+                .isEqualTo("kafka://b1:9092,kafka://b2:9092");
+        assertThat(sanitize("ldap://a:b@h1 ldap://c:d@h2")).isEqualTo("ldap://h1 ldap://h2");
+        assertThat(sanitize("tcp://a@h/" + Character.toString(0x1F5DD).repeat(497) + "/https://user:PASSWORD123@e"))
+                .describedAs("a larger cap must not preserve a credential the smaller one removed")
+                .doesNotContain("PASSWORD123");
+    }
+
+    /**
+     * A fragment-only location keeps its own text, because the empty string means absent.
+     *
+     * <p>
+     * A CycloneDX occurrence inside an OpenAPI or JSON document carries a JSON pointer. Cutting at position zero made
+     * every pointer the empty location, so they shared one discriminator with each other and with a component that
+     * stated no location at all.
+     */
+    @Test
+    void aFragmentOnlyLocationIsNotTheEmptyLocation() {
+        assertThat(sanitize("#/components/schemas/PrivateKey")).isEqualTo("#/components/schemas/PrivateKey");
+        assertThat(sanitize("#/components/schemas/PrivateKey"))
+                .isNotEqualTo(sanitize("#/components/schemas/PublicKey"));
+        assertThat(sanitize("#L42")).isEqualTo("#L42");
+        assertThat(sanitize("?path=/etc/ssl/private/a.key")).isEqualTo("?path=/etc/ssl/private/a.key");
+        assertThat(sanitize("a.py#L42")).describedAs("a trailing fragment on a real path still goes").isEqualTo("a.py");
+    }
+
+    /** An unpaired surrogate has no UTF-8 encoding, so it reaches neither the digest nor the jsonb column. */
+    @Test
+    void anUnpairedSurrogateIsScrubbedWhereverItSits() {
+        assertThat(sanitize("a\uD83Db")).isEqualTo("ab");
+        assertThat(sanitize("a\uDE00b")).isEqualTo("ab");
+        assertThat(sanitize("a".repeat(1023) + "\uD83D" + "b")).isEqualTo("a".repeat(1023) + "b");
+        assertThat(sanitize("a" + Character.toString(0x1F5DD) + "b"))
+                .describedAs("a well-formed pair is untouched")
+                .isEqualTo("a" + Character.toString(0x1F5DD) + "b");
+    }
+
     // ---------------------------------------------------------------- occurrence discriminator
 
     /**
@@ -482,6 +531,29 @@ class TextNormalizationTest {
         assertThat(Occurrences.triples(occurrences("[{\"location\": \"a\", \"line\": \"%3F\"}]")))
                 .describedAs("a producer spelling the sentinel is escaped, so it cannot impersonate a refusal")
                 .isEqualTo("a#%253F#");
+    }
+
+    /**
+     * A position is rendered through its exact value, not through Jackson's node type.
+     *
+     * <p>
+     * {@code isIntegralNumber} asks how the producer serialized the number, so every double-spelled line collapsed onto
+     * one refusal: {@code 1.0} and {@code 2.0} keyed identically, and {@code 1e3} -- the line 1000 -- was refused for
+     * its spelling. A producer whose JSON writer emits {@code 1.0} for an integer had its discriminator degraded to
+     * location-only, which merges twelve of thirty-three distinct secret keys.
+     */
+    @Test
+    void aPositionRendersThroughItsValueNotItsSpelling() {
+        assertThat(Occurrences.triples(occurrences("[{\"location\": \"a\", \"line\": 1.0}]"))).isEqualTo("a#1#");
+        assertThat(Occurrences.triples(occurrences("[{\"location\": \"a\", \"line\": 2.0}]"))).isEqualTo("a#2#");
+        assertThat(Occurrences.triples(occurrences("[{\"location\": \"a\", \"line\": 1e3}]"))).isEqualTo("a#1000#");
+        assertThat(Occurrences.triples(occurrences("[{\"location\": \"a\", \"line\": 0.0}]"))).isEqualTo("a#0#");
+        assertThat(Occurrences.triples(occurrences("[{\"location\": \"a\", \"line\": 1.0}]")))
+                .describedAs("two different lines must not key alike")
+                .isNotEqualTo(Occurrences.triples(occurrences("[{\"location\": \"a\", \"line\": 2.0}]")));
+        assertThat(Occurrences.triples(occurrences("[{\"location\": \"a\", \"line\": -1.5}]")))
+                .describedAs("only a genuinely fractional position names no line")
+                .isEqualTo("a#%3F#");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/cbom/asset/identity/TextNormalizationTest.java
+++ b/src/test/java/com/otilm/core/cbom/asset/identity/TextNormalizationTest.java
@@ -441,10 +441,10 @@ class TextNormalizationTest {
      */
     @Test
     void aFragmentOnlyLocationIsNotTheEmptyLocation() {
-        assertThat(sanitize("#/components/schemas/PrivateKey")).isEqualTo("#/components/schemas/PrivateKey");
+        assertThat(sanitize("#/components/schemas/PrivateKey")).isEqualTo("/components/schemas/PrivateKey");
         assertThat(sanitize("#/components/schemas/PrivateKey"))
                 .isNotEqualTo(sanitize("#/components/schemas/PublicKey"));
-        assertThat(sanitize("#L42")).isEqualTo("#L42");
+        assertThat(sanitize("#L42")).isEqualTo("L42");
         assertThat(sanitize("a.py#L42")).describedAs("a trailing fragment on a real path still goes").isEqualTo("a.py");
     }
 
@@ -459,8 +459,42 @@ class TextNormalizationTest {
     void aLeadingDelimiterNeverKeepsAQueryString() {
         assertThat(sanitize("?session=SECRETTOKEN&sig=HMACSECRET")).isEmpty();
         assertThat(sanitize("#/components/schemas/PrivateKey?session=SECRETTOKEN"))
-                .isEqualTo("#/components/schemas/PrivateKey");
-        assertThat(sanitize("#frag?session=SECRETTOKEN")).isEqualTo("#frag");
+                .isEqualTo("/components/schemas/PrivateKey");
+        assertThat(sanitize("#frag?session=SECRETTOKEN")).isEqualTo("frag");
+    }
+
+    /**
+     * No sanitized location carries the triple's own separator.
+     *
+     * <p>
+     * The location slot is the one slot {@link PreImageSlot} does not escape, so a location holding a {@code #} and a
+     * newline renders as two triple lines and one occurrence impersonates two. Keeping a leading fragment's delimiter
+     * re-opened this; keeping only its text closes it, because a {@code #} can then never reach the slot at all.
+     */
+    @Test
+    void noSanitizedLocationCarriesTheTripleSeparator() {
+        assertThat(sanitize("##\na")).doesNotContain("#");
+        assertThat(sanitize("#a##\nb#1#2")).doesNotContain("#");
+        assertThat(Occurrences.triples(occurrences("[{\"location\": \"##\\na\"}]")))
+                .describedAs("one occurrence cannot render as two triples")
+                .isNotEqualTo(Occurrences.triples(occurrences("[{},{\"location\": \"a\"}]")));
+    }
+
+    /**
+     * A network-path reference carries user-info too.
+     *
+     * <p>
+     * {@code //user:secret@host/x} is a well-formed URI reference that {@code java.net.URI} parses with
+     * {@code userInfo=user:secret}, and it is what a scanner emits for a protocol-relative URL. Anchoring the pattern
+     * on a literal {@code ://} let it through.
+     */
+    @Test
+    void aNetworkPathReferenceLosesItsCredentialToo() {
+        assertThat(sanitize("//user:secret@host/x")).isEqualTo("//host/x");
+        assertThat(sanitize("x://user:secret@host/x")).isEqualTo("x://host/x");
+        assertThat(sanitize("kafka://u1:p1@b1:9092,kafka://u2:p2@b2:9092"))
+                .describedAs("every credential, not the first")
+                .isEqualTo("kafka://b1:9092,kafka://b2:9092");
     }
 
     /**

--- a/src/test/java/com/otilm/core/cbom/asset/identity/TextNormalizationTest.java
+++ b/src/test/java/com/otilm/core/cbom/asset/identity/TextNormalizationTest.java
@@ -71,21 +71,26 @@ class TextNormalizationTest {
         assertThat(AsciiText.lookupKey(input)).isEqualTo(expected);
     }
 
+    @Test
+    void lookupKeysUseTheReferenceWhitespaceSet() {
+        assertThat(AsciiText.lookupKey("A\u0085E\u00A0S\u2007G\u202FC\u200BM")).isEqualTo("aesgc\u200Bm");
+    }
+
     // ---------------------------------------------------------------- whitespace
 
     /**
      * The whitespace stripped is the reference's, not the JDK's.
      *
      * <p>
-     * Measured, the two definitions disagree on exactly these three code points, and {@link String#strip()} misses all
-     * three because it consults {@link Character#isWhitespace}. The two no-break spaces are the ones that occur in
-     * producer text pasted out of documents: a trailing one survives {@code strip()}, NFKC then turns it into an
-     * ordinary trailing space, and {@code "RSA "} keys apart from {@code "RSA"} -- a silent inventory split on a
-     * formatting accident.
+     * Measured, the two definitions disagree on exactly these four code points, and {@link String#strip()} misses all
+     * four because it consults {@link Character#isWhitespace}. The no-break spaces are the ones that occur in producer
+     * text pasted out of documents: a trailing one survives {@code strip()}, NFKC then turns it into an ordinary
+     * trailing space, and {@code "RSA "} keys apart from {@code "RSA"} -- a silent inventory split on a formatting
+     * accident.
      */
     @ParameterizedTest
-    @ValueSource(ints = {0x0085, 0x00A0, 0x202F})
-    void theThreeCodePointsJavaMissesAreStripped(int codePoint) {
+    @ValueSource(ints = {0x0085, 0x00A0, 0x2007, 0x202F})
+    void theFourCodePointsJavaMissesAreStripped(int codePoint) {
         String character = Character.toString(codePoint);
 
         assertThat(Character.isWhitespace(codePoint))
@@ -260,6 +265,7 @@ class TextNormalizationTest {
             "2025-01-01t00:00:00z",
             "2025-01-01T00:00:00+00:00",
             "2025-01-01T02:00:00+02:00",
+            "2025-01-01T02:00:00+0200",
             "2024-12-31T19:00:00-05:00",
             "20250101000000Z",
             "2025-01-01T00:00:00.123456789Z"})
@@ -268,8 +274,8 @@ class TextNormalizationTest {
     }
 
     @Test
-    void anOffsetIsResolvedRatherThanKept() {
-        assertThat(ValidityTimestamps.normalize("2025-01-01T02:00:00+0200")).isEqualTo("1735689600");
+    void aSpaceSeparatedOffsetIsKeptRatherThanFolded() {
+        assertThat(ValidityTimestamps.normalize("2025-01-01 02:00:00+02:00")).isEqualTo("2025-01-01 02:00:00+02:00");
     }
 
     /**
@@ -279,8 +285,19 @@ class TextNormalizationTest {
     @Test
     void anUnparseableTimestampIsKeptRatherThanDropped() {
         assertThat(ValidityTimestamps.normalize("not-a-date")).isEqualTo("not-a-date");
+        assertThat(ValidityTimestamps.normalize("release.1")).isEqualTo("release.1");
+        assertThat(ValidityTimestamps.normalize("v1.2.3")).isEqualTo("v1.2.3");
         assertThat(ValidityTimestamps.normalize("")).isEmpty();
         assertThat(ValidityTimestamps.normalize(null)).isEmpty();
+    }
+
+    @Test
+    void calendarInvalidTimestampsStayLiteral() {
+        assertThat(ValidityTimestamps.normalize("2025-02-28T00:00:00Z")).isEqualTo("1740700800");
+        assertThat(ValidityTimestamps.normalize("2025-02-29T00:00:00Z")).isEqualTo("2025-02-29T00:00:00Z");
+        assertThat(ValidityTimestamps.normalize("2025-02-30T00:00:00Z")).isEqualTo("2025-02-30T00:00:00Z");
+        assertThat(ValidityTimestamps.normalize("2025-02-28T24:00:00Z")).isEqualTo("2025-02-28T24:00:00Z");
+        assertThat(ValidityTimestamps.normalize("20250229000000Z")).isEqualTo("20250229000000Z");
     }
 
     @Test
@@ -361,23 +378,26 @@ class TextNormalizationTest {
     }
 
     /**
-     * The cap may not cut between the halves of a surrogate pair.
+     * The cap counts code points rather than UTF-16 units.
      *
      * <p>
-     * The cap counts UTF-16 units, so 1023 basic-plane characters followed by one astral character left a lone high
-     * surrogate as the last char. {@link IdentityDigests#sha256Hex} refuses that, so the component became a reported
-     * skip and vanished from the inventory; the same string also has no valid UTF-8 encoding for the jsonb evidence
-     * column. The pair is dropped whole instead.
+     * Counting storage units caps an astral-heavy URI before the user-info delimiter is even visible, so a credential
+     * can survive the sanitization step that should have removed it.
      */
     @Test
-    void theLengthCapNeverSplitsASurrogatePair() {
+    void theLocationLengthCapCountsCodePoints() {
         String astral = Character.toString(0x1F5DD);
 
-        assertThat(sanitize("a".repeat(1023) + astral))
-                .describedAs("the pair starts at unit 1023 and cannot fit, so neither half is kept")
-                .isEqualTo("a".repeat(1023));
-        assertThat(sanitize("a".repeat(1022) + astral)).isEqualTo("a".repeat(1022) + astral);
+        assertThat(sanitize("a".repeat(1023) + astral + "b")).isEqualTo("a".repeat(1023) + astral);
         assertThat(sanitize("a".repeat(2000))).hasSize(1024);
+    }
+
+    @Test
+    void userInfoIsStrippedBeforeTheLocationIsCapped() {
+        String astral = Character.toString(0x1F5DD);
+        String location = "tcp://" + astral.repeat(611) + ":SuperSecretPassword123@host:443/path";
+
+        assertThat(sanitize(location)).doesNotContain("SuperSecret").isEqualTo("tcp://host:443/path");
     }
 
     // ---------------------------------------------------------------- occurrence discriminator
@@ -406,16 +426,17 @@ class TextNormalizationTest {
         assertThat(Occurrences.discriminator(component)).isEqualTo(IdentityDigests.sha256Hex("a.py#1#2"));
     }
 
-    /** Triples are sorted and de-duplicated, so a producer's array order cannot re-key an asset between scans. */
+    /** Triples are sorted, but repeated sightings are kept because multiplicity is a stated fact. */
     @Test
-    void arrayOrderAndRepetitionDoNotReachTheKey() {
+    void arrayOrderDoesNotReachTheKeyButRepetitionDoes() {
         String ascending = Occurrences
                 .triples(occurrences("[{\"location\": \"a.py\", \"line\": 1}, {\"location\": \"b.py\", \"line\": 2}]"));
         String descendingWithARepeat = Occurrences
                 .triples(occurrences("[{\"location\": \"b.py\", \"line\": 2}, {\"location\": \"a.py\", \"line\": 1},"
                         + " {\"location\": \"b.py\", \"line\": 2}]"));
 
-        assertThat(ascending).isEqualTo("a.py#1#\nb.py#2#").isEqualTo(descendingWithARepeat);
+        assertThat(ascending).isEqualTo("a.py#1#\nb.py#2#");
+        assertThat(descendingWithARepeat).isEqualTo("a.py#1#\nb.py#2#\nb.py#2#");
     }
 
     /**
@@ -423,16 +444,26 @@ class TextNormalizationTest {
      *
      * <p>
      * {@code JsonNode.asText()} on a large integral node can yield exponent notation, which would key the same line two
-     * ways depending on how the producer serialized it. A non-integral line has no exact integer to render, so it keeps
-     * the producer's own spelling rather than being rounded into one.
+     * ways depending on how the producer serialized it. A non-integral line has no exact integer to render.
      */
     @Test
     void anIntegralLineRendersThroughItsExactValue() {
         assertThat(Occurrences.triples(occurrences("[{\"location\": \"a\", \"line\": 10000000000}]")))
                 .isEqualTo("a#10000000000#");
         assertThat(Occurrences.triples(occurrences("[{\"location\": \"a\", \"line\": 1.5}]")))
-                .describedAs("no exact integer exists, so the producer's spelling stands")
-                .isEqualTo("a#1.5#");
+                .describedAs("no exact integer exists, so the numeric value is refused")
+                .isEqualTo("a##");
+    }
+
+    @Test
+    void triplesSortByCodePointNotUtf16StorageUnits() {
+        String supplementary = Character.toString(0x10000);
+        String privateUse = Character.toString(0xE000);
+
+        assertThat(Occurrences
+                .triples(occurrences(
+                        "[{\"location\": \"" + supplementary + "\"}," + "{\"location\": \"" + privateUse + "\"}]")))
+                .isEqualTo(privateUse + "##\n" + supplementary + "##");
     }
 
     /**


### PR DESCRIPTION
4918
mmary

Part 1 of 2 in the core#2165 adjudication series, and the first link in a stack
that has to land in order: `main` <- **this PR** <- core#2170. core#2072 has
landed on `main`, so this PR carries the primitive-layer core#2165 repairs that
can merge independently of the generated identity-table work. core#2170's
264-vector fixture already encodes the behaviour this PR settles, so it must not
merge first.

This lands the core#2165 repairs that fit in the primitive identity layer now
present on `main`:

- make timestamp normalization strict, preserve non-timestamp fallbacks, and
  fold colonized RFC 3339 offsets
- sanitize occurrence locations in the safe order and cap by code point; keep
  duplicate triples and refuse non-integral numeric positions
- constrain cipher-suite identifier parsing and render each token to even-width
  hex up to `0xFFFF`
- store the contracted redaction envelope `{"redacted": true, "length": n}` with
  no digest
- prevent certificate digest sub-delimiter forgery and avoid keying on
  self-contradictory digest algorithms
- apply the reference whitespace set to lookup separators

## Measured cost

Against the 2026-08-31 corpus (180 documents, 4 815 assets), two of these
changes move a row and the rest are free:

- **duplicate occurrence triples** -- 12 occurrence-bearing assets across 4
  documents repeat an identical `location#line#offset`
  (`Chat2DB_cdxgen` collapses 79 -> 73 and 38 -> 10 under the old `TreeSet`)
- **the fourth cipher-suite encoding** -- `["0x1301"]`, `["0x1302"]`,
  `["0x1303"]`, one row each in CycloneDX's own
  `valid-cryptography-full-1.7` fixture, now merging with the 17 per-byte rows
  spelling the same suites; the 2 133 -> 2 134 identity split does not happen

Zero-row today, so free to settle now and not after first ingest: 0 of 490
distinct validity strings are calendar-invalid, 0 of 390 certificate hash
entries repeat an algorithm, 0 `alg`/`content` values carry a colon, 0
fractional numeric positions, and 0 occurrence locations carry userinfo, `#`,
CR or LF or exceed 194 characters.

## Review findings repaired in this branch

The second commit answers a review against the ai-toolkit review contract and
the architecture gate. Two findings were behavioural:

- the fraction pattern was anchored to the extended time-of-day spelling only,
  so `20250101000000.123Z` -- GeneralizedTime, where a fraction is legal --
  stopped folding and began keying on its spelling
- a refused non-integral position rendered as the empty slot, which is what an
  *absent* position renders as, so an occurrence stating an unusable line keyed
  identically to one stating no line

The rest corrected the record: the code-point cap's stated reason described a
credential surviving user-info stripping, which this code cannot do on either
side of the diff (the cap is the last step of `sanitizeLocation`), and the test
named for that ordering could not fail either way. The digest escaper was a copy
of `PreImageSlot.of`'s walk, and nothing recorded that the pre-image carries the
**doubly**-escaped `%253A` rather than `%3A`. Four tests were added where a
JaCoCo pass showed a property claimed but not exercised.

## Series / dependency note

This intentionally does **not** close core#2165. The rest is blocked until the
core#2168 identity-table/vector work is available under this stack:
`CryptoAssetIdentity`, `DocumentScope`, `IdentityTables`, generated
`identity-tables.json`, identity vectors/gold corpus, and the full tier-routing
chain are required for the remaining adjudications.

Two adjudications this branch surfaces and does **not** settle, both zero-cost
while the `crypto_asset` table is empty:

- the `%3F` refused-position sentinel is this branch's own choice of bytes, not
  a ratified spelling -- if a core#2170 vector encodes `a##` for a non-integral
  line, that vector and this decide each other
- even-width cipher-suite padding is not injective for odd-width tokens
  (`["0x131","0x1"]` and `["0x01","0x3101"]` both render `013101`); nothing in
  the token stream says whether a token is one byte or a whole code, so this is
  a gap in the ratified rule rather than a defect here

core#2165 item 18 also stays half-open: the `\s` lookup-separator site is fixed
here and is the only one in this package, but `AssetNormalizer.normalizeMode`
and `IdentityTables.isSentinel`/`familyToken` live on core#2170.

## Deferred by ruling, not by oversight

Karol's review surfaced five things that are decisions rather than repairs -- each moves keys or
stored payload shape for rows that exist, so each needs the ratifier rather than a patch:

- **Manufactured occurrence multiplicity.** `a.py?x=1` and `a.py?x=2` are distinct to the producer
  and become duplicates only because the query is stripped, so a scanner changing how many query
  variants it reports re-keys the asset. De-duplicating after sanitization, or keying the
  pre-sanitized location, changes the digest for the 12 assets across 4 documents that the
  keep-duplicates arm was chosen for. A core#2165 item-9a amendment.
- **The unbounded occurrence pre-image.** `triples()` walks the raw `JsonNode`, so
  `OccurrenceEvidenceCapper`'s `MAX_OCCURRENCES = 50` does not apply -- it caps a
  `List<Map<String,Object>>` at write time instead. Measured: 100k identical occurrences give a
  6,099,999-character pre-image over one distinct triple. Any bound changes the digest above it.
- **The publishable-material digest.** The merged `interfaces` `@Schema` scopes the redaction
  envelope to *secret* material and treats an absent classification as secret; it does not ask for
  the digest to be dropped for material the platform classifies as publishable. Dropping it for
  `public-key` is broader than the contract requires, and two distinct public keys now canonicalize
  identically at the five core#2170 sites that hash this payload. This settles core#2165 D-6 on the
  contract rather than as "a product decision".
- **The ungated fingerprint channel.** `hashes[]` is `PREFERENCE`-gated and the 1.7 `fingerprint`
  field is not, so MD5 is a claim on one side and refused on the other. Gating it drops a digest
  tier from certificates that have one today.
- **Cross-channel digest contradiction.** `fingerprint{SHA-256,aa}` with `hashes:[{SHA-256,bb}]` is
  accepted where the same pair inside `hashes[]` is refused, and `claimed()` returns the digest
  twice when both channels agree. `bothDigestChannelsAreClaimedFingerprintFirst` pins the current
  asymmetry, so a fix has to change that test. core#2165 item 5's ingest-finding half also has no
  findings channel in this class.

Also still open from item 11: `PreImageSlot` does not escape `#`, the occurrence triple's own
delimiter, so a *textual* line or offset can move the line/offset boundary. The escape set is
shared with the core#2170 DN composite, so adding a member re-keys every slot containing a `#`.
The javadoc now states the limit instead of claiming the property.

## Tests

`/usr/bin/mvn4 -B -Dtest='com.otilm.core.cbom.asset.identity.*Test,com.otilm.core.cbom.asset.*Test,com.otilm.core.architecture.*Test,ContextSignatureGuardTest' test spotless:check checkstyle:check`
-- 306 tests, 0 failures, format and architecture gates clean, on a clean build.
No new Spring context signature, so `ContextSignatureGuardTest.BASELINE` is
untouched.

Refs core#2165.
