### PR TITLE
Grant transitive MEMBERS permissions to the attribute-content-resolver role

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <sonar.projectKey>ilm_core</sonar.projectKey>
         <sonar.sources>src/main/java</sonar.sources>
         <sonar.cpd.exclusions>src/main/java/com/otilm/core/dao/entity/**</sonar.cpd.exclusions>
-        <sonar.coverage.exclusions>src/main/java/com/otilm/core/dao/entity/**,src/main/java/com/otilm/core/api/**,src/main/java/com/otilm/core/util/converter/**,src/main/java/db/migration/V202607031200__CreateAttributeContentResolverUserAndPermissions.java</sonar.coverage.exclusions>
+        <sonar.coverage.exclusions>src/main/java/com/otilm/core/dao/entity/**,src/main/java/com/otilm/core/api/**,src/main/java/com/otilm/core/util/converter/**,src/main/java/db/migration/V202607031200__CreateAttributeContentResolverUserAndPermissions.java,src/main/java/db/migration/V202608311000__GrantRaProfileMembersToAttributeContentResolver.java</sonar.coverage.exclusions>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/com/otilm/core/util/DatabaseMigration.java
+++ b/src/main/java/com/otilm/core/util/DatabaseMigration.java
@@ -75,7 +75,7 @@ public class DatabaseMigration {
         V202604011901__BackfillExtendedKeyUsageCritical(-1003930180, true),
         V202607031200__CreateAttributeContentResolverUserAndPermissions(1703465896, false),
         V202608071000__RegistrationSubjectDnNormalizedMigration(612311821),
-        V202608311000__GrantRaProfileMembersToAttributeContentResolver(-1002111901);
+        V202608311000__GrantRaProfileMembersToAttributeContentResolver(-2072942854);
 
         private final int checksum;
 

--- a/src/main/java/com/otilm/core/util/DatabaseMigration.java
+++ b/src/main/java/com/otilm/core/util/DatabaseMigration.java
@@ -74,7 +74,8 @@ public class DatabaseMigration {
         V202509191412__LogRecordsRefactor(79840308, true),
         V202604011901__BackfillExtendedKeyUsageCritical(-1003930180, true),
         V202607031200__CreateAttributeContentResolverUserAndPermissions(1703465896, false),
-        V202608071000__RegistrationSubjectDnNormalizedMigration(612311821);
+        V202608071000__RegistrationSubjectDnNormalizedMigration(612311821),
+        V202608311000__GrantRaProfileMembersToAttributeContentResolver(-1002111901);
 
         private final int checksum;
 

--- a/src/main/java/db/migration/V202608311000__GrantRaProfileMembersToAttributeContentResolver.java
+++ b/src/main/java/db/migration/V202608311000__GrantRaProfileMembersToAttributeContentResolver.java
@@ -1,0 +1,64 @@
+package db.migration;
+
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.util.AuthHelper;
+import com.otilm.core.util.DatabaseAuthMigration;
+import com.otilm.core.util.DatabaseMigration;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Grants {@code RA_PROFILE:MEMBERS} and {@code GROUP:MEMBERS} to the {@code attribute-content-resolver} role.
+ * <p>
+ * A CERTIFICATE dereference runs as this identity and passes through
+ * {@code RaProfileInternalService.evaluateCertificateRaProfilePermissions}, whose authorization names
+ * {@code RA_PROFILE:MEMBERS} as the parent gate — the certificate counterpart of the SECRET path's
+ * {@code VAULT_PROFILE:MEMBERS}. {@code GROUP:MEMBERS} covers the group-membership fallback the authorization
+ * core evaluates when a direct decision denies, so a policy-shape change cannot reintroduce a transitive 403
+ * for group-assigned certificates. Note the fallback is not certificate-scoped: should it ever become reachable
+ * for this role, the grant authorizes group-based DETAIL/LIST on any group-eligible resource — deliberate
+ * fail-safe breadth, consistent with the seed migration's coverage philosophy.
+ * <p>
+ * {@code ATTRIBUTE:MEMBERS} guards the custom-attribute content filter
+ * ({@code AttributeEngine#loadCustomAttributesSecurityResourceFilter}): without a role-level grant that filter
+ * is an empty allowlist and content is silently dropped rather than denied with a 403 — the harder-to-diagnose
+ * gap should the dereference path ever load custom attributes.
+ */
+// Flyway mandates the V<version>__<Description> class-name format, which cannot match Sonar's S101 identifier pattern.
+@SuppressWarnings("java:S101")
+public class V202608311000__GrantRaProfileMembersToAttributeContentResolver extends BaseJavaMigration {
+
+    @Override
+    public Integer getChecksum() {
+        return DatabaseMigration.JavaMigrationChecksums.V202608311000__GrantRaProfileMembersToAttributeContentResolver
+                .getChecksum();
+    }
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        Map<Resource, List<ResourceAction>> addedResourceActions = new EnumMap<>(Resource.class);
+        addedResourceActions.put(Resource.RA_PROFILE, List.of(ResourceAction.MEMBERS));
+        addedResourceActions.put(Resource.GROUP, List.of(ResourceAction.MEMBERS));
+        addedResourceActions.put(Resource.ATTRIBUTE, List.of(ResourceAction.MEMBERS));
+
+        // On a fresh install this migration runs before Core's catalog sync, and the auth service rejects
+        // permissions naming an unknown resource/action. Additive no-op where the pair is already known.
+        DatabaseAuthMigration.seedResources(addedResourceActions);
+
+        String roleUuid = DatabaseAuthMigration
+                .getSystemRolesMapping()
+                .get(AuthHelper.ATTRIBUTE_CONTENT_RESOLVER_USERNAME);
+        if (roleUuid == null) {
+            throw new IllegalStateException(
+                    "System role '%s' not found; V202607031200 must have created it before this migration runs"
+                            .formatted(AuthHelper.ATTRIBUTE_CONTENT_RESOLVER_USERNAME));
+        }
+
+        DatabaseAuthMigration.updateRolePermissions(roleUuid, addedResourceActions);
+    }
+}

