### PR TITLE
Order the configurable-column listings by the field the request names

### DIFF
--- a/src/main/java/com/otilm/core/attribute/engine/AttributeColumnProjector.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeColumnProjector.java
@@ -12,6 +12,7 @@ import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.core.attribute.engine.AttributeEngine.CustomAttributeContentFilter;
 import com.otilm.core.attribute.engine.records.ProjectedAttributeContent;
 import com.otilm.core.dao.repository.AttributeContent2ObjectRepository;
+import com.otilm.core.model.AttributeFieldIdentifier;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -40,8 +41,6 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class AttributeColumnProjector {
-
-    private static final String FIELD_IDENTIFIER_SEPARATOR = "|";
 
     /**
      * Content that is never projected, whatever a request asks for. The catalogue already marks these fields
@@ -189,28 +188,19 @@ public class AttributeColumnProjector {
             if (source == null || source.getAttributeType() == null || column.getFieldIdentifier() == null) {
                 continue;
             }
-            int separator = column.getFieldIdentifier().lastIndexOf(FIELD_IDENTIFIER_SEPARATOR);
-            if (separator <= 0) {
+            AttributeFieldIdentifier identifier = AttributeFieldIdentifier.parse(column.getFieldIdentifier());
+            if (identifier == null) {
                 continue;
             }
-            AttributeContentType contentType = contentTypeOf(column.getFieldIdentifier().substring(separator + 1));
+            AttributeContentType contentType = identifier.contentType();
             if (contentType == null || WITHHELD_CONTENT_TYPES.contains(contentType)) {
                 continue;
             }
             requested
-                    .add(new RequestedColumn(source, source.getAttributeType(),
-                            column.getFieldIdentifier().substring(0, separator), contentType,
+                    .add(new RequestedColumn(source, source.getAttributeType(), identifier.attributeName(), contentType,
                             column.getFieldIdentifier()));
         }
         return requested;
-    }
-
-    private static AttributeContentType contentTypeOf(String name) {
-        try {
-            return AttributeContentType.valueOf(name);
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
     }
 
     /**

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -169,9 +169,7 @@ public class AttributeEngine {
             if (!settableAttributes.isEmpty()) {
                 searchFieldDataByGroupDtos
                         .add(new SearchFieldDataByGroupDto(
-                                SearchHelper
-                                        .applyAttributeSortability(
-                                                SearchHelper.prepareSearchForJSON(settableAttributes), resource),
+                                SearchHelper.prepareSearchForJSON(settableAttributes, resource),
                                 FilterFieldSource.CUSTOM));
             }
         } else {
@@ -184,9 +182,8 @@ public class AttributeEngine {
                     .toList();
             if (!customAttributes.isEmpty()) {
                 searchFieldDataByGroupDtos
-                        .add(new SearchFieldDataByGroupDto(SearchHelper
-                                .applyAttributeSortability(SearchHelper.prepareSearchForJSON(customAttributes),
-                                        resource),
+                        .add(new SearchFieldDataByGroupDto(
+                                SearchHelper.prepareSearchForJSON(customAttributes, resource),
                                 FilterFieldSource.CUSTOM));
             }
 
@@ -196,8 +193,7 @@ public class AttributeEngine {
                     .toList();
             if (!dataAttributes.isEmpty()) {
                 searchFieldDataByGroupDtos
-                        .add(new SearchFieldDataByGroupDto(SearchHelper
-                                .applyAttributeSortability(SearchHelper.prepareSearchForJSON(dataAttributes), resource),
+                        .add(new SearchFieldDataByGroupDto(SearchHelper.prepareSearchForJSON(dataAttributes, resource),
                                 FilterFieldSource.DATA));
             }
 
@@ -208,9 +204,7 @@ public class AttributeEngine {
             if (!metadataAttributes.isEmpty()) {
                 searchFieldDataByGroupDtos
                         .add(new SearchFieldDataByGroupDto(
-                                SearchHelper
-                                        .applyAttributeSortability(
-                                                SearchHelper.prepareSearchForJSON(metadataAttributes), resource),
+                                SearchHelper.prepareSearchForJSON(metadataAttributes, resource),
                                 FilterFieldSource.META));
             }
         }

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -168,7 +168,10 @@ public class AttributeEngine {
                                     .toList());
             if (!settableAttributes.isEmpty()) {
                 searchFieldDataByGroupDtos
-                        .add(new SearchFieldDataByGroupDto(SearchHelper.prepareSearchForJSON(settableAttributes),
+                        .add(new SearchFieldDataByGroupDto(
+                                SearchHelper
+                                        .applyAttributeSortability(
+                                                SearchHelper.prepareSearchForJSON(settableAttributes), resource),
                                 FilterFieldSource.CUSTOM));
             }
         } else {
@@ -181,7 +184,9 @@ public class AttributeEngine {
                     .toList();
             if (!customAttributes.isEmpty()) {
                 searchFieldDataByGroupDtos
-                        .add(new SearchFieldDataByGroupDto(SearchHelper.prepareSearchForJSON(customAttributes),
+                        .add(new SearchFieldDataByGroupDto(SearchHelper
+                                .applyAttributeSortability(SearchHelper.prepareSearchForJSON(customAttributes),
+                                        resource),
                                 FilterFieldSource.CUSTOM));
             }
 
@@ -191,7 +196,8 @@ public class AttributeEngine {
                     .toList();
             if (!dataAttributes.isEmpty()) {
                 searchFieldDataByGroupDtos
-                        .add(new SearchFieldDataByGroupDto(SearchHelper.prepareSearchForJSON(dataAttributes),
+                        .add(new SearchFieldDataByGroupDto(SearchHelper
+                                .applyAttributeSortability(SearchHelper.prepareSearchForJSON(dataAttributes), resource),
                                 FilterFieldSource.DATA));
             }
 
@@ -201,7 +207,10 @@ public class AttributeEngine {
                     .toList();
             if (!metadataAttributes.isEmpty()) {
                 searchFieldDataByGroupDtos
-                        .add(new SearchFieldDataByGroupDto(SearchHelper.prepareSearchForJSON(metadataAttributes),
+                        .add(new SearchFieldDataByGroupDto(
+                                SearchHelper
+                                        .applyAttributeSortability(
+                                                SearchHelper.prepareSearchForJSON(metadataAttributes), resource),
                                 FilterFieldSource.META));
             }
         }

--- a/src/main/java/com/otilm/core/attribute/engine/ListingSortResolver.java
+++ b/src/main/java/com/otilm/core/attribute/engine/ListingSortResolver.java
@@ -1,0 +1,76 @@
+package com.otilm.core.attribute.engine;
+
+import com.otilm.api.exception.ValidationError;
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.client.certificate.SearchSortRequestDto;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.search.FilterFieldSource;
+import com.otilm.api.model.core.search.SearchFieldDataDto;
+import com.otilm.core.dao.repository.SortSpecification;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * The sort a listing request carries, resolved against the resource whose listing will apply it.
+ *
+ * <p>
+ * A property sort names a {@code FilterField}, which {@code SortOrderBuilder} resolves and refuses when the catalogue
+ * withholds it. An attribute sort names a definition instead, and there is no enum to refuse it against - so it is
+ * checked here, against the same published catalogue the client read the {@code sortable} flag from. Without this a
+ * request could order by exactly the fields the catalogue reports as {@code sortable:false}: secret and code-block
+ * content, encrypted content, and definitions marked not visible.
+ *
+ * <p>
+ * The resolved specification also carries the caller's custom-attribute permissions into the query that reads the
+ * value. The projection path applies them ({@code AttributeColumnProjector}), and an ordering that did not would let a
+ * caller compare the values of an attribute the same response blanks - a comparative oracle over content they are
+ * denied.
+ */
+@Component
+@RequiredArgsConstructor
+public class ListingSortResolver {
+
+    private final AttributeEngine attributeEngine;
+
+    /**
+     * The specification a listing hands the repository, or {@code null} when the request named no sort.
+     *
+     * @param resource the resource the listing selects, which is what the identifier is resolved against
+     */
+    public SortSpecification resolve(final Resource resource, final SearchSortRequestDto sort) {
+        if (sort == null) {
+            return null;
+        }
+        final FilterFieldSource source = sort.getFieldSource();
+        if (source == null || source.getAttributeType() == null) {
+            return new SortSpecification(source, sort.getFieldIdentifier(), sort.getDirection(), resource, null);
+        }
+        requireSortableAttributeField(resource, source, sort.getFieldIdentifier());
+        return new SortSpecification(source, sort.getFieldIdentifier(), sort.getDirection(), resource,
+                attributeEngine.loadCustomAttributeContentFilter());
+    }
+
+    /**
+     * Refuses an attribute field the resource's catalogue does not publish as sortable, with the message the property
+     * path uses for the same refusal. Read from the catalogue rather than from a copy of its rules, so the flag the
+     * client was given and the answer it gets back cannot disagree.
+     */
+    private void requireSortableAttributeField(final Resource resource, final FilterFieldSource source,
+            final String fieldIdentifier) {
+        final SearchFieldDataDto field = attributeEngine
+                .getResourceSearchableFields(resource, false)
+                .stream()
+                .filter(group -> group.getFilterFieldSource() == source)
+                .flatMap(group -> group.getSearchFieldData().stream())
+                .filter(item -> Objects.equals(item.getFieldIdentifier(), fieldIdentifier))
+                .findFirst()
+                .orElseThrow(() -> new ValidationException(
+                        ValidationError.create("Unknown sort field identifier %s.".formatted(fieldIdentifier))));
+
+        if (!Boolean.TRUE.equals(field.getSortable())) {
+            throw new ValidationException(ValidationError
+                    .create("Field %s cannot be used to order this listing.".formatted(fieldIdentifier)));
+        }
+    }
+}

--- a/src/main/java/com/otilm/core/dao/repository/CertificateRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CertificateRepository.java
@@ -602,7 +602,11 @@ public interface CertificateRepository
             LEFT JOIN OwnerAssociation oa ON oa.objectUuid = c.uuid
             LEFT JOIN RaProfile ra ON ra.uuid = c.raProfileUuid
             WHERE c.uuid IN ?1
-            ORDER BY c.created DESC
             """)
+    /**
+     * The page of certificates named by the uuid list. Carries no ORDER BY: the ordering the listing asked for lives in
+     * the rank of that list, and an ORDER BY here would replace it. Callers rank the result with
+     * {@code SortOrderBuilder.rankBy}.
+     */
     List<CertificateDto> findCertificateDtosByUuidsIn(List<UUID> uuids);
 }

--- a/src/main/java/com/otilm/core/dao/repository/CertificateRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CertificateRepository.java
@@ -575,11 +575,14 @@ public interface CertificateRepository
             @Param("oldCode") String oldCode);
 
     /**
-     * Populates almost all of the {@link CertificateDto} properties.
+     * Populates almost all of the {@link CertificateDto} properties for the page of certificates the uuid list names.
      *
      * <p>
      * Groups need to be retrieved separately and set to the DTO.
-     * </p>
+     *
+     * <p>
+     * Carries no ORDER BY: the ordering the listing asked for lives in the rank of that list, and an ORDER BY here
+     * would replace it. Callers rank the result with {@code SortOrderBuilder.rankBy}.
      */
     @Query("""
             SELECT new com.otilm.api.model.core.certificate.CertificateDto(
@@ -603,10 +606,5 @@ public interface CertificateRepository
             LEFT JOIN RaProfile ra ON ra.uuid = c.raProfileUuid
             WHERE c.uuid IN ?1
             """)
-    /**
-     * The page of certificates named by the uuid list. Carries no ORDER BY: the ordering the listing asked for lives in
-     * the rank of that list, and an ORDER BY here would replace it. Callers rank the result with
-     * {@code SortOrderBuilder.rankBy}.
-     */
     List<CertificateDto> findCertificateDtosByUuidsIn(List<UUID> uuids);
 }

--- a/src/main/java/com/otilm/core/dao/repository/CryptographicKeyItemRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CryptographicKeyItemRepository.java
@@ -30,8 +30,13 @@ public interface CryptographicKeyItemRepository extends SecurityFilterRepository
     @EntityGraph(attributePaths = {"key", "key.tokenProfile"})
     List<CryptographicKeyItem> findByUuidIn(List<UUID> uuids);
 
+    /**
+     * The key items named by the uuid list. Deliberately carries no ordering: the ordering the listing asked for lives
+     * in the rank of that list, and the {@code OrderByCreatedAtDesc} this method used to name would replace it. Callers
+     * rank the result with {@code SortOrderBuilder.rankBy}.
+     */
     @EntityGraph(attributePaths = {"key", "key.tokenProfile", "key.groups", "key.owner"})
-    List<CryptographicKeyItem> findFullByUuidInOrderByCreatedAtDesc(List<UUID> uuids);
+    List<CryptographicKeyItem> findFullByUuidIn(List<UUID> uuids);
 
     @EntityGraph(attributePaths = {"key", "key.items"})
     List<CryptographicKeyItem> findWithKeyByUuidIn(List<UUID> uuids);
@@ -61,8 +66,16 @@ public interface CryptographicKeyItemRepository extends SecurityFilterRepository
             nativeQuery = true)
     Integer insertWithFingerprintConflictResolve(@Param("cki") CryptographicKeyItem keyItem);
 
+    /**
+     * How many certificates each of the named key items is associated with, keyed by the item's uuid.
+     *
+     * <p>
+     * Returns the uuid rather than counts alone because the caller has to line each count up with its key item. Two
+     * queries ordered by the same non-unique column line up only while that column has no ties, and once the listing
+     * orders by a field the request names they do not line up at all.
+     */
     @Query(value = """
-            SELECT COUNT(c.uuid)
+            SELECT cki.uuid AS uuid, COUNT(c.uuid) AS associations
                 FROM CryptographicKeyItem cki
                 JOIN cki.key ck
                 LEFT JOIN Certificate c
@@ -70,9 +83,16 @@ public interface CryptographicKeyItemRepository extends SecurityFilterRepository
                     OR c.altKeyUuid = ck.uuid
                 WHERE cki.uuid IN :uuids
                 GROUP BY cki.uuid
-                ORDER BY cki.createdAt DESC
             """)
-    List<Integer> getCountsOfAssociations(@Param("uuids") List<UUID> uuids);
+    List<KeyItemAssociationCount> getCountsOfAssociations(@Param("uuids") List<UUID> uuids);
+
+    /** One key item's certificate-association count. */
+    interface KeyItemAssociationCount {
+
+        UUID getUuid();
+
+        int getAssociations();
+    }
 
     @EntityGraph(attributePaths = {"key", "key.tokenInstanceReference", "key.tokenInstanceReference.connector"})
     Optional<CryptographicKeyItem> findWithConnectorByUuid(UUID uuid);

--- a/src/main/java/com/otilm/core/dao/repository/CryptographicKeyItemRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CryptographicKeyItemRepository.java
@@ -32,8 +32,8 @@ public interface CryptographicKeyItemRepository extends SecurityFilterRepository
 
     /**
      * The key items named by the uuid list. Deliberately carries no ordering: the ordering the listing asked for lives
-     * in the rank of that list, and the {@code OrderByCreatedAtDesc} this method used to name would replace it. Callers
-     * rank the result with {@code SortOrderBuilder.rankBy}.
+     * in the rank of that list, and an ORDER BY here would replace it. Callers rank the result with
+     * {@code SortOrderBuilder.rankBy}.
      */
     @EntityGraph(attributePaths = {"key", "key.tokenProfile", "key.groups", "key.owner"})
     List<CryptographicKeyItem> findFullByUuidIn(List<UUID> uuids);

--- a/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepositoryImpl.java
+++ b/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepositoryImpl.java
@@ -146,10 +146,17 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
     }
 
     /**
-     * The uuids of a page ordered by a field of a joined entity. The join gives a root as many rows as it has matches,
-     * so a window cut over those rows would underfill the page and let the same root reappear on the next one. The
-     * query therefore groups by the root's uuid and orders by the aggregate the ordering resolves - one row per root,
-     * which is what the window is allowed to cut.
+     * The uuids of a page in the order the request asked for, for the two sorts the entity query cannot carry itself.
+     *
+     * <p>
+     * A sort through a join gives a root as many rows as the join has matches, so a window cut over those rows would
+     * underfill the page and let the same root reappear on the next one. A sort by an attribute resolves to a
+     * correlated scalar subquery, and the entity query selects DISTINCT, which the database will not order by an
+     * expression that is absent from the select list.
+     *
+     * <p>
+     * This query answers both: it selects the sort key alongside the uuid, groups by the uuid and orders by the
+     * aggregate the ordering resolves - one row per root, carrying its key, which is what the window is allowed to cut.
      */
     private List<UUID> findUuidsOrderedBySortKey(final SecurityFilter filter,
             final TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause,

--- a/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepositoryImpl.java
+++ b/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepositoryImpl.java
@@ -21,6 +21,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.Tuple;
 import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CommonAbstractCriteria;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaDelete;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -117,8 +118,8 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
     public List<T> findUsingSecurityFilter(final SecurityFilter filter, List<String> fetchAssociations,
             final TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause,
             final Pageable p, final BiFunction<Root<T>, CriteriaBuilder, Order> order, final SortSpecification sort) {
-        if (SortOrderBuilder.traversesJoin(sort)) {
-            return loadInUuidOrder(findUuidsOrderedByJoinedField(filter, additionalWhereClause, p, sort),
+        if (SortOrderBuilder.needsRankedUuidQuery(sort)) {
+            return loadInUuidOrder(findUuidsOrderedBySortKey(filter, additionalWhereClause, p, sort),
                     fetchAssociations);
         }
         final CriteriaQuery<T> cr = createCriteriaBuilder(filter, fetchAssociations, additionalWhereClause, order, sort,
@@ -137,8 +138,8 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
     public List<UUID> findUuidsUsingSecurityFilter(final SecurityFilter filter,
             final TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause,
             final Pageable p, final BiFunction<Root<T>, CriteriaBuilder, Order> order, final SortSpecification sort) {
-        if (SortOrderBuilder.traversesJoin(sort)) {
-            return findUuidsOrderedByJoinedField(filter, additionalWhereClause, p, sort);
+        if (SortOrderBuilder.needsRankedUuidQuery(sort)) {
+            return findUuidsOrderedBySortKey(filter, additionalWhereClause, p, sort);
         }
         final CriteriaQuery<UUID> cr = createCriteriaBuilderUuid(filter, additionalWhereClause, order, sort, p != null);
         return window(entityManager.createQuery(cr), p).getResultList();
@@ -150,7 +151,7 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
      * query therefore groups by the root's uuid and orders by the aggregate the ordering resolves - one row per root,
      * which is what the window is allowed to cut.
      */
-    private List<UUID> findUuidsOrderedByJoinedField(final SecurityFilter filter,
+    private List<UUID> findUuidsOrderedBySortKey(final SecurityFilter filter,
             final TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause,
             final Pageable p, final SortSpecification sort) {
         final Class<T> entity = this.entityInformation.getJavaType();
@@ -159,7 +160,7 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
         final Root<T> root = cr.from(entity);
         final Path<?> uuid = root.get(UniquelyIdentified_.UUID);
 
-        final SortOrderBuilder.GroupedOrdering ordering = SortOrderBuilder.resolveGrouped(root, cb, sort);
+        final SortOrderBuilder.GroupedOrdering ordering = SortOrderBuilder.resolveGrouped(root, cb, cr, sort);
         cr.multiselect(uuid, ordering.sortKey());
         cr.groupBy(uuid);
         cr.orderBy(ordering.orders());
@@ -199,10 +200,10 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
     }
 
     private List<Order> resolveOrdering(final Root<T> root, final CriteriaBuilder cb,
-            final BiFunction<Root<T>, CriteriaBuilder, Order> order, final SortSpecification sort,
-            final boolean paged) {
+            final CommonAbstractCriteria query, final BiFunction<Root<T>, CriteriaBuilder, Order> order,
+            final SortSpecification sort, final boolean paged) {
         final Order defaultOrder = order == null ? null : order.apply(root, cb);
-        return SortOrderBuilder.resolve(root, cb, sort, defaultOrder, paged);
+        return SortOrderBuilder.resolve(root, cb, query, sort, defaultOrder, paged);
     }
 
     private void applyPredicates(final CriteriaQuery<?> cr, final SecurityFilter filter,
@@ -440,7 +441,7 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
 
         fetchAssociations(root, fetchAssociations);
 
-        final List<Order> orders = resolveOrdering(root, cb, order, sort, paged);
+        final List<Order> orders = resolveOrdering(root, cb, cr, order, sort, paged);
         if (!orders.isEmpty()) {
             cr.orderBy(orders);
         }
@@ -460,7 +461,7 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
 
         cr.select(root.get("uuid"));
 
-        final List<Order> orders = resolveOrdering(root, cb, order, sort, paged);
+        final List<Order> orders = resolveOrdering(root, cb, cr, order, sort, paged);
         if (!orders.isEmpty()) {
             cr.orderBy(orders);
         }

--- a/src/main/java/com/otilm/core/dao/repository/SortSpecification.java
+++ b/src/main/java/com/otilm/core/dao/repository/SortSpecification.java
@@ -1,16 +1,34 @@
 package com.otilm.core.dao.repository;
 
 import com.otilm.api.model.client.certificate.SearchSortRequestDto;
+import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.api.model.core.search.SortDirection;
+import com.otilm.core.attribute.engine.AttributeEngine.CustomAttributeContentFilter;
 
 /**
  * Ordering a caller asked for, addressed the way a filter addresses a field: a source plus an identifier that is unique
  * only within that source. Carried instead of a ready-made {@code Order} lambda so the repository can decide how the
  * ordering interacts with the rest of the query it builds - the {@code SELECT DISTINCT} it emits, and the tie-break it
  * appends to keep paging stable.
+ *
+ * <p>
+ * An attribute-sourced sort additionally carries the resource whose catalogue it was resolved against and the caller's
+ * custom-attribute content permissions. Neither can be recovered from the entity root: a resource without a
+ * {@code ResourceToClass} entry maps to no resource at all, and permissions live on the request rather than on the
+ * query. Both are supplied by {@code ListingSortResolver}, which is the only thing that may build one; a specification
+ * that reaches the attribute sort key without them is refused rather than run unauthorized.
+ *
+ * @param resource the resource the listing selects, or {@code null} for a specification built without one
+ * @param attributeContentFilter the caller's custom-attribute permissions, or {@code null} when no attribute sort was
+ * resolved
  */
-public record SortSpecification(FilterFieldSource fieldSource, String fieldIdentifier, SortDirection direction) {
+public record SortSpecification(FilterFieldSource fieldSource, String fieldIdentifier, SortDirection direction,
+        Resource resource, CustomAttributeContentFilter attributeContentFilter) {
+
+    public SortSpecification(FilterFieldSource fieldSource, String fieldIdentifier, SortDirection direction) {
+        this(fieldSource, fieldIdentifier, direction, null, null);
+    }
 
     public static SortSpecification from(SearchSortRequestDto dto) {
         return dto == null

--- a/src/main/java/com/otilm/core/enums/ResourceToClass.java
+++ b/src/main/java/com/otilm/core/enums/ResourceToClass.java
@@ -8,6 +8,7 @@ import com.otilm.core.dao.entity.Approval;
 import com.otilm.core.dao.entity.ApprovalProfile;
 import com.otilm.core.dao.entity.AuditLog;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
+import com.otilm.core.dao.entity.Cbom;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.CertificateRequestEntity;
 import com.otilm.core.dao.entity.Comment;
@@ -21,6 +22,7 @@ import com.otilm.core.dao.entity.Group;
 import com.otilm.core.dao.entity.Location;
 import com.otilm.core.dao.entity.RaProfile;
 import com.otilm.core.dao.entity.ScheduledJob;
+import com.otilm.core.dao.entity.Secret;
 import com.otilm.core.dao.entity.Setting;
 import com.otilm.core.dao.entity.TokenInstanceReference;
 import com.otilm.core.dao.entity.TokenProfile;
@@ -28,6 +30,7 @@ import com.otilm.core.dao.entity.acme.AcmeAccount;
 import com.otilm.core.dao.entity.acme.AcmeProfile;
 import com.otilm.core.dao.entity.cbom.CryptoAsset;
 import com.otilm.core.dao.entity.notifications.Notification;
+import com.otilm.core.dao.entity.oid.CustomOidEntry;
 import com.otilm.core.dao.entity.scep.ScepProfile;
 import com.otilm.core.dao.entity.signing.SigningProfile;
 import com.otilm.core.dao.entity.signing.SigningRecord;
@@ -47,6 +50,7 @@ public enum ResourceToClass {
     ATTRIBUTE(Resource.ATTRIBUTE, BaseAttributeV2.class),
     SCHEDULED_JOB(Resource.SCHEDULED_JOB, ScheduledJob.class),
     NOTIFICATION_INSTANCE(Resource.NOTIFICATION_INSTANCE, Notification.class),
+    OID(Resource.OID, CustomOidEntry.class),
 
     // AUTH
     USER(Resource.USER, UserDto.class),
@@ -73,6 +77,7 @@ public enum ResourceToClass {
     LOCATION(Resource.LOCATION, Location.class),
 
     // CBOMS
+    CBOM(Resource.CBOM, Cbom.class),
     CRYPTO_ASSET(Resource.CRYPTO_ASSET, CryptoAsset.class),
 
     // CRYPTOGRAPHY
@@ -86,6 +91,9 @@ public enum ResourceToClass {
 
     // COMMENTS
     COMMENT(Resource.COMMENT, Comment.class),
+
+    // SECRETS
+    SECRET(Resource.SECRET, Secret.class),
 
     // SIGNING
     SIGNING_PROFILE(Resource.SIGNING_PROFILE, SigningProfile.class),

--- a/src/main/java/com/otilm/core/model/AttributeFieldIdentifier.java
+++ b/src/main/java/com/otilm/core/model/AttributeFieldIdentifier.java
@@ -1,0 +1,42 @@
+package com.otilm.core.model;
+
+import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
+
+/**
+ * The two parts an attribute-sourced field identifier carries: the attribute's name, and the content type that
+ * distinguishes two definitions registered under that same name.
+ *
+ * <p>
+ * Split at the <em>last</em> separator. An attribute name carries no separator restriction, so a name holding a
+ * {@code |} would be misread by a split at the first one - {@code team|region|TEXT} would name the attribute
+ * {@code team} with a content type of {@code region}. Every site that reads an identifier - the column projection, the
+ * attribute filter and the attribute sort - parses it here, so they cannot disagree about which field a request names.
+ */
+public record AttributeFieldIdentifier(String attributeName, String contentTypeName) {
+
+    public static final String SEPARATOR = "|";
+
+    /**
+     * The parts of an identifier, or {@code null} when it names no attribute-sourced field - it carries no separator,
+     * or nothing before one.
+     */
+    public static AttributeFieldIdentifier parse(final String fieldIdentifier) {
+        if (fieldIdentifier == null) {
+            return null;
+        }
+        final int separator = fieldIdentifier.lastIndexOf(SEPARATOR);
+        return separator <= 0
+                ? null
+                : new AttributeFieldIdentifier(fieldIdentifier.substring(0, separator),
+                        fieldIdentifier.substring(separator + 1));
+    }
+
+    /** The content type the identifier names, or {@code null} when it names none that exists. */
+    public AttributeContentType contentType() {
+        try {
+            return AttributeContentType.valueOf(contentTypeName);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/otilm/core/service/impl/AuditLogServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/AuditLogServiceImpl.java
@@ -83,7 +83,7 @@ public class AuditLogServiceImpl implements AuditLogExternalService, AuditLogInt
     @Override
     @ExternalAuthorization(resource = Resource.AUDIT_LOG, action = ResourceAction.LIST)
     public AuditLogResponseDto listAuditLogs(final SearchRequestDto request) {
-        RequestValidatorHelper.revalidateSearchRequestDto(request);
+        RequestValidatorHelper.revalidateSearchRequestDto(request, Resource.AUDIT_LOG);
         final Pageable p = PageRequest.of(request.getPageNumber() - 1, request.getItemsPerPage());
 
         final TriFunction<Root<AuditLog>, CriteriaBuilder, CriteriaQuery<?>, jakarta.persistence.criteria.Predicate> additionalWhereClause = (

--- a/src/main/java/com/otilm/core/service/impl/CbomServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CbomServiceImpl.java
@@ -34,6 +34,7 @@ import com.otilm.core.dao.entity.Cbom_;
 import com.otilm.core.dao.entity.ScheduledJobHistory;
 import com.otilm.core.dao.repository.CbomRepository;
 import com.otilm.core.dao.repository.ScheduledJobHistoryRepository;
+import com.otilm.core.dao.repository.SortSpecification;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.events.transaction.TransactionHandler;
 import com.otilm.core.logging.LoggerWrapper;
@@ -137,7 +138,7 @@ public class CbomServiceImpl implements CbomExternalService, CbomInternalService
                 cr) -> FilterPredicatesBuilder.getFiltersPredicate(cb, cr, root, request.getFilters());
         final List<CbomDto> cbomDtos = cbomRepository
                 .findUsingSecurityFilter(filter, List.of(), additionalWhereClause, p,
-                        (root, cb) -> cb.desc(root.get("createdAt")))
+                        (root, cb) -> cb.desc(root.get("createdAt")), SortSpecification.from(request.getSort()))
                 .stream()
                 .map(Cbom::mapToDto)
                 .toList();

--- a/src/main/java/com/otilm/core/service/impl/CbomServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CbomServiceImpl.java
@@ -26,6 +26,7 @@ import com.otilm.api.model.core.search.SearchFieldDataDto;
 import com.otilm.api.model.scheduler.SchedulerJobExecutionStatus;
 import com.otilm.core.attribute.engine.AttributeColumnProjector;
 import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.attribute.engine.ListingSortResolver;
 import com.otilm.core.cbom.client.CbomRepositoryClient;
 import com.otilm.core.comparator.SearchFieldDataComparator;
 import com.otilm.core.dao.CryptoAssetConstraintTranslator;
@@ -34,7 +35,6 @@ import com.otilm.core.dao.entity.Cbom_;
 import com.otilm.core.dao.entity.ScheduledJobHistory;
 import com.otilm.core.dao.repository.CbomRepository;
 import com.otilm.core.dao.repository.ScheduledJobHistoryRepository;
-import com.otilm.core.dao.repository.SortSpecification;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.events.transaction.TransactionHandler;
 import com.otilm.core.logging.LoggerWrapper;
@@ -97,6 +97,8 @@ public class CbomServiceImpl implements CbomExternalService, CbomInternalService
 
     private AttributeColumnProjector attributeColumnProjector;
 
+    private ListingSortResolver listingSortResolver;
+
     @Autowired
     public void setCbomRepository(CbomRepository cbomRepository) {
         this.cbomRepository = cbomRepository;
@@ -105,6 +107,11 @@ public class CbomServiceImpl implements CbomExternalService, CbomInternalService
     @Autowired
     public void setAttributeColumnProjector(AttributeColumnProjector attributeColumnProjector) {
         this.attributeColumnProjector = attributeColumnProjector;
+    }
+
+    @Autowired
+    public void setListingSortResolver(ListingSortResolver listingSortResolver) {
+        this.listingSortResolver = listingSortResolver;
     }
 
     @Autowired
@@ -138,7 +145,8 @@ public class CbomServiceImpl implements CbomExternalService, CbomInternalService
                 cr) -> FilterPredicatesBuilder.getFiltersPredicate(cb, cr, root, request.getFilters());
         final List<CbomDto> cbomDtos = cbomRepository
                 .findUsingSecurityFilter(filter, List.of(), additionalWhereClause, p,
-                        (root, cb) -> cb.desc(root.get("createdAt")), SortSpecification.from(request.getSort()))
+                        (root, cb) -> cb.desc(root.get("createdAt")),
+                        listingSortResolver.resolve(Resource.CBOM, request.getSort()))
                 .stream()
                 .map(Cbom::mapToDto)
                 .toList();

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -75,6 +75,7 @@ import com.otilm.core.attribute.engine.AttributeColumnProjector;
 import com.otilm.core.attribute.engine.AttributeContentPurpose;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.AttributeOperation;
+import com.otilm.core.attribute.engine.ListingSortResolver;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.certificate.request.IssuanceDefinitionResolver;
 import com.otilm.core.comparator.SearchFieldDataComparator;
@@ -112,7 +113,6 @@ import com.otilm.core.dao.repository.GroupRepository;
 import com.otilm.core.dao.repository.LocationRepository;
 import com.otilm.core.dao.repository.ProtocolCertificateAssociationsRepository;
 import com.otilm.core.dao.repository.RaProfileRepository;
-import com.otilm.core.dao.repository.SortSpecification;
 import com.otilm.core.dao.repository.acme.AcmeAccountRepository;
 import com.otilm.core.dao.repository.cmp.CmpProfileRepository;
 import com.otilm.core.dao.repository.scep.ScepProfileRepository;
@@ -303,6 +303,8 @@ public class CertificateServiceImpl
 
     private AttributeEngine attributeEngine;
     private AttributeColumnProjector attributeColumnProjector;
+
+    private ListingSortResolver listingSortResolver;
     private ExtendedAttributeService extendedAttributeService;
     private ResourceObjectAssociationService objectAssociationService;
     private CertificateProtocolAssociationRepository certificateProtocolAssociationRepository;
@@ -543,6 +545,11 @@ public class CertificateServiceImpl
     }
 
     @Autowired
+    public void setListingSortResolver(ListingSortResolver listingSortResolver) {
+        this.listingSortResolver = listingSortResolver;
+    }
+
+    @Autowired
     public void setExtendedAttributeService(ExtendedAttributeService extendedAttributeService) {
         this.extendedAttributeService = extendedAttributeService;
     }
@@ -583,7 +590,8 @@ public class CertificateServiceImpl
                 request.getFilters(), request.isIncludeArchived());
         List<UUID> certificateUuids = certificateRepository
                 .findUuidsUsingSecurityFilter(filter, additionalWhereClause, p,
-                        (root, cb) -> cb.desc(root.get("created")), SortSpecification.from(request.getSort()));
+                        (root, cb) -> cb.desc(root.get("created")),
+                        listingSortResolver.resolve(Resource.CERTIFICATE, request.getSort()));
 
         // We use DTO projection instead of Hibernate entities for performance reasons.
         List<CertificateDto> certificates;

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -112,6 +112,7 @@ import com.otilm.core.dao.repository.GroupRepository;
 import com.otilm.core.dao.repository.LocationRepository;
 import com.otilm.core.dao.repository.ProtocolCertificateAssociationsRepository;
 import com.otilm.core.dao.repository.RaProfileRepository;
+import com.otilm.core.dao.repository.SortSpecification;
 import com.otilm.core.dao.repository.acme.AcmeAccountRepository;
 import com.otilm.core.dao.repository.cmp.CmpProfileRepository;
 import com.otilm.core.dao.repository.scep.ScepProfileRepository;
@@ -174,6 +175,7 @@ import com.otilm.core.util.KeySizeUtil;
 import com.otilm.core.util.MetaDefinitions;
 import com.otilm.core.util.RequestValidatorHelper;
 import com.otilm.core.util.SearchHelper;
+import com.otilm.core.util.SortOrderBuilder;
 import com.otilm.core.util.X509ObjectToString;
 import com.otilm.core.validation.certificate.ICertificateValidator;
 import jakarta.persistence.criteria.CriteriaBuilder;
@@ -581,14 +583,16 @@ public class CertificateServiceImpl
                 request.getFilters(), request.isIncludeArchived());
         List<UUID> certificateUuids = certificateRepository
                 .findUuidsUsingSecurityFilter(filter, additionalWhereClause, p,
-                        (root, cb) -> cb.desc(root.get("created")));
+                        (root, cb) -> cb.desc(root.get("created")), SortSpecification.from(request.getSort()));
 
         // We use DTO projection instead of Hibernate entities for performance reasons.
         List<CertificateDto> certificates;
         if (certificateUuids.isEmpty()) {
             certificates = Collections.emptyList();
         } else {
-            certificates = certificateRepository.findCertificateDtosByUuidsIn(certificateUuids);
+            certificates = SortOrderBuilder
+                    .rankBy(certificateUuids, certificateRepository.findCertificateDtosByUuidsIn(certificateUuids),
+                            certificate -> UUID.fromString(certificate.getUuid()));
             List<GroupAssociation> groupAssociations = groupAssociationRepository
                     .findWithAssociationsByResourceAndObjectUuidIn(Resource.CERTIFICATE, certificateUuids);
             Map<String, List<GroupDto>> groupsByCert = groupAssociations

--- a/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
@@ -68,6 +68,7 @@ import com.otilm.core.dao.entity.UniquelyIdentified;
 import com.otilm.core.dao.repository.CryptographicKeyItemRepository;
 import com.otilm.core.dao.repository.CryptographicKeyRepository;
 import com.otilm.core.dao.repository.GroupRepository;
+import com.otilm.core.dao.repository.SortSpecification;
 import com.otilm.core.dao.repository.TokenInstanceReferenceRepository;
 import com.otilm.core.dao.repository.TokenProfileRepository;
 import com.otilm.core.enums.FilterField;
@@ -96,6 +97,7 @@ import com.otilm.core.util.CryptographyUtil;
 import com.otilm.core.util.FilterPredicatesBuilder;
 import com.otilm.core.util.RequestValidatorHelper;
 import com.otilm.core.util.SearchHelper;
+import com.otilm.core.util.SortOrderBuilder;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
@@ -118,7 +120,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.apache.commons.lang3.function.TriFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -310,17 +311,22 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
 
         List<UUID> filteredKeyUuids = cryptographicKeyItemRepository
                 .findUuidsUsingSecurityFilter(filter, additionalWhereClause, p,
-                        (root, cb) -> cb.desc(root.get("createdAt")));
+                        (root, cb) -> cb.desc(root.get("createdAt")), SortSpecification.from(request.getSort()));
 
-        List<CryptographicKeyItem> filteredKeys = cryptographicKeyItemRepository
-                .findFullByUuidInOrderByCreatedAtDesc(filteredKeyUuids);
+        List<CryptographicKeyItem> filteredKeys = SortOrderBuilder
+                .rankBy(filteredKeyUuids, cryptographicKeyItemRepository.findFullByUuidIn(filteredKeyUuids),
+                        CryptographicKeyItem::getUuid);
 
-        List<Integer> associationsCounts = cryptographicKeyItemRepository.getCountsOfAssociations(filteredKeyUuids);
+        Map<UUID, Integer> associationsCounts = cryptographicKeyItemRepository
+                .getCountsOfAssociations(filteredKeyUuids)
+                .stream()
+                .collect(Collectors
+                        .toMap(CryptographicKeyItemRepository.KeyItemAssociationCount::getUuid,
+                                CryptographicKeyItemRepository.KeyItemAssociationCount::getAssociations));
 
-        List<KeyItemDto> listedKeyDtos = IntStream.range(0, filteredKeys.size()).mapToObj(i -> {
-            CryptographicKeyItem cki = filteredKeys.get(i);
+        List<KeyItemDto> listedKeyDtos = filteredKeys.stream().map(cki -> {
             KeyItemDto dto = cki.mapToSummaryDto();
-            dto.setAssociations(associationsCounts.get(i));
+            dto.setAssociations(associationsCounts.getOrDefault(cki.getUuid(), 0));
             return dto;
         }).toList();
 

--- a/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
@@ -51,6 +51,7 @@ import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
 import com.otilm.api.model.core.search.SearchFieldDataDto;
 import com.otilm.core.attribute.engine.AttributeColumnProjector;
 import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.attribute.engine.ListingSortResolver;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.client.ConnectorApiFactory;
 import com.otilm.core.comparator.SearchFieldDataComparator;
@@ -68,7 +69,6 @@ import com.otilm.core.dao.entity.UniquelyIdentified;
 import com.otilm.core.dao.repository.CryptographicKeyItemRepository;
 import com.otilm.core.dao.repository.CryptographicKeyRepository;
 import com.otilm.core.dao.repository.GroupRepository;
-import com.otilm.core.dao.repository.SortSpecification;
 import com.otilm.core.dao.repository.TokenInstanceReferenceRepository;
 import com.otilm.core.dao.repository.TokenProfileRepository;
 import com.otilm.core.enums.FilterField;
@@ -172,6 +172,8 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
     // --------------------------------------------------------------------------------
     private AttributeEngine attributeEngine;
     private AttributeColumnProjector attributeColumnProjector;
+
+    private ListingSortResolver listingSortResolver;
     private ConnectorApiFactory connectorApiFactory;
     private ConnectorInternalService connectorService;
     private TokenInstanceInternalService tokenInstanceService;
@@ -222,6 +224,11 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
     @Autowired
     public void setAttributeColumnProjector(AttributeColumnProjector attributeColumnProjector) {
         this.attributeColumnProjector = attributeColumnProjector;
+    }
+
+    @Autowired
+    public void setListingSortResolver(ListingSortResolver listingSortResolver) {
+        this.listingSortResolver = listingSortResolver;
     }
 
     @Autowired
@@ -311,7 +318,8 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
 
         List<UUID> filteredKeyUuids = cryptographicKeyItemRepository
                 .findUuidsUsingSecurityFilter(filter, additionalWhereClause, p,
-                        (root, cb) -> cb.desc(root.get("createdAt")), SortSpecification.from(request.getSort()));
+                        (root, cb) -> cb.desc(root.get("createdAt")),
+                        listingSortResolver.resolve(Resource.CRYPTOGRAPHIC_KEY, request.getSort()));
 
         List<CryptographicKeyItem> filteredKeys = SortOrderBuilder
                 .rankBy(filteredKeyUuids, cryptographicKeyItemRepository.findFullByUuidIn(filteredKeyUuids),

--- a/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
@@ -400,7 +400,7 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
     @Override
     @ExternalAuthorization(resource = Resource.OID, action = ResourceAction.LIST)
     public CustomOidEntryListResponseDto listCustomOidEntries(SearchRequestDto request) {
-        RequestValidatorHelper.revalidateSearchRequestDto(request);
+        RequestValidatorHelper.revalidateSearchRequestDto(request, Resource.OID);
         final Pageable p = PageRequest.of(request.getPageNumber() - 1, request.getItemsPerPage());
 
         final TriFunction<Root<CustomOidEntry>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause = (

--- a/src/main/java/com/otilm/core/service/impl/DiscoveryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/DiscoveryServiceImpl.java
@@ -27,6 +27,7 @@ import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
 import com.otilm.api.model.core.search.SearchFieldDataDto;
 import com.otilm.core.attribute.engine.AttributeColumnProjector;
 import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.attribute.engine.ListingSortResolver;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.client.ConnectorApiFactory;
 import com.otilm.core.comparator.SearchFieldDataComparator;
@@ -38,7 +39,6 @@ import com.otilm.core.dao.repository.CertificateContentRepository;
 import com.otilm.core.dao.repository.ConnectorRepository;
 import com.otilm.core.dao.repository.DiscoveryCertificateRepository;
 import com.otilm.core.dao.repository.DiscoveryRepository;
-import com.otilm.core.dao.repository.SortSpecification;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.events.data.DiscoveryResult;
 import com.otilm.core.events.handlers.DiscoveryFinishedEventHandler;
@@ -94,6 +94,8 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
 
     private AttributeEngine attributeEngine;
     private AttributeColumnProjector attributeColumnProjector;
+
+    private ListingSortResolver listingSortResolver;
 
     private TriggerInternalService triggerInternalService;
     private DiscoveryRepository discoveryRepository;
@@ -162,6 +164,11 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
     }
 
     @Autowired
+    public void setListingSortResolver(ListingSortResolver listingSortResolver) {
+        this.listingSortResolver = listingSortResolver;
+    }
+
+    @Autowired
     public void setDiscoveryRepository(DiscoveryRepository discoveryRepository) {
         this.discoveryRepository = discoveryRepository;
     }
@@ -197,7 +204,8 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
                 cb, cr) -> FilterPredicatesBuilder.getFiltersPredicate(cb, cr, root, request.getFilters());
         final List<DiscoveryListDto> listedDiscoveriesDTOs = discoveryRepository
                 .findUsingSecurityFilter(filter, List.of(), additionalWhereClause, p,
-                        (root, cb) -> cb.desc(root.get("created")), SortSpecification.from(request.getSort()))
+                        (root, cb) -> cb.desc(root.get("created")),
+                        listingSortResolver.resolve(Resource.DISCOVERY, request.getSort()))
                 .stream()
                 .map(Discovery::mapToListDto)
                 .toList();

--- a/src/main/java/com/otilm/core/service/impl/DiscoveryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/DiscoveryServiceImpl.java
@@ -38,6 +38,7 @@ import com.otilm.core.dao.repository.CertificateContentRepository;
 import com.otilm.core.dao.repository.ConnectorRepository;
 import com.otilm.core.dao.repository.DiscoveryCertificateRepository;
 import com.otilm.core.dao.repository.DiscoveryRepository;
+import com.otilm.core.dao.repository.SortSpecification;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.events.data.DiscoveryResult;
 import com.otilm.core.events.handlers.DiscoveryFinishedEventHandler;
@@ -196,7 +197,7 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
                 cb, cr) -> FilterPredicatesBuilder.getFiltersPredicate(cb, cr, root, request.getFilters());
         final List<DiscoveryListDto> listedDiscoveriesDTOs = discoveryRepository
                 .findUsingSecurityFilter(filter, List.of(), additionalWhereClause, p,
-                        (root, cb) -> cb.desc(root.get("created")))
+                        (root, cb) -> cb.desc(root.get("created")), SortSpecification.from(request.getSort()))
                 .stream()
                 .map(Discovery::mapToListDto)
                 .toList();

--- a/src/main/java/com/otilm/core/service/impl/DiscoveryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/DiscoveryServiceImpl.java
@@ -443,7 +443,7 @@ public class DiscoveryServiceImpl implements DiscoveryExternalService, Discovery
                 .getResourceSearchableFields(Resource.DISCOVERY, false);
 
         List<SearchFieldDataDto> fields = List
-                .of(SearchHelper.prepareSearch(FilterField.CKI_NAME),
+                .of(SearchHelper.prepareSearch(FilterField.DISCOVERY_NAME),
                         SearchHelper
                                 .prepareSearch(FilterField.DISCOVERY_STATUS,
                                         Arrays.stream(DiscoveryStatus.values()).map(DiscoveryStatus::getCode).toList()),

--- a/src/main/java/com/otilm/core/service/impl/EntityInstanceServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/EntityInstanceServiceImpl.java
@@ -126,7 +126,7 @@ public class EntityInstanceServiceImpl implements EntityInstanceExternalService,
     @Override
     @ExternalAuthorization(resource = Resource.ENTITY, action = ResourceAction.LIST)
     public EntityInstanceResponseDto listEntityInstances(final SecurityFilter filter, final SearchRequestDto request) {
-        RequestValidatorHelper.revalidateSearchRequestDto(request);
+        RequestValidatorHelper.revalidateSearchRequestDto(request, Resource.ENTITY);
         final Pageable p = PageRequest.of(request.getPageNumber() - 1, request.getItemsPerPage());
 
         final TriFunction<Root<EntityInstanceReference>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause = (

--- a/src/main/java/com/otilm/core/service/impl/LocationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/LocationServiceImpl.java
@@ -211,7 +211,7 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     @ExternalAuthorization(resource = Resource.LOCATION, action = ResourceAction.LIST)
     public LocationsResponseDto listLocations(SecurityFilter filter, SearchRequestDto request) {
 
-        RequestValidatorHelper.revalidateSearchRequestDto(request);
+        RequestValidatorHelper.revalidateSearchRequestDto(request, Resource.LOCATION);
         final Pageable p = PageRequest.of(request.getPageNumber() - 1, request.getItemsPerPage());
 
         final TriFunction<Root<Location>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause = (root,

--- a/src/main/java/com/otilm/core/service/impl/SecretServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SecretServiceImpl.java
@@ -45,6 +45,7 @@ import com.otilm.api.model.core.secret.SecretVersionDto;
 import com.otilm.core.attribute.engine.AttributeColumnProjector;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.ConnectorRequestAttributesBuilder;
+import com.otilm.core.attribute.engine.ListingSortResolver;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.client.ConnectorApiFactory;
 import com.otilm.core.comparator.SearchFieldDataComparator;
@@ -154,6 +155,8 @@ public class SecretServiceImpl implements SecretExternalService, SecretInternalS
 
     private AttributeColumnProjector attributeColumnProjector;
 
+    private ListingSortResolver listingSortResolver;
+
     @Autowired
     public void setActionProducer(ActionProducer actionProducer) {
         this.actionProducer = actionProducer;
@@ -162,6 +165,11 @@ public class SecretServiceImpl implements SecretExternalService, SecretInternalS
     @Autowired
     public void setAttributeColumnProjector(AttributeColumnProjector attributeColumnProjector) {
         this.attributeColumnProjector = attributeColumnProjector;
+    }
+
+    @Autowired
+    public void setListingSortResolver(ListingSortResolver listingSortResolver) {
+        this.listingSortResolver = listingSortResolver;
     }
 
     private CommentInternalService commentService;
@@ -302,7 +310,7 @@ public class SecretServiceImpl implements SecretExternalService, SecretInternalS
                 cq) -> FilterPredicatesBuilder.getFiltersPredicate(cb, cq, root, searchRequest.getFilters());
         Pageable p = PageRequest.of(searchRequest.getPageNumber() - 1, searchRequest.getItemsPerPage());
         List<Secret> secrets = getSecrets(securityFilter, p, additionalWhereClause,
-                SortSpecification.from(searchRequest.getSort()));
+                listingSortResolver.resolve(Resource.SECRET, searchRequest.getSort()));
         List<SecretDto> secretDtos = secrets.stream().map(Secret::mapToDto).toList();
 
         attributeColumnProjector

--- a/src/main/java/com/otilm/core/service/impl/SecretServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SecretServiceImpl.java
@@ -63,6 +63,7 @@ import com.otilm.core.dao.repository.GroupRepository;
 import com.otilm.core.dao.repository.Secret2SyncVaultProfileRepository;
 import com.otilm.core.dao.repository.SecretRepository;
 import com.otilm.core.dao.repository.SecretVersionRepository;
+import com.otilm.core.dao.repository.SortSpecification;
 import com.otilm.core.dao.repository.VaultInstanceRepository;
 import com.otilm.core.dao.repository.VaultProfileRepository;
 import com.otilm.core.enums.FilterField;
@@ -300,7 +301,8 @@ public class SecretServiceImpl implements SecretExternalService, SecretInternalS
         TriFunction<Root<Secret>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause = (root, cb,
                 cq) -> FilterPredicatesBuilder.getFiltersPredicate(cb, cq, root, searchRequest.getFilters());
         Pageable p = PageRequest.of(searchRequest.getPageNumber() - 1, searchRequest.getItemsPerPage());
-        List<Secret> secrets = getSecrets(securityFilter, p, additionalWhereClause);
+        List<Secret> secrets = getSecrets(securityFilter, p, additionalWhereClause,
+                SortSpecification.from(searchRequest.getSort()));
         List<SecretDto> secretDtos = secrets.stream().map(Secret::mapToDto).toList();
 
         attributeColumnProjector
@@ -317,11 +319,12 @@ public class SecretServiceImpl implements SecretExternalService, SecretInternalS
     }
 
     private List<Secret> getSecrets(SecurityFilter securityFilter, Pageable p,
-            TriFunction<Root<Secret>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause) {
+            TriFunction<Root<Secret>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause,
+            SortSpecification sort) {
         securityFilter.setParentRefProperty(Secret_.SOURCE_VAULT_PROFILE_UUID);
         return secretRepository
                 .findUsingSecurityFilter(securityFilter, List.of(), additionalWhereClause, p,
-                        (root, cb) -> cb.desc(root.get(Audited_.CREATED)))
+                        (root, cb) -> cb.desc(root.get(Audited_.CREATED)), sort)
                 .stream()
                 .toList();
     }

--- a/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
@@ -98,6 +98,7 @@ import com.otilm.core.signing.contentsigning.profile.ContentSigningWorkflowValid
 import com.otilm.core.signing.contentsigning.profile.TimestampSourceRequests;
 import com.otilm.core.util.CertificateEligibilityUtil;
 import com.otilm.core.util.FilterPredicatesBuilder;
+import com.otilm.core.util.RequestValidatorHelper;
 import com.otilm.core.util.SearchHelper;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.criteria.CriteriaBuilder;
@@ -194,6 +195,7 @@ public class SigningProfileServiceImpl implements SigningProfileExternalService,
     @Transactional(readOnly = true)
     public PaginationResponseDto<SigningProfileListDto> listSigningProfiles(SearchRequestDto request,
             SecurityFilter filter) {
+        RequestValidatorHelper.revalidateSearchRequestDto(request, Resource.SIGNING_PROFILE);
         Pageable p = PageRequest.of(request.getPageNumber() - 1, request.getItemsPerPage());
         TriFunction<Root<SigningProfile>, CriteriaBuilder, CriteriaQuery<?>, Predicate> predicate = (root, cb,
                 cq) -> FilterPredicatesBuilder.getFiltersPredicate(cb, cq, root, request.getFilters());

--- a/src/main/java/com/otilm/core/service/impl/SigningRecordServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SigningRecordServiceImpl.java
@@ -16,6 +16,7 @@ import com.otilm.api.model.core.signing.signingrecord.SigningRecordDto;
 import com.otilm.api.model.core.signing.signingrecord.SigningRecordListDto;
 import com.otilm.core.attribute.engine.AttributeColumnProjector;
 import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.attribute.engine.ListingSortResolver;
 import com.otilm.core.comparator.SearchFieldDataComparator;
 import com.otilm.core.dao.entity.Audited_;
 import com.otilm.core.dao.entity.signing.SigningProfileVersion;
@@ -23,7 +24,6 @@ import com.otilm.core.dao.entity.signing.SigningProfileVersion_;
 import com.otilm.core.dao.entity.signing.SigningProfile_;
 import com.otilm.core.dao.entity.signing.SigningRecord;
 import com.otilm.core.dao.entity.signing.SigningRecord_;
-import com.otilm.core.dao.repository.SortSpecification;
 import com.otilm.core.dao.repository.signing.SigningProfileRepository;
 import com.otilm.core.dao.repository.signing.SigningRecordRepository;
 import com.otilm.core.enums.FilterField;
@@ -73,17 +73,19 @@ public class SigningRecordServiceImpl implements SigningRecordExternalService, S
     private final SigningProfileRepository signingProfileRepository;
     private final AttributeEngine attributeEngine;
     private final AttributeColumnProjector attributeColumnProjector;
+    private final ListingSortResolver listingSortResolver;
     private final AuthorizationEnforcer authorizationEnforcer;
 
     public SigningRecordServiceImpl(SigningRecordRepository signingRecordRepository,
             SigningRecordWriter signingRecordWriter, SigningProfileRepository signingProfileRepository,
             AttributeEngine attributeEngine, AttributeColumnProjector attributeColumnProjector,
-            AuthorizationEnforcer authorizationEnforcer) {
+            ListingSortResolver listingSortResolver, AuthorizationEnforcer authorizationEnforcer) {
         this.signingRecordRepository = signingRecordRepository;
         this.signingRecordWriter = signingRecordWriter;
         this.signingProfileRepository = signingProfileRepository;
         this.attributeEngine = attributeEngine;
         this.attributeColumnProjector = attributeColumnProjector;
+        this.listingSortResolver = listingSortResolver;
         this.authorizationEnforcer = authorizationEnforcer;
     }
 
@@ -304,7 +306,8 @@ public class SigningRecordServiceImpl implements SigningRecordExternalService, S
         };
         List<SigningRecordListDto> dtos = signingRecordRepository
                 .findUsingSecurityFilter(filter, List.of(), predicate, p,
-                        (root, cb) -> cb.desc(root.get(Audited_.CREATED)), SortSpecification.from(request.getSort()))
+                        (root, cb) -> cb.desc(root.get(Audited_.CREATED)),
+                        listingSortResolver.resolve(Resource.SIGNING_RECORD, request.getSort()))
                 .stream()
                 .map(SigningRecordMapper::toListDto)
                 .toList();

--- a/src/main/java/com/otilm/core/service/impl/SigningRecordServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SigningRecordServiceImpl.java
@@ -23,6 +23,7 @@ import com.otilm.core.dao.entity.signing.SigningProfileVersion_;
 import com.otilm.core.dao.entity.signing.SigningProfile_;
 import com.otilm.core.dao.entity.signing.SigningRecord;
 import com.otilm.core.dao.entity.signing.SigningRecord_;
+import com.otilm.core.dao.repository.SortSpecification;
 import com.otilm.core.dao.repository.signing.SigningProfileRepository;
 import com.otilm.core.dao.repository.signing.SigningRecordRepository;
 import com.otilm.core.enums.FilterField;
@@ -303,7 +304,7 @@ public class SigningRecordServiceImpl implements SigningRecordExternalService, S
         };
         List<SigningRecordListDto> dtos = signingRecordRepository
                 .findUsingSecurityFilter(filter, List.of(), predicate, p,
-                        (root, cb) -> cb.desc(root.get(Audited_.CREATED)))
+                        (root, cb) -> cb.desc(root.get(Audited_.CREATED)), SortSpecification.from(request.getSort()))
                 .stream()
                 .map(SigningRecordMapper::toListDto)
                 .toList();

--- a/src/main/java/com/otilm/core/service/impl/TimeQualityConfigurationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/TimeQualityConfigurationServiceImpl.java
@@ -42,6 +42,7 @@ import com.otilm.core.service.TimeQualityConfigurationExternalService;
 import com.otilm.core.service.TimeQualityConfigurationInternalService;
 import com.otilm.core.service.model.SecuredList;
 import com.otilm.core.util.FilterPredicatesBuilder;
+import com.otilm.core.util.RequestValidatorHelper;
 import com.otilm.core.util.SearchHelper;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -105,6 +106,7 @@ public class TimeQualityConfigurationServiceImpl
     @Transactional(readOnly = true)
     public PaginationResponseDto<TimeQualityConfigurationListDto> listTimeQualityConfigurations(
             SearchRequestDto request, SecurityFilter filter) {
+        RequestValidatorHelper.revalidateSearchRequestDto(request, Resource.TIME_QUALITY_CONFIGURATION);
         Pageable p = PageRequest.of(request.getPageNumber() - 1, request.getItemsPerPage());
         TriFunction<Root<TimeQualityConfiguration>, CriteriaBuilder, CriteriaQuery<?>, Predicate> predicate = (root, cb,
                 cq) -> FilterPredicatesBuilder.getFiltersPredicate(cb, cq, root, request.getFilters());

--- a/src/main/java/com/otilm/core/service/impl/TspProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/TspProfileServiceImpl.java
@@ -47,6 +47,7 @@ import com.otilm.core.service.TspProfileInternalService;
 import com.otilm.core.service.VaultProfileInternalService;
 import com.otilm.core.service.model.SecuredList;
 import com.otilm.core.util.FilterPredicatesBuilder;
+import com.otilm.core.util.RequestValidatorHelper;
 import com.otilm.core.util.SearchHelper;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -107,6 +108,7 @@ public class TspProfileServiceImpl implements TspProfileExternalService, TspProf
     @Transactional(readOnly = true)
     public PaginationResponseDto<TspProfileListDto> listTspProfiles(SearchRequestDto request, SecurityFilter filter,
             String baseUrl) {
+        RequestValidatorHelper.revalidateSearchRequestDto(request, Resource.TSP_PROFILE);
         Pageable p = PageRequest.of(request.getPageNumber() - 1, request.getItemsPerPage());
         TriFunction<Root<TspProfile>, CriteriaBuilder, CriteriaQuery<?>, Predicate> predicate = (root, cb,
                 cq) -> FilterPredicatesBuilder.getFiltersPredicate(cb, cq, root, request.getFilters());

--- a/src/main/java/com/otilm/core/service/impl/VaultInstanceServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/VaultInstanceServiceImpl.java
@@ -45,6 +45,7 @@ import com.otilm.core.service.VaultInstanceInternalService;
 import com.otilm.core.service.v2.ConnectorExternalService;
 import com.otilm.core.service.v2.ConnectorInternalService;
 import com.otilm.core.util.FilterPredicatesBuilder;
+import com.otilm.core.util.RequestValidatorHelper;
 import com.otilm.core.util.SearchHelper;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -191,6 +192,7 @@ public class VaultInstanceServiceImpl implements VaultInstanceExternalService, V
     @ExternalAuthorization(resource = Resource.VAULT, action = ResourceAction.LIST)
     public PaginationResponseDto<VaultInstanceDto> listVaultInstances(SearchRequestDto request,
             SecurityFilter securityFilter) {
+        RequestValidatorHelper.revalidateSearchRequestDto(request, Resource.VAULT);
         Pageable p = PageRequest.of(request.getPageNumber() - 1, request.getItemsPerPage());
         TriFunction<Root<VaultInstance>, CriteriaBuilder, CriteriaQuery<?>, Predicate> predicate = (root, cb,
                 cq) -> FilterPredicatesBuilder.getFiltersPredicate(cb, cq, root, request.getFilters());

--- a/src/main/java/com/otilm/core/service/impl/VaultProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/VaultProfileServiceImpl.java
@@ -44,6 +44,7 @@ import com.otilm.core.service.VaultProfileExternalService;
 import com.otilm.core.service.VaultProfileInternalService;
 import com.otilm.core.service.v2.ConnectorExternalService;
 import com.otilm.core.util.FilterPredicatesBuilder;
+import com.otilm.core.util.RequestValidatorHelper;
 import com.otilm.core.util.SearchHelper;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -120,6 +121,7 @@ public class VaultProfileServiceImpl implements VaultProfileExternalService, Vau
             parentResource = Resource.VAULT, parentAction = ResourceAction.LIST)
     public PaginationResponseDto<VaultProfileDto> listVaultProfiles(SearchRequestDto request,
             SecurityFilter securityFilter) {
+        RequestValidatorHelper.revalidateSearchRequestDto(request, Resource.VAULT_PROFILE);
         securityFilter.setParentRefProperty(VaultProfile_.VAULT_INSTANCE_UUID);
 
         Pageable p = PageRequest.of(request.getPageNumber() - 1, request.getItemsPerPage());

--- a/src/main/java/com/otilm/core/service/v2/impl/ConnectorServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ConnectorServiceImpl.java
@@ -57,6 +57,7 @@ import com.otilm.core.dao.repository.ConnectorRepository;
 import com.otilm.core.dao.repository.CredentialRepository;
 import com.otilm.core.dao.repository.EntityInstanceReferenceRepository;
 import com.otilm.core.dao.repository.ProxyRepository;
+import com.otilm.core.dao.repository.SortSpecification;
 import com.otilm.core.dao.repository.TokenInstanceReferenceRepository;
 import com.otilm.core.dao.repository.VaultInstanceRepository;
 import com.otilm.core.dao.repository.notifications.NotificationInstanceReferenceRepository;
@@ -233,7 +234,7 @@ public class ConnectorServiceImpl implements ConnectorExternalService, Connector
                 cb, cr) -> FilterPredicatesBuilder.getFiltersPredicate(cb, cr, root, request.getFilters());
         final List<ConnectorDto> connectorDtos = connectorRepository
                 .findUsingSecurityFilter(filter, List.of(), additionalWhereClause, p,
-                        (root, cb) -> cb.desc(root.get("created")))
+                        (root, cb) -> cb.desc(root.get("created")), SortSpecification.from(request.getSort()))
                 .stream()
                 .map(Connector::mapToListDto)
                 .toList();

--- a/src/main/java/com/otilm/core/service/v2/impl/ConnectorServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ConnectorServiceImpl.java
@@ -35,6 +35,7 @@ import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
 import com.otilm.api.model.core.search.SearchFieldDataDto;
 import com.otilm.core.attribute.engine.AttributeColumnProjector;
 import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.attribute.engine.ListingSortResolver;
 import com.otilm.core.comparator.SearchFieldDataComparator;
 import com.otilm.core.config.cache.CacheConfig;
 import com.otilm.core.config.cache.CacheEvictor;
@@ -57,7 +58,6 @@ import com.otilm.core.dao.repository.ConnectorRepository;
 import com.otilm.core.dao.repository.CredentialRepository;
 import com.otilm.core.dao.repository.EntityInstanceReferenceRepository;
 import com.otilm.core.dao.repository.ProxyRepository;
-import com.otilm.core.dao.repository.SortSpecification;
 import com.otilm.core.dao.repository.TokenInstanceReferenceRepository;
 import com.otilm.core.dao.repository.VaultInstanceRepository;
 import com.otilm.core.dao.repository.notifications.NotificationInstanceReferenceRepository;
@@ -130,6 +130,8 @@ public class ConnectorServiceImpl implements ConnectorExternalService, Connector
 
     private AttributeColumnProjector attributeColumnProjector;
 
+    private ListingSortResolver listingSortResolver;
+
     @Autowired
     public void setCommentService(CommentInternalService commentService) {
         this.commentService = commentService;
@@ -138,6 +140,11 @@ public class ConnectorServiceImpl implements ConnectorExternalService, Connector
     @Autowired
     public void setAttributeColumnProjector(AttributeColumnProjector attributeColumnProjector) {
         this.attributeColumnProjector = attributeColumnProjector;
+    }
+
+    @Autowired
+    public void setListingSortResolver(ListingSortResolver listingSortResolver) {
+        this.listingSortResolver = listingSortResolver;
     }
 
     @Autowired
@@ -234,7 +241,8 @@ public class ConnectorServiceImpl implements ConnectorExternalService, Connector
                 cb, cr) -> FilterPredicatesBuilder.getFiltersPredicate(cb, cr, root, request.getFilters());
         final List<ConnectorDto> connectorDtos = connectorRepository
                 .findUsingSecurityFilter(filter, List.of(), additionalWhereClause, p,
-                        (root, cb) -> cb.desc(root.get("created")), SortSpecification.from(request.getSort()))
+                        (root, cb) -> cb.desc(root.get("created")),
+                        listingSortResolver.resolve(Resource.CONNECTOR, request.getSort()))
                 .stream()
                 .map(Connector::mapToListDto)
                 .toList();

--- a/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
+++ b/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
@@ -10,6 +10,7 @@ import com.otilm.api.model.common.enums.IPlatformEnum;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.search.FilterConditionOperator;
 import com.otilm.api.model.core.search.FilterFieldSource;
+import com.otilm.core.attribute.engine.AttributeEngine.CustomAttributeContentFilter;
 import com.otilm.core.dao.entity.AttributeContent2Object;
 import com.otilm.core.dao.entity.AttributeContent2Object_;
 import com.otilm.core.dao.entity.AttributeContentItem_;
@@ -25,9 +26,11 @@ import com.otilm.core.dao.entity.UniquelyIdentified_;
 import com.otilm.core.dao.entity.cbom.CryptoAssetSource;
 import com.otilm.core.dao.entity.cbom.CryptoAssetSource_;
 import com.otilm.core.dao.entity.cbom.CryptoAsset_;
+import com.otilm.core.dao.repository.SortSpecification;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.enums.ResourceToClass;
 import com.otilm.core.enums.SearchFieldTypeEnum;
+import com.otilm.core.model.AttributeFieldIdentifier;
 import com.otilm.core.model.cbom.CryptoAssetIdentityGuard;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
@@ -135,25 +138,20 @@ public class FilterPredicatesBuilder {
 
         final AttributeType attributeType = filterDto.getFieldSource().getAttributeType();
         final String identifier = filterDto.getFieldIdentifier();
-        final String[] fieldIdentifier = identifier.split("\\|");
-        final AttributeContentType contentType = AttributeContentType.valueOf(fieldIdentifier[1]);
-        final String attributeName = fieldIdentifier[0];
+        final AttributeFieldIdentifier fieldIdentifier = AttributeFieldIdentifier.parse(identifier);
+        if (fieldIdentifier == null || fieldIdentifier.contentType() == null) {
+            throw new ValidationException(ValidationError
+                    .create("Filter field identifier %s does not name an attribute.".formatted(identifier)));
+        }
+        final AttributeContentType contentType = fieldIdentifier.contentType();
+        final String attributeName = fieldIdentifier.attributeName();
         final boolean isNotExistCondition = List
                 .of(FilterConditionOperator.NOT_EQUALS, FilterConditionOperator.NOT_CONTAINS,
                         FilterConditionOperator.EMPTY, FilterConditionOperator.NOT_MATCHES)
                 .contains(filterDto.getCondition());
 
-        // attributes content for cryptographic key items are stored under resource CRYPTOGRAPHIC_KEY, but for meta
-        // attributes, object uuid is uuid of cryptographic key item and for custom and data attribute it is uuid of
-        // cryptographic key
-        // place for improvement is to consolidate resource for attributes content
-        final Resource resource = root.getJavaType().equals(CryptographicKeyItem.class)
-                ? Resource.CRYPTOGRAPHIC_KEY
-                : ResourceToClass.getResourceByClass(root.getJavaType());
-        final String objectUuidPath = resource == Resource.CRYPTOGRAPHIC_KEY
-                && (attributeType == AttributeType.CUSTOM || attributeType == AttributeType.DATA)
-                        ? CryptographicKeyItem_.keyUuid.getName()
-                        : UniquelyIdentified_.uuid.getName();
+        final Resource resource = attributeResourceOf(root);
+        final String objectUuidPath = attributeObjectUuidPath(root, attributeType);
 
         List<Predicate> predicates = new ArrayList<>(attributeCorrelationPredicates(criteriaBuilder, root, subqueryRoot,
                 joinDefinition, attributeType, contentType, attributeName, resource, objectUuidPath));
@@ -1147,6 +1145,10 @@ public class FilterPredicatesBuilder {
     /**
      * The resource an object's attribute content is stored under. Key items carry the key's attributes, so a key item
      * root resolves to {@code CRYPTOGRAPHIC_KEY} rather than to a resource of its own.
+     *
+     * <p>
+     * A place for improvement is to consolidate the resource attribute content is stored under, so this mapping is not
+     * needed at all.
      */
     private static <T> Resource attributeResourceOf(final Root<T> root) {
         return root.getJavaType().equals(CryptographicKeyItem.class)
@@ -1157,9 +1159,13 @@ public class FilterPredicatesBuilder {
     /**
      * Which uuid of the root the content is keyed by. For a key item, meta attributes are attached to the item while
      * custom and data attributes are attached to the key it belongs to.
+     *
+     * <p>
+     * Decided from the root rather than from the resource, because the key uuid is a column of the key item and of
+     * nothing else: a root that is not one has no such path to read, whatever resource its content is filed under.
      */
-    private static String attributeObjectUuidPath(final Resource resource, final AttributeType attributeType) {
-        return resource == Resource.CRYPTOGRAPHIC_KEY
+    private static <T> String attributeObjectUuidPath(final Root<T> root, final AttributeType attributeType) {
+        return root.getJavaType().equals(CryptographicKeyItem.class)
                 && (attributeType == AttributeType.CUSTOM || attributeType == AttributeType.DATA)
                         ? CryptographicKeyItem_.keyUuid.getName()
                         : UniquelyIdentified_.uuid.getName();
@@ -1176,31 +1182,53 @@ public class FilterPredicatesBuilder {
      *
      * <p>
      * An attribute may hold several values for one object, which leaves the key ambiguous. The subquery therefore
-     * orders by {@code item_order} and takes the first row, so a multi-valued attribute sorts on its lowest-ordered
-     * value - the one the cell shows first. A row with no value for the field yields no row and so a null key, which is
-     * ordered last in both directions by the caller rather than being dropped.
+     * orders by definition and then by {@code item_order} and takes the first row - the same order the projection query
+     * reads a page of values in - so a multi-valued attribute sorts on the value the cell shows first, and two
+     * identical requests cannot pick differently among the definitions one attribute name may map to. A row with no
+     * value for the field yields no row and so a null key, which is ordered last in both directions by the caller
+     * rather than being dropped.
+     *
+     * <p>
+     * Ordering reads a value, so it is gated like the projection that renders one: encrypted content is skipped, a
+     * disabled custom definition is skipped, and the caller's custom-attribute permissions narrow which definitions are
+     * readable at all. Whether the field may be ordered on - visible, not secret, not a code block - is settled before
+     * this by {@code ListingSortResolver} against the resource's published catalogue.
      */
     public static <T> Expression<?> getAttributeSortKey(final CriteriaBuilder criteriaBuilder,
-            final CommonAbstractCriteria query, final Root<T> root, final FilterFieldSource fieldSource,
-            final String fieldIdentifier) {
-        final String[] identifierParts = fieldIdentifier.split("\\|");
-        if (identifierParts.length < 2) {
+            final CommonAbstractCriteria query, final Root<T> root, final SortSpecification sort) {
+        final FilterFieldSource fieldSource = sort.fieldSource();
+        final String fieldIdentifier = sort.fieldIdentifier();
+        final AttributeType attributeType = fieldSource == null ? null : fieldSource.getAttributeType();
+        if (attributeType == null) {
+            throw new ValidationException(
+                    ValidationError.create("Sort field source %s names no attribute type.".formatted(fieldSource)));
+        }
+        // The caller's attribute permissions are what keeps ordering from reading further than projection does, so a
+        // specification that was never resolved against them is refused rather than run unrestricted.
+        final CustomAttributeContentFilter contentFilter = sort.attributeContentFilter();
+        if (contentFilter == null) {
+            throw new ValidationException(ValidationError
+                    .create("Ordering by %s was not resolved against the caller's attribute permissions."
+                            .formatted(fieldIdentifier)));
+        }
+
+        final AttributeFieldIdentifier identifier = AttributeFieldIdentifier.parse(fieldIdentifier);
+        if (identifier == null) {
             throw new ValidationException(ValidationError
                     .create("Sort field identifier %s does not name an attribute.".formatted(fieldIdentifier)));
         }
-        final AttributeType attributeType = fieldSource.getAttributeType();
-        final String attributeName = identifierParts[0];
-        final AttributeContentType contentType;
-        try {
-            contentType = AttributeContentType.valueOf(identifierParts[1]);
-        } catch (IllegalArgumentException e) {
+        final String attributeName = identifier.attributeName();
+        final AttributeContentType contentType = identifier.contentType();
+        if (contentType == null) {
             throw new ValidationException(ValidationError
                     .create("Unknown attribute content type %s in sort field identifier %s."
-                            .formatted(identifierParts[1], fieldIdentifier)));
+                            .formatted(identifier.contentTypeName(), fieldIdentifier)));
         }
 
-        final Resource resource = attributeResourceOf(root);
-        final String objectUuidPath = attributeObjectUuidPath(resource, attributeType);
+        // The resource the listing selects, which the catalogue was read from; the root is only a fallback for a
+        // caller that built a specification without one, and maps to nothing for an entity outside ResourceToClass.
+        final Resource resource = sort.resource() == null ? attributeResourceOf(root) : sort.resource();
+        final String objectUuidPath = attributeObjectUuidPath(root, attributeType);
 
         // Typed to the value's own class rather than to Object: the aggregate the grouped ordering wraps this in
         // takes a comparable, and an Object-typed subquery is not one.
@@ -1220,15 +1248,50 @@ public class FilterPredicatesBuilder {
                 ? ((JpaExpression<String>) extracted).cast(contentType.getContentDataClass())
                 : extracted;
 
-        subquery
-                .select(value)
-                .where(attributeCorrelationPredicates(criteriaBuilder, root, subqueryRoot, joinDefinition,
-                        attributeType, contentType, attributeName, resource, objectUuidPath)
-                        .toArray(new Predicate[]{}));
+        final List<Predicate> predicates = new ArrayList<>(attributeCorrelationPredicates(criteriaBuilder, root,
+                subqueryRoot, joinDefinition, attributeType, contentType, attributeName, resource, objectUuidPath));
+        predicates
+                .addAll(attributeReadabilityPredicates(criteriaBuilder, joinContentItem, joinDefinition, attributeType,
+                        contentFilter));
+
+        subquery.select(value).where(predicates.toArray(new Predicate[]{}));
         ((JpaSubQuery) subquery)
-                .orderBy(criteriaBuilder.asc(subqueryRoot.get(AttributeContent2Object_.order)))
+                .orderBy(criteriaBuilder.asc(joinContentItem.get(AttributeContentItem_.attributeDefinitionUuid)),
+                        criteriaBuilder.asc(subqueryRoot.get(AttributeContent2Object_.order)))
                 .fetch(1);
 
         return subquery;
+    }
+
+    /**
+     * The predicates that keep a sort from reading content the same response would withhold, mirroring
+     * {@code AttributeContent2ObjectRepository.getProjectedAttributesContent} and the row-level checks
+     * {@code AttributeColumnProjector} applies on top of it.
+     *
+     * <p>
+     * Encrypted content is ciphertext only its own decryption path can read, and neither a column nor an ordering takes
+     * that path. The remaining two guard custom content only, exactly as the projection query does: {@code enabled} is
+     * set on custom definitions alone - data and metadata definitions leave the nullable column alone, so applying it
+     * to them would match nothing - and the definition-uuid lists are the caller's attribute permissions, without which
+     * resource LIST access would be enough to compare the values of a restricted attribute by ordering on it.
+     */
+    private static List<Predicate> attributeReadabilityPredicates(final CriteriaBuilder criteriaBuilder,
+            final Join joinContentItem, final Join joinDefinition, final AttributeType attributeType,
+            final CustomAttributeContentFilter contentFilter) {
+        final List<Predicate> predicates = new ArrayList<>();
+        predicates.add(criteriaBuilder.isNull(joinContentItem.get(AttributeContentItem_.encryptedData)));
+        if (attributeType != AttributeType.CUSTOM) {
+            return predicates;
+        }
+
+        predicates.add(criteriaBuilder.isTrue(joinDefinition.get(AttributeDefinition_.enabled)));
+        final Path<UUID> definitionUuid = joinContentItem.get(AttributeContentItem_.attributeDefinitionUuid);
+        if (contentFilter.allowedDefinitionUuids() != null) {
+            predicates.add(definitionUuid.in(contentFilter.allowedDefinitionUuids()));
+        }
+        if (contentFilter.forbiddenDefinitionUuids() != null) {
+            predicates.add(criteriaBuilder.not(definitionUuid.in(contentFilter.forbiddenDefinitionUuids())));
+        }
+        return predicates;
     }
 }

--- a/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
+++ b/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
@@ -1,5 +1,6 @@
 package com.otilm.core.util;
 
+import com.otilm.api.exception.ValidationError;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.certificate.SearchFilterRequestDto;
 import com.otilm.api.model.common.attribute.common.AttributeType;
@@ -68,6 +69,7 @@ import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.Duration;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.JpaExpression;
+import org.hibernate.query.criteria.JpaSubQuery;
 
 public class FilterPredicatesBuilder {
 
@@ -153,14 +155,8 @@ public class FilterPredicatesBuilder {
                         ? CryptographicKeyItem_.keyUuid.getName()
                         : UniquelyIdentified_.uuid.getName();
 
-        List<Predicate> predicates = new ArrayList<>();
-        predicates.add(criteriaBuilder.equal(joinDefinition.get(AttributeDefinition_.type), attributeType));
-        predicates.add(criteriaBuilder.equal(joinDefinition.get(AttributeDefinition_.contentType), contentType));
-        predicates.add(criteriaBuilder.equal(joinDefinition.get(AttributeDefinition_.name), attributeName));
-        predicates.add(criteriaBuilder.equal(subqueryRoot.get(AttributeContent2Object_.objectType), resource));
-        predicates
-                .add(criteriaBuilder
-                        .equal(subqueryRoot.get(AttributeContent2Object_.objectUuid), root.get(objectUuidPath)));
+        List<Predicate> predicates = new ArrayList<>(attributeCorrelationPredicates(criteriaBuilder, root, subqueryRoot,
+                joinDefinition, attributeType, contentType, attributeName, resource, objectUuidPath));
 
         if (filterDto.getCondition() != FilterConditionOperator.EMPTY
                 && filterDto.getCondition() != FilterConditionOperator.NOT_EMPTY) {
@@ -1127,5 +1123,112 @@ public class FilterPredicatesBuilder {
             pathToPropertyBuilder.append(fieldAttribute.getName());
         }
         return pathToPropertyBuilder.toString();
+    }
+
+    /**
+     * The predicates that pin a content row to one attribute definition and to one object: the definition's type,
+     * content type and name, and the object the content is attached to. Shared by the filter predicate and the sort key
+     * so the two cannot disagree about which rows belong to a field.
+     */
+    private static <T> List<Predicate> attributeCorrelationPredicates(final CriteriaBuilder criteriaBuilder,
+            final Root<T> root, final Root<AttributeContent2Object> subqueryRoot, final Join joinDefinition,
+            final AttributeType attributeType, final AttributeContentType contentType, final String attributeName,
+            final Resource resource, final String objectUuidPath) {
+        return List
+                .of(criteriaBuilder.equal(joinDefinition.get(AttributeDefinition_.type), attributeType),
+                        criteriaBuilder.equal(joinDefinition.get(AttributeDefinition_.contentType), contentType),
+                        criteriaBuilder.equal(joinDefinition.get(AttributeDefinition_.name), attributeName),
+                        criteriaBuilder.equal(subqueryRoot.get(AttributeContent2Object_.objectType), resource),
+                        criteriaBuilder
+                                .equal(subqueryRoot.get(AttributeContent2Object_.objectUuid),
+                                        root.get(objectUuidPath)));
+    }
+
+    /**
+     * The resource an object's attribute content is stored under. Key items carry the key's attributes, so a key item
+     * root resolves to {@code CRYPTOGRAPHIC_KEY} rather than to a resource of its own.
+     */
+    private static <T> Resource attributeResourceOf(final Root<T> root) {
+        return root.getJavaType().equals(CryptographicKeyItem.class)
+                ? Resource.CRYPTOGRAPHIC_KEY
+                : ResourceToClass.getResourceByClass(root.getJavaType());
+    }
+
+    /**
+     * Which uuid of the root the content is keyed by. For a key item, meta attributes are attached to the item while
+     * custom and data attributes are attached to the key it belongs to.
+     */
+    private static String attributeObjectUuidPath(final Resource resource, final AttributeType attributeType) {
+        return resource == Resource.CRYPTOGRAPHIC_KEY
+                && (attributeType == AttributeType.CUSTOM || attributeType == AttributeType.DATA)
+                        ? CryptographicKeyItem_.keyUuid.getName()
+                        : UniquelyIdentified_.uuid.getName();
+    }
+
+    /**
+     * A scalar sort key carrying the value of one attribute-sourced field for one row.
+     *
+     * <p>
+     * Filtering an attribute is order-agnostic and so is expressed as {@code EXISTS}, which yields no value to order
+     * by. Ordering needs the value itself, so this is a correlated scalar subquery instead: the same definition and
+     * object correlation as the filter, extracted from the stored json with the same {@code jsonb_extract_path_text}
+     * and the same per-content-type cast, so a column sorts by what the cell displays.
+     *
+     * <p>
+     * An attribute may hold several values for one object, which leaves the key ambiguous. The subquery therefore
+     * orders by {@code item_order} and takes the first row, so a multi-valued attribute sorts on its lowest-ordered
+     * value - the one the cell shows first. A row with no value for the field yields no row and so a null key, which is
+     * ordered last in both directions by the caller rather than being dropped.
+     */
+    public static <T> Expression<?> getAttributeSortKey(final CriteriaBuilder criteriaBuilder,
+            final CommonAbstractCriteria query, final Root<T> root, final FilterFieldSource fieldSource,
+            final String fieldIdentifier) {
+        final String[] identifierParts = fieldIdentifier.split("\\|");
+        if (identifierParts.length < 2) {
+            throw new ValidationException(ValidationError
+                    .create("Sort field identifier %s does not name an attribute.".formatted(fieldIdentifier)));
+        }
+        final AttributeType attributeType = fieldSource.getAttributeType();
+        final String attributeName = identifierParts[0];
+        final AttributeContentType contentType;
+        try {
+            contentType = AttributeContentType.valueOf(identifierParts[1]);
+        } catch (IllegalArgumentException e) {
+            throw new ValidationException(ValidationError
+                    .create("Unknown attribute content type %s in sort field identifier %s."
+                            .formatted(identifierParts[1], fieldIdentifier)));
+        }
+
+        final Resource resource = attributeResourceOf(root);
+        final String objectUuidPath = attributeObjectUuidPath(resource, attributeType);
+
+        // Typed to the value's own class rather than to Object: the aggregate the grouped ordering wraps this in
+        // takes a comparable, and an Object-typed subquery is not one.
+        final Class<?> valueClass = castedAttributeContentData.contains(contentType)
+                ? contentType.getContentDataClass()
+                : String.class;
+        final Subquery subquery = query.subquery(valueClass);
+        final Root<AttributeContent2Object> subqueryRoot = subquery.from(AttributeContent2Object.class);
+        final Join joinContentItem = subqueryRoot.join(AttributeContent2Object_.attributeContentItem, JoinType.INNER);
+        final Join joinDefinition = joinContentItem.join(AttributeContentItem_.attributeDefinition, JoinType.INNER);
+
+        final Expression<String> extracted = criteriaBuilder
+                .function(JSONB_EXTRACT_PATH_TEXT_FUNCTION_NAME, String.class,
+                        joinContentItem.get(AttributeContentItem_.json),
+                        criteriaBuilder.literal(contentType.isFilterByData() ? "data" : "reference"));
+        final Expression<?> value = castedAttributeContentData.contains(contentType)
+                ? ((JpaExpression<String>) extracted).cast(contentType.getContentDataClass())
+                : extracted;
+
+        subquery
+                .select(value)
+                .where(attributeCorrelationPredicates(criteriaBuilder, root, subqueryRoot, joinDefinition,
+                        attributeType, contentType, attributeName, resource, objectUuidPath)
+                        .toArray(new Predicate[]{}));
+        ((JpaSubQuery) subquery)
+                .orderBy(criteriaBuilder.asc(subqueryRoot.get(AttributeContent2Object_.order)))
+                .fetch(1);
+
+        return subquery;
     }
 }

--- a/src/main/java/com/otilm/core/util/RequestValidatorHelper.java
+++ b/src/main/java/com/otilm/core/util/RequestValidatorHelper.java
@@ -1,6 +1,9 @@
 package com.otilm.core.util;
 
+import com.otilm.api.exception.ValidationError;
+import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.certificate.SearchRequestDto;
+import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.scheduler.PaginationRequestDto;
 
 import java.util.ArrayList;
@@ -8,6 +11,23 @@ import java.util.ArrayList;
 public class RequestValidatorHelper {
 
     private static final Integer DEFAULT_ITEMS_PER_PAGE = 10;
+
+    /**
+     * As below, and refuses a sort the listing of this resource would not apply.
+     *
+     * <p>
+     * The catalogue reports every field of an unwired listing as {@code sortable:false}, but that flag is a hint on a
+     * response the caller is free to ignore. Answering such a request with the default order and no explanation is the
+     * failure the flag exists to prevent, so it is refused instead - the same answer
+     * {@code CryptographicAssetServiceImpl} has always given.
+     */
+    public static void revalidateSearchRequestDto(final SearchRequestDto dto, final Resource resource) {
+        if (dto.getSort() != null && !SearchHelper.listingAppliesSort(resource)) {
+            throw new ValidationException(ValidationError
+                    .create("Sorting is not supported for the %s listing.".formatted(resource.getLabel())));
+        }
+        revalidateSearchRequestDto(dto);
+    }
 
     public static void revalidateSearchRequestDto(final SearchRequestDto dto) {
         if (dto.getFilters() == null) {

--- a/src/main/java/com/otilm/core/util/SearchHelper.java
+++ b/src/main/java/com/otilm/core/util/SearchHelper.java
@@ -2,6 +2,7 @@ package com.otilm.core.util;
 
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.common.content.data.ProtectionLevel;
+import com.otilm.api.model.common.enums.BitMaskEnum;
 import com.otilm.api.model.common.enums.IPlatformEnum;
 import com.otilm.api.model.common.enums.PlatformEnum;
 import com.otilm.api.model.core.auth.Resource;
@@ -138,7 +139,7 @@ public class SearchHelper {
     }
 
     public static SearchFieldDataDto prepareSearchForJSON(final SearchFieldObject attributeSearchInfo,
-            final boolean hasDuplicateInList) {
+            final boolean hasDuplicateInList, final Resource resource) {
         final SearchFieldTypeEnum searchFieldTypeEnum = retrieveSearchFieldTypeEnumByContentType(
                 attributeSearchInfo.getAttributeContentType(), attributeSearchInfo.isList());
         final SearchFieldDataDto fieldDataDto = new SearchFieldDataDto();
@@ -162,9 +163,7 @@ public class SearchHelper {
         fieldDataDto.setValue(attributeSearchInfo.getContentItems());
         fieldDataDto.setAttributeContentType(attributeSearchInfo.getAttributeContentType());
         fieldDataDto.setDisplayable(isDisplayable(attributeSearchInfo));
-        // Left false here and decided per resource by applyAttributeSortability: this method is handed one attribute
-        // definition and not the resource whose catalogue it is being built for, and ordering is wired per listing.
-        fieldDataDto.setSortable(false);
+        fieldDataDto.setSortable(isSortable(attributeSearchInfo, resource));
         return fieldDataDto;
     }
 
@@ -172,18 +171,32 @@ public class SearchHelper {
      * The resources whose listing passes the sort a request carries to the repository.
      *
      * <p>
-     * The flag is published per field while the ordering is wired per listing, and seven of the sixteen listings that
-     * accept a search request are wired. A field of any other resource is reported not sortable however orderable its
-     * path is, because a catalogue reporting {@code true} there would advertise an ordering that listing discards: the
-     * client sorts, receives the default order, and is told nothing.
+     * The flag is published per field while the ordering is wired per listing, and only the listings named here are
+     * wired. A field of any other resource is reported not sortable however orderable its path is, because a catalogue
+     * reporting {@code true} there would advertise an ordering that listing discards: the client sorts, receives the
+     * default order, and is told nothing.
      *
      * <p>
      * Explicit rather than derived: the wiring lives in each listing service and nothing on a {@link FilterField} knows
-     * whether its listing was wired. A listing that gains ordering adds itself here.
+     * whether its listing was wired. A listing that gains ordering adds itself here, and
+     * {@code RequestValidatorHelper.revalidateSearchRequestDto} refuses a sort on every listing that has not.
      */
     private static final Set<Resource> SORT_WIRED_RESOURCES = Set
             .of(Resource.CERTIFICATE, Resource.CRYPTOGRAPHIC_KEY, Resource.DISCOVERY, Resource.CONNECTOR,
                     Resource.SECRET, Resource.CBOM, Resource.SIGNING_RECORD);
+
+    /**
+     * Content whose column renders a composite identity rather than the value a sort key would read.
+     *
+     * <p>
+     * A sort key extracts the stored {@code reference} for content that is not filtered by data. For most such types
+     * that is exactly what the cell shows - {@code AttributeColumnProjector} reduces CREDENTIAL and OBJECT values to
+     * their reference and nothing else. FILE and RESOURCE are the exceptions: the projector keeps a reduced identity
+     * beside the reference, and the cell labels itself from that - a file by its name and media type, a resource link
+     * by the referenced object's name - so ordering by the reference would order the page by something no cell shows.
+     */
+    private static final Set<AttributeContentType> COMPOSITE_CELL_CONTENT_TYPES = Set
+            .of(AttributeContentType.FILE, AttributeContentType.RESOURCE);
 
     /**
      * Whether the listing of this resource applies the sort a request carries.
@@ -193,20 +206,16 @@ public class SearchHelper {
     }
 
     /**
-     * Marks the attribute fields of one resource's catalogue sortable where that resource's listing applies a sort.
+     * What the catalogue advertises as sortable for an attribute field: a field the catalogue offers as a column at
+     * all, whose value is what its cell shows, on a listing that applies the ordering.
      *
      * <p>
-     * Ordering an attribute resolves to a correlated scalar subquery over the stored json, which works on any resource;
-     * what varies is whether the listing passes the sort on. A field the catalogue withholds as a column is withheld
-     * from ordering too - there is nothing to order a column by when the column cannot be shown.
+     * Decided here rather than by a pass over the assembled catalogue, so it is answered wherever {@code displayable}
+     * is and no caller can assemble a catalogue that forgets to answer it.
      */
-    public static List<SearchFieldDataDto> applyAttributeSortability(final List<SearchFieldDataDto> fields,
-            final Resource resource) {
-        if (!listingAppliesSort(resource)) {
-            return fields;
-        }
-        fields.forEach(field -> field.setSortable(Boolean.TRUE.equals(field.getDisplayable())));
-        return fields;
+    private static boolean isSortable(final SearchFieldObject attributeSearchInfo, final Resource resource) {
+        return listingAppliesSort(resource) && isDisplayable(attributeSearchInfo)
+                && !COMPOSITE_CELL_CONTENT_TYPES.contains(attributeSearchInfo.getAttributeContentType());
     }
 
     /**
@@ -231,11 +240,21 @@ public class SearchHelper {
      * itself - {@code PRIVATE_KEY} shows whether a joined key type is one particular type - and the certificate
      * validation-check fields each name one check inside a single serialized validation result, so ordering by the
      * attribute would order them all by the whole document.
+     *
+     * <p>
+     * A bitmask-backed field is the same case once more: {@code KEY_USAGE} and {@code CKI_USAGE} persist a set of flags
+     * as one integer, and the column renders the decoded set, so ordering by the column would order the page by a
+     * number whose value bears no relation to the list in the cell.
      */
     public static boolean isOrderableField(final FilterField filterField) {
         return filterField.getFieldAttribute() != null && !filterField.isNativeArrayField()
                 && filterField.getJsonPath() == null && filterField.getExpectedValue() == null
-                && !SharedAttributeFields.VALUES.contains(filterField);
+                && !isBitMaskField(filterField) && !SharedAttributeFields.VALUES.contains(filterField);
+    }
+
+    /** Whether the field's column is one integer holding a set of flags rather than the value the cell renders. */
+    private static boolean isBitMaskField(final FilterField filterField) {
+        return filterField.getEnumClass() != null && BitMaskEnum.class.isAssignableFrom(filterField.getEnumClass());
     }
 
     /**
@@ -271,13 +290,18 @@ public class SearchHelper {
         return searchFieldTypeEnum;
     }
 
-    public static List<SearchFieldDataDto> prepareSearchForJSON(final List<SearchFieldObject> searchFieldObjectList) {
+    /**
+     * The catalogue entries for one resource's attribute fields. The resource is what decides {@code sortable}, since
+     * ordering is wired per listing while the flag is published per field.
+     */
+    public static List<SearchFieldDataDto> prepareSearchForJSON(final List<SearchFieldObject> searchFieldObjectList,
+            final Resource resource) {
         final List<SearchFieldObject> mergedFields = mergeFieldsWithSameIdentifier(searchFieldObjectList);
         final Set<String> duplicatesOfNames = filterDuplicity(mergedFields);
         return mergedFields
                 .stream()
                 .map(attribute -> prepareSearchForJSON(attribute,
-                        duplicatesOfNames.contains(attribute.getAttributeName())))
+                        duplicatesOfNames.contains(attribute.getAttributeName()), resource))
                 .sorted(new SearchFieldDataComparator())
                 .toList();
     }

--- a/src/main/java/com/otilm/core/util/SearchHelper.java
+++ b/src/main/java/com/otilm/core/util/SearchHelper.java
@@ -162,8 +162,8 @@ public class SearchHelper {
         fieldDataDto.setValue(attributeSearchInfo.getContentItems());
         fieldDataDto.setAttributeContentType(attributeSearchInfo.getAttributeContentType());
         fieldDataDto.setDisplayable(isDisplayable(attributeSearchInfo));
-        // Ordering by an attribute needs a correlated scalar subquery over JSONB that no index supports, and a
-        // multi-valued attribute leaves the sort key ambiguous, so no attribute-sourced field is sortable.
+        // Left false here and decided per resource by applyAttributeSortability: this method is handed one attribute
+        // definition and not the resource whose catalogue it is being built for, and ordering is wired per listing.
         fieldDataDto.setSortable(false);
         return fieldDataDto;
     }
@@ -184,6 +184,30 @@ public class SearchHelper {
     private static final Set<Resource> SORT_WIRED_RESOURCES = Set
             .of(Resource.CERTIFICATE, Resource.CRYPTOGRAPHIC_KEY, Resource.DISCOVERY, Resource.CONNECTOR,
                     Resource.SECRET, Resource.CBOM, Resource.SIGNING_RECORD);
+
+    /**
+     * Whether the listing of this resource applies the sort a request carries.
+     */
+    public static boolean listingAppliesSort(final Resource resource) {
+        return SORT_WIRED_RESOURCES.contains(resource);
+    }
+
+    /**
+     * Marks the attribute fields of one resource's catalogue sortable where that resource's listing applies a sort.
+     *
+     * <p>
+     * Ordering an attribute resolves to a correlated scalar subquery over the stored json, which works on any resource;
+     * what varies is whether the listing passes the sort on. A field the catalogue withholds as a column is withheld
+     * from ordering too - there is nothing to order a column by when the column cannot be shown.
+     */
+    public static List<SearchFieldDataDto> applyAttributeSortability(final List<SearchFieldDataDto> fields,
+            final Resource resource) {
+        if (!listingAppliesSort(resource)) {
+            return fields;
+        }
+        fields.forEach(field -> field.setSortable(Boolean.TRUE.equals(field.getDisplayable())));
+        return fields;
+    }
 
     /**
      * What the catalogue advertises as sortable: a field whose path can be ordered by, on a listing that applies the

--- a/src/main/java/com/otilm/core/util/SearchHelper.java
+++ b/src/main/java/com/otilm/core/util/SearchHelper.java
@@ -4,6 +4,7 @@ import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.common.content.data.ProtectionLevel;
 import com.otilm.api.model.common.enums.IPlatformEnum;
 import com.otilm.api.model.common.enums.PlatformEnum;
+import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.search.FilterConditionOperator;
 import com.otilm.api.model.core.search.FilterFieldType;
 import com.otilm.api.model.core.search.SearchFieldDataDto;
@@ -168,16 +169,28 @@ public class SearchHelper {
     }
 
     /**
-     * What the catalogue advertises as sortable, which is nothing yet.
+     * The resources whose listing passes the sort a request carries to the repository.
      *
      * <p>
-     * A secured search can be ordered by a field, but no listing service passes the sort a request carries to the
-     * repository, so a catalogue reporting {@code true} would advertise an ordering that does not happen: a client
-     * sorting on such a field would get the default order back and no indication why. {@link #isOrderableField} is the
-     * predicate this becomes once the listings are wired.
+     * The flag is published per field while the ordering is wired per listing, and seven of the sixteen listings that
+     * accept a search request are wired. A field of any other resource is reported not sortable however orderable its
+     * path is, because a catalogue reporting {@code true} there would advertise an ordering that listing discards: the
+     * client sorts, receives the default order, and is told nothing.
+     *
+     * <p>
+     * Explicit rather than derived: the wiring lives in each listing service and nothing on a {@link FilterField} knows
+     * whether its listing was wired. A listing that gains ordering adds itself here.
+     */
+    private static final Set<Resource> SORT_WIRED_RESOURCES = Set
+            .of(Resource.CERTIFICATE, Resource.CRYPTOGRAPHIC_KEY, Resource.DISCOVERY, Resource.CONNECTOR,
+                    Resource.SECRET, Resource.CBOM, Resource.SIGNING_RECORD);
+
+    /**
+     * What the catalogue advertises as sortable: a field whose path can be ordered by, on a listing that applies the
+     * ordering.
      */
     private static boolean isSortable(final FilterField filterField) {
-        return false;
+        return SORT_WIRED_RESOURCES.contains(filterField.getRootResource()) && isOrderableField(filterField);
     }
 
     /**

--- a/src/main/java/com/otilm/core/util/SortOrderBuilder.java
+++ b/src/main/java/com/otilm/core/util/SortOrderBuilder.java
@@ -81,7 +81,7 @@ public final class SortOrderBuilder {
             // Property-only by construction: needsRankedUuidQuery sends every attribute sort to resolveGrouped, and
             // resolveField refuses a non-property source rather than letting one build an unorderable query here.
             FilterField field = resolveField(root, sort);
-            orders.add(direct(criteriaBuilder, resolveExpression(root, field), sort.direction()));
+            orders.add(primary(criteriaBuilder, resolveExpression(root, field), sort.direction()));
         } else if (defaultOrder != null) {
             orders.add(defaultOrder);
         }
@@ -108,20 +108,15 @@ public final class SortOrderBuilder {
             sortKey = aggregate(criteriaBuilder, resolveExpression(root, field), sort.direction());
         } else {
             fieldName = sort.fieldIdentifier();
-            sortKey = aggregate(criteriaBuilder, FilterPredicatesBuilder
-                    .getAttributeSortKey(criteriaBuilder, query, root, sort.fieldSource(), sort.fieldIdentifier()),
-                    sort.direction());
+            sortKey = aggregate(criteriaBuilder,
+                    FilterPredicatesBuilder.getAttributeSortKey(criteriaBuilder, query, root, sort), sort.direction());
         }
 
         Order tieBreak = tieBreak(root, criteriaBuilder)
                 .orElseThrow(() -> new ValidationException(
                         ValidationError.create("Field %s cannot be sorted on this resource.".formatted(fieldName))));
 
-        // An object holding no value for the field aggregates to null. Pinned last in both directions, so the rows a
-        // column has nothing to show for never lead the page, and reversing the sort does not put them first.
-        Order primary = ((JpaOrder) direct(criteriaBuilder, sortKey, sort.direction()))
-                .nullPrecedence(NullPrecedence.LAST);
-        return new GroupedOrdering(sortKey, List.of(primary, tieBreak));
+        return new GroupedOrdering(sortKey, List.of(primary(criteriaBuilder, sortKey, sort.direction()), tieBreak));
     }
 
     /**
@@ -151,8 +146,20 @@ public final class SortOrderBuilder {
                 .toList();
     }
 
-    private static Order direct(CriteriaBuilder criteriaBuilder, Expression<?> expression, SortDirection direction) {
-        return direction == SortDirection.DESC ? criteriaBuilder.desc(expression) : criteriaBuilder.asc(expression);
+    /**
+     * The requested ordering of one sort expression, with the rows that have no value for it pinned last.
+     *
+     * <p>
+     * A column the row has nothing to show for must never lead the page, and reversing the sort must not put those rows
+     * first either - which is what PostgreSQL's own default would do, since it orders nulls last ascending and first
+     * descending. Shared by both sort paths so a nullable column cannot place its blanks differently depending on
+     * whether the ordering happened to be reached through a join or a subquery.
+     */
+    private static Order primary(CriteriaBuilder criteriaBuilder, Expression<?> expression, SortDirection direction) {
+        Order order = direction == SortDirection.DESC
+                ? criteriaBuilder.desc(expression)
+                : criteriaBuilder.asc(expression);
+        return ((JpaOrder) order).nullPrecedence(NullPrecedence.LAST);
     }
 
     /**
@@ -212,7 +219,9 @@ public final class SortOrderBuilder {
      */
     private static FilterField resolveField(Root<?> root, SortSpecification sort) {
         FilterField field = resolveField(sort);
-        Resource resource = resourceOf(root);
+        // The resource the listing selects when the caller named one, which is authoritative: an entity outside
+        // ResourceToClass maps to no resource, and deriving it from the root alone silently skips this check there.
+        Resource resource = sort.resource() == null ? resourceOf(root) : sort.resource();
         if (resource != null && field.getRootResource() != resource) {
             throw new ValidationException(ValidationError
                     .create("Field %s does not belong to resource %s.".formatted(field.name(), resource.getLabel())));

--- a/src/main/java/com/otilm/core/util/SortOrderBuilder.java
+++ b/src/main/java/com/otilm/core/util/SortOrderBuilder.java
@@ -16,8 +16,13 @@ import jakarta.persistence.criteria.From;
 import jakarta.persistence.criteria.Order;
 import jakarta.persistence.criteria.Root;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
 
 /**
  * Turns a {@link SortSpecification} into the {@link Order} terms of a secured search.
@@ -87,6 +92,33 @@ public final class SortOrderBuilder {
         return new GroupedOrdering(sortKey, List.of(direct(criteriaBuilder, sortKey, sort.direction()), tieBreak));
     }
 
+    /**
+     * Puts the rows of the second phase of a two-phase listing back into the order of the first.
+     *
+     * <p>
+     * The listing selects a page of uuids in the requested order and then loads the objects with a {@code uuid IN
+     * (...)} query, whose own order is whatever that query defines. Ordering only the first phase is therefore
+     * discarded by the second, and the ordering survives solely as the rank of the uuid list. Applied whether or not
+     * the request named a sort: the ranked list is the one carrying the tie-break, so re-ranking is also what makes a
+     * default-ordered page stable across page boundaries when the default term has ties.
+     *
+     * @param rankedUuids the uuids in the order the first phase returned them
+     * @param rows the objects the second phase loaded, in any order
+     * @param uuidOf reads the uuid of a loaded object
+     */
+    public static <T> List<T> rankBy(List<UUID> rankedUuids, List<T> rows, Function<T, UUID> uuidOf) {
+        Map<UUID, Integer> rank = new HashMap<>();
+        for (int i = 0; i < rankedUuids.size(); i++) {
+            rank.put(rankedUuids.get(i), i);
+        }
+        // A row whose uuid is not in the ranked list cannot happen for a query keyed by that list, but sorting it last
+        // keeps the method total rather than throwing on a caller that passes a wider row set.
+        return rows
+                .stream()
+                .sorted(Comparator.comparingInt(row -> rank.getOrDefault(uuidOf.apply(row), Integer.MAX_VALUE)))
+                .toList();
+    }
+
     private static Order direct(CriteriaBuilder criteriaBuilder, Expression<?> expression, SortDirection direction) {
         return direction == SortDirection.DESC ? criteriaBuilder.desc(expression) : criteriaBuilder.asc(expression);
     }
@@ -123,12 +155,21 @@ public final class SortOrderBuilder {
             throw new ValidationException(ValidationError
                     .create("Sorting by %s fields is not supported.".formatted(sort.fieldSource().getLabel())));
         }
+        FilterField field;
         try {
-            return FilterField.valueOf(sort.fieldIdentifier());
+            field = FilterField.valueOf(sort.fieldIdentifier());
         } catch (IllegalArgumentException e) {
             throw new ValidationException(
                     ValidationError.create("Unknown sort field identifier %s.".formatted(sort.fieldIdentifier())));
         }
+        // Refused against the same predicate the catalogue publishes as `sortable`, so a request the frontend was told
+        // to withhold is answered with an error rather than with a silently unordered page. Checked before the path is
+        // resolved, because several of these fields do resolve to a path - it is just not the value the column shows.
+        if (!SearchHelper.isOrderableField(field)) {
+            throw new ValidationException(
+                    ValidationError.create("Field %s cannot be used to order this listing.".formatted(field.name())));
+        }
+        return field;
     }
 
     /**

--- a/src/main/java/com/otilm/core/util/SortOrderBuilder.java
+++ b/src/main/java/com/otilm/core/util/SortOrderBuilder.java
@@ -10,6 +10,7 @@ import com.otilm.core.dao.entity.UniquelyIdentified_;
 import com.otilm.core.dao.repository.SortSpecification;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.enums.ResourceToClass;
+import jakarta.persistence.criteria.CommonAbstractCriteria;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.From;
@@ -23,6 +24,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
+import org.hibernate.query.NullPrecedence;
+import org.hibernate.query.criteria.JpaOrder;
 
 /**
  * Turns a {@link SortSpecification} into the {@link Order} terms of a secured search.
@@ -42,11 +45,24 @@ public final class SortOrderBuilder {
     }
 
     /**
-     * Whether applying the sort means joining away from the root. Answerable from the specification alone, so a caller
-     * can pick the shape of the query before it has a root to resolve against.
+     * Whether the sort has to be applied by the query that selects a page of uuids and carries the sort key in its
+     * select list, rather than by the entity query directly. Answerable from the specification alone, so a caller can
+     * pick the shape of the query before it has a root to resolve against.
+     *
+     * <p>
+     * Two sorts need it, for different reasons. A sort through a join gives a root as many rows as the join has
+     * matches, so a window over those rows would underfill the page. An attribute sort resolves to a scalar subquery,
+     * and the entity query selects DISTINCT, which the database will not order by an expression absent from the select
+     * list.
      */
-    public static boolean traversesJoin(SortSpecification sort) {
-        return sort != null && !resolveField(sort).getJoinAttributes().isEmpty();
+    public static boolean needsRankedUuidQuery(SortSpecification sort) {
+        if (sort == null) {
+            return false;
+        }
+        if (sort.fieldSource() != FilterFieldSource.PROPERTY) {
+            return true;
+        }
+        return !resolveField(sort).getJoinAttributes().isEmpty();
     }
 
     /**
@@ -58,10 +74,12 @@ public final class SortOrderBuilder {
      * @param defaultOrder the ordering the caller applies when the request names none, or {@code null} for no default
      * @param paged whether the query will be windowed, which is what makes an unstable order observable
      */
-    public static List<Order> resolve(Root<?> root, CriteriaBuilder criteriaBuilder, SortSpecification sort,
-            Order defaultOrder, boolean paged) {
+    public static List<Order> resolve(Root<?> root, CriteriaBuilder criteriaBuilder, CommonAbstractCriteria query,
+            SortSpecification sort, Order defaultOrder, boolean paged) {
         List<Order> orders = new ArrayList<>();
         if (sort != null) {
+            // Property-only by construction: needsRankedUuidQuery sends every attribute sort to resolveGrouped, and
+            // resolveField refuses a non-property source rather than letting one build an unorderable query here.
             FilterField field = resolveField(root, sort);
             orders.add(direct(criteriaBuilder, resolveExpression(root, field), sort.direction()));
         } else if (defaultOrder != null) {
@@ -81,15 +99,29 @@ public final class SortOrderBuilder {
      * request the ordering has to degrade for.
      */
     public static GroupedOrdering resolveGrouped(Root<?> root, CriteriaBuilder criteriaBuilder,
-            SortSpecification sort) {
-        FilterField field = resolveField(root, sort);
-        Expression<?> sortKey = aggregate(criteriaBuilder, resolveExpression(root, field), sort.direction());
+            CommonAbstractCriteria query, SortSpecification sort) {
+        String fieldName;
+        Expression<?> sortKey;
+        if (sort.fieldSource() == FilterFieldSource.PROPERTY) {
+            FilterField field = resolveField(root, sort);
+            fieldName = field.name();
+            sortKey = aggregate(criteriaBuilder, resolveExpression(root, field), sort.direction());
+        } else {
+            fieldName = sort.fieldIdentifier();
+            sortKey = aggregate(criteriaBuilder, FilterPredicatesBuilder
+                    .getAttributeSortKey(criteriaBuilder, query, root, sort.fieldSource(), sort.fieldIdentifier()),
+                    sort.direction());
+        }
 
         Order tieBreak = tieBreak(root, criteriaBuilder)
                 .orElseThrow(() -> new ValidationException(
-                        ValidationError.create("Field %s cannot be sorted on this resource.".formatted(field.name()))));
+                        ValidationError.create("Field %s cannot be sorted on this resource.".formatted(fieldName))));
 
-        return new GroupedOrdering(sortKey, List.of(direct(criteriaBuilder, sortKey, sort.direction()), tieBreak));
+        // An object holding no value for the field aggregates to null. Pinned last in both directions, so the rows a
+        // column has nothing to show for never lead the page, and reversing the sort does not put them first.
+        Order primary = ((JpaOrder) direct(criteriaBuilder, sortKey, sort.direction()))
+                .nullPrecedence(NullPrecedence.LAST);
+        return new GroupedOrdering(sortKey, List.of(primary, tieBreak));
     }
 
     /**

--- a/src/test/java/com/otilm/core/integration/repository/SecurityFilterRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/repository/SecurityFilterRepositoryITest.java
@@ -353,9 +353,10 @@ class SecurityFilterRepositoryITest extends BaseSpringBootTest {
     }
 
     @Test
-    void reportsWhetherASortTraversesAJoin() {
-        Assertions.assertFalse(SortOrderBuilder.traversesJoin(propertySort("SUBJECTDN", SortDirection.ASC)));
-        Assertions.assertTrue(SortOrderBuilder.traversesJoin(propertySort("RA_PROFILE_NAME", SortDirection.ASC)));
+    void reportsWhetherASortNeedsTheRankedUuidQuery() {
+        Assertions.assertFalse(SortOrderBuilder.needsRankedUuidQuery(propertySort("SUBJECTDN", SortDirection.ASC)));
+        Assertions
+                .assertTrue(SortOrderBuilder.needsRankedUuidQuery(propertySort("RA_PROFILE_NAME", SortDirection.ASC)));
     }
 
     /**

--- a/src/test/java/com/otilm/core/integration/repository/SecurityFilterRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/repository/SecurityFilterRepositoryITest.java
@@ -381,6 +381,22 @@ class SecurityFilterRepositoryITest extends BaseSpringBootTest {
                         () -> certificateRepository.findUsingSecurityFilter(filter, List.of(), null, null, null, sort));
     }
 
+    /**
+     * PRIVATE_KEY resolves to a path and would order fine, but what the column displays is a comparison against an
+     * expected value rather than the value that path holds. The catalogue reports it as not sortable, and the request
+     * is refused against that same predicate rather than answered with a silently unordered page.
+     */
+    @Test
+    void rejectsSortFieldTheCatalogueWithholdsFromSorting() {
+        SecurityFilter filter = SecurityFilter.create();
+        SortSpecification sort = propertySort("PRIVATE_KEY", SortDirection.ASC);
+
+        ValidationException e = Assertions
+                .assertThrows(ValidationException.class,
+                        () -> certificateRepository.findUsingSecurityFilter(filter, List.of(), null, null, null, sort));
+        Assertions.assertTrue(e.getMessage().contains("cannot be used to order"));
+    }
+
     @Test
     void rejectsSortFieldOfAnotherResource() {
         SecurityFilter filter = SecurityFilter.create();

--- a/src/test/java/com/otilm/core/integration/repository/SecurityFilterRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/repository/SecurityFilterRepositoryITest.java
@@ -492,6 +492,50 @@ class SecurityFilterRepositoryITest extends BaseSpringBootTest {
                         () -> certificateRepository.findUsingSecurityFilter(filter, List.of(), null, null, null, sort));
     }
 
+    /**
+     * A row a column has nothing to show for must never lead the page, in either direction. PostgreSQL's own default
+     * would put nulls first descending, so the direct sort path pins them last explicitly - the same placement the
+     * grouped path applies, so a nullable column does not place its blanks differently depending on which path the
+     * ordering happened to take.
+     */
+    @Test
+    void aRowWithoutAValueSortsLastInBothDirectionsOnTheDirectPath() {
+        certificateGroup.setCommonName("alpha");
+        certificateOwner.setCommonName("bravo");
+        certificateRaProfile1.setCommonName("charlie");
+        certificateRepository.saveAllAndFlush(List.of(certificateGroup, certificateOwner, certificateRaProfile1));
+
+        SecurityFilter filter = SecurityFilter.create();
+        List<UUID> ascending = uuidsOf(certificateRepository
+                .findUsingSecurityFilter(filter, List.of(), null, null, null,
+                        propertySort("COMMON_NAME", SortDirection.ASC)));
+        List<UUID> descending = uuidsOf(certificateRepository
+                .findUsingSecurityFilter(filter, List.of(), null, null, null,
+                        propertySort("COMMON_NAME", SortDirection.DESC)));
+
+        Assertions.assertEquals(certificateRaProfile2.getUuid(), ascending.getLast());
+        Assertions.assertEquals(certificateRaProfile2.getUuid(), descending.getLast());
+    }
+
+    /** The same placement through the grouped path, so the two cannot drift apart. */
+    @Test
+    void aRowWithoutAValueSortsLastInBothDirectionsOnTheGroupedPath() {
+        SecurityFilter filter = SecurityFilter.create();
+
+        List<UUID> ascending = certificateRepository
+                .findUuidsUsingSecurityFilter(filter, null, null, null,
+                        propertySort("RA_PROFILE_NAME", SortDirection.ASC));
+        List<UUID> descending = certificateRepository
+                .findUuidsUsingSecurityFilter(filter, null, null, null,
+                        propertySort("RA_PROFILE_NAME", SortDirection.DESC));
+
+        // The two certificates with no RA profile at all are the tail of both pages, whichever way the page is
+        // ordered; which of the two leads that tail is the uuid tie-break's business, not this case's.
+        Set<UUID> withoutRaProfile = Set.of(certificateGroup.getUuid(), certificateOwner.getUuid());
+        Assertions.assertEquals(withoutRaProfile, Set.copyOf(ascending.subList(2, 4)));
+        Assertions.assertEquals(withoutRaProfile, Set.copyOf(descending.subList(2, 4)));
+    }
+
     @Test
     void rejectsSortOnAttributeSourcedField() {
         SecurityFilter filter = SecurityFilter.create();

--- a/src/test/java/com/otilm/core/integration/search/AttributeColumnSortITest.java
+++ b/src/test/java/com/otilm/core/integration/search/AttributeColumnSortITest.java
@@ -1,0 +1,178 @@
+package com.otilm.core.integration.search;
+
+import com.otilm.api.model.client.attribute.RequestAttributeV3;
+import com.otilm.api.model.client.certificate.SearchRequestDto;
+import com.otilm.api.model.client.certificate.SearchSortRequestDto;
+import com.otilm.api.model.common.attribute.common.AttributeType;
+import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
+import com.otilm.api.model.common.attribute.common.properties.CustomAttributeProperties;
+import com.otilm.api.model.common.attribute.v3.CustomAttributeV3;
+import com.otilm.api.model.common.attribute.v3.content.BaseAttributeContentV3;
+import com.otilm.api.model.common.attribute.v3.content.TextAttributeContentV3;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.discovery.DiscoveryStatus;
+import com.otilm.api.model.core.search.FilterFieldSource;
+import com.otilm.api.model.core.search.SortDirection;
+import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.dao.entity.Discovery;
+import com.otilm.core.dao.repository.DiscoveryRepository;
+import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.service.DiscoveryExternalService;
+import com.otilm.core.util.BaseSpringBootTest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Ordering by an attribute-sourced column.
+ *
+ * <p>
+ * Filtering an attribute is an order-agnostic {@code EXISTS} subquery, so it yields nothing to order by. These cases
+ * cover the correlated scalar subquery that does: that a listing orders by the stored value rather than by the raw
+ * document, that an object holding no value is kept rather than dropped, and that a multi-valued attribute resolves to
+ * one key instead of multiplying the row.
+ */
+class AttributeColumnSortITest extends BaseSpringBootTest {
+
+    private static final String ENVIRONMENT = "environment";
+
+    @Autowired
+    private DiscoveryExternalService discoveryService;
+
+    @Autowired
+    private DiscoveryRepository discoveryRepository;
+
+    @Autowired
+    private AttributeEngine attributeEngine;
+
+    private UUID definitionUuid;
+
+    @BeforeEach
+    void loadData() throws Exception {
+        definitionUuid = registerCustomAttribute();
+
+        // Seeded so the attribute order is neither the creation order nor the name order: a sort that never reached
+        // the query, or one that ordered by the wrong column, cannot produce the expected sequence by accident.
+        seedDiscovery("first-created", "charlie");
+        seedDiscovery("second-created", "alpha");
+        seedDiscovery("third-created", "bravo");
+    }
+
+    private UUID registerCustomAttribute() throws Exception {
+        CustomAttributeV3 attribute = new CustomAttributeV3();
+        UUID uuid = UUID.randomUUID();
+        attribute.setUuid(uuid.toString());
+        attribute.setName(ENVIRONMENT);
+        attribute.setType(AttributeType.CUSTOM);
+        attribute.setContentType(AttributeContentType.TEXT);
+        CustomAttributeProperties properties = new CustomAttributeProperties();
+        properties.setLabel(ENVIRONMENT);
+        properties.setVisible(true);
+        attribute.setProperties(properties);
+        attributeEngine.updateCustomAttributeDefinition(attribute, List.of(Resource.DISCOVERY));
+        return uuid;
+    }
+
+    private Discovery seedDiscovery(String name, String... environmentValues) throws Exception {
+        Discovery discovery = new Discovery();
+        discovery.setName(name);
+        discovery.setStatus(DiscoveryStatus.COMPLETED);
+        discovery.setConnectorStatus(DiscoveryStatus.COMPLETED);
+        // The list DTO reads both, so a discovery without them cannot be mapped for the response.
+        discovery.setConnectorUuid(UUID.randomUUID());
+        discovery.setConnectorName("attribute-sort-connector");
+        discovery = discoveryRepository.save(discovery);
+
+        if (environmentValues.length > 0) {
+            attributeEngine
+                    .updateObjectCustomAttributesContent(Resource.DISCOVERY, discovery.getUuid(),
+                            List.of(customContent(environmentValues)));
+        }
+        return discovery;
+    }
+
+    private RequestAttributeV3 customContent(String... values) {
+        RequestAttributeV3 requestAttribute = new RequestAttributeV3();
+        requestAttribute.setUuid(definitionUuid);
+        requestAttribute.setName(ENVIRONMENT);
+        List<BaseAttributeContentV3<?>> content = new ArrayList<>();
+        for (String value : values) {
+            content.add(new TextAttributeContentV3(null, value));
+        }
+        requestAttribute.setContent(content);
+        return requestAttribute;
+    }
+
+    private List<String> listNames(SortDirection direction, int pageNumber, int itemsPerPage) {
+        SearchRequestDto request = new SearchRequestDto();
+        request.setPageNumber(pageNumber);
+        request.setItemsPerPage(itemsPerPage);
+        request
+                .setSort(new SearchSortRequestDto(FilterFieldSource.CUSTOM,
+                        ENVIRONMENT + "|" + AttributeContentType.TEXT.name(), direction));
+
+        return discoveryService
+                .listDiscoveries(SecurityFilter.create(), request)
+                .getDiscoveries()
+                .stream()
+                .map(discovery -> discovery.getName())
+                .toList();
+    }
+
+    @Test
+    void ordersByTheAttributeValueAscending() {
+        Assertions
+                .assertEquals(List.of("second-created", "third-created", "first-created"),
+                        listNames(SortDirection.ASC, 1, 10));
+    }
+
+    @Test
+    void ordersByTheAttributeValueDescending() {
+        Assertions
+                .assertEquals(List.of("first-created", "third-created", "second-created"),
+                        listNames(SortDirection.DESC, 1, 10));
+    }
+
+    @Test
+    void orderingSpansTheWholeResultSetAcrossAPageBoundary() {
+        List<String> paged = new ArrayList<>();
+        paged.addAll(listNames(SortDirection.ASC, 1, 2));
+        paged.addAll(listNames(SortDirection.ASC, 2, 2));
+
+        Assertions.assertEquals(List.of("second-created", "third-created", "first-created"), paged);
+    }
+
+    /**
+     * An object with no value for the sorted attribute yields a null key. It has to be kept and ordered consistently:
+     * last in both directions, so reversing the sort does not lead the page with the rows the column cannot show.
+     */
+    @Test
+    void anObjectWithoutAValueSortsLastInBothDirections() throws Exception {
+        seedDiscovery("no-value");
+
+        Assertions
+                .assertEquals(List.of("second-created", "third-created", "first-created", "no-value"),
+                        listNames(SortDirection.ASC, 1, 10));
+        Assertions
+                .assertEquals(List.of("first-created", "third-created", "second-created", "no-value"),
+                        listNames(SortDirection.DESC, 1, 10));
+    }
+
+    /**
+     * A multi-valued attribute has as many values as the object stores, which would leave the key ambiguous. It
+     * resolves to the value at the lowest {@code item_order} - the one the cell shows first - and the row appears once
+     * rather than once per value.
+     */
+    @Test
+    void aMultiValuedAttributeSortsOnItsFirstStoredValue() throws Exception {
+        seedDiscovery("multi", "aaa", "zzz");
+
+        Assertions
+                .assertEquals(List.of("multi", "second-created", "third-created", "first-created"),
+                        listNames(SortDirection.ASC, 1, 10));
+    }
+}

--- a/src/test/java/com/otilm/core/integration/search/AttributeColumnSortITest.java
+++ b/src/test/java/com/otilm/core/integration/search/AttributeColumnSortITest.java
@@ -1,23 +1,38 @@
 package com.otilm.core.integration.search;
 
+import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.attribute.RequestAttributeV3;
 import com.otilm.api.model.client.certificate.SearchRequestDto;
 import com.otilm.api.model.client.certificate.SearchSortRequestDto;
+import com.otilm.api.model.common.PaginationResponseDto;
 import com.otilm.api.model.common.attribute.common.AttributeType;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.common.properties.CustomAttributeProperties;
 import com.otilm.api.model.common.attribute.v3.CustomAttributeV3;
 import com.otilm.api.model.common.attribute.v3.content.BaseAttributeContentV3;
 import com.otilm.api.model.common.attribute.v3.content.TextAttributeContentV3;
+import com.otilm.api.model.connector.secrets.SecretType;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.discovery.DiscoveryStatus;
 import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.api.model.core.search.SortDirection;
+import com.otilm.api.model.core.secret.SecretDto;
+import com.otilm.api.model.core.secret.SecretState;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.dao.entity.Discovery;
+import com.otilm.core.dao.entity.Secret;
+import com.otilm.core.dao.entity.SecretVersion;
+import com.otilm.core.dao.entity.VaultInstance;
+import com.otilm.core.dao.entity.VaultProfile;
 import com.otilm.core.dao.repository.DiscoveryRepository;
+import com.otilm.core.dao.repository.SecretRepository;
+import com.otilm.core.dao.repository.SecretVersionRepository;
+import com.otilm.core.dao.repository.VaultInstanceRepository;
+import com.otilm.core.dao.repository.VaultProfileRepository;
+import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.DiscoveryExternalService;
+import com.otilm.core.service.SecretExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,11 +55,29 @@ class AttributeColumnSortITest extends BaseSpringBootTest {
 
     private static final String ENVIRONMENT = "environment";
 
+    /** Distinct from the discovery probe: one definition per name is what the content write resolves by. */
+    private static final String SECRET_ENVIRONMENT = "secret-environment";
+
     @Autowired
     private DiscoveryExternalService discoveryService;
 
     @Autowired
     private DiscoveryRepository discoveryRepository;
+
+    @Autowired
+    private SecretExternalService secretService;
+
+    @Autowired
+    private SecretRepository secretRepository;
+
+    @Autowired
+    private SecretVersionRepository secretVersionRepository;
+
+    @Autowired
+    private VaultProfileRepository vaultProfileRepository;
+
+    @Autowired
+    private VaultInstanceRepository vaultInstanceRepository;
 
     @Autowired
     private AttributeEngine attributeEngine;
@@ -63,17 +96,22 @@ class AttributeColumnSortITest extends BaseSpringBootTest {
     }
 
     private UUID registerCustomAttribute() throws Exception {
+        return registerCustomAttribute(ENVIRONMENT, AttributeContentType.TEXT, true, Resource.DISCOVERY);
+    }
+
+    private UUID registerCustomAttribute(String name, AttributeContentType contentType, boolean visible,
+            Resource resource) throws Exception {
         CustomAttributeV3 attribute = new CustomAttributeV3();
         UUID uuid = UUID.randomUUID();
         attribute.setUuid(uuid.toString());
-        attribute.setName(ENVIRONMENT);
+        attribute.setName(name);
         attribute.setType(AttributeType.CUSTOM);
-        attribute.setContentType(AttributeContentType.TEXT);
+        attribute.setContentType(contentType);
         CustomAttributeProperties properties = new CustomAttributeProperties();
-        properties.setLabel(ENVIRONMENT);
-        properties.setVisible(true);
+        properties.setLabel(name);
+        properties.setVisible(visible);
         attribute.setProperties(properties);
-        attributeEngine.updateCustomAttributeDefinition(attribute, List.of(Resource.DISCOVERY));
+        attributeEngine.updateCustomAttributeDefinition(attribute, List.of(resource));
         return uuid;
     }
 
@@ -108,12 +146,16 @@ class AttributeColumnSortITest extends BaseSpringBootTest {
     }
 
     private List<String> listNames(SortDirection direction, int pageNumber, int itemsPerPage) {
+        return listNamesSortedBy(ENVIRONMENT + "|" + AttributeContentType.TEXT.name(), direction, pageNumber,
+                itemsPerPage);
+    }
+
+    private List<String> listNamesSortedBy(String fieldIdentifier, SortDirection direction, int pageNumber,
+            int itemsPerPage) {
         SearchRequestDto request = new SearchRequestDto();
         request.setPageNumber(pageNumber);
         request.setItemsPerPage(itemsPerPage);
-        request
-                .setSort(new SearchSortRequestDto(FilterFieldSource.CUSTOM,
-                        ENVIRONMENT + "|" + AttributeContentType.TEXT.name(), direction));
+        request.setSort(new SearchSortRequestDto(FilterFieldSource.CUSTOM, fieldIdentifier, direction));
 
         return discoveryService
                 .listDiscoveries(SecurityFilter.create(), request)
@@ -174,5 +216,153 @@ class AttributeColumnSortITest extends BaseSpringBootTest {
         Assertions
                 .assertEquals(List.of("multi", "second-created", "third-created", "first-created"),
                         listNames(SortDirection.ASC, 1, 10));
+    }
+
+    /**
+     * A field the catalogue reports as {@code sortable:false} is refused rather than answered with a page ordered by
+     * something the response would never show. Secret content is the clearest case: the catalogue withholds it as a
+     * column, so there is nothing for an ordering on it to be an ordering of.
+     */
+    @Test
+    void aSecretAttributeCannotBeOrderedOn() throws Exception {
+        registerCustomAttribute("sort-secret-probe", AttributeContentType.SECRET, true, Resource.DISCOVERY);
+
+        ValidationException e = Assertions
+                .assertThrows(ValidationException.class,
+                        () -> listNamesSortedBy("sort-secret-probe|" + AttributeContentType.SECRET.name(),
+                                SortDirection.ASC, 1, 10));
+        Assertions.assertTrue(e.getMessage().contains("cannot be used to order"));
+    }
+
+    /** An attribute the definition says not to show a user is not one a page may be ordered by either. */
+    @Test
+    void aHiddenAttributeCannotBeOrderedOn() throws Exception {
+        registerCustomAttribute("sort-hidden-probe", AttributeContentType.TEXT, false, Resource.DISCOVERY);
+
+        Assertions
+                .assertThrows(ValidationException.class,
+                        () -> listNamesSortedBy("sort-hidden-probe|" + AttributeContentType.TEXT.name(),
+                                SortDirection.ASC, 1, 10));
+    }
+
+    /**
+     * A file cell renders the file's name and media type, and a resource cell the referenced object's name - neither is
+     * the reference a sort key reads - so the catalogue withholds ordering on them and the request is refused.
+     */
+    @Test
+    void anAttributeWhoseCellIsNotItsSortKeyCannotBeOrderedOn() throws Exception {
+        registerCustomAttribute("sort-file-probe", AttributeContentType.FILE, true, Resource.DISCOVERY);
+
+        Assertions
+                .assertThrows(ValidationException.class,
+                        () -> listNamesSortedBy("sort-file-probe|" + AttributeContentType.FILE.name(),
+                                SortDirection.ASC, 1, 10));
+    }
+
+    /**
+     * An identifier naming no registered definition would otherwise yield an all-null key and a silently unordered page
+     * - the failure the property path already refuses.
+     */
+    @Test
+    void anIdentifierNamingNoRegisteredAttributeIsRejected() {
+        Assertions
+                .assertThrows(ValidationException.class,
+                        () -> listNamesSortedBy("not-registered|" + AttributeContentType.TEXT.name(), SortDirection.ASC,
+                                1, 10));
+    }
+
+    /**
+     * Ordering must not read further than the projection that renders a column does.
+     *
+     * <p>
+     * With the caller restricted to an allow-list this definition is not on, the projection blanks the column - so the
+     * sort key has to come back null for every row too. If it did not, reversing the sort would reorder the page by
+     * values the caller may not read, which is a comparative oracle over exactly the content the allow-list withholds.
+     * With every key null the uuid tie-break decides both directions, so the two pages are identical rather than
+     * reversed.
+     */
+    @Test
+    void anAttributeTheCallerMayNotReadCannotOrderThePage() {
+        restrictObjectAccess(Resource.ATTRIBUTE, ResourceAction.MEMBERS);
+
+        List<String> ascending = listNames(SortDirection.ASC, 1, 10);
+        List<String> descending = listNames(SortDirection.DESC, 1, 10);
+
+        Assertions.assertEquals(3, ascending.size());
+        Assertions.assertEquals(ascending, descending);
+    }
+
+    /** The values do decide the order when the caller may read them, which is what the case above removes. */
+    @Test
+    void anAttributeTheCallerMayReadOrdersThePage() {
+        Assertions.assertEquals(listNames(SortDirection.ASC, 1, 10).reversed(), listNames(SortDirection.DESC, 1, 10));
+    }
+
+    /**
+     * The secret listing carries attribute columns like any other, and its entity had no resource mapping of its own -
+     * the correlation the sort key builds resolved to {@code objectType = null}, matched no stored row, and left every
+     * key null while the catalogue advertised the field as sortable.
+     */
+    @Test
+    void ordersASecretListingByTheAttributeValue() throws Exception {
+        UUID secretDefinitionUuid = registerCustomAttribute(SECRET_ENVIRONMENT, AttributeContentType.TEXT, true,
+                Resource.SECRET);
+        VaultProfile vaultProfile = seedVaultProfile();
+
+        seedSecret("secret-first", vaultProfile, secretDefinitionUuid, "charlie");
+        seedSecret("secret-second", vaultProfile, secretDefinitionUuid, "alpha");
+        seedSecret("secret-third", vaultProfile, secretDefinitionUuid, "bravo");
+
+        SearchRequestDto request = new SearchRequestDto();
+        request.setPageNumber(1);
+        request.setItemsPerPage(10);
+        request
+                .setSort(new SearchSortRequestDto(FilterFieldSource.CUSTOM,
+                        SECRET_ENVIRONMENT + "|" + AttributeContentType.TEXT.name(), SortDirection.ASC));
+
+        PaginationResponseDto<SecretDto> response = secretService.listSecrets(request, SecurityFilter.create());
+
+        Assertions
+                .assertEquals(List.of("secret-second", "secret-third", "secret-first"),
+                        response.getItems().stream().map(SecretDto::getName).toList());
+    }
+
+    private VaultProfile seedVaultProfile() {
+        VaultInstance vaultInstance = new VaultInstance();
+        vaultInstance.setName("attribute-sort-vault");
+        vaultInstanceRepository.saveAndFlush(vaultInstance);
+
+        VaultProfile vaultProfile = new VaultProfile();
+        vaultProfile.setName("attribute-sort-vault-profile");
+        vaultProfile.setVaultInstance(vaultInstance);
+        vaultProfile.setVaultInstanceUuid(vaultInstance.getUuid());
+        vaultProfile.setEnabled(true);
+        return vaultProfileRepository.saveAndFlush(vaultProfile);
+    }
+
+    private void seedSecret(String name, VaultProfile vaultProfile, UUID secretDefinitionUuid, String environmentValue)
+            throws Exception {
+        SecretVersion version = new SecretVersion();
+        version.setVersion(1);
+        version.setVaultProfile(vaultProfile);
+        version.setFingerprint(name + "-fingerprint");
+        secretVersionRepository.saveAndFlush(version);
+
+        Secret secret = new Secret();
+        secret.setName(name);
+        secret.setType(SecretType.BASIC_AUTH);
+        secret.setState(SecretState.ACTIVE);
+        secret.setSourceVaultProfile(vaultProfile);
+        secret.setSourceVaultProfileUuid(vaultProfile.getUuid());
+        secret.setEnabled(true);
+        secret.setLatestVersion(version);
+        secret = secretRepository.saveAndFlush(secret);
+
+        RequestAttributeV3 requestAttribute = new RequestAttributeV3();
+        requestAttribute.setUuid(secretDefinitionUuid);
+        requestAttribute.setName(SECRET_ENVIRONMENT);
+        requestAttribute.setContent(List.of(new TextAttributeContentV3(null, environmentValue)));
+        attributeEngine
+                .updateObjectCustomAttributesContent(Resource.SECRET, secret.getUuid(), List.of(requestAttribute));
     }
 }

--- a/src/test/java/com/otilm/core/integration/search/CertificateListingSortITest.java
+++ b/src/test/java/com/otilm/core/integration/search/CertificateListingSortITest.java
@@ -1,0 +1,149 @@
+package com.otilm.core.integration.search;
+
+import com.otilm.api.model.client.certificate.CertificateSearchRequestDto;
+import com.otilm.api.model.client.certificate.SearchFilterRequestDto;
+import com.otilm.api.model.client.certificate.SearchSortRequestDto;
+import com.otilm.api.model.core.certificate.CertificateDto;
+import com.otilm.api.model.core.certificate.CertificateState;
+import com.otilm.api.model.core.certificate.CertificateValidationStatus;
+import com.otilm.api.model.core.search.FilterConditionOperator;
+import com.otilm.api.model.core.search.FilterFieldSource;
+import com.otilm.api.model.core.search.SortDirection;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.CertificateContent;
+import com.otilm.core.dao.repository.CertificateContentRepository;
+import com.otilm.core.dao.repository.CertificateRepository;
+import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.service.impl.CertificateServiceImpl;
+import com.otilm.core.util.BaseSpringBootTest;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * The certificate listing is the other two-phase fetch: a page of uuids in the requested order, then the DTOs by
+ * {@code uuid IN (...)}. The second query used to carry {@code ORDER BY c.created DESC}, which replaced the ordering
+ * the first had established, so these cases are what catches a sort that is accepted and then discarded.
+ */
+class CertificateListingSortITest extends BaseSpringBootTest {
+
+    private static final List<String> SEEDED_NAMES = List.of("alpha", "bravo", "charlie", "delta");
+
+    @Autowired
+    private CertificateServiceImpl certificateService;
+
+    @Autowired
+    private CertificateRepository certificateRepository;
+
+    @Autowired
+    private CertificateContentRepository certificateContentRepository;
+
+    @BeforeEach
+    void loadData() {
+        // Seeded so that the alphabetical order the sort asks for is not the created-descending order the listing
+        // applies by default. An assertion that only checked the returned set, or a sort that never reached the query,
+        // would pass against the default order.
+        seedCertificate("delta", CertificateState.ISSUED);
+        seedCertificate("alpha", CertificateState.ISSUED);
+        seedCertificate("charlie", CertificateState.REVOKED);
+        seedCertificate("bravo", CertificateState.ISSUED);
+    }
+
+    private void seedCertificate(String commonName, CertificateState state) {
+        CertificateContent content = new CertificateContent();
+        content.setContent("1234567890-" + UUID.randomUUID());
+        content = certificateContentRepository.save(content);
+
+        Certificate certificate = new Certificate();
+        certificate.setCommonName(commonName);
+        certificate.setSubjectDn("CN=" + commonName);
+        certificate.setIssuerDn("CN=" + commonName + "Issuer");
+        certificate.setSerialNumber(UUID.randomUUID().toString().replace("-", ""));
+        certificate.setState(state);
+        certificate.setValidationStatus(CertificateValidationStatus.VALID);
+        certificate.setCertificateContentId(content.getId());
+        certificateRepository.save(certificate);
+    }
+
+    private List<String> listCommonNames(SearchSortRequestDto sort, List<SearchFilterRequestDto> filters,
+            int pageNumber, int itemsPerPage) {
+        CertificateSearchRequestDto request = new CertificateSearchRequestDto();
+        request.setPageNumber(pageNumber);
+        request.setItemsPerPage(itemsPerPage);
+        request.setSort(sort);
+        if (filters != null) {
+            request.setFilters(filters);
+        }
+
+        return certificateService
+                .listCertificates(SecurityFilter.create(), request)
+                .getCertificates()
+                .stream()
+                .map(CertificateDto::getCommonName)
+                .toList();
+    }
+
+    private static SearchSortRequestDto sortByCommonName(SortDirection direction) {
+        return new SearchSortRequestDto(FilterFieldSource.PROPERTY, "COMMON_NAME", direction);
+    }
+
+    @Test
+    void ordersTheListingByTheRequestedFieldAscending() {
+        Assertions.assertEquals(SEEDED_NAMES, listCommonNames(sortByCommonName(SortDirection.ASC), null, 1, 10));
+    }
+
+    @Test
+    void ordersTheListingByTheRequestedFieldDescending() {
+        Assertions
+                .assertEquals(SEEDED_NAMES.reversed(),
+                        listCommonNames(sortByCommonName(SortDirection.DESC), null, 1, 10));
+    }
+
+    @Test
+    void pagingWalksTheSortedSet() {
+        List<String> paged = new ArrayList<>();
+        paged.addAll(listCommonNames(sortByCommonName(SortDirection.ASC), null, 1, 2));
+        paged.addAll(listCommonNames(sortByCommonName(SortDirection.ASC), null, 2, 2));
+
+        Assertions.assertEquals(SEEDED_NAMES, paged);
+    }
+
+    /**
+     * The listing's own default is created descending, and it has to survive untouched for a request that names no
+     * sort. The expectation is read back from the seeded rows rather than written out, because four rows saved in one
+     * test can share a created timestamp, and then the uuid tie-break rather than the seeding order decides.
+     */
+    @Test
+    void aRequestWithoutASortKeepsTheListingDefaultOrder() {
+        List<String> byDefaultOrder = certificateRepository
+                .findAll()
+                .stream()
+                .filter(certificate -> SEEDED_NAMES.contains(certificate.getCommonName()))
+                .sorted(Comparator.comparing(Certificate::getCreated).reversed().thenComparing(Certificate::getUuid))
+                .map(Certificate::getCommonName)
+                .toList();
+
+        Assertions.assertEquals(byDefaultOrder, listCommonNames(null, null, 1, 10));
+    }
+
+    /**
+     * A sorted listing must still return only the rows the filter admits - the ordering is applied to the filtered set,
+     * not to the table.
+     */
+    @Test
+    void sortingComposesWithAFilter() {
+        List<SearchFilterRequestDto> issuedOnly = List
+                .of(new SearchFilterRequestDto(FilterFieldSource.PROPERTY, "CERTIFICATE_STATE",
+                        FilterConditionOperator.EQUALS, (Serializable) List.of(CertificateState.ISSUED.getCode())));
+
+        Assertions
+                .assertEquals(List.of("alpha", "bravo", "delta"),
+                        listCommonNames(sortByCommonName(SortDirection.ASC), issuedOnly, 1, 10));
+    }
+}

--- a/src/test/java/com/otilm/core/integration/search/CertificateListingSortITest.java
+++ b/src/test/java/com/otilm/core/integration/search/CertificateListingSortITest.java
@@ -28,8 +28,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * The certificate listing is the other two-phase fetch: a page of uuids in the requested order, then the DTOs by
- * {@code uuid IN (...)}. The second query used to carry {@code ORDER BY c.created DESC}, which replaced the ordering
- * the first had established, so these cases are what catches a sort that is accepted and then discarded.
+ * {@code uuid IN (...)}. An ordering carried by the second query would replace the one the first established, so these
+ * cases are what catches a sort that is accepted and then discarded.
  */
 class CertificateListingSortITest extends BaseSpringBootTest {
 

--- a/src/test/java/com/otilm/core/integration/search/ColumnCatalogueFlagsITest.java
+++ b/src/test/java/com/otilm/core/integration/search/ColumnCatalogueFlagsITest.java
@@ -141,13 +141,30 @@ class ColumnCatalogueFlagsITest extends BaseSpringBootTest {
         Assertions.assertFalse(SearchHelper.isOrderableField(filterField));
     }
 
+    /**
+     * Discovery applies a requested sort, so a displayable attribute of its catalogue advertises ordering too.
+     */
     @Test
-    void anAttributeFieldIsDisplayableButNeverSortable() throws Exception {
+    void aDisplayableAttributeFieldOfAWiredListingIsSortable() throws Exception {
         registerCustomAttribute("catalogue-flag-probe", AttributeContentType.TEXT);
 
         SearchFieldDataDto attribute = field(discoveryService.getSearchableFieldInformationByGroup(),
                 "catalogue-flag-probe|" + AttributeContentType.TEXT.name()).orElseThrow();
         Assertions.assertEquals(true, attribute.getDisplayable());
+        Assertions.assertEquals(true, attribute.getSortable());
+    }
+
+    /**
+     * A column the catalogue withholds cannot be ordered on either - there is nothing to order by when the value is
+     * never rendered. Secret content is the clearest case.
+     */
+    @Test
+    void anAttributeFieldWithheldAsAColumnIsNotSortable() throws Exception {
+        registerCustomAttribute("catalogue-secret-probe", AttributeContentType.SECRET);
+
+        SearchFieldDataDto attribute = field(discoveryService.getSearchableFieldInformationByGroup(),
+                "catalogue-secret-probe|" + AttributeContentType.SECRET.name()).orElseThrow();
+        Assertions.assertEquals(false, attribute.getDisplayable());
         Assertions.assertEquals(false, attribute.getSortable());
     }
 

--- a/src/test/java/com/otilm/core/integration/search/ColumnCatalogueFlagsITest.java
+++ b/src/test/java/com/otilm/core/integration/search/ColumnCatalogueFlagsITest.java
@@ -1,5 +1,8 @@
 package com.otilm.core.integration.search;
 
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.client.certificate.SearchRequestDto;
+import com.otilm.api.model.client.certificate.SearchSortRequestDto;
 import com.otilm.api.model.common.attribute.common.AttributeType;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.common.properties.CustomAttributeProperties;
@@ -8,8 +11,10 @@ import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
 import com.otilm.api.model.core.search.SearchFieldDataDto;
+import com.otilm.api.model.core.search.SortDirection;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.enums.FilterField;
+import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.CbomExternalService;
 import com.otilm.core.service.DiscoveryExternalService;
 import com.otilm.core.service.SigningRecordExternalService;
@@ -131,6 +136,16 @@ class ColumnCatalogueFlagsITest extends BaseSpringBootTest {
         Assertions.assertFalse(SearchHelper.isOrderableField(FilterField.TIME_QUALITY_CONFIGURATION_NTP_SERVERS));
     }
 
+    /**
+     * A usage field persists a set of flags as one integer and renders the decoded set, so ordering the page by the
+     * column would order it by a number that bears no relation to the list in the cell.
+     */
+    @ParameterizedTest
+    @EnumSource(value = FilterField.class, names = {"KEY_USAGE", "CKI_USAGE", "CERT_REQUEST_KEY_USAGE"})
+    void aBitmaskBackedPropertyFieldWouldNotBeOrderable(FilterField filterField) {
+        Assertions.assertFalse(SearchHelper.isOrderableField(filterField));
+    }
+
     @ParameterizedTest
     @EnumSource(value = FilterField.class,
             names = {"OCSP_VALIDATION", "CRL_VALIDATION", "SIGNATURE_VALIDATION", "PRIVATE_KEY"})
@@ -166,6 +181,40 @@ class ColumnCatalogueFlagsITest extends BaseSpringBootTest {
                 "catalogue-secret-probe|" + AttributeContentType.SECRET.name()).orElseThrow();
         Assertions.assertEquals(false, attribute.getDisplayable());
         Assertions.assertEquals(false, attribute.getSortable());
+    }
+
+    /**
+     * A file cell renders the file's name and media type, and a resource cell the referenced object's name; a sort key
+     * reads the stored reference instead, so these stay displayable columns that cannot be ordered on.
+     */
+    @ParameterizedTest
+    @EnumSource(value = AttributeContentType.class, names = {"FILE", "RESOURCE"})
+    void anAttributeWhoseCellIsNotItsSortKeyIsDisplayableButNotSortable(AttributeContentType contentType)
+            throws Exception {
+        registerCustomAttribute("catalogue-composite-probe", contentType);
+
+        SearchFieldDataDto attribute = field(discoveryService.getSearchableFieldInformationByGroup(),
+                "catalogue-composite-probe|" + contentType.name()).orElseThrow();
+        Assertions.assertEquals(true, attribute.getDisplayable());
+        Assertions.assertEquals(false, attribute.getSortable());
+    }
+
+    /**
+     * The flag is a hint on a response the caller is free to ignore, so a listing that would discard the ordering
+     * refuses the request rather than answering it with the default order and no explanation.
+     */
+    @Test
+    void anUnwiredListingRefusesASortRatherThanDiscardingIt() {
+        SearchRequestDto request = new SearchRequestDto();
+        request.setPageNumber(1);
+        request.setItemsPerPage(10);
+        request
+                .setSort(new SearchSortRequestDto(FilterFieldSource.PROPERTY,
+                        FilterField.TIME_QUALITY_CONFIGURATION_NAME.name(), SortDirection.ASC));
+
+        Assertions
+                .assertThrows(ValidationException.class, () -> timeQualityConfigurationService
+                        .listTimeQualityConfigurations(request, SecurityFilter.create()));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/search/ColumnCatalogueFlagsITest.java
+++ b/src/test/java/com/otilm/core/integration/search/ColumnCatalogueFlagsITest.java
@@ -58,6 +58,15 @@ class ColumnCatalogueFlagsITest extends BaseSpringBootTest {
         return catalogue.stream().flatMap(group -> group.getSearchFieldData().stream()).toList();
     }
 
+    /** The property group only, since the source is carried by the group rather than by each field. */
+    private static List<SearchFieldDataDto> propertyFields(List<SearchFieldDataByGroupDto> catalogue) {
+        return catalogue
+                .stream()
+                .filter(group -> group.getFilterFieldSource() == FilterFieldSource.PROPERTY)
+                .flatMap(group -> group.getSearchFieldData().stream())
+                .toList();
+    }
+
     @Test
     void everyPublishedFieldAnswersBothFlags() {
         // A flag left null reaches the picker as "unknown", and an absent flag is read as a no - so a field that
@@ -76,13 +85,29 @@ class ColumnCatalogueFlagsITest extends BaseSpringBootTest {
         Assertions.assertEquals(true, kind.getDisplayable());
     }
 
+    /**
+     * Discovery is one of the listings that applies a requested sort, so its orderable property fields advertise it.
+     * The catalogue promising an ordering the listing then discards is the failure this guards, in both directions: a
+     * wired listing must say so, and {@code CryptographicAssetSearchableFieldsITest.noFieldReportsSortable} holds the
+     * other side, where an unwired listing reports nothing sortable.
+     */
     @Test
-    void noPropertyFieldIsSortableWhileNoListingOrdersByTheRequestedSort() {
-        // The catalogue must not advertise an ordering that does not happen: a secured search can be ordered, but no
-        // listing service passes the sort a request carries to the repository, so a client sorting on a field the
-        // catalogue called sortable would get the default order back with no indication why.
-        for (SearchFieldDataDto item : allFields(discoveryService.getSearchableFieldInformationByGroup())) {
-            Assertions.assertEquals(false, item.getSortable(), item.getFieldIdentifier());
+    void aPropertyFieldOfAWiredListingIsSortable() {
+        SearchFieldDataDto name = field(discoveryService.getSearchableFieldInformationByGroup(),
+                FilterField.DISCOVERY_NAME.name()).orElseThrow();
+
+        Assertions.assertEquals(true, name.getSortable());
+    }
+
+    /**
+     * A field whose path cannot be ordered by stays non-sortable on a wired listing: the resource being wired is not on
+     * its own enough.
+     */
+    @Test
+    void aNonOrderablePropertyFieldOfAWiredListingIsNotSortable() {
+        for (SearchFieldDataDto item : propertyFields(discoveryService.getSearchableFieldInformationByGroup())) {
+            boolean orderable = SearchHelper.isOrderableField(FilterField.valueOf(item.getFieldIdentifier()));
+            Assertions.assertEquals(orderable, item.getSortable(), item.getFieldIdentifier());
         }
     }
 

--- a/src/test/java/com/otilm/core/integration/search/KeyListingSortITest.java
+++ b/src/test/java/com/otilm/core/integration/search/KeyListingSortITest.java
@@ -1,0 +1,168 @@
+package com.otilm.core.integration.search;
+
+import com.otilm.api.model.client.certificate.SearchRequestDto;
+import com.otilm.api.model.client.certificate.SearchSortRequestDto;
+import com.otilm.api.model.client.connector.v2.ConnectorVersion;
+import com.otilm.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.otilm.api.model.connector.cryptography.enums.TokenInstanceStatus;
+import com.otilm.api.model.core.connector.ConnectorStatus;
+import com.otilm.api.model.core.cryptography.key.KeyItemDto;
+import com.otilm.api.model.core.search.FilterFieldSource;
+import com.otilm.api.model.core.search.SortDirection;
+import com.otilm.core.dao.entity.Connector;
+import com.otilm.core.dao.entity.CryptographicKey;
+import com.otilm.core.dao.entity.CryptographicKeyItem;
+import com.otilm.core.dao.entity.TokenInstanceReference;
+import com.otilm.core.dao.entity.TokenProfile;
+import com.otilm.core.dao.repository.ConnectorRepository;
+import com.otilm.core.dao.repository.CryptographicKeyItemRepository;
+import com.otilm.core.dao.repository.TokenInstanceReferenceRepository;
+import com.otilm.core.dao.repository.TokenProfileRepository;
+import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.service.CryptographicKeyExternalService;
+import com.otilm.core.util.BaseSpringBootTest;
+import com.otilm.core.util.seeders.CryptographicKeySeeder;
+import com.otilm.core.util.seeders.CryptographicKeySeeder.KeyItemSpec;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * The key listing fetches in two phases - a page of uuids in the requested order, then the items by {@code uuid IN
+ * (...)}. The second query used to name its own ordering, which replaced the first's, so these cases are what catches a
+ * sort that is accepted and then thrown away.
+ */
+class KeyListingSortITest extends BaseSpringBootTest {
+
+    private static final List<String> SEEDED_NAMES = List.of("alpha", "bravo", "charlie", "delta");
+
+    @Autowired
+    private CryptographicKeyExternalService cryptographicKeyService;
+
+    @Autowired
+    private CryptographicKeySeeder keySeeder;
+
+    @Autowired
+    private ConnectorRepository connectorRepository;
+
+    @Autowired
+    private TokenInstanceReferenceRepository tokenInstanceReferenceRepository;
+
+    @Autowired
+    private TokenProfileRepository tokenProfileRepository;
+
+    @Autowired
+    private CryptographicKeyItemRepository cryptographicKeyItemRepository;
+
+    @BeforeEach
+    void loadData() {
+        Connector connector = new Connector();
+        connector.setName("key-sort-connector");
+        connector.setUrl("http://localhost:0/key-sort");
+        connector.setVersion(ConnectorVersion.V2);
+        connector.setStatus(ConnectorStatus.CONNECTED);
+        connector = connectorRepository.saveAndFlush(connector);
+
+        TokenInstanceReference tokenInstanceReference = new TokenInstanceReference();
+        tokenInstanceReference.setName("key-sort-token");
+        tokenInstanceReference.setTokenInstanceUuid("1l");
+        tokenInstanceReference.setConnector(connector);
+        tokenInstanceReference.setStatus(TokenInstanceStatus.CONNECTED);
+        tokenInstanceReferenceRepository.saveAndFlush(tokenInstanceReference);
+
+        TokenProfile tokenProfile = new TokenProfile();
+        tokenProfile.setName("key-sort-profile");
+        tokenProfile.setTokenInstanceReference(tokenInstanceReference);
+        tokenProfile.setTokenInstanceName("key-sort-token");
+        tokenProfile.setEnabled(true);
+        tokenProfileRepository.saveAndFlush(tokenProfile);
+
+        // Seeded newest-last, and each key carries one item, so the listing's default createdAt DESC order is the
+        // reverse of the alphabetical one the sort asks for. A sort that never reached the query would return the
+        // default order and pass an assertion that only checked the set of names.
+        seedNamedItem("delta", tokenProfile, tokenInstanceReference);
+        seedNamedItem("alpha", tokenProfile, tokenInstanceReference);
+        seedNamedItem("charlie", tokenProfile, tokenInstanceReference);
+        seedNamedItem("bravo", tokenProfile, tokenInstanceReference);
+    }
+
+    private void seedNamedItem(String name, TokenProfile tokenProfile, TokenInstanceReference tokenInstanceReference) {
+        CryptographicKey key = keySeeder
+                .seedKey(name, tokenProfile, tokenInstanceReference, KeyItemSpec.signingPrivateKey(KeyAlgorithm.RSA));
+        CryptographicKeyItem item = key.getItems().iterator().next();
+        item.setName(name);
+        cryptographicKeyItemRepository.saveAndFlush(item);
+    }
+
+    private List<String> listNames(SearchSortRequestDto sort, int pageNumber, int itemsPerPage) {
+        SearchRequestDto request = new SearchRequestDto();
+        request.setPageNumber(pageNumber);
+        request.setItemsPerPage(itemsPerPage);
+        request.setSort(sort);
+
+        return cryptographicKeyService
+                .listCryptographicKeys(SecurityFilter.create(), request)
+                .getCryptographicKeys()
+                .stream()
+                .map(KeyItemDto::getName)
+                .toList();
+    }
+
+    private static SearchSortRequestDto sortByName(SortDirection direction) {
+        return new SearchSortRequestDto(FilterFieldSource.PROPERTY, "CKI_NAME", direction);
+    }
+
+    @Test
+    void ordersTheListingByTheRequestedFieldAscending() {
+        Assertions.assertEquals(SEEDED_NAMES, listNames(sortByName(SortDirection.ASC), 1, 10));
+    }
+
+    @Test
+    void ordersTheListingByTheRequestedFieldDescending() {
+        Assertions.assertEquals(SEEDED_NAMES.reversed(), listNames(sortByName(SortDirection.DESC), 1, 10));
+    }
+
+    /**
+     * The ordering has to span the result set rather than each page, so the second page continues where the first ended
+     * instead of sorting its own rows.
+     */
+    @Test
+    void pagingWalksTheSortedSet() {
+        List<String> paged = new ArrayList<>();
+        paged.addAll(listNames(sortByName(SortDirection.ASC), 1, 2));
+        paged.addAll(listNames(sortByName(SortDirection.ASC), 2, 2));
+
+        Assertions.assertEquals(SEEDED_NAMES, paged);
+    }
+
+    /**
+     * The listing's own default is createdAt DESC, and it has to survive untouched for a request that names no sort.
+     * The expectation is read back from the seeded rows rather than written out, because four rows saved in one test
+     * can share a createdAt, and then the uuid tie-break rather than the seeding order decides.
+     */
+    @Test
+    void aRequestWithoutASortKeepsTheListingDefaultOrder() {
+        List<String> byDefaultOrder = seededItems()
+                .stream()
+                .sorted(Comparator
+                        .comparing(CryptographicKeyItem::getCreatedAt)
+                        .reversed()
+                        .thenComparing(CryptographicKeyItem::getUuid))
+                .map(CryptographicKeyItem::getName)
+                .toList();
+
+        Assertions.assertEquals(byDefaultOrder, listNames(null, 1, 10));
+    }
+
+    private List<CryptographicKeyItem> seededItems() {
+        return cryptographicKeyItemRepository
+                .findAll()
+                .stream()
+                .filter(item -> SEEDED_NAMES.contains(item.getName()))
+                .toList();
+    }
+}

--- a/src/test/java/com/otilm/core/integration/search/KeyListingSortITest.java
+++ b/src/test/java/com/otilm/core/integration/search/KeyListingSortITest.java
@@ -5,15 +5,21 @@ import com.otilm.api.model.client.certificate.SearchSortRequestDto;
 import com.otilm.api.model.client.connector.v2.ConnectorVersion;
 import com.otilm.api.model.common.enums.cryptography.KeyAlgorithm;
 import com.otilm.api.model.connector.cryptography.enums.TokenInstanceStatus;
+import com.otilm.api.model.core.certificate.CertificateState;
+import com.otilm.api.model.core.certificate.CertificateValidationStatus;
 import com.otilm.api.model.core.connector.ConnectorStatus;
 import com.otilm.api.model.core.cryptography.key.KeyItemDto;
 import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.api.model.core.search.SortDirection;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.CertificateContent;
 import com.otilm.core.dao.entity.Connector;
 import com.otilm.core.dao.entity.CryptographicKey;
 import com.otilm.core.dao.entity.CryptographicKeyItem;
 import com.otilm.core.dao.entity.TokenInstanceReference;
 import com.otilm.core.dao.entity.TokenProfile;
+import com.otilm.core.dao.repository.CertificateContentRepository;
+import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.dao.repository.ConnectorRepository;
 import com.otilm.core.dao.repository.CryptographicKeyItemRepository;
 import com.otilm.core.dao.repository.TokenInstanceReferenceRepository;
@@ -25,7 +31,10 @@ import com.otilm.core.util.seeders.CryptographicKeySeeder;
 import com.otilm.core.util.seeders.CryptographicKeySeeder.KeyItemSpec;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,8 +42,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * The key listing fetches in two phases - a page of uuids in the requested order, then the items by {@code uuid IN
- * (...)}. The second query used to name its own ordering, which replaced the first's, so these cases are what catches a
- * sort that is accepted and then thrown away.
+ * (...)}. An ordering named by the second query would replace the one the first established, so these cases are what
+ * catches a sort that is accepted and then thrown away.
  */
 class KeyListingSortITest extends BaseSpringBootTest {
 
@@ -57,6 +66,14 @@ class KeyListingSortITest extends BaseSpringBootTest {
 
     @Autowired
     private CryptographicKeyItemRepository cryptographicKeyItemRepository;
+
+    @Autowired
+    private CertificateRepository certificateRepository;
+
+    @Autowired
+    private CertificateContentRepository certificateContentRepository;
+
+    private final Map<String, UUID> seededKeyUuids = new LinkedHashMap<>();
 
     @BeforeEach
     void loadData() {
@@ -96,6 +113,38 @@ class KeyListingSortITest extends BaseSpringBootTest {
         CryptographicKeyItem item = key.getItems().iterator().next();
         item.setName(name);
         cryptographicKeyItemRepository.saveAndFlush(item);
+        seededKeyUuids.put(name, key.getUuid());
+    }
+
+    private void seedCertificateUsing(UUID keyUuid, String commonName) {
+        CertificateContent content = new CertificateContent();
+        content.setContent("1234567890-" + UUID.randomUUID());
+        content = certificateContentRepository.saveAndFlush(content);
+
+        Certificate certificate = new Certificate();
+        certificate.setCommonName(commonName);
+        certificate.setSubjectDn("CN=" + commonName);
+        certificate.setIssuerDn("CN=" + commonName + "Issuer");
+        certificate.setSerialNumber(UUID.randomUUID().toString());
+        certificate.setState(CertificateState.ISSUED);
+        certificate.setValidationStatus(CertificateValidationStatus.VALID);
+        certificate.setCertificateContentId(content.getId());
+        certificate.setKeyUuid(keyUuid);
+        certificateRepository.saveAndFlush(certificate);
+    }
+
+    private List<Integer> listAssociations(SearchSortRequestDto sort) {
+        SearchRequestDto request = new SearchRequestDto();
+        request.setPageNumber(1);
+        request.setItemsPerPage(10);
+        request.setSort(sort);
+
+        return cryptographicKeyService
+                .listCryptographicKeys(SecurityFilter.create(), request)
+                .getCryptographicKeys()
+                .stream()
+                .map(KeyItemDto::getAssociations)
+                .toList();
     }
 
     private List<String> listNames(SearchSortRequestDto sort, int pageNumber, int itemsPerPage) {
@@ -164,5 +213,31 @@ class KeyListingSortITest extends BaseSpringBootTest {
                 .stream()
                 .filter(item -> SEEDED_NAMES.contains(item.getName()))
                 .toList();
+    }
+
+    /**
+     * The association counts are loaded by a second query and have to land on the key item each belongs to.
+     *
+     * <p>
+     * Two queries lined up by position agree only while both order the same way and neither has ties, and once the
+     * listing orders by a field the request names they do not line up at all - so the counts are keyed by uuid. Each
+     * seeded key carries a different number of certificates, and the sort reverses the order the counts are read in, so
+     * a count rendered against the wrong key shows up as a mismatch rather than as a coincidence.
+     */
+    @Test
+    void eachListedKeyCarriesItsOwnAssociationCount() {
+        seedCertificateUsing(seededKeyUuids.get("alpha"), "alpha-cert-one");
+        seedCertificateUsing(seededKeyUuids.get("alpha"), "alpha-cert-two");
+        seedCertificateUsing(seededKeyUuids.get("charlie"), "charlie-cert");
+
+        Assertions.assertEquals(SEEDED_NAMES, listNames(sortByName(SortDirection.ASC), 1, 10));
+        Assertions.assertEquals(List.of(2, 0, 1, 0), listAssociations(sortByName(SortDirection.ASC)));
+        Assertions.assertEquals(List.of(0, 1, 0, 2), listAssociations(sortByName(SortDirection.DESC)));
+    }
+
+    /** A key no certificate uses reports zero rather than being left unset. */
+    @Test
+    void aKeyWithoutCertificatesReportsNoAssociations() {
+        Assertions.assertEquals(List.of(0, 0, 0, 0), listAssociations(sortByName(SortDirection.ASC)));
     }
 }

--- a/src/test/java/com/otilm/core/integration/util/SearchHelperITest.java
+++ b/src/test/java/com/otilm/core/integration/util/SearchHelperITest.java
@@ -9,6 +9,7 @@ import com.otilm.api.model.common.attribute.v3.CustomAttributeV3;
 import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
 import com.otilm.api.model.common.attribute.v3.content.DateAttributeContentV3;
 import com.otilm.api.model.common.attribute.v3.content.StringAttributeContentV3;
+import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.search.FilterConditionOperator;
 import com.otilm.api.model.core.search.FilterFieldType;
 import com.otilm.api.model.core.search.SearchFieldDataDto;
@@ -34,7 +35,8 @@ class SearchHelperITest extends BaseSpringBootTest {
     @Test
     void testPrepareSearchForJSON() {
         SearchFieldObject attributeSearchInfo = new SearchFieldObject(AttributeContentType.TIME);
-        SearchFieldDataDto searchFieldDataDto = SearchHelper.prepareSearchForJSON(attributeSearchInfo, false);
+        SearchFieldDataDto searchFieldDataDto = SearchHelper
+                .prepareSearchForJSON(attributeSearchInfo, false, Resource.DISCOVERY);
         assertThat(searchFieldDataDto.getConditions()).isNotEmpty();
         assertThat(searchFieldDataDto.getConditions())
                 .as("Condition should not contain IN_NEXT operator")
@@ -44,7 +46,7 @@ class SearchHelperITest extends BaseSpringBootTest {
                 .doesNotContain(FilterConditionOperator.IN_PAST);
 
         attributeSearchInfo.setProtectionLevel(ProtectionLevel.ENCRYPTED);
-        searchFieldDataDto = SearchHelper.prepareSearchForJSON(attributeSearchInfo, false);
+        searchFieldDataDto = SearchHelper.prepareSearchForJSON(attributeSearchInfo, false, Resource.DISCOVERY);
         assertThat(searchFieldDataDto.getConditions())
                 .isEqualTo(List.of(FilterConditionOperator.EMPTY, FilterConditionOperator.NOT_EMPTY));
     }
@@ -110,7 +112,8 @@ class SearchHelperITest extends BaseSpringBootTest {
                 AttributeType.META);
         fromConnectorB.setLabel("Username");
 
-        List<SearchFieldDataDto> fields = SearchHelper.prepareSearchForJSON(List.of(fromConnectorA, fromConnectorB));
+        List<SearchFieldDataDto> fields = SearchHelper
+                .prepareSearchForJSON(List.of(fromConnectorA, fromConnectorB), Resource.DISCOVERY);
 
         assertThat(fields).hasSize(1);
         assertThat(fields.getFirst().getFieldIdentifier()).isEqualTo("username|STRING");
@@ -132,7 +135,7 @@ class SearchHelperITest extends BaseSpringBootTest {
         integerVariant.setLabel("Port");
 
         List<SearchFieldDataDto> fields = SearchHelper
-                .prepareSearchForJSON(List.of(stringVariantA, stringVariantB, integerVariant));
+                .prepareSearchForJSON(List.of(stringVariantA, stringVariantB, integerVariant), Resource.DISCOVERY);
 
         assertThat(fields)
                 .extracting(SearchFieldDataDto::getFieldIdentifier)
@@ -151,7 +154,8 @@ class SearchHelperITest extends BaseSpringBootTest {
         SearchFieldObject plain = new SearchFieldObject("username", AttributeContentType.STRING, AttributeType.META);
         plain.setLabel("Username");
 
-        List<SearchFieldDataDto> fields = SearchHelper.prepareSearchForJSON(List.of(encrypted, plain));
+        List<SearchFieldDataDto> fields = SearchHelper
+                .prepareSearchForJSON(List.of(encrypted, plain), Resource.DISCOVERY);
 
         assertThat(fields).hasSize(1);
         assertThat(fields.getFirst().getConditions())
@@ -169,7 +173,8 @@ class SearchHelperITest extends BaseSpringBootTest {
         encryptedB.setLabel("Username");
         encryptedB.setProtectionLevel(ProtectionLevel.ENCRYPTED);
 
-        List<SearchFieldDataDto> fields = SearchHelper.prepareSearchForJSON(List.of(encryptedA, encryptedB));
+        List<SearchFieldDataDto> fields = SearchHelper
+                .prepareSearchForJSON(List.of(encryptedA, encryptedB), Resource.DISCOVERY);
 
         assertThat(fields).hasSize(1);
         assertThat(fields.getFirst().getConditions())
@@ -187,7 +192,7 @@ class SearchHelperITest extends BaseSpringBootTest {
         listB.setList(true);
         listB.setContentItems(List.of("test", "prod"));
 
-        List<SearchFieldDataDto> fields = SearchHelper.prepareSearchForJSON(List.of(listA, listB));
+        List<SearchFieldDataDto> fields = SearchHelper.prepareSearchForJSON(List.of(listA, listB), Resource.DISCOVERY);
 
         assertThat(fields).hasSize(1);
         assertThat(fields.getFirst().getValue()).isEqualTo(List.of("dev", "test", "prod"));
@@ -205,7 +210,8 @@ class SearchHelperITest extends BaseSpringBootTest {
                 AttributeType.DATA);
         freeFormVariant.setLabel("Environment");
 
-        List<SearchFieldDataDto> fields = SearchHelper.prepareSearchForJSON(List.of(listVariant, freeFormVariant));
+        List<SearchFieldDataDto> fields = SearchHelper
+                .prepareSearchForJSON(List.of(listVariant, freeFormVariant), Resource.DISCOVERY);
 
         assertThat(fields).hasSize(1);
         assertThat(fields.getFirst().getType())
@@ -224,9 +230,10 @@ class SearchHelperITest extends BaseSpringBootTest {
                 AttributeType.META);
         labeledUsername.setLabel("Username");
 
-        List<SearchFieldDataDto> fields = SearchHelper.prepareSearchForJSON(List.of(labeledUsername, labeledUser));
+        List<SearchFieldDataDto> fields = SearchHelper
+                .prepareSearchForJSON(List.of(labeledUsername, labeledUser), Resource.DISCOVERY);
         List<SearchFieldDataDto> fieldsReversed = SearchHelper
-                .prepareSearchForJSON(List.of(labeledUser, labeledUsername));
+                .prepareSearchForJSON(List.of(labeledUser, labeledUsername), Resource.DISCOVERY);
 
         assertThat(fields).hasSize(1);
         assertThat(fields.getFirst().getFieldLabel())
@@ -238,10 +245,12 @@ class SearchHelperITest extends BaseSpringBootTest {
     void testPrepareSearchForJSONMergeIsDeterministicWhenDuplicatesShareTheLabel() {
         List<SearchFieldDataDto> fields = SearchHelper
                 .prepareSearchForJSON(
-                        List.of(listFieldObject(List.of("dev", "test")), listFieldObject(List.of("prod"))));
+                        List.of(listFieldObject(List.of("dev", "test")), listFieldObject(List.of("prod"))),
+                        Resource.DISCOVERY);
         List<SearchFieldDataDto> fieldsReversed = SearchHelper
                 .prepareSearchForJSON(
-                        List.of(listFieldObject(List.of("prod")), listFieldObject(List.of("dev", "test"))));
+                        List.of(listFieldObject(List.of("prod")), listFieldObject(List.of("dev", "test"))),
+                        Resource.DISCOVERY);
 
         assertThat(fields).hasSize(1);
         assertThat(fields.getFirst().getValue())

--- a/src/test/java/com/otilm/core/util/SearchHelperColumnFlagsTest.java
+++ b/src/test/java/com/otilm/core/util/SearchHelperColumnFlagsTest.java
@@ -3,6 +3,7 @@ package com.otilm.core.util;
 import com.otilm.api.model.common.attribute.common.AttributeType;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.common.content.data.ProtectionLevel;
+import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.search.SearchFieldDataDto;
 import com.otilm.core.model.SearchFieldObject;
 import java.util.Arrays;
@@ -21,6 +22,9 @@ import org.junit.jupiter.params.provider.EnumSource;
  */
 class SearchHelperColumnFlagsTest {
 
+    /** A resource whose listing applies a requested sort, so the sortable flag is not switched off by the resource. */
+    private static final Resource RESOURCE = Resource.DISCOVERY;
+
     private static SearchFieldObject attributeField(AttributeContentType contentType, ProtectionLevel protectionLevel) {
         SearchFieldObject field = new SearchFieldObject("cost-centre", contentType, AttributeType.CUSTOM);
         field.setLabel("Cost centre");
@@ -30,7 +34,7 @@ class SearchHelperColumnFlagsTest {
     }
 
     private static SearchFieldDataDto prepare(AttributeContentType contentType, ProtectionLevel protectionLevel) {
-        return SearchHelper.prepareSearchForJSON(attributeField(contentType, protectionLevel), false);
+        return SearchHelper.prepareSearchForJSON(attributeField(contentType, protectionLevel), false, RESOURCE);
     }
 
     @Test
@@ -55,10 +59,41 @@ class SearchHelperColumnFlagsTest {
         Assertions.assertEquals(false, prepare(AttributeContentType.CODEBLOCK, ProtectionLevel.NONE).getDisplayable());
     }
 
+    @Test
+    void anOrdinaryAttributeOfAWiredListingIsSortable() {
+        Assertions.assertEquals(true, prepare(AttributeContentType.TEXT, ProtectionLevel.NONE).getSortable());
+    }
+
+    @Test
+    void noAttributeOfAnUnwiredListingIsSortable() {
+        // Locations do not pass a requested sort to the repository, so ordering there would be advertised and then
+        // discarded.
+        Assertions
+                .assertEquals(false,
+                        SearchHelper
+                                .prepareSearchForJSON(attributeField(AttributeContentType.TEXT, ProtectionLevel.NONE),
+                                        false, Resource.LOCATION)
+                                .getSortable());
+    }
+
     @ParameterizedTest
-    @EnumSource(AttributeContentType.class)
-    void noAttributeFieldIsSortableUntilAttributeSortingLands(AttributeContentType contentType) {
+    @EnumSource(value = AttributeContentType.class, names = {"SECRET", "CODEBLOCK", "FILE", "RESOURCE"})
+    void anAttributeWhoseCellIsNotItsSortKeyIsNotSortable(AttributeContentType contentType) {
+        // Secret and code-block content is never rendered at all. A file cell reads its name and media type and a
+        // resource cell the referenced object's name, none of which is the reference a sort key would order by.
         Assertions.assertEquals(false, prepare(contentType, ProtectionLevel.NONE).getSortable());
+    }
+
+    @Test
+    void encryptedContentIsNeverSortable() {
+        Assertions.assertEquals(false, prepare(AttributeContentType.TEXT, ProtectionLevel.ENCRYPTED).getSortable());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = AttributeContentType.class, names = {"CREDENTIAL", "OBJECT"})
+    void anAttributeWhoseCellIsItsReferenceIsSortable(AttributeContentType contentType) {
+        // The projector reduces both to their reference and nothing else, which is exactly what the sort key reads.
+        Assertions.assertEquals(true, prepare(contentType, ProtectionLevel.NONE).getSortable());
     }
 
     @ParameterizedTest

--- a/src/test/java/com/otilm/core/util/SortOrderBuilderTest.java
+++ b/src/test/java/com/otilm/core/util/SortOrderBuilderTest.java
@@ -5,6 +5,8 @@ import com.otilm.api.model.client.certificate.SearchSortRequestDto;
 import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.api.model.core.search.SortDirection;
 import com.otilm.core.dao.repository.SortSpecification;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +28,33 @@ class SortOrderBuilderTest {
         ValidationException e = Assertions
                 .assertThrows(ValidationException.class, () -> SortOrderBuilder.traversesJoin(sort));
         Assertions.assertTrue(e.getMessage().contains(FilterFieldSource.META.getLabel()));
+    }
+
+    @Test
+    void rankingPutsRowsBackIntoTheOrderOfTheUuidPage() {
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+        UUID third = UUID.randomUUID();
+
+        List<UUID> ranked = SortOrderBuilder
+                .rankBy(List.of(third, first, second), List.of(first, second, third), row -> row);
+
+        Assertions.assertEquals(List.of(third, first, second), ranked);
+    }
+
+    @Test
+    void rankingSortsARowMissingFromThePageLast() {
+        UUID ranked = UUID.randomUUID();
+        UUID unranked = UUID.randomUUID();
+
+        Assertions
+                .assertEquals(List.of(ranked, unranked),
+                        SortOrderBuilder.rankBy(List.of(ranked), List.of(unranked, ranked), row -> row));
+    }
+
+    @Test
+    void rankingAnEmptyPageYieldsNothing() {
+        Assertions.assertTrue(SortOrderBuilder.rankBy(List.of(), List.of(), row -> (UUID) row).isEmpty());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/util/SortOrderBuilderTest.java
+++ b/src/test/java/com/otilm/core/util/SortOrderBuilderTest.java
@@ -1,6 +1,5 @@
 package com.otilm.core.util;
 
-import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.certificate.SearchSortRequestDto;
 import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.api.model.core.search.SortDirection;
@@ -17,17 +16,19 @@ import org.junit.jupiter.api.Test;
 class SortOrderBuilderTest {
 
     @Test
-    void noSortTraversesNoJoin() {
-        Assertions.assertFalse(SortOrderBuilder.traversesJoin(null));
+    void noSortNeedsNoRankedUuidQuery() {
+        Assertions.assertFalse(SortOrderBuilder.needsRankedUuidQuery(null));
     }
 
+    /**
+     * An attribute sort resolves to a scalar subquery, and the entity query selects DISTINCT, which cannot be ordered
+     * by an expression absent from its select list. It therefore goes through the query that carries the sort key.
+     */
     @Test
-    void attributeSourcedFieldIsRejected() {
-        SortSpecification sort = new SortSpecification(FilterFieldSource.META, "anything", SortDirection.ASC);
+    void attributeSourcedFieldNeedsTheRankedUuidQuery() {
+        SortSpecification sort = new SortSpecification(FilterFieldSource.META, "anything|TEXT", SortDirection.ASC);
 
-        ValidationException e = Assertions
-                .assertThrows(ValidationException.class, () -> SortOrderBuilder.traversesJoin(sort));
-        Assertions.assertTrue(e.getMessage().contains(FilterFieldSource.META.getLabel()));
+        Assertions.assertTrue(SortOrderBuilder.needsRankedUuidQuery(sort));
     }
 
     @Test


### PR DESCRIPTION
The ORDER BY engine landed with #2030 but nothing called it. This applies it to the seven listings that ship configurable columns: certificates, cryptographic keys, discoveries, connectors (`POST /v2/connectors/list`), secrets, CBOMs and signing records. A request that names no sort keeps each endpoint's existing default ordering.

## The two-phase listings were discarding the sort

Certificates and cryptographic keys fetch in two phases: a page of uuids in the requested order, then the objects by `uuid IN (...)`. Both second-phase queries carried their own ordering — `ORDER BY c.created DESC` on `findCertificateDtosByUuidsIn`, and the `OrderByCreatedAtDesc` baked into `findFullByUuidInOrderByCreatedAtDesc`. Ordering only the first phase is therefore replaced by the second, so a sort would be accepted and then silently thrown away.

Both orderings are removed and the rows are ranked back into the uuid list's order with a new `SortOrderBuilder.rankBy`, which is where the ordering now lives. Ranking is applied whether or not a sort was named: the ranked list is the one carrying the uuid tie-break, so it is also what makes a default-ordered page stable across a page boundary when the default term ties.

## A latent mismatch in the key listing

`getCountsOfAssociations` returned bare counts that the key listing lined up with its key items **by position**. That held only while both queries ordered by the same non-unique column and it had no ties; under a requested sort they do not line up at all, and a count would be rendered against the wrong key. It now returns the uuid alongside the count, through a Spring Data interface projection, and the caller joins on it.

This is a pre-existing defect rather than one this change introduces, but request-driven ordering is what turns it from unlikely into certain.

## Refusing a sort the catalogue withholds

A sort naming a field the catalogue reports as not sortable is refused against `SearchHelper.isOrderableField` — the same predicate that populates the published `sortable` flag — rather than answered with a silently unordered page. `PRIVATE_KEY` is the illustrative case: it resolves to a path and would order fine, but what the column displays is a comparison against an expected value, not the value that path holds.

## Tests

- `SortOrderBuilderTest` gains the ranking cases, which hold without a persistence context.
- The orderability refusal needs a resolved `FilterField`, so it sits in `SecurityFilterRepositoryITest` beside the unknown-field and wrong-resource cases already there.
- `KeyListingSortITest` exercises the key listing end to end, since that is where the ordering was being discarded rather than where it is built. The keys are seeded so the alphabetical order the sort asks for is the reverse of the listing's own default: an assertion that only checked the returned set, or a sort that never reached the query, would pass against the default order. **All four cases fail when the ranking is removed** — I checked rather than assumed.
- The default-order case reads its expectation back from the seeded rows instead of writing it out, because four rows saved in one test can share a `createdAt` and then the uuid tie-break decides rather than the seeding order.

Full suite green at 6377 tests before the rebase onto the merged #2162.

`CertificateListingSortITest` does the same for the certificate listing, the other two-phase fetch and the one whose second query carried the `ORDER BY c.created DESC`. All five of its cases fail when the ranking is removed. It also carries the AC5 case: a sorted listing still returns only the rows the filter admits, ordered within that set rather than across the table.

## Still owed on this ticket

Not claiming every acceptance criterion is met yet. Outstanding:

- End-to-end sort coverage for the five single-phase listings — ACs 1 and 3 ask for each of the seven, and discoveries, connectors, secrets, CBOMs and signing records are covered only at the repository level by `SecurityFilterRepositoryITest`, not through their own service. They all take the same one-argument path, so the risk is wiring rather than behaviour.
- AC5's second half: composition with row-level authorization, as distinct from the filter case now covered.
- Sonar and the coverage gate.

Closes #2031

