### PR TITLE
Carry the predecessor's identity into renew and rekey

### DIFF
--- a/src/main/java/com/otilm/core/certificate/request/RenewContentSeeder.java
+++ b/src/main/java/com/otilm/core/certificate/request/RenewContentSeeder.java
@@ -1,0 +1,86 @@
+package com.otilm.core.certificate.request;
+
+import com.otilm.api.exception.CertificateRequestException;
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.connector.v3.certificate.X509RequestContent;
+import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.CertificateRequestEntity;
+import com.otilm.core.model.request.CertificateRequest;
+import com.otilm.core.util.CertificateRequestUtils;
+import com.otilm.core.util.CertificateUtil;
+import com.otilm.core.util.X509RequestContentRenderer;
+import java.io.IOException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.asn1.x509.Extensions;
+
+/**
+ * Seeds the identity a successor inherits from the certificate it replaces — subject DN and SAN, no extensions — for
+ * the structured renew wire and for the rekey CSR the platform builds itself.
+ */
+@Slf4j
+public final class RenewContentSeeder {
+
+    private RenewContentSeeder() {
+    }
+
+    /**
+     * The typed identity for the structured renew wire: the CSR the operator supplied when there is one, and otherwise
+     * the predecessor certificate. Empty when that identity cannot be carried in full, in which case the caller leaves
+     * {@code requestContent} unset and the connector parses the CSR the wire already carries.
+     */
+    public static Optional<X509RequestContent> seed(Certificate oldCertificate, Certificate newCertificate,
+            ClientCertificateRenewRequestDto request) {
+        try {
+            ParsedRequestContent parsed = operatorSuppliedCsr(newCertificate, request)
+                    ? X509RequestContentParser.parse(storedCsr(newCertificate))
+                    : X509RequestContentParser.parse(storedCertificate(oldCertificate));
+            if (!parsed.unsupportedSans().isEmpty()) {
+                log
+                        .warn("Not seeding structured renew content: subject alternative name {} has no typed representation",
+                                parsed.unsupportedSans());
+                return Optional.empty();
+            }
+            return Optional.of(parsed.content());
+        } catch (CertificateException | CertificateRequestException | RuntimeException e) {
+            log.warn("Not seeding structured renew content: the identity to carry forward could not be read", e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * The SAN extension block a rekey CSR inherits, or null when the predecessor carries no SAN. Fails closed: the
+     * platform builds this CSR itself, so nothing downstream can recover a SAN dropped here.
+     */
+    public static Extensions rekeySanExtensions(X509Certificate oldCertificate) {
+        ParsedRequestContent parsed = X509RequestContentParser.parse(oldCertificate);
+        if (!parsed.unsupportedSans().isEmpty()) {
+            throw new ValidationException(
+                    "The certificate carries a subject alternative name the platform cannot re-request: %s"
+                            .formatted(String.join(", ", parsed.unsupportedSans())));
+        }
+        try {
+            return X509RequestContentRenderer.toExtensions(parsed.content());
+        } catch (IOException e) {
+            throw new ValidationException(
+                    "Failed to build the subject alternative name of the re-keyed request. Error: " + e.getMessage());
+        }
+    }
+
+    private static boolean operatorSuppliedCsr(Certificate newCertificate, ClientCertificateRenewRequestDto request) {
+        return request != null && request.getRequest() != null && newCertificate.getCertificateRequest() != null;
+    }
+
+    private static CertificateRequest storedCsr(Certificate certificate) throws CertificateRequestException {
+        CertificateRequestEntity stored = certificate.getCertificateRequest();
+        return CertificateRequestUtils
+                .createCertificateRequest(stored.getContent(), stored.getCertificateRequestFormat());
+    }
+
+    private static X509Certificate storedCertificate(Certificate certificate) throws CertificateException {
+        return CertificateUtil.parseCertificate(certificate.getCertificateContent().getContent());
+    }
+}

--- a/src/main/java/com/otilm/core/certificate/request/RenewContentSeeder.java
+++ b/src/main/java/com/otilm/core/certificate/request/RenewContentSeeder.java
@@ -13,16 +13,18 @@ import com.otilm.core.util.X509RequestContentRenderer;
 import java.io.IOException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.asn1.x500.RDN;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.Extensions;
 
 /**
- * Seeds the identity a successor inherits from the certificate it replaces — subject DN and SAN, no extensions — for
- * the structured renew wire and for the rekey CSR the platform builds itself.
+ * Seeds what a successor inherits, for the structured renew wire and for the rekey CSR the platform builds itself. A
+ * predecessor certificate yields its subject DN and SAN; the extensions of an issued certificate are the CA's and are
+ * never seeded. A CSR source yields what the operator requested in it, extensions included, because the content is
+ * authoritative for a structured connector.
  */
 @Slf4j
 public final class RenewContentSeeder {
@@ -54,15 +56,20 @@ public final class RenewContentSeeder {
                         .warn("Not seeding structured renew content: the subject packs a multi-valued RDN, which typed content cannot express");
                 return Optional.empty();
             }
-            if (!parsed.unsupportedSans().isEmpty()) {
+            if (!parsed.unsupportedSans().isEmpty() || !parsed.unrepresentableExtensionValues().isEmpty()) {
+                // The content is authoritative for the connector, so a partial one narrows what was requested.
+                // Both lists hold what the typed model could not carry; either one means send nothing.
                 log
-                        .warn("Not seeding structured renew content: subject alternative name {} has no typed representation",
-                                parsed.unsupportedSans());
+                        .warn("Not seeding structured renew content: {} has no typed representation",
+                                Stream
+                                        .concat(parsed.unsupportedSans().stream(),
+                                                parsed.unrepresentableExtensionValues().stream())
+                                        .toList());
                 return Optional.empty();
             }
-            X509RequestContent content = identityOnly(parsed.content());
-            if (isEmpty(content.getSubject()) && isEmpty(content.getSubjectAltNames())) {
-                log.warn("Not seeding structured renew content: no subject or subject alternative name to carry");
+            X509RequestContent content = parsed.content();
+            if (!content.isRequestContentProvided()) {
+                log.warn("Not seeding structured renew content: the source carries no identity to send");
                 return Optional.empty();
             }
             return Optional.of(content);
@@ -81,9 +88,11 @@ public final class RenewContentSeeder {
         try {
             parsed = X509RequestContentParser.parse(oldCertificate);
         } catch (RuntimeException e) {
+            // Malformed ASN.1 surfaces as unchecked BouncyCastle exceptions whose messages may carry internals,
+            // and this one reaches the client as a 422 body; log it and answer with fixed wording.
+            log.warn("The certificate's identity could not be decoded for a re-keyed request", e);
             throw new ValidationException(
-                    "The certificate's identity could not be decoded, so it cannot be carried into a re-keyed request. Error: "
-                            + e.getMessage());
+                    "The certificate's identity could not be decoded, so it cannot be carried into a re-keyed request");
         }
         if (!parsed.unsupportedSans().isEmpty()) {
             throw new ValidationException(
@@ -93,8 +102,8 @@ public final class RenewContentSeeder {
         try {
             return X509RequestContentRenderer.toExtensions(parsed.content());
         } catch (IOException e) {
-            throw new ValidationException(
-                    "Failed to build the subject alternative name of the re-keyed request. Error: " + e.getMessage());
+            log.warn("Failed to encode the subject alternative name of a re-keyed request", e);
+            throw new ValidationException("Failed to build the subject alternative name of the re-keyed request");
         }
     }
 
@@ -111,23 +120,6 @@ public final class RenewContentSeeder {
             }
         }
         return false;
-    }
-
-    /**
-     * Narrows parsed content to the identity the renew wire carries. A CSR source also yields key usage, extended key
-     * usage and requested extensions; those stay on the CSR travelling beside the content, so both sources put the same
-     * shape on the wire and nothing extension-shaped can reach it reduced.
-     */
-    private static X509RequestContent identityOnly(X509RequestContent content) {
-        content.setKeyUsage(null);
-        content.setExtendedKeyUsage(null);
-        content.setExtensions(null);
-        return content;
-    }
-
-    /** Content with neither dimension would fail the wire model's own "something must be provided" assertion. */
-    private static boolean isEmpty(List<?> values) {
-        return values == null || values.isEmpty();
     }
 
     private static boolean operatorSuppliedCsr(Certificate newCertificate, ClientCertificateRenewRequestDto request) {

--- a/src/main/java/com/otilm/core/certificate/request/RenewContentSeeder.java
+++ b/src/main/java/com/otilm/core/certificate/request/RenewContentSeeder.java
@@ -13,6 +13,7 @@ import com.otilm.core.util.X509RequestContentRenderer;
 import java.io.IOException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.asn1.x509.Extensions;
@@ -44,7 +45,12 @@ public final class RenewContentSeeder {
                                 parsed.unsupportedSans());
                 return Optional.empty();
             }
-            return Optional.of(parsed.content());
+            X509RequestContent content = identityOnly(parsed.content());
+            if (isEmpty(content.getSubject()) && isEmpty(content.getSubjectAltNames())) {
+                log.warn("Not seeding structured renew content: no subject or subject alternative name to carry");
+                return Optional.empty();
+            }
+            return Optional.of(content);
         } catch (CertificateException | CertificateRequestException | RuntimeException e) {
             log.warn("Not seeding structured renew content: the identity to carry forward could not be read", e);
             return Optional.empty();
@@ -56,7 +62,14 @@ public final class RenewContentSeeder {
      * platform builds this CSR itself, so nothing downstream can recover a SAN dropped here.
      */
     public static Extensions rekeySanExtensions(X509Certificate oldCertificate) {
-        ParsedRequestContent parsed = X509RequestContentParser.parse(oldCertificate);
+        ParsedRequestContent parsed;
+        try {
+            parsed = X509RequestContentParser.parse(oldCertificate);
+        } catch (RuntimeException e) {
+            throw new ValidationException(
+                    "The certificate's identity could not be decoded, so it cannot be carried into a re-keyed request. Error: "
+                            + e.getMessage());
+        }
         if (!parsed.unsupportedSans().isEmpty()) {
             throw new ValidationException(
                     "The certificate carries a subject alternative name the platform cannot re-request: %s"
@@ -68,6 +81,23 @@ public final class RenewContentSeeder {
             throw new ValidationException(
                     "Failed to build the subject alternative name of the re-keyed request. Error: " + e.getMessage());
         }
+    }
+
+    /**
+     * Narrows parsed content to the identity the renew wire carries. A CSR source also yields key usage, extended key
+     * usage and requested extensions; those stay on the CSR travelling beside the content, so both sources put the same
+     * shape on the wire and nothing extension-shaped can reach it reduced.
+     */
+    private static X509RequestContent identityOnly(X509RequestContent content) {
+        content.setKeyUsage(null);
+        content.setExtendedKeyUsage(null);
+        content.setExtensions(null);
+        return content;
+    }
+
+    /** Content with neither dimension would fail the wire model's own "something must be provided" assertion. */
+    private static boolean isEmpty(List<?> values) {
+        return values == null || values.isEmpty();
     }
 
     private static boolean operatorSuppliedCsr(Certificate newCertificate, ClientCertificateRenewRequestDto request) {

--- a/src/main/java/com/otilm/core/certificate/request/RenewContentSeeder.java
+++ b/src/main/java/com/otilm/core/certificate/request/RenewContentSeeder.java
@@ -16,6 +16,8 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.asn1.x500.RDN;
+import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.Extensions;
 
 /**
@@ -36,9 +38,22 @@ public final class RenewContentSeeder {
     public static Optional<X509RequestContent> seed(Certificate oldCertificate, Certificate newCertificate,
             ClientCertificateRenewRequestDto request) {
         try {
-            ParsedRequestContent parsed = operatorSuppliedCsr(newCertificate, request)
-                    ? X509RequestContentParser.parse(storedCsr(newCertificate))
-                    : X509RequestContentParser.parse(storedCertificate(oldCertificate));
+            ParsedRequestContent parsed;
+            X500Name sourceSubject;
+            if (operatorSuppliedCsr(newCertificate, request)) {
+                CertificateRequest csr = storedCsr(newCertificate);
+                sourceSubject = csr.getSubject();
+                parsed = X509RequestContentParser.parse(csr);
+            } else {
+                X509Certificate certificate = storedCertificate(oldCertificate);
+                sourceSubject = X500Name.getInstance(certificate.getSubjectX500Principal().getEncoded());
+                parsed = X509RequestContentParser.parse(certificate);
+            }
+            if (hasMultiValuedRdn(sourceSubject)) {
+                log
+                        .warn("Not seeding structured renew content: the subject packs a multi-valued RDN, which typed content cannot express");
+                return Optional.empty();
+            }
             if (!parsed.unsupportedSans().isEmpty()) {
                 log
                         .warn("Not seeding structured renew content: subject alternative name {} has no typed representation",
@@ -81,6 +96,21 @@ public final class RenewContentSeeder {
             throw new ValidationException(
                     "Failed to build the subject alternative name of the re-keyed request. Error: " + e.getMessage());
         }
+    }
+
+    /**
+     * Whether the subject packs two or more attributes into a single RDN, rendered {@code CN=host+O=Acme}. A typed
+     * subject is a flat ordered list, so that grouping is lost and rebuilding the DN yields {@code CN=host,O=Acme} — a
+     * different DER encoding and a different X.500 name, which no DN comparison treats as equal. The CSR beside the
+     * content carries the true subject, so the content is dropped rather than sent altered.
+     */
+    private static boolean hasMultiValuedRdn(X500Name subject) {
+        for (RDN rdn : subject.getRDNs()) {
+            if (rdn.size() > 1) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/com/otilm/core/certificate/request/X509RequestContentParser.java
+++ b/src/main/java/com/otilm/core/certificate/request/X509RequestContentParser.java
@@ -19,6 +19,7 @@ import com.otilm.core.util.StructuredExtensionCodec;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -42,9 +43,10 @@ import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.asn1.x509.OtherName;
 
 /**
- * Parses a {@link CertificateRequest} (PKCS#10 or CRMF) into typed {@link X509RequestContent}, decoding directly from
- * BouncyCastle ASN.1 so RFC 4514 special characters survive verbatim. SAN kinds {@link GeneralNameType} cannot model
- * are reported in {@link ParsedRequestContent#unsupportedSans()}.
+ * Parses a {@link CertificateRequest} (PKCS#10 or CRMF) or an issued {@link X509Certificate} into typed
+ * {@link X509RequestContent}, decoding directly from BouncyCastle ASN.1 so RFC 4514 special characters survive
+ * verbatim. SAN kinds {@link GeneralNameType} cannot model are reported in
+ * {@link ParsedRequestContent#unsupportedSans()}.
  */
 @Slf4j
 public final class X509RequestContentParser {
@@ -61,6 +63,19 @@ public final class X509RequestContentParser {
         List<String> unrepresentable = new ArrayList<>();
         x509.setExtensions(parseExtensions(request, x509, unrepresentable));
         return new ParsedRequestContent(x509, unsupportedSans, unrepresentable);
+    }
+
+    /**
+     * Parses an issued certificate's identity into typed content: subject RDNs and SAN entries, no extensions. SAN
+     * kinds {@link GeneralNameType} cannot model are reported in {@link ParsedRequestContent#unsupportedSans()}.
+     */
+    public static ParsedRequestContent parse(X509Certificate certificate) {
+        X509RequestContent x509 = new X509RequestContent();
+        x509.setCertificateType(CertificateType.X509);
+        x509.setSubject(parseSubject(X500Name.getInstance(certificate.getSubjectX500Principal().getEncoded())));
+        List<String> unsupportedSans = new ArrayList<>();
+        x509.setSubjectAltNames(parseSans(certificateSans(certificate), unsupportedSans));
+        return new ParsedRequestContent(x509, unsupportedSans, new ArrayList<>());
     }
 
     /**
@@ -128,12 +143,24 @@ public final class X509RequestContentParser {
     }
 
     private static List<GeneralNameEntry> parseSans(CertificateRequest request, List<String> unsupportedSans) {
-        List<GeneralNameEntry> result = new ArrayList<>();
         Extensions extensions = extractExtensions(request);
-        if (extensions == null) {
-            return result;
+        GeneralNames generalNames = extensions == null
+                ? null
+                : GeneralNames.fromExtensions(extensions, Extension.subjectAlternativeName);
+        return parseSans(generalNames, unsupportedSans);
+    }
+
+    /** The SAN extension of an issued certificate, read as raw DER so an exotic kind reaches the loop below. */
+    private static GeneralNames certificateSans(X509Certificate certificate) {
+        byte[] encoded = certificate.getExtensionValue(Extension.subjectAlternativeName.getId());
+        if (encoded == null) {
+            return null;
         }
-        GeneralNames generalNames = GeneralNames.fromExtensions(extensions, Extension.subjectAlternativeName);
+        return GeneralNames.getInstance(ASN1OctetString.getInstance(encoded).getOctets());
+    }
+
+    private static List<GeneralNameEntry> parseSans(GeneralNames generalNames, List<String> unsupportedSans) {
+        List<GeneralNameEntry> result = new ArrayList<>();
         if (generalNames == null) {
             return result;
         }
@@ -145,11 +172,11 @@ public final class X509RequestContentParser {
                     result.add(entry);
                 } else {
                     unsupportedSans.add(kind);
-                    log.warn("SAN {} in CSR has no typed representation; counted for whitelist enforcement", kind);
+                    log.warn("SAN {} has no typed representation; counted for whitelist enforcement", kind);
                 }
             } catch (RuntimeException | IOException ex) {
                 unsupportedSans.add(kind);
-                log.warn("Failed to decode SAN {} in CSR; counted for whitelist enforcement", kind, ex);
+                log.warn("Failed to decode SAN {}; counted for whitelist enforcement", kind, ex);
             }
         }
         return result;

--- a/src/main/java/com/otilm/core/certificate/request/X509RequestContentParser.java
+++ b/src/main/java/com/otilm/core/certificate/request/X509RequestContentParser.java
@@ -29,7 +29,9 @@ import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1IA5String;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1OctetString;
+import org.bouncycastle.asn1.ASN1PrintableString;
 import org.bouncycastle.asn1.ASN1String;
+import org.bouncycastle.asn1.ASN1UTF8String;
 import org.bouncycastle.asn1.pkcs.Attribute;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.AttributeTypeAndValue;
@@ -220,14 +222,32 @@ public final class X509RequestContentParser {
         entry.setType(GeneralNameType.OTHER_NAME);
         entry.setOtherNameOid(otherName.getTypeID().getId());
         ASN1Encodable value = otherName.getValue();
-        if (value instanceof ASN1String str) {
-            entry.setValue(str.getString());
-            entry.setValueEncoding(ExtensionValueEncoding.UTF8_STRING);
+        ExtensionValueEncoding stringEncoding = namedStringEncoding(value);
+        if (stringEncoding != null) {
+            entry.setValue(((ASN1String) value).getString());
+            entry.setValueEncoding(stringEncoding);
         } else {
             entry.setValue(Base64.getEncoder().encodeToString(value.toASN1Primitive().getEncoded()));
             entry.setValueEncoding(ExtensionValueEncoding.DER);
         }
         return entry;
+    }
+
+    /**
+     * The encoding a string value keeps its ASN.1 type under, or null when only Base64(DER) preserves it. A value
+     * recorded under the wrong encoding is re-encoded as that type when rendered back into a request.
+     */
+    private static ExtensionValueEncoding namedStringEncoding(ASN1Encodable value) {
+        if (value instanceof ASN1UTF8String) {
+            return ExtensionValueEncoding.UTF8_STRING;
+        }
+        if (value instanceof ASN1IA5String) {
+            return ExtensionValueEncoding.IA5_STRING;
+        }
+        if (value instanceof ASN1PrintableString) {
+            return ExtensionValueEncoding.PRINTABLE_STRING;
+        }
+        return null;
     }
 
     private static String decodeIpAddress(byte[] octets) {

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
@@ -39,6 +39,7 @@ import com.otilm.core.attribute.engine.AttributeOperation;
 import com.otilm.core.attribute.engine.OutboundSecretContainment;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.certificate.request.RegisterWireBuilder;
+import com.otilm.core.certificate.request.RenewContentSeeder;
 import com.otilm.core.client.ConnectorApiFactory;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.Certificate;
@@ -131,6 +132,9 @@ public class AuthorityProviderV3Adapter extends AbstractAuthorityProviderAdapter
             wire.setFormat(newCert.getCertificateRequest().getCertificateRequestFormat());
         }
         wire.setExistingCertificate(oldCert.getCertificateContent().getContent());
+        if (capabilityService.supports(authority, FeatureFlag.CERTIFICATE_REQUEST_STRUCTURED)) {
+            RenewContentSeeder.seed(oldCert, newCert, req).ifPresent(wire::setRequestContent);
+        }
         wire.setMeta(loadMeta(oldCert, authority));
         wire.setAttributes(renewAttributesFor(newCert, authority));
         wire.setAuthorityAttributes(authorityAttributesFor(authority));

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -2365,7 +2365,13 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
                             CERTIFICATE_REQUESTED_EVENT_MESSAGE);
 
             AuthorityProviderAdapter adapter = adapterFactory.forAuthority(raProfile.getAuthorityInstanceReference());
-            AdapterOperationResult rekeyResult = adapter.renew(oldCertificate, certificate, null);
+            // Rekey reaches the connector as a renew. An uploaded CSR is the operator's own statement of identity,
+            // so it has to travel with the call; a CSR regenerated from the predecessor carries none.
+            ClientCertificateRenewRequestDto renewEquivalent = ClientCertificateRenewRequestDto
+                    .builder()
+                    .request(request == null ? null : request.getRequest())
+                    .build();
+            AdapterOperationResult rekeyResult = adapter.renew(oldCertificate, certificate, renewEquivalent);
             connectorAccepted = true;
 
             if (rekeyResult.isAsync()) {

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -59,6 +59,7 @@ import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.certificate.request.IssuanceDefinitionResolver;
 import com.otilm.core.certificate.request.ProtocolRequestAttributeValidator;
 import com.otilm.core.certificate.request.RegisterWireBuilder;
+import com.otilm.core.certificate.request.RenewContentSeeder;
 import com.otilm.core.certificate.request.RequestAttributePolicyViolationException;
 import com.otilm.core.client.ConnectorApiFactory;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
@@ -2317,8 +2318,9 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         }
 
         String requestContent = generateBase64EncodedCsr(keyUuid,
-                getTokenProfileUuid(request.getTokenProfileUuid(), oldCertificate), principal, null,
-                signatureAttributes, request.getAltKeyUuid(), altTokenProfileUuid, altSignatureAttributes);
+                getTokenProfileUuid(request.getTokenProfileUuid(), oldCertificate), principal,
+                RenewContentSeeder.rekeySanExtensions(x509Certificate), signatureAttributes, request.getAltKeyUuid(),
+                altTokenProfileUuid, altSignatureAttributes);
 
         certificateRequestDto.setKeyUuid(keyUuid);
         certificateRequestDto.setRequest(requestContent);

--- a/src/main/java/com/otilm/core/util/X509RequestContentRenderer.java
+++ b/src/main/java/com/otilm/core/util/X509RequestContentRenderer.java
@@ -253,6 +253,7 @@ public final class X509RequestContentRenderer {
         }
         return switch (encoding) {
             case IA5_STRING -> new DERIA5String(value);
+            case PRINTABLE_STRING -> new DERPrintableString(value);
             case OCTET_STRING -> new DEROctetString(value.getBytes(StandardCharsets.UTF_8));
             // DER: caller supplies a base64-encoded DER object; parse it back, preserving its ASN.1 type.
             case DER -> decodeDerOrFallback(value);

--- a/src/test/java/com/otilm/core/certificate/request/RenewContentSeederTest.java
+++ b/src/test/java/com/otilm/core/certificate/request/RenewContentSeederTest.java
@@ -9,21 +9,27 @@ import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.CertificateContent;
 import com.otilm.core.dao.entity.CertificateRequestEntity;
 import com.otilm.core.util.CertificateTestUtil;
+import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
+import java.util.Date;
 import java.util.Optional;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.Extensions;
 import org.bouncycastle.asn1.x509.ExtensionsGenerator;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
@@ -192,6 +198,65 @@ class RenewContentSeederTest {
                 .hasMessageContaining("x400Address");
     }
 
+    @Test
+    void carriesOnlyIdentity_whenSeedingFromASuppliedCsrThatAlsoRequestsExtensions() throws Exception {
+        // given — a CSR whose extension block holds an EKU beside its SAN
+        Certificate oldCertificate = certificateEntity(
+                CertificateTestUtil.createCertificateWithSubjectAndSans("CN=old.example.com"));
+        String supplied = pkcs10WithEku("CN=new.example.com");
+        Certificate newCertificate = new Certificate();
+        newCertificate.setCertificateRequest(csrEntity(supplied));
+
+        // when
+        Optional<X509RequestContent> seeded = RenewContentSeeder
+                .seed(oldCertificate, newCertificate,
+                        ClientCertificateRenewRequestDto.builder().request(supplied).build());
+
+        // then — subject and SAN travel; everything else stays on the CSR beside the content
+        assertThat(seeded).isPresent();
+        assertThat(seeded.get().getSubject().getFirst().getValue()).isEqualTo("new.example.com");
+        assertThat(seeded.get().getSubjectAltNames()).isNotEmpty();
+        assertThat(seeded.get().getExtendedKeyUsage()).isNull();
+        assertThat(seeded.get().getKeyUsage()).isNull();
+        assertThat(seeded.get().getExtensions()).isNull();
+    }
+
+    @Test
+    void seedsNothing_whenThereIsNeitherSubjectNorSanToCarry() throws Exception {
+        // given — an empty-subject certificate with no SAN; content carrying neither would fail the wire
+        // model's own "at least one of" assertion
+        Certificate oldCertificate = certificateEntity(CertificateTestUtil.createCertificateWithSubjectAndSans(""));
+
+        // when
+        Optional<X509RequestContent> seeded = RenewContentSeeder.seed(oldCertificate, new Certificate(), null);
+
+        // then
+        assertThat(seeded).isEmpty();
+    }
+
+    @Test
+    void rekeySanExtensions_failsClosed_whenTheSanExtensionIsMalformed() throws Exception {
+        // given — a SAN extension whose value is not a GeneralNames sequence at all
+        X509Certificate oldCertificate = certificateWithRawSanExtension(new byte[]{0x01, 0x02, 0x03});
+
+        // when / then — a controlled validation failure, not a raw decoding exception
+        assertThatThrownBy(() -> RenewContentSeeder.rekeySanExtensions(oldCertificate))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("could not be decoded");
+    }
+
+    @Test
+    void seedsNothing_whenTheSanExtensionIsMalformed() throws Exception {
+        // given
+        Certificate oldCertificate = certificateEntity(certificateWithRawSanExtension(new byte[]{0x01, 0x02, 0x03}));
+
+        // when
+        Optional<X509RequestContent> seeded = RenewContentSeeder.seed(oldCertificate, new Certificate(), null);
+
+        // then — renew falls back to the CSR rather than failing
+        assertThat(seeded).isEmpty();
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static Certificate certificateEntity(X509Certificate certificate) throws Exception {
@@ -222,5 +287,38 @@ class RenewContentSeederTest {
         builder.addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extGen.generate());
         ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build(kp.getPrivate());
         return Base64.getEncoder().encodeToString(builder.build(signer).getEncoded());
+    }
+
+    private static String pkcs10WithEku(String subjectDn) throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        PKCS10CertificationRequestBuilder builder = new JcaPKCS10CertificationRequestBuilder(new X500Name(subjectDn),
+                kp.getPublic());
+        ExtensionsGenerator extGen = new ExtensionsGenerator();
+        extGen
+                .addExtension(Extension.subjectAlternativeName, false,
+                        new GeneralNames(new GeneralName(GeneralName.dNSName, "supplied.example.com")));
+        extGen.addExtension(Extension.extendedKeyUsage, false, new ExtendedKeyUsage(KeyPurposeId.id_kp_serverAuth));
+        builder.addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extGen.generate());
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build(kp.getPrivate());
+        return Base64.getEncoder().encodeToString(builder.build(signer).getEncoded());
+    }
+
+    /** A certificate whose SAN extension value is the given bytes verbatim, so decoding it fails. */
+    private static X509Certificate certificateWithRawSanExtension(byte[] extensionValue) throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        X500Name subject = new X500Name("CN=malformed.example.com");
+        JcaX509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(subject, BigInteger.ONE, new Date(),
+                new Date(System.currentTimeMillis() + 86400000L), subject, kp.getPublic());
+        builder.addExtension(Extension.subjectAlternativeName, false, extensionValue);
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .build(kp.getPrivate());
+        return new JcaX509CertificateConverter()
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .getCertificate(builder.build(signer));
     }
 }

--- a/src/test/java/com/otilm/core/certificate/request/RenewContentSeederTest.java
+++ b/src/test/java/com/otilm/core/certificate/request/RenewContentSeederTest.java
@@ -103,6 +103,23 @@ class RenewContentSeederTest {
     }
 
     @Test
+    void seedsFromPredecessorCertificate_whenTheRequestNamesACsrTheSuccessorDoesNotCarry() throws Exception {
+        // given — a request DTO carrying a CSR, but no stored request on the successor to read it back from
+        Certificate oldCertificate = certificateEntity(
+                CertificateTestUtil.createCertificateWithSubjectAndSans("CN=old.example.com"));
+        Certificate newCertificate = new Certificate();
+
+        // when
+        Optional<X509RequestContent> seeded = RenewContentSeeder
+                .seed(oldCertificate, newCertificate,
+                        ClientCertificateRenewRequestDto.builder().request(pkcs10("CN=new.example.com")).build());
+
+        // then — the predecessor is the fallback, never an unread CSR
+        assertThat(seeded).isPresent();
+        assertThat(seeded.get().getSubject().getFirst().getValue()).isEqualTo("old.example.com");
+    }
+
+    @Test
     void seedsNothing_whenAPredecessorSanCannotBeRepresented() throws Exception {
         // given — an x400Address SAN; sending the rest would be an identity narrower than the predecessor's
         Certificate oldCertificate = certificateEntity(CertificateTestUtil

--- a/src/test/java/com/otilm/core/certificate/request/RenewContentSeederTest.java
+++ b/src/test/java/com/otilm/core/certificate/request/RenewContentSeederTest.java
@@ -19,6 +19,7 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.Optional;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.DERBitString;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.X500Name;
@@ -184,7 +185,7 @@ class RenewContentSeederTest {
         // when
         Extensions extensions = RenewContentSeeder.rekeySanExtensions(oldCertificate);
 
-        // then — the CSR is built exactly as before this change for a certificate with no SAN
+        // then — a predecessor without SAN produces no extension block
         assertThat(extensions).isNull();
     }
 
@@ -202,8 +203,9 @@ class RenewContentSeederTest {
     }
 
     @Test
-    void carriesOnlyIdentity_whenSeedingFromASuppliedCsrThatAlsoRequestsExtensions() throws Exception {
-        // given — a CSR whose extension block holds an EKU beside its SAN
+    void carriesTheSuppliedCsrExtensions_soAStructuredConnectorSeesWhatWasRequested() throws Exception {
+        // given — a CSR whose extension block holds an EKU beside its SAN. The content is authoritative for a
+        // structured connector, so operator-requested extensions have to travel in it, not only in the CSR.
         Certificate oldCertificate = certificateEntity(
                 CertificateTestUtil.createCertificateWithSubjectAndSans("CN=old.example.com"));
         String supplied = pkcs10WithEku("CN=new.example.com");
@@ -215,13 +217,31 @@ class RenewContentSeederTest {
                 .seed(oldCertificate, newCertificate,
                         ClientCertificateRenewRequestDto.builder().request(supplied).build());
 
-        // then — subject and SAN travel; everything else stays on the CSR beside the content
+        // then
         assertThat(seeded).isPresent();
         assertThat(seeded.get().getSubject().getFirst().getValue()).isEqualTo("new.example.com");
         assertThat(seeded.get().getSubjectAltNames()).isNotEmpty();
-        assertThat(seeded.get().getExtendedKeyUsage()).isNull();
-        assertThat(seeded.get().getKeyUsage()).isNull();
-        assertThat(seeded.get().getExtensions()).isNull();
+        assertThat(seeded.get().getExtendedKeyUsage()).containsExactly(KeyPurposeId.id_kp_serverAuth.getId());
+    }
+
+    @Test
+    void seedsNothing_whenASuppliedCsrRequestsAKeyUsageBitTheModelCannotName() throws Exception {
+        // given — bit 9 is outside the nine X.509 names, so the codec drops it from the typed key usage while
+        // reporting it; sending the rest would narrow the usage the operator asked for
+        Certificate oldCertificate = certificateEntity(
+                CertificateTestUtil.createCertificateWithSubjectAndSans("CN=old.example.com"));
+        String supplied = pkcs10WithRawKeyUsage("CN=new.example.com",
+                new DERBitString(new byte[]{(byte) 0x80, (byte) 0x40}, 6));
+        Certificate newCertificate = new Certificate();
+        newCertificate.setCertificateRequest(csrEntity(supplied));
+
+        // when
+        Optional<X509RequestContent> seeded = RenewContentSeeder
+                .seed(oldCertificate, newCertificate,
+                        ClientCertificateRenewRequestDto.builder().request(supplied).build());
+
+        // then
+        assertThat(seeded).isEmpty();
     }
 
     @Test
@@ -343,6 +363,22 @@ class RenewContentSeederTest {
         extGen
                 .addExtension(Extension.subjectAlternativeName, false,
                         new GeneralNames(new GeneralName(GeneralName.dNSName, "supplied.example.com")));
+        builder.addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extGen.generate());
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build(kp.getPrivate());
+        return Base64.getEncoder().encodeToString(builder.build(signer).getEncoded());
+    }
+
+    private static String pkcs10WithRawKeyUsage(String subjectDn, DERBitString keyUsage) throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        PKCS10CertificationRequestBuilder builder = new JcaPKCS10CertificationRequestBuilder(new X500Name(subjectDn),
+                kp.getPublic());
+        ExtensionsGenerator extGen = new ExtensionsGenerator();
+        extGen
+                .addExtension(Extension.subjectAlternativeName, false,
+                        new GeneralNames(new GeneralName(GeneralName.dNSName, "supplied.example.com")));
+        extGen.addExtension(Extension.keyUsage, false, keyUsage);
         builder.addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extGen.generate());
         ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build(kp.getPrivate());
         return Base64.getEncoder().encodeToString(builder.build(signer).getEncoded());

--- a/src/test/java/com/otilm/core/certificate/request/RenewContentSeederTest.java
+++ b/src/test/java/com/otilm/core/certificate/request/RenewContentSeederTest.java
@@ -18,9 +18,12 @@ import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.Date;
 import java.util.Optional;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.X500NameBuilder;
+import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.Extensions;
@@ -257,6 +260,53 @@ class RenewContentSeederTest {
         assertThat(seeded).isEmpty();
     }
 
+    @Test
+    void seedsNothing_whenThePredecessorSubjectPacksAMultiValuedRdn() throws Exception {
+        // given — CN=host+O=Acme is one RDN naming the entry by both attributes; a flat typed subject would be
+        // rebuilt as CN=host,O=Acme, a different DER encoding that no DN comparison matches
+        Certificate oldCertificate = certificateEntity(CertificateTestUtil
+                .createCertificateWithSubjectAndSans(multiValuedSubject(),
+                        new GeneralName(GeneralName.dNSName, "old.example.com")));
+
+        // when
+        Optional<X509RequestContent> seeded = RenewContentSeeder.seed(oldCertificate, new Certificate(), null);
+
+        // then — the CSR beside the content carries the true subject
+        assertThat(seeded).isEmpty();
+    }
+
+    @Test
+    void seedsNothing_whenASuppliedCsrSubjectPacksAMultiValuedRdn() throws Exception {
+        // given
+        Certificate oldCertificate = certificateEntity(
+                CertificateTestUtil.createCertificateWithSubjectAndSans("CN=old.example.com"));
+        String supplied = pkcs10(multiValuedSubject());
+        Certificate newCertificate = new Certificate();
+        newCertificate.setCertificateRequest(csrEntity(supplied));
+
+        // when
+        Optional<X509RequestContent> seeded = RenewContentSeeder
+                .seed(oldCertificate, newCertificate,
+                        ClientCertificateRenewRequestDto.builder().request(supplied).build());
+
+        // then
+        assertThat(seeded).isEmpty();
+    }
+
+    @Test
+    void seedsRepeatedAttributes_whichAreSeparateRdnsNotAMultiValuedOne() throws Exception {
+        // given — OU=First,OU=Second is two RDNs, so the flat typed subject rebuilds it exactly
+        Certificate oldCertificate = certificateEntity(
+                CertificateTestUtil.createCertificateWithSubjectAndSans("CN=old.example.com,OU=First,OU=Second"));
+
+        // when
+        Optional<X509RequestContent> seeded = RenewContentSeeder.seed(oldCertificate, new Certificate(), null);
+
+        // then
+        assertThat(seeded).isPresent();
+        assertThat(seeded.get().getSubject()).extracting("value").containsExactly("old.example.com", "First", "Second");
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static Certificate certificateEntity(X509Certificate certificate) throws Exception {
@@ -274,12 +324,21 @@ class RenewContentSeederTest {
         return entity;
     }
 
+    private static X500Name multiValuedSubject() {
+        return new X500NameBuilder(BCStyle.INSTANCE)
+                .addMultiValuedRDN(new ASN1ObjectIdentifier[]{BCStyle.CN, BCStyle.O}, new String[]{"host", "Acme"})
+                .build();
+    }
+
     private static String pkcs10(String subjectDn) throws Exception {
+        return pkcs10(new X500Name(subjectDn));
+    }
+
+    private static String pkcs10(X500Name subject) throws Exception {
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
         kpg.initialize(2048);
         KeyPair kp = kpg.generateKeyPair();
-        PKCS10CertificationRequestBuilder builder = new JcaPKCS10CertificationRequestBuilder(new X500Name(subjectDn),
-                kp.getPublic());
+        PKCS10CertificationRequestBuilder builder = new JcaPKCS10CertificationRequestBuilder(subject, kp.getPublic());
         ExtensionsGenerator extGen = new ExtensionsGenerator();
         extGen
                 .addExtension(Extension.subjectAlternativeName, false,

--- a/src/test/java/com/otilm/core/certificate/request/RenewContentSeederTest.java
+++ b/src/test/java/com/otilm/core/certificate/request/RenewContentSeederTest.java
@@ -89,8 +89,8 @@ class RenewContentSeederTest {
 
     @Test
     void seedsFromSuppliedCsr_whenTheOperatorProvidedOneOnRenew() throws Exception {
-        // given — renew validates only the public key, so a supplied CSR may carry a different identity;
-        // structured content must not override what the operator asked for
+        // given — renew validates only the public key, so a supplied CSR may carry a different identity.
+        // Structured content must not override what the operator asked for.
         Certificate oldCertificate = certificateEntity(CertificateTestUtil
                 .createCertificateWithSubjectAndSans("CN=old.example.com",
                         new GeneralName(GeneralName.dNSName, "old.example.com")));

--- a/src/test/java/com/otilm/core/certificate/request/RenewContentSeederTest.java
+++ b/src/test/java/com/otilm/core/certificate/request/RenewContentSeederTest.java
@@ -1,0 +1,209 @@
+package com.otilm.core.certificate.request;
+
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.connector.v3.certificate.X509RequestContent;
+import com.otilm.api.model.core.certificate.GeneralNameType;
+import com.otilm.api.model.core.enums.CertificateRequestFormat;
+import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.CertificateContent;
+import com.otilm.core.dao.entity.CertificateRequestEntity;
+import com.otilm.core.util.CertificateTestUtil;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.Optional;
+import org.bouncycastle.asn1.DERSequence;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.asn1.x509.ExtensionsGenerator;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RenewContentSeederTest {
+
+    @BeforeAll
+    static void addBouncyCastleProvider() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    @Test
+    void seedsFromPredecessorCertificate_whenTheRequestCarriesNoCsr() throws Exception {
+        // given — the rekey path passes a null request DTO
+        Certificate oldCertificate = certificateEntity(CertificateTestUtil
+                .createCertificateWithSubjectAndSans("CN=old.example.com",
+                        new GeneralName(GeneralName.dNSName, "old.example.com")));
+        Certificate newCertificate = new Certificate();
+
+        // when
+        Optional<X509RequestContent> seeded = RenewContentSeeder.seed(oldCertificate, newCertificate, null);
+
+        // then
+        assertThat(seeded).isPresent();
+        assertThat(seeded.get().getSubject().getFirst().getValue()).isEqualTo("old.example.com");
+        assertThat(seeded.get().getSubjectAltNames()).singleElement().satisfies(s -> {
+            assertThat(s.getType()).isEqualTo(GeneralNameType.DNS);
+            assertThat(s.getValue()).isEqualTo("old.example.com");
+        });
+    }
+
+    @Test
+    void seedsFromPredecessorCertificate_whenRenewReusesTheStoredCsr() throws Exception {
+        // given — a renew DTO with no CSR of its own; a CA-rewritten DN travels on the certificate, not the CSR
+        Certificate oldCertificate = certificateEntity(
+                CertificateTestUtil.createCertificateWithSubjectAndSans("CN=rewritten-by-ca.example.com"));
+        Certificate newCertificate = new Certificate();
+        newCertificate.setCertificateRequest(csrEntity(pkcs10("CN=as-requested.example.com")));
+
+        // when
+        Optional<X509RequestContent> seeded = RenewContentSeeder
+                .seed(oldCertificate, newCertificate, ClientCertificateRenewRequestDto.builder().build());
+
+        // then
+        assertThat(seeded).isPresent();
+        assertThat(seeded.get().getSubject().getFirst().getValue()).isEqualTo("rewritten-by-ca.example.com");
+    }
+
+    @Test
+    void seedsFromSuppliedCsr_whenTheOperatorProvidedOneOnRenew() throws Exception {
+        // given — renew validates only the public key, so a supplied CSR may carry a different identity;
+        // structured content must not override what the operator asked for
+        Certificate oldCertificate = certificateEntity(CertificateTestUtil
+                .createCertificateWithSubjectAndSans("CN=old.example.com",
+                        new GeneralName(GeneralName.dNSName, "old.example.com")));
+        String supplied = pkcs10("CN=new.example.com");
+        Certificate newCertificate = new Certificate();
+        newCertificate.setCertificateRequest(csrEntity(supplied));
+
+        // when
+        Optional<X509RequestContent> seeded = RenewContentSeeder
+                .seed(oldCertificate, newCertificate,
+                        ClientCertificateRenewRequestDto.builder().request(supplied).build());
+
+        // then
+        assertThat(seeded).isPresent();
+        assertThat(seeded.get().getSubject().getFirst().getValue()).isEqualTo("new.example.com");
+    }
+
+    @Test
+    void seedsNothing_whenAPredecessorSanCannotBeRepresented() throws Exception {
+        // given — an x400Address SAN; sending the rest would be an identity narrower than the predecessor's
+        Certificate oldCertificate = certificateEntity(CertificateTestUtil
+                .createCertificateWithSubjectAndSans("CN=old.example.com",
+                        new GeneralName(GeneralName.dNSName, "old.example.com"),
+                        new GeneralName(GeneralName.x400Address, new DERSequence())));
+
+        // when
+        Optional<X509RequestContent> seeded = RenewContentSeeder.seed(oldCertificate, new Certificate(), null);
+
+        // then — the connector falls back to parsing the CSR the wire already carries
+        assertThat(seeded).isEmpty();
+    }
+
+    @Test
+    void seedsNothing_whenTheStoredCertificateCannotBeParsed() {
+        // given
+        Certificate oldCertificate = new Certificate();
+        CertificateContent content = new CertificateContent();
+        content.setContent("bm90LWEtY2VydA==");
+        oldCertificate.setCertificateContent(content);
+
+        // when
+        Optional<X509RequestContent> seeded = RenewContentSeeder.seed(oldCertificate, new Certificate(), null);
+
+        // then — a broken predecessor must not fail a renew that works today
+        assertThat(seeded).isEmpty();
+    }
+
+    @Test
+    void rekeySanExtensions_carriesThePredecessorSan() throws Exception {
+        // given
+        X509Certificate oldCertificate = CertificateTestUtil
+                .createCertificateWithSubjectAndSans("CN=old.example.com",
+                        new GeneralName(GeneralName.dNSName, "old.example.com"),
+                        new GeneralName(GeneralName.iPAddress, "10.0.0.1"));
+
+        // when
+        Extensions extensions = RenewContentSeeder.rekeySanExtensions(oldCertificate);
+
+        // then
+        assertThat(extensions).isNotNull();
+        GeneralNames sans = GeneralNames.fromExtensions(extensions, Extension.subjectAlternativeName);
+        assertThat(sans.getNames()).hasSize(2);
+        assertThat(extensions.getExtensionOIDs()).containsExactly(Extension.subjectAlternativeName);
+    }
+
+    @Test
+    void rekeySanExtensions_returnsNull_whenThePredecessorHasNoSan() throws Exception {
+        // given
+        X509Certificate oldCertificate = CertificateTestUtil.createCertificateWithSubjectAndSans("CN=old.example.com");
+
+        // when
+        Extensions extensions = RenewContentSeeder.rekeySanExtensions(oldCertificate);
+
+        // then — the CSR is built exactly as before this change for a certificate with no SAN
+        assertThat(extensions).isNull();
+    }
+
+    @Test
+    void rekeySanExtensions_failsClosed_whenASanCannotBeRepresented() throws Exception {
+        // given — the platform builds this CSR itself, so there is no CSR for the connector to fall back on
+        X509Certificate oldCertificate = CertificateTestUtil
+                .createCertificateWithSubjectAndSans("CN=old.example.com",
+                        new GeneralName(GeneralName.x400Address, new DERSequence()));
+
+        // when / then
+        assertThatThrownBy(() -> RenewContentSeeder.rekeySanExtensions(oldCertificate))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("x400Address");
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static Certificate certificateEntity(X509Certificate certificate) throws Exception {
+        CertificateContent content = new CertificateContent();
+        content.setContent(Base64.getEncoder().encodeToString(certificate.getEncoded()));
+        Certificate entity = new Certificate();
+        entity.setCertificateContent(content);
+        return entity;
+    }
+
+    private static CertificateRequestEntity csrEntity(String base64Csr) throws NoSuchAlgorithmException {
+        CertificateRequestEntity entity = new CertificateRequestEntity();
+        entity.setContent(base64Csr);
+        entity.setCertificateRequestFormat(CertificateRequestFormat.PKCS10);
+        return entity;
+    }
+
+    private static String pkcs10(String subjectDn) throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        PKCS10CertificationRequestBuilder builder = new JcaPKCS10CertificationRequestBuilder(new X500Name(subjectDn),
+                kp.getPublic());
+        ExtensionsGenerator extGen = new ExtensionsGenerator();
+        extGen
+                .addExtension(Extension.subjectAlternativeName, false,
+                        new GeneralNames(new GeneralName(GeneralName.dNSName, "supplied.example.com")));
+        builder.addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extGen.generate());
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build(kp.getPrivate());
+        return Base64.getEncoder().encodeToString(builder.build(signer).getEncoded());
+    }
+}

--- a/src/test/java/com/otilm/core/certificate/request/X509RequestContentParserTest.java
+++ b/src/test/java/com/otilm/core/certificate/request/X509RequestContentParserTest.java
@@ -487,6 +487,24 @@ class X509RequestContentParserTest {
         }
 
         @Test
+        void flattensAMultiValuedRdn_fromACertificateSubject() throws Exception {
+            // given — CN=host+O=Acme, one RDN carrying both attributes
+            X509Certificate certificate = CertificateTestUtil
+                    .createCertificateWithSubjectAndSans(new X500NameBuilder(BCStyle.INSTANCE)
+                            .addMultiValuedRDN(new ASN1ObjectIdentifier[]{BCStyle.CN, BCStyle.O},
+                                    new String[]{"host", "Acme"})
+                            .build());
+
+            // when
+            X509RequestContent content = X509RequestContentParser.parse(certificate).content();
+
+            // then — each component becomes its own entry, so the grouping is not expressible in typed content;
+            // RenewContentSeeder refuses to seed such a subject rather than sending an altered DN
+            assertThat(content.getSubject()).extracting("type").containsExactly("CN", "O");
+            assertThat(content.getSubject()).extracting("value").containsExactly("host", "Acme");
+        }
+
+        @Test
         void seededSanSurvivesRenderAndReparse() throws Exception {
             // given — the seeder is the renderer's inverse; a drift between them loses SAN on rekey
             X509Certificate certificate = CertificateTestUtil

--- a/src/test/java/com/otilm/core/certificate/request/X509RequestContentParserTest.java
+++ b/src/test/java/com/otilm/core/certificate/request/X509RequestContentParserTest.java
@@ -23,7 +23,10 @@ import java.util.List;
 import java.util.Map;
 import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.DERBMPString;
+import org.bouncycastle.asn1.DERIA5String;
 import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.DERPrintableString;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.DERUTF8String;
 import org.bouncycastle.asn1.crmf.CertReqMessages;
@@ -406,6 +409,81 @@ class X509RequestContentParserTest {
             assertThat(content.getExtensions()).isNull();
             assertThat(content.getKeyUsage()).isNull();
             assertThat(content.getExtendedKeyUsage()).isNull();
+        }
+
+        @Test
+        void keepsOtherNameStringType_forIa5AndPrintableValues() throws Exception {
+            // given — a value recorded under the wrong encoding is re-encoded as that type when rendered back
+            X509Certificate certificate = CertificateTestUtil
+                    .createCertificateWithSubjectAndSans("CN=host.example.com", new GeneralName(GeneralName.otherName,
+                            new OtherName(new ASN1ObjectIdentifier("1.2.3.4.1"), new DERIA5String("ia5@example.com"))
+                                    .toASN1Primitive()),
+                            new GeneralName(GeneralName.otherName, new OtherName(new ASN1ObjectIdentifier("1.2.3.4.2"),
+                                    new DERPrintableString("PRINTABLE")).toASN1Primitive()));
+
+            // when
+            X509RequestContent content = X509RequestContentParser.parse(certificate).content();
+
+            // then
+            assertThat(content.getSubjectAltNames().get(0).getValueEncoding())
+                    .isEqualTo(ExtensionValueEncoding.IA5_STRING);
+            assertThat(content.getSubjectAltNames().get(0).getValue()).isEqualTo("ia5@example.com");
+            assertThat(content.getSubjectAltNames().get(1).getValueEncoding())
+                    .isEqualTo(ExtensionValueEncoding.PRINTABLE_STRING);
+            assertThat(content.getSubjectAltNames().get(1).getValue()).isEqualTo("PRINTABLE");
+        }
+
+        @Test
+        void fallsBackToDer_forAStringTypeTheEncodingsCannotName() throws Exception {
+            // given — BMPString has no ExtensionValueEncoding counterpart, so only Base64(DER) preserves its type
+            X509Certificate certificate = CertificateTestUtil
+                    .createCertificateWithSubjectAndSans("CN=host.example.com",
+                            new GeneralName(GeneralName.otherName,
+                                    new OtherName(new ASN1ObjectIdentifier("1.2.3.4.3"), new DERBMPString("bmp"))
+                                            .toASN1Primitive()));
+
+            // when
+            X509RequestContent content = X509RequestContentParser.parse(certificate).content();
+
+            // then
+            assertThat(content.getSubjectAltNames()).singleElement().satisfies(san -> {
+                assertThat(san.getValueEncoding()).isEqualTo(ExtensionValueEncoding.DER);
+                assertThat(san.getValue()).isNotEqualTo("bmp");
+            });
+        }
+
+        @Test
+        void otherNameSurvivesRenderAndReparse_forEveryStringType() throws Exception {
+            // given — the rekey CSR is rendered from this content, so a coerced type would change the identity
+            X509Certificate certificate = CertificateTestUtil
+                    .createCertificateWithSubjectAndSans("CN=host.example.com",
+                            new GeneralName(GeneralName.otherName,
+                                    new OtherName(new ASN1ObjectIdentifier("1.3.6.1.4.1.311.20.2.3"),
+                                            new DERUTF8String("user@example.com")).toASN1Primitive()),
+                            new GeneralName(GeneralName.otherName,
+                                    new OtherName(new ASN1ObjectIdentifier("1.2.3.4.1"),
+                                            new DERIA5String("ia5@example.com")).toASN1Primitive()),
+                            new GeneralName(GeneralName.otherName,
+                                    new OtherName(new ASN1ObjectIdentifier("1.2.3.4.2"),
+                                            new DERPrintableString("PRINTABLE")).toASN1Primitive()),
+                            new GeneralName(GeneralName.otherName,
+                                    new OtherName(new ASN1ObjectIdentifier("1.2.3.4.3"), new DERBMPString("bmp"))
+                                            .toASN1Primitive()));
+            X509RequestContent seeded = X509RequestContentParser.parse(certificate).content();
+
+            // when
+            Extensions rendered = X509RequestContentRenderer.toExtensions(seeded);
+            GeneralNames renderedSans = GeneralNames.fromExtensions(rendered, Extension.subjectAlternativeName);
+
+            // then — each otherName keeps the ASN.1 type it had in the certificate
+            assertThat(OtherName.getInstance(renderedSans.getNames()[0].getName()).getValue())
+                    .isInstanceOf(DERUTF8String.class);
+            assertThat(OtherName.getInstance(renderedSans.getNames()[1].getName()).getValue())
+                    .isInstanceOf(DERIA5String.class);
+            assertThat(OtherName.getInstance(renderedSans.getNames()[2].getName()).getValue())
+                    .isInstanceOf(DERPrintableString.class);
+            assertThat(OtherName.getInstance(renderedSans.getNames()[3].getName()).getValue())
+                    .isInstanceOf(DERBMPString.class);
         }
 
         @Test

--- a/src/test/java/com/otilm/core/certificate/request/X509RequestContentParserTest.java
+++ b/src/test/java/com/otilm/core/certificate/request/X509RequestContentParserTest.java
@@ -4,6 +4,7 @@ import com.otilm.api.model.connector.v3.certificate.X509RequestContent;
 import com.otilm.api.model.core.certificate.CertificateKeyUsage;
 import com.otilm.api.model.core.certificate.CertificateType;
 import com.otilm.api.model.core.certificate.GeneralNameType;
+import com.otilm.api.model.core.oid.ExtensionValueEncoding;
 import com.otilm.api.model.core.oid.OidCategory;
 import com.otilm.core.model.request.CertificateRequest;
 import com.otilm.core.model.request.CrmfCertificateRequest;
@@ -11,10 +12,12 @@ import com.otilm.core.model.request.Pkcs10CertificateRequest;
 import com.otilm.core.oid.OidHandler;
 import com.otilm.core.oid.OidRecord;
 import com.otilm.core.service.cmp.CmpTestUtil;
+import com.otilm.core.util.CertificateTestUtil;
 import com.otilm.core.util.X509RequestContentRenderer;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Security;
+import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -283,6 +286,146 @@ class X509RequestContentParserTest {
                 assertThat(s.getOtherNameOid()).isEqualTo("1.3.6.1.4.1.311.20.2.3");
                 assertThat(s.getValue()).isEqualTo("user@example.com");
             });
+        }
+    }
+
+    @Nested
+    class FromCertificate {
+
+        @Test
+        void parsesOrderedRdnsAndTypeDiscriminator_fromCertificateSubject() throws Exception {
+            // given
+            X509Certificate certificate = CertificateTestUtil
+                    .createCertificateWithSubjectAndSans("CN=host.example.com,O=Example");
+
+            // when
+            X509RequestContent content = X509RequestContentParser.parse(certificate).content();
+
+            // then
+            assertThat(content.getSubject()).extracting("type").containsExactly("CN", "O");
+            assertThat(content.getSubject().getFirst().getValue()).isEqualTo("host.example.com");
+            assertThat(content.getCertificateType()).isEqualTo(CertificateType.X509);
+        }
+
+        @Test
+        void splitsMultiValuedRdn_intoSeparateEntries() throws Exception {
+            // given — repeated OUs are the case the projector emits and the wire must carry in order
+            X509Certificate certificate = CertificateTestUtil
+                    .createCertificateWithSubjectAndSans("CN=host.example.com,OU=First,OU=Second");
+
+            // when
+            X509RequestContent content = X509RequestContentParser.parse(certificate).content();
+
+            // then
+            assertThat(content.getSubject()).extracting("value").containsExactly("host.example.com", "First", "Second");
+        }
+
+        @Test
+        void parsesEveryTypedSanKind_fromCertificateExtension() throws Exception {
+            // given
+            X509Certificate certificate = CertificateTestUtil
+                    .createCertificateWithSubjectAndSans("CN=host.example.com",
+                            new GeneralName(GeneralName.dNSName, "host.example.com"),
+                            new GeneralName(GeneralName.rfc822Name, "admin@example.com"),
+                            new GeneralName(GeneralName.iPAddress, "10.0.0.1"),
+                            new GeneralName(GeneralName.uniformResourceIdentifier, "https://example.com/a"),
+                            new GeneralName(GeneralName.registeredID, "1.2.3.4.5"),
+                            new GeneralName(GeneralName.directoryName, new X500Name("CN=dir.example.com")));
+
+            // when
+            X509RequestContent content = X509RequestContentParser.parse(certificate).content();
+
+            // then
+            assertThat(content.getSubjectAltNames())
+                    .extracting("type")
+                    .containsExactly(GeneralNameType.DNS, GeneralNameType.EMAIL, GeneralNameType.IP,
+                            GeneralNameType.URI, GeneralNameType.REGISTERED_ID, GeneralNameType.DIRECTORY_NAME);
+            assertThat(content.getSubjectAltNames().get(2).getValue()).isEqualTo("10.0.0.1");
+        }
+
+        @Test
+        void recoversOtherNameOidAndEncoding_fromCertificateSan() throws Exception {
+            // given — a UPN otherName, the form the OTHER_NAME wire entry needs both OID and encoding for
+            var otherName = new OtherName(new ASN1ObjectIdentifier("1.3.6.1.4.1.311.20.2.3"),
+                    new DERUTF8String("user@example.com"));
+            X509Certificate certificate = CertificateTestUtil
+                    .createCertificateWithSubjectAndSans("CN=host.example.com",
+                            new GeneralName(GeneralName.otherName, otherName.toASN1Primitive()));
+
+            // when
+            X509RequestContent content = X509RequestContentParser.parse(certificate).content();
+
+            // then
+            assertThat(content.getSubjectAltNames()).singleElement().satisfies(s -> {
+                assertThat(s.getType()).isEqualTo(GeneralNameType.OTHER_NAME);
+                assertThat(s.getOtherNameOid()).isEqualTo("1.3.6.1.4.1.311.20.2.3");
+                assertThat(s.getValue()).isEqualTo("user@example.com");
+                assertThat(s.getValueEncoding()).isEqualTo(ExtensionValueEncoding.UTF8_STRING);
+            });
+        }
+
+        @Test
+        void yieldsEmptySans_whenCertificateHasNoSanExtension() throws Exception {
+            // given
+            X509Certificate certificate = CertificateTestUtil
+                    .createCertificateWithSubjectAndSans("CN=host.example.com");
+
+            // when
+            ParsedRequestContent parsed = X509RequestContentParser.parse(certificate);
+
+            // then
+            assertThat(parsed.content().getSubjectAltNames()).isEmpty();
+            assertThat(parsed.unsupportedSans()).isEmpty();
+        }
+
+        @Test
+        void reportsUnrepresentableSanKind_insteadOfSilentlyDropping() throws Exception {
+            // given — an x400Address SAN, which GeneralNameType cannot model
+            X509Certificate certificate = CertificateTestUtil
+                    .createCertificateWithSubjectAndSans("CN=host.example.com",
+                            new GeneralName(GeneralName.dNSName, "host.example.com"),
+                            new GeneralName(GeneralName.x400Address, new DERSequence()));
+
+            // when
+            ParsedRequestContent parsed = X509RequestContentParser.parse(certificate);
+
+            // then — the representable entry is decoded, the other is surfaced for the caller's policy
+            assertThat(parsed.content().getSubjectAltNames()).hasSize(1);
+            assertThat(parsed.unsupportedSans()).containsExactly("x400Address");
+        }
+
+        @Test
+        void seedsNoExtensions_notEvenKeyUsageOrExtendedKeyUsage() throws Exception {
+            // given — the certificate carries an EKU, which is the CA's to set and must not be re-requested
+            X509Certificate certificate = CertificateTestUtil.createCertificateWithEku(false);
+
+            // when
+            X509RequestContent content = X509RequestContentParser.parse(certificate).content();
+
+            // then — left null so @JsonInclude(NON_NULL) keeps them off the wire entirely
+            assertThat(content.getExtensions()).isNull();
+            assertThat(content.getKeyUsage()).isNull();
+            assertThat(content.getExtendedKeyUsage()).isNull();
+        }
+
+        @Test
+        void seededSanSurvivesRenderAndReparse() throws Exception {
+            // given — the seeder is the renderer's inverse; a drift between them loses SAN on rekey
+            X509Certificate certificate = CertificateTestUtil
+                    .createCertificateWithSubjectAndSans("CN=host.example.com",
+                            new GeneralName(GeneralName.dNSName, "host.example.com"),
+                            new GeneralName(GeneralName.iPAddress, "10.0.0.1"),
+                            new GeneralName(GeneralName.rfc822Name, "admin@example.com"));
+            X509RequestContent seeded = X509RequestContentParser.parse(certificate).content();
+
+            // when
+            Extensions rendered = X509RequestContentRenderer.toExtensions(seeded);
+            X509RequestContent reparsed = X509RequestContentParser.parse(pkcs10WithExtensions(rendered)).content();
+
+            // then
+            assertThat(reparsed.getSubjectAltNames())
+                    .usingRecursiveFieldByFieldElementComparator()
+                    .containsExactlyElementsOf(seeded.getSubjectAltNames());
         }
     }
 

--- a/src/test/java/com/otilm/core/certificate/request/X509RequestContentParserTest.java
+++ b/src/test/java/com/otilm/core/certificate/request/X509RequestContentParserTest.java
@@ -311,8 +311,9 @@ class X509RequestContentParserTest {
         }
 
         @Test
-        void splitsMultiValuedRdn_intoSeparateEntries() throws Exception {
-            // given — repeated OUs are the case the projector emits and the wire must carry in order
+        void keepsRepeatedAttributesInOrder_asSeparateEntries() throws Exception {
+            // given — repeated OUs are separate RDNs, the case the projector emits and the wire carries in order;
+            // a multi-valued RDN is a different thing, covered below
             X509Certificate certificate = CertificateTestUtil
                     .createCertificateWithSubjectAndSans("CN=host.example.com,OU=First,OU=Second");
 

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceV2ITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceV2ITest.java
@@ -104,6 +104,9 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
@@ -116,6 +119,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -623,6 +627,53 @@ class ClientOperationServiceV2ITest extends BaseSpringBootTest {
         Assertions
                 .assertDoesNotThrow(() -> clientOperationInternalService
                         .revokeCertificateAction(certificate.getUuid(), request, true));
+    }
+
+    @Test
+    void rekeyFromKeyCarriesThePredecessorSanIntoTheRegeneratedCsr() throws Exception {
+        stubAuthorityProviderAttributesEndpoints();
+
+        CryptographicKey key = createCryptographicKey(null);
+        CertificateContent content = new CertificateContent();
+        X509Certificate predecessor = CertificateTestUtil
+                .createCertificateWithSubjectAndSans("CN=rekey.example.com",
+                        new GeneralName(GeneralName.dNSName, "rekey.example.com"),
+                        new GeneralName(GeneralName.iPAddress, "10.0.0.1"));
+        content.setContent(Base64.getEncoder().encodeToString(predecessor.getEncoded()));
+        certificateContentRepository.save(content);
+        certificate.setCertificateContent(content);
+        certificate.setHybridCertificate(false);
+        certificate.setAltKeyUuid(null);
+        certificateRepository.save(certificate);
+
+        ClientCertificateRekeyRequestDto request = new ClientCertificateRekeyRequestDto();
+        request.setFormat(CertificateRequestFormat.PKCS10);
+        request.setKeyUuid(key.getUuid());
+        request.setTokenProfileUuid(key.getTokenProfileUuid());
+        request.setSignatureAttributes(List.of());
+        when(cryptographicOperationService
+                .generateCsr(eq(key.getUuid()), eq(key.getTokenProfileUuid()), any(), any(), anyList(), any(), any(),
+                        any()))
+                .thenReturn(Base64.getEncoder().encodeToString(predecessor.getEncoded()));
+
+        try {
+            clientOperationService
+                    .rekeyCertificate(authorityInstanceReference.getSecuredParentUuid(), raProfile.getSecuredUuid(),
+                            String.valueOf(certificate.getUuid()), request);
+        } catch (Exception e) {
+            // The stubbed CSR is a certificate, so the submission after it may fail; the captured argument is
+            // recorded before that and is all this test asserts.
+        }
+
+        ArgumentCaptor<Extensions> extensions = ArgumentCaptor.forClass(Extensions.class);
+        verify(cryptographicOperationService)
+                .generateCsr(eq(key.getUuid()), eq(key.getTokenProfileUuid()), any(), extensions.capture(), anyList(),
+                        any(), any(), any());
+        GeneralNames sans = GeneralNames.fromExtensions(extensions.getValue(), Extension.subjectAlternativeName);
+        Assertions
+                .assertNotNull(sans,
+                        "the regenerated rekey CSR must carry the predecessor's SAN, not a null extension block");
+        Assertions.assertEquals(2, sans.getNames().length);
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/v3/V3RenewRevokeITest.java
+++ b/src/test/java/com/otilm/core/integration/service/v3/V3RenewRevokeITest.java
@@ -11,6 +11,7 @@ import com.otilm.api.model.core.certificate.CertificateDetailDto;
 import com.otilm.api.model.core.certificate.CertificateRelationType;
 import com.otilm.api.model.core.certificate.CertificateState;
 import com.otilm.api.model.core.certificate.CertificateValidationStatus;
+import com.otilm.api.model.core.v2.ClientCertificateRekeyRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
@@ -39,11 +40,22 @@ import com.otilm.core.util.CertificateTestUtil;
 import com.otilm.core.util.builders.AuthorityFixtures;
 import com.otilm.core.util.builders.CertificateRequestEntityBuilder;
 import com.otilm.core.util.builders.V3ConnectorStubs;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.ExtensionsGenerator;
 import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -169,6 +181,56 @@ class V3RenewRevokeITest extends BaseSpringBootTest {
                                         equalTo("predecessor.example.com")))
                                 .withRequestBody(matchingJsonPath("$.requestContent.subjectAltNames[0].value",
                                         equalTo("predecessor.example.com"))));
+    }
+
+    @Test
+    void rekey_seedsFromAnUploadedCsr_notThePredecessor() throws Exception {
+        AuthorityFixtures.Fixture fixture = AuthorityFixtures
+                .v3Authority(repos(), wireMockServer, FeatureFlag.CERTIFICATE_REQUEST_STRUCTURED);
+        V3ConnectorStubs.stubAttributesAndValidate(wireMockServer);
+        UUID predecessorUuid = seedRenewalPairWithRealPredecessor(fixture);
+        UUID successorUuid = successorUuid(predecessorUuid);
+        // An uploaded rekey CSR keeps the predecessor's DN (the entry validates that) but may carry a different
+        // SAN, which is the operator's own statement and must not be overridden by the predecessor's.
+        String uploaded = pkcs10WithSan("CN=predecessor.example.com", "uploaded.example.com");
+        CertificateRequestEntity uploadedCsr = CertificateRequestEntityBuilder
+                .aCertificateRequest()
+                .withContent(uploaded)
+                .build();
+        certificateRequestRepository.save(uploadedCsr);
+        Certificate successor = reloadCert(successorUuid);
+        successor.setCertificateRequest(uploadedCsr);
+        successor.setCertificateRequestUuid(uploadedCsr.getUuid());
+        certificateRepository.save(successor);
+        stubRenewSchemaAndAccept();
+
+        ClientCertificateRekeyRequestDto request = new ClientCertificateRekeyRequestDto();
+        request.setRequest(uploaded);
+
+        Assertions
+                .assertDoesNotThrow(
+                        () -> clientOperationInternalService.rekeyCertificateAction(successorUuid, request, true));
+
+        wireMockServer
+                .verify(1,
+                        postRequestedFor(urlEqualTo(V3_RENEW_PATH))
+                                .withRequestBody(matchingJsonPath("$.requestContent.subjectAltNames[0].value",
+                                        equalTo("uploaded.example.com"))));
+    }
+
+    private String pkcs10WithSan(String subjectDn, String dnsName) throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        PKCS10CertificationRequestBuilder builder = new JcaPKCS10CertificationRequestBuilder(new X500Name(subjectDn),
+                kp.getPublic());
+        ExtensionsGenerator extGen = new ExtensionsGenerator();
+        extGen
+                .addExtension(Extension.subjectAlternativeName, false,
+                        new GeneralNames(new GeneralName(GeneralName.dNSName, dnsName)));
+        builder.addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extGen.generate());
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build(kp.getPrivate());
+        return Base64.getEncoder().encodeToString(builder.build(signer).getEncoded());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/v3/V3RenewRevokeITest.java
+++ b/src/test/java/com/otilm/core/integration/service/v3/V3RenewRevokeITest.java
@@ -3,6 +3,7 @@ package com.otilm.core.integration.service.v3;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.otilm.api.model.client.attribute.RequestAttributeV3;
+import com.otilm.api.model.client.connector.v2.FeatureFlag;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.v3.content.StringAttributeContentV3;
 import com.otilm.api.model.core.auth.Resource;
@@ -34,11 +35,15 @@ import com.otilm.core.service.CertificateExternalService;
 import com.otilm.core.service.v2.ClientOperationInternalService;
 import com.otilm.core.service.v2.ExtendedAttributeService;
 import com.otilm.core.util.BaseSpringBootTest;
+import com.otilm.core.util.CertificateTestUtil;
 import com.otilm.core.util.builders.AuthorityFixtures;
 import com.otilm.core.util.builders.CertificateRequestEntityBuilder;
 import com.otilm.core.util.builders.V3ConnectorStubs;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
+import org.bouncycastle.asn1.x509.GeneralName;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,6 +51,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
@@ -138,6 +144,65 @@ class V3RenewRevokeITest extends BaseSpringBootTest {
                         "the predecessor must stay ISSUED while the successor awaits asynchronous completion");
         wireMockServer.verify(1, postRequestedFor(urlEqualTo(V3_RENEW_PATH)));
         wireMockServer.verify(0, postRequestedFor(urlPathMatching(V2_RENEW_PATTERN)));
+    }
+
+    @Test
+    void renew_carriesSeededRequestContent_whenConnectorAdvertisesStructured() throws Exception {
+        AuthorityFixtures.Fixture fixture = AuthorityFixtures
+                .v3Authority(repos(), wireMockServer, FeatureFlag.CERTIFICATE_REQUEST_STRUCTURED);
+        V3ConnectorStubs.stubAttributesAndValidate(wireMockServer);
+        UUID predecessorUuid = seedRenewalPairWithRealPredecessor(fixture);
+        UUID successorUuid = successorUuid(predecessorUuid);
+        stubRenewSchemaAndAccept();
+
+        Assertions
+                .assertDoesNotThrow(() -> clientOperationInternalService
+                        .renewCertificateAction(successorUuid, ClientCertificateRenewRequestDto.builder().build(),
+                                true));
+
+        wireMockServer
+                .verify(1,
+                        postRequestedFor(urlEqualTo(V3_RENEW_PATH))
+                                .withRequestBody(matchingJsonPath("$.requestContent.certificateType", equalTo("X.509")))
+                                .withRequestBody(matchingJsonPath("$.requestContent.subject[0].type", equalTo("CN")))
+                                .withRequestBody(matchingJsonPath("$.requestContent.subject[0].value",
+                                        equalTo("predecessor.example.com")))
+                                .withRequestBody(matchingJsonPath("$.requestContent.subjectAltNames[0].value",
+                                        equalTo("predecessor.example.com"))));
+    }
+
+    @Test
+    void renew_omitsRequestContent_whenConnectorDoesNotAdvertiseStructured() throws Exception {
+        AuthorityFixtures.Fixture fixture = buildV3Fixture();
+        V3ConnectorStubs.stubAttributesAndValidate(wireMockServer);
+        UUID predecessorUuid = seedRenewalPairWithRealPredecessor(fixture);
+        UUID successorUuid = successorUuid(predecessorUuid);
+        stubRenewSchemaAndAccept();
+
+        Assertions
+                .assertDoesNotThrow(() -> clientOperationInternalService
+                        .renewCertificateAction(successorUuid, ClientCertificateRenewRequestDto.builder().build(),
+                                true));
+
+        wireMockServer
+                .verify(1, postRequestedFor(urlEqualTo(V3_RENEW_PATH))
+                        .withRequestBody(matchingJsonPath("$.requestContent", absent())));
+    }
+
+    /**
+     * Seeds the renewal pair with a predecessor whose stored content is a real certificate carrying a DNS SAN, so the
+     * renew wire has an identity to seed from.
+     */
+    private UUID seedRenewalPairWithRealPredecessor(AuthorityFixtures.Fixture fixture) throws Exception {
+        X509Certificate predecessorCertificate = CertificateTestUtil
+                .createCertificateWithSubjectAndSans("CN=predecessor.example.com",
+                        new GeneralName(GeneralName.dNSName, "predecessor.example.com"));
+        UUID predecessorUuid = seedRenewalPair(fixture);
+        Certificate predecessor = reloadCert(predecessorUuid);
+        CertificateContent content = predecessor.getCertificateContent();
+        content.setContent(Base64.getEncoder().encodeToString(predecessorCertificate.getEncoded()));
+        certificateContentRepository.save(content);
+        return predecessorUuid;
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
@@ -45,6 +45,8 @@ import com.otilm.api.model.connector.v3.certificate.X509RequestContent;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.authority.CertificateRevocationReason;
 import com.otilm.api.model.core.certificate.CertificateType;
+import com.otilm.api.model.core.certificate.GeneralNameType;
+import com.otilm.api.model.core.enums.CertificateRequestFormat;
 import com.otilm.api.model.core.oid.ExtensionValueEncoding;
 import com.otilm.api.model.core.oid.OidCategory;
 import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
@@ -68,11 +70,21 @@ import com.otilm.core.oid.OidRecord;
 import com.otilm.core.service.handler.ConnectorCapabilityService;
 import com.otilm.core.service.handler.OperationAttributeResolver;
 import com.otilm.core.service.v2.ConnectorInternalService;
+import com.otilm.core.util.CertificateTestUtil;
 import java.net.URI;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -884,6 +896,91 @@ class AuthorityProviderV3AdapterTest {
         ArgumentCaptor<CertificateRenewRequestDtoV3> wire = ArgumentCaptor.forClass(CertificateRenewRequestDtoV3.class);
         verify(certClientV3).renew(eq(connectorInfo), wire.capture());
         assertEquals(renewValues, wire.getValue().getAttributes());
+    }
+
+    @Test
+    void renewCarriesSeededContentWhenConnectorAdvertisesStructured() throws Exception {
+        givenPredecessorWithDnsSan();
+        when(capabilityService.supports(authority, FeatureFlag.CERTIFICATE_REQUEST_STRUCTURED)).thenReturn(true);
+
+        CertificateRenewRequestDtoV3 wire = renewAndCaptureWire(new ClientCertificateRenewRequestDto());
+
+        X509RequestContent content = assertInstanceOf(X509RequestContent.class, wire.getRequestContent());
+        assertEquals("old.example.com", content.getSubject().get(0).getValue());
+        assertEquals(GeneralNameType.DNS, content.getSubjectAltNames().get(0).getType());
+        assertEquals("old.example.com", content.getSubjectAltNames().get(0).getValue());
+        // the CSR still travels beside the content, authoritative for key and proof of possession
+        assertEquals("dGVzdGNzcg==", wire.getRequest());
+    }
+
+    @Test
+    void renewLeavesContentUnsetWhenConnectorDoesNotAdvertiseStructured() throws Exception {
+        givenPredecessorWithDnsSan();
+        when(capabilityService.supports(authority, FeatureFlag.CERTIFICATE_REQUEST_STRUCTURED)).thenReturn(false);
+
+        CertificateRenewRequestDtoV3 wire = renewAndCaptureWire(new ClientCertificateRenewRequestDto());
+
+        assertNull(wire.getRequestContent());
+    }
+
+    @Test
+    void renewSeedsFromSuppliedCsrRatherThanThePredecessor() throws Exception {
+        givenPredecessorWithDnsSan();
+        when(capabilityService.supports(authority, FeatureFlag.CERTIFICATE_REQUEST_STRUCTURED)).thenReturn(true);
+        String supplied = suppliedCsr("CN=new.example.com");
+        cert.getCertificateRequest().setContent(supplied);
+        cert.getCertificateRequest().setCertificateRequestFormat(CertificateRequestFormat.PKCS10);
+        ClientCertificateRenewRequestDto req = new ClientCertificateRenewRequestDto();
+        req.setRequest(supplied);
+
+        CertificateRenewRequestDtoV3 wire = renewAndCaptureWire(req);
+
+        X509RequestContent content = assertInstanceOf(X509RequestContent.class, wire.getRequestContent());
+        assertEquals("new.example.com", content.getSubject().get(0).getValue());
+    }
+
+    @Test
+    void rekeySeedsFromThePredecessorEvenWithNoRequestDto() throws Exception {
+        givenPredecessorWithDnsSan();
+        when(capabilityService.supports(authority, FeatureFlag.CERTIFICATE_REQUEST_STRUCTURED)).thenReturn(true);
+
+        // null request DTO = the rekey path, which reaches the connector through renew
+        CertificateRenewRequestDtoV3 wire = renewAndCaptureWire(null);
+
+        X509RequestContent content = assertInstanceOf(X509RequestContent.class, wire.getRequestContent());
+        assertEquals("old.example.com", content.getSubject().get(0).getValue());
+    }
+
+    private void givenPredecessorWithDnsSan() throws Exception {
+        oldCert
+                .getCertificateContent()
+                .setContent(Base64
+                        .getEncoder()
+                        .encodeToString(CertificateTestUtil
+                                .createCertificateWithSubjectAndSans("CN=old.example.com",
+                                        new GeneralName(GeneralName.dNSName, "old.example.com"))
+                                .getEncoded()));
+    }
+
+    private String suppliedCsr(String subjectDn) throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        PKCS10CertificationRequestBuilder builder = new JcaPKCS10CertificationRequestBuilder(new X500Name(subjectDn),
+                kp.getPublic());
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build(kp.getPrivate());
+        return Base64.getEncoder().encodeToString(builder.build(signer).getEncoded());
+    }
+
+    private CertificateRenewRequestDtoV3 renewAndCaptureWire(ClientCertificateRenewRequestDto req)
+            throws ConnectorException {
+        when(certClientV3.renew(eq(connectorInfo), any()))
+                .thenReturn(ResponseEntity.ok(new CertificateDataResponseDto()));
+        adapter.renew(oldCert, cert, req);
+        ArgumentCaptor<CertificateRenewRequestDtoV3> captor = ArgumentCaptor
+                .forClass(CertificateRenewRequestDtoV3.class);
+        verify(certClientV3).renew(eq(connectorInfo), captor.capture());
+        return captor.getValue();
     }
 
     // ---- attribute listing / validation / connection check ----

--- a/src/test/java/com/otilm/core/util/CertificateTestUtil.java
+++ b/src/test/java/com/otilm/core/util/CertificateTestUtil.java
@@ -312,13 +312,18 @@ public class CertificateTestUtil {
      */
     public static X509Certificate createCertificateWithSubjectAndSans(String subjectDn, GeneralName... sans)
             throws NoSuchAlgorithmException, OperatorCreationException, CertificateException, IOException {
+        return createCertificateWithSubjectAndSans(new X500Name(subjectDn), sans);
+    }
+
+    /** As above, for a subject no DN string can express, such as one packing a multi-valued RDN. */
+    public static X509Certificate createCertificateWithSubjectAndSans(X500Name subject, GeneralName... sans)
+            throws NoSuchAlgorithmException, OperatorCreationException, CertificateException, IOException {
         ensureBouncyCastleProvider();
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
         keyGen.initialize(2048);
         KeyPair keyPair = keyGen.generateKeyPair();
         Date notBefore = new Date();
         Date notAfter = new Date(System.currentTimeMillis() + 365L * 24 * 60 * 60 * 1000);
-        X500Name subject = new X500Name(subjectDn);
         JcaX509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(subject, BigInteger.ONE, notBefore,
                 notAfter, subject, keyPair.getPublic());
         if (sans.length > 0) {

--- a/src/test/java/com/otilm/core/util/CertificateTestUtil.java
+++ b/src/test/java/com/otilm/core/util/CertificateTestUtil.java
@@ -37,6 +37,8 @@ import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.ExtensionsGenerator;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.asn1.x509.SubjectAltPublicKeyInfo;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
@@ -296,6 +298,33 @@ public class CertificateTestUtil {
         certBuilder
                 .addExtension(Extension.extendedKeyUsage, true, new ExtendedKeyUsage(KeyPurposeId.id_kp_timeStamping));
         ContentSigner signer = new JcaContentSignerBuilder(signatureAlgorithm)
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .build(keyPair.getPrivate());
+        return new JcaX509CertificateConverter()
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .getCertificate(certBuilder.build(signer));
+    }
+
+    /**
+     * Builds a self-signed RSA certificate with the given subject and, when any are supplied, a SAN extension holding
+     * the given general names verbatim. Converted through the BouncyCastle provider so SAN kinds a stricter JDK parser
+     * would reject survive into the certificate.
+     */
+    public static X509Certificate createCertificateWithSubjectAndSans(String subjectDn, GeneralName... sans)
+            throws NoSuchAlgorithmException, OperatorCreationException, CertificateException, IOException {
+        ensureBouncyCastleProvider();
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair keyPair = keyGen.generateKeyPair();
+        Date notBefore = new Date();
+        Date notAfter = new Date(System.currentTimeMillis() + 365L * 24 * 60 * 60 * 1000);
+        X500Name subject = new X500Name(subjectDn);
+        JcaX509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(subject, BigInteger.ONE, notBefore,
+                notAfter, subject, keyPair.getPublic());
+        if (sans.length > 0) {
+            certBuilder.addExtension(Extension.subjectAlternativeName, false, new GeneralNames(sans));
+        }
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
                 .setProvider(BouncyCastleProvider.PROVIDER_NAME)
                 .build(keyPair.getPrivate());
         return new JcaX509CertificateConverter()

--- a/src/test/java/com/otilm/core/util/X509RequestContentRendererTest.java
+++ b/src/test/java/com/otilm/core/util/X509RequestContentRendererTest.java
@@ -23,6 +23,7 @@ import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.ASN1String;
 import org.bouncycastle.asn1.DERIA5String;
 import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.DERPrintableString;
 import org.bouncycastle.asn1.DERUTF8String;
 import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
 import org.bouncycastle.asn1.x509.Extension;
@@ -466,15 +467,28 @@ class X509RequestContentRendererTest {
 
         @Test
         void encodesAsUtf8String_whenEncodingHasNoDedicatedBranch() throws Exception {
-            // given — PRINTABLE_STRING falls through to the default UTF8String branch
-            var x509 = sansOf(otherName("printable", ExtensionValueEncoding.PRINTABLE_STRING));
+            // given — BIT_STRING falls through to the default UTF8String branch
+            var x509 = sansOf(otherName("bits", ExtensionValueEncoding.BIT_STRING));
 
             // when
             ASN1Encodable value = otherNameValueOf(x509);
 
             // then
             assertThat(value).isInstanceOf(DERUTF8String.class);
-            assertThat(((ASN1String) value).getString()).isEqualTo("printable");
+            assertThat(((ASN1String) value).getString()).isEqualTo("bits");
+        }
+
+        @Test
+        void encodesAsPrintableString_whenTheEncodingSaysSo() throws Exception {
+            // given — a parsed otherName keeps its PrintableString type, so rendering has to honour it
+            var x509 = sansOf(otherName("PRINTABLE", ExtensionValueEncoding.PRINTABLE_STRING));
+
+            // when
+            ASN1Encodable value = otherNameValueOf(x509);
+
+            // then
+            assertThat(value).isInstanceOf(DERPrintableString.class);
+            assertThat(((ASN1String) value).getString()).isEqualTo("PRINTABLE");
         }
 
         private static GeneralNameEntry otherName(String value, ExtensionValueEncoding encoding) {


### PR DESCRIPTION
Closes #1706
Refs #1688 — its first Definition-of-Done item; the issue stays open for the spec/plan reconciliation item.

Carries the identity of the certificate being replaced — subject DN and SAN — into renew and rekey: as typed `requestContent` on the v3 renew wire when the connector advertises structured content, and as a real SAN extension block in the rekey CSR the platform builds itself.

No `interfaces` change: `CertificateRenewRequestDtoV3.requestContent` and the `FeatureFlag` values already ship.

## What was missing

`AuthorityProviderV3Adapter.renew` set the CSR, the existing certificate, meta and the three attribute sets, and never touched `requestContent` or the capability gate — so a structured-capable connector had to re-parse the CSR on renew, and the otpki renew leg had nothing to consume.

Separately, `createRequestFromKeys` passed `null` for the projected `Extensions` when regenerating a rekey CSR from a key. SAN is itself an X.509 extension (`2.5.29.17`) and can only ride in the CSR's extension block, so every re-keyed certificate lost its SAN outright — v2 and v3 alike, structured or not.

## The kernel is an entry point, not a new class

`X509RequestContentParser` already decodes RDNs, recovers an `otherName`'s OID and encoding, decodes IP octets, and reports SAN kinds `GeneralNameType` cannot model. It gains `parse(X509Certificate)`; only the two inputs are new — the subject from `getSubjectX500Principal()`, and the SAN extension read as raw DER — and the per-name loop is now shared by both sources. Reading raw DER rather than `getSubjectAlternativeNames()` is deliberate: an exotic kind then reaches the loop that reports it, instead of being rejected before parsing.

Subject and SAN only. `keyUsage` and `extendedKeyUsage` stay unseeded even though the content model now carries them as typed fields: in an issued certificate both are commonly set by the CA's certificate profile, so echoing them back as a request input can contradict the profile that will issue the successor. Extension seeding stays deferred per direction of 2026-07-11; whenever it is picked up it needs a positive allow-list of request-controlled OIDs, never a blanket copy of an issued certificate's extensions — that would echo back CA-owned AKI/SKI, CRL DP, AIA, SCTs and a CA-finalized Basic Constraints.

## Seeding lives in the adapter, and that is what covers rekey

`rekeyCertificateAction` reaches the connector through `adapter.renew(oldCert, newCert, null)` — rekey is a renew at the authority. So one call site inside the v3 adapter covers both legs, behind the same `CERTIFICATE_REQUEST_STRUCTURED` gate `register` uses, with no change to `AuthorityProviderAdapter.renew`'s signature and none to the v2 adapter. Orchestrator-side seeding, as the phase-4 plan sketched it, would have had to be wired twice — once with a null request DTO — and would compute an identity v2 authorities cannot use.

## Where the seeded identity comes from

The predecessor certificate, except when the operator supplied a CSR on renew — then that CSR.

Renew validates only the public key against the predecessor (`validatePublicKeyForCsrAndCertificate(..., true)`); unlike rekey it does not call `validateSubjectDnForCertificate`, so a supplied renew CSR may legitimately carry a different DN or SAN. Seeding from the old certificate there would let structured content silently override what the operator asked for on any structured-capable authority. A reuse-CSR renew and a rekey both take the certificate instead — which is where a CA-rewritten DN travels.

## An identity that cannot be represented in full is never sent reduced

`x400Address` and `ediPartyName` have no `GeneralNameType` counterpart — both are structured ASN.1 with no canonical string form, and `GeneralNameEntry` carries a single string — and a modelled kind can still fail to decode (an `iPAddress` that is neither 4 nor 16 octets). Either way the parser reports the kind rather than dropping it.

- **Renew** then sends no `requestContent` at all, and the connector parses the CSR — today's behaviour exactly, so no regression, and never a structured identity narrower than the certificate it replaces.
- **Rekey** fails closed with a `ValidationException`. The platform builds that CSR itself, so nothing downstream could recover a SAN dropped there.

## No separate validation pass over seeded content

#1706 named `CertificateRequestContentValidator`. That validator checks content against resolved request-attribute definitions under a whitelist policy — it is the gate for externally supplied requests (ACME/SCEP/CMP and uploaded CSRs), not a well-formedness check. Running it here would whitelist-check a *historical* identity against today's profile, so renewing a certificate whose DN predates or exceeds the current request-attribute set would start failing.

Operator input is already validated at its own boundary: `submitCertificateRequest` → `generateBase64EncodedCsr(request.getRequest(), …)` → `validateUploadedRequestAttributes`, which renew and rekey both reach through `submitAndShapeFailure` before any action runs. What remains is platform-derived from an issued certificate, and the model's invariants hold by construction — blank RDNs are skipped, an `otherName` always carries OID and encoding.

Task 5b of the phase-4 plan also had the seeder default every field to `readOnly` and un-set it per `FieldKind`. The shipped model carries no `readOnly` field anywhere, so that dimension is retired rather than deferred.

## Tests

- **Certificate source:** RDN order, repeated OUs, every typed SAN kind, a UPN `otherName` recovering OID + `UTF8_STRING`, a certificate with no SAN, `x400Address` reported rather than dropped, and an EKU-bearing certificate asserting nothing lands in `extensions` / `keyUsage` / `extendedKeyUsage`.
- **Round-trip:** seeded content → `X509RequestContentRenderer.toExtensions` → re-parse equals the original. The seeder is the renderer's inverse and the two must not drift.
- **Seeder:** each source case including rekey's null DTO, drop-on-unrepresentable, and an unparseable predecessor.
- **Adapter:** content populated when the capability is advertised and null when it is not; seeded from the supplied CSR; seeded from the predecessor on rekey.
- **Integration:** the renew wire carries subject + SAN against a structured-capable connector and nothing against one without the flag; the rekey CSR carries the predecessor's SAN. Both were first checked against a deliberately broken baseline — the rekey one with the call site reverted to `null`, the wire one with the capability dropped — so neither passes vacuously.

New-code coverage: `RenewContentSeeder` 88% line / 100% branch, `X509RequestContentParser` 96% / 90%. All four CI profiles green locally, `ContextSignatureGuardTest.BASELINE` unchanged at 61.

## Unblocks

OmniTrustILM/otpki-connector#5's renew leg, which was instructed to drop that leg for as long as nothing populated `requestContent` on renew.