--- a/src/main/java/db/migration/V202608311000__GrantRaProfileMembersToAttributeContentResolver.java
+++ b/src/main/java/db/migration/V202608311000__GrantRaProfileMembersToAttributeContentResolver.java
@@ -13,21 +13,23 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Grants {@code RA_PROFILE:MEMBERS} and {@code GROUP:MEMBERS} to the {@code attribute-content-resolver} role.
+ * Grants {@code RA_PROFILE:MEMBERS}, {@code GROUP:MEMBERS}, and {@code ATTRIBUTE:MEMBERS} to the
+ * {@code attribute-content-resolver} role, so a CERTIFICATE dereference running as this identity is not denied a
+ * transitive 403. Each grant is motivated separately.
  * <p>
- * A CERTIFICATE dereference runs as this identity and passes through
- * {@code RaProfileInternalService.evaluateCertificateRaProfilePermissions}, whose authorization names
- * {@code RA_PROFILE:MEMBERS} as the parent gate — the certificate counterpart of the SECRET path's
- * {@code VAULT_PROFILE:MEMBERS}. {@code GROUP:MEMBERS} covers the group-membership fallback the authorization
- * core evaluates when a direct decision denies, so a policy-shape change cannot reintroduce a transitive 403
- * for group-assigned certificates. Note the fallback is not certificate-scoped: should it ever become reachable
- * for this role, the grant authorizes group-based DETAIL/LIST on any group-eligible resource — deliberate
- * fail-safe breadth, consistent with the seed migration's coverage philosophy.
+ * <b>{@code RA_PROFILE:MEMBERS} (primary fix):</b> a CERTIFICATE dereference passes through
+ * {@code RaProfileInternalService.evaluateCertificateRaProfilePermissions}, whose authorization names it as the
+ * parent gate — the certificate counterpart of the SECRET path's {@code VAULT_PROFILE:MEMBERS}.
  * <p>
- * {@code ATTRIBUTE:MEMBERS} guards the custom-attribute content filter
- * ({@code AttributeEngine#loadCustomAttributesSecurityResourceFilter}): without a role-level grant that filter
- * is an empty allowlist and content is silently dropped rather than denied with a 403 — the harder-to-diagnose
- * gap should the dereference path ever load custom attributes.
+ * <b>{@code GROUP:MEMBERS} (fail-safe):</b> covers the group-membership fallback the authorization core evaluates
+ * when a direct decision denies, so a policy-shape change cannot reintroduce a transitive 403 for group-assigned
+ * certificates. The fallback is not certificate-scoped: if reachable for this role it authorizes group-based
+ * DETAIL/LIST on any group-eligible resource — deliberate breadth, matching the seed migration.
+ * <p>
+ * <b>{@code ATTRIBUTE:MEMBERS} (fail-safe):</b> guards the custom-attribute content filter
+ * ({@code AttributeEngine#loadCustomAttributesSecurityResourceFilter}), which without a role-level grant is an
+ * empty allowlist that silently drops content instead of returning a 403 — the harder-to-diagnose gap should the
+ * dereference path ever load custom attributes.
  */
 // Flyway mandates the V<version>__<Description> class-name format, which cannot match Sonar's S101 identifier pattern.
 @SuppressWarnings("java:S101")


### PR DESCRIPTION
## TLDR

Fixes #2153 - any v3 authority operation on an authority with a non-empty RESOURCE/CERTIFICATES attribute (otpki `tlsTrust`) returned 403 "Required 'Members' permission for 'RA Profile'" for every caller, superadmin included. One Flyway migration adds the missing transitive grant plus two reasoned fail-safe grants to the resolver role; no code changes.

## Root cause

`OperationAttributeResolver` elevates to the system identity `attribute-content-resolver` for RESOURCE dereference, so the caller's permissions are irrelevant from there on. Certificate content resolution passes through `RaProfileInternalService.evaluateCertificateRaProfilePermissions`, whose authorization names `RA_PROFILE:MEMBERS` as the parent gate. The seed migration (V202607031200) anticipated the analogous transitive gate for SECRET dereference (`VAULT_PROFILE:MEMBERS`) but missed the certificate one - the role has no `raProfiles` entry at all and `allowAllResources=false`, so OPA denies regardless of who is calling.

## What is granted

- `RA_PROFILE:MEMBERS` - the live fix.
- `GROUP:MEMBERS` - fail-safe: covers the group-membership fallback; unreachable under the current policy shape, but this bug class is exactly a transitive gate surfacing after policy evolution. Failure mode if ever missing: explicit 403.
- `ATTRIBUTE:MEMBERS` - fail-safe: covers the custom-attribute content filter (`AttributeEngine#loadCustomAttributesSecurityResourceFilter`), whose failure mode without a role-level grant is silent content filtering rather than a 403 - the harder-to-diagnose gap should the dereference path ever load custom attributes.

Pairs are seeded before the role update for fresh installs (catalog sync runs only after Flyway); `updateRolePermissions` merges additively, existing grants preserved.

## Verification

- Checksum registered via the guard cycle: `JavaMigrationChecksumTest` failed with the computed value, registered, green (`DatabaseMigrationTest` green too).
- Reviewed by four independent reviewers (Copilot CLI, guided, superpowers, hygiene): core mechanics confirmed (merge semantics, additive seeding, gate location `RaProfileServiceImpl:681-684`); all surviving findings addressed in the javadoc or consciously accepted (no behavioral migration test - repo precedent, the harness has no live auth service).
- Follow-up (not this PR): `documentation` repo's `roles-permissions.md` row for this role needs the updated permission list; tracked for the docs release.