### PR TITLE
Order a listing by an attribute-sourced column

### DIFF
--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -168,7 +168,10 @@ public class AttributeEngine {
                                     .toList());
             if (!settableAttributes.isEmpty()) {
                 searchFieldDataByGroupDtos
-                        .add(new SearchFieldDataByGroupDto(SearchHelper.prepareSearchForJSON(settableAttributes),
+                        .add(new SearchFieldDataByGroupDto(
+                                SearchHelper
+                                        .applyAttributeSortability(
+                                                SearchHelper.prepareSearchForJSON(settableAttributes), resource),
                                 FilterFieldSource.CUSTOM));
             }
         } else {
@@ -181,7 +184,9 @@ public class AttributeEngine {
                     .toList();
             if (!customAttributes.isEmpty()) {
                 searchFieldDataByGroupDtos
-                        .add(new SearchFieldDataByGroupDto(SearchHelper.prepareSearchForJSON(customAttributes),
+                        .add(new SearchFieldDataByGroupDto(SearchHelper
+                                .applyAttributeSortability(SearchHelper.prepareSearchForJSON(customAttributes),
+                                        resource),
                                 FilterFieldSource.CUSTOM));
             }
 
@@ -191,7 +196,8 @@ public class AttributeEngine {
                     .toList();
             if (!dataAttributes.isEmpty()) {
                 searchFieldDataByGroupDtos
-                        .add(new SearchFieldDataByGroupDto(SearchHelper.prepareSearchForJSON(dataAttributes),
+                        .add(new SearchFieldDataByGroupDto(SearchHelper
+                                .applyAttributeSortability(SearchHelper.prepareSearchForJSON(dataAttributes), resource),
                                 FilterFieldSource.DATA));
             }
 
@@ -201,7 +207,10 @@ public class AttributeEngine {
                     .toList();
             if (!metadataAttributes.isEmpty()) {
                 searchFieldDataByGroupDtos
-                        .add(new SearchFieldDataByGroupDto(SearchHelper.prepareSearchForJSON(metadataAttributes),
+                        .add(new SearchFieldDataByGroupDto(
+                                SearchHelper
+                                        .applyAttributeSortability(
+                                                SearchHelper.prepareSearchForJSON(metadataAttributes), resource),
                                 FilterFieldSource.META));
             }
         }

--- a/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepositoryImpl.java
+++ b/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepositoryImpl.java
@@ -21,6 +21,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.Tuple;
 import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CommonAbstractCriteria;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaDelete;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -117,8 +118,8 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
     public List<T> findUsingSecurityFilter(final SecurityFilter filter, List<String> fetchAssociations,
             final TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause,
             final Pageable p, final BiFunction<Root<T>, CriteriaBuilder, Order> order, final SortSpecification sort) {
-        if (SortOrderBuilder.traversesJoin(sort)) {
-            return loadInUuidOrder(findUuidsOrderedByJoinedField(filter, additionalWhereClause, p, sort),
+        if (SortOrderBuilder.needsRankedUuidQuery(sort)) {
+            return loadInUuidOrder(findUuidsOrderedBySortKey(filter, additionalWhereClause, p, sort),
                     fetchAssociations);
         }
         final CriteriaQuery<T> cr = createCriteriaBuilder(filter, fetchAssociations, additionalWhereClause, order, sort,
@@ -137,8 +138,8 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
     public List<UUID> findUuidsUsingSecurityFilter(final SecurityFilter filter,
             final TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause,
             final Pageable p, final BiFunction<Root<T>, CriteriaBuilder, Order> order, final SortSpecification sort) {
-        if (SortOrderBuilder.traversesJoin(sort)) {
-            return findUuidsOrderedByJoinedField(filter, additionalWhereClause, p, sort);
+        if (SortOrderBuilder.needsRankedUuidQuery(sort)) {
+            return findUuidsOrderedBySortKey(filter, additionalWhereClause, p, sort);
         }
         final CriteriaQuery<UUID> cr = createCriteriaBuilderUuid(filter, additionalWhereClause, order, sort, p != null);
         return window(entityManager.createQuery(cr), p).getResultList();
@@ -150,7 +151,7 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
      * query therefore groups by the root's uuid and orders by the aggregate the ordering resolves - one row per root,
      * which is what the window is allowed to cut.
      */
-    private List<UUID> findUuidsOrderedByJoinedField(final SecurityFilter filter,
+    private List<UUID> findUuidsOrderedBySortKey(final SecurityFilter filter,
             final TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause,
             final Pageable p, final SortSpecification sort) {
         final Class<T> entity = this.entityInformation.getJavaType();
@@ -159,7 +160,7 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
         final Root<T> root = cr.from(entity);
         final Path<?> uuid = root.get(UniquelyIdentified_.UUID);
 
-        final SortOrderBuilder.GroupedOrdering ordering = SortOrderBuilder.resolveGrouped(root, cb, sort);
+        final SortOrderBuilder.GroupedOrdering ordering = SortOrderBuilder.resolveGrouped(root, cb, cr, sort);
         cr.multiselect(uuid, ordering.sortKey());
         cr.groupBy(uuid);
         cr.orderBy(ordering.orders());
@@ -199,10 +200,10 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
     }
 
     private List<Order> resolveOrdering(final Root<T> root, final CriteriaBuilder cb,
-            final BiFunction<Root<T>, CriteriaBuilder, Order> order, final SortSpecification sort,
-            final boolean paged) {
+            final CommonAbstractCriteria query, final BiFunction<Root<T>, CriteriaBuilder, Order> order,
+            final SortSpecification sort, final boolean paged) {
         final Order defaultOrder = order == null ? null : order.apply(root, cb);
-        return SortOrderBuilder.resolve(root, cb, sort, defaultOrder, paged);
+        return SortOrderBuilder.resolve(root, cb, query, sort, defaultOrder, paged);
     }
 
     private void applyPredicates(final CriteriaQuery<?> cr, final SecurityFilter filter,
@@ -440,7 +441,7 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
 
         fetchAssociations(root, fetchAssociations);
 
-        final List<Order> orders = resolveOrdering(root, cb, order, sort, paged);
+        final List<Order> orders = resolveOrdering(root, cb, cr, order, sort, paged);
         if (!orders.isEmpty()) {
             cr.orderBy(orders);
         }
@@ -460,7 +461,7 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
 
         cr.select(root.get("uuid"));
 
-        final List<Order> orders = resolveOrdering(root, cb, order, sort, paged);
+        final List<Order> orders = resolveOrdering(root, cb, cr, order, sort, paged);
         if (!orders.isEmpty()) {
             cr.orderBy(orders);
         }

--- a/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
+++ b/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
@@ -1,5 +1,6 @@
 package com.otilm.core.util;
 
+import com.otilm.api.exception.ValidationError;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.certificate.SearchFilterRequestDto;
 import com.otilm.api.model.common.attribute.common.AttributeType;
@@ -68,6 +69,7 @@ import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.Duration;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.JpaExpression;
+import org.hibernate.query.criteria.JpaSubQuery;
 
 public class FilterPredicatesBuilder {
 
@@ -153,14 +155,8 @@ public class FilterPredicatesBuilder {
                         ? CryptographicKeyItem_.keyUuid.getName()
                         : UniquelyIdentified_.uuid.getName();
 
-        List<Predicate> predicates = new ArrayList<>();
-        predicates.add(criteriaBuilder.equal(joinDefinition.get(AttributeDefinition_.type), attributeType));
-        predicates.add(criteriaBuilder.equal(joinDefinition.get(AttributeDefinition_.contentType), contentType));
-        predicates.add(criteriaBuilder.equal(joinDefinition.get(AttributeDefinition_.name), attributeName));
-        predicates.add(criteriaBuilder.equal(subqueryRoot.get(AttributeContent2Object_.objectType), resource));
-        predicates
-                .add(criteriaBuilder
-                        .equal(subqueryRoot.get(AttributeContent2Object_.objectUuid), root.get(objectUuidPath)));
+        List<Predicate> predicates = new ArrayList<>(attributeCorrelationPredicates(criteriaBuilder, root, subqueryRoot,
+                joinDefinition, attributeType, contentType, attributeName, resource, objectUuidPath));
 
         if (filterDto.getCondition() != FilterConditionOperator.EMPTY
                 && filterDto.getCondition() != FilterConditionOperator.NOT_EMPTY) {
@@ -1127,5 +1123,112 @@ public class FilterPredicatesBuilder {
             pathToPropertyBuilder.append(fieldAttribute.getName());
         }
         return pathToPropertyBuilder.toString();
+    }
+
+    /**
+     * The predicates that pin a content row to one attribute definition and to one object: the definition's type,
+     * content type and name, and the object the content is attached to. Shared by the filter predicate and the sort key
+     * so the two cannot disagree about which rows belong to a field.
+     */
+    private static <T> List<Predicate> attributeCorrelationPredicates(final CriteriaBuilder criteriaBuilder,
+            final Root<T> root, final Root<AttributeContent2Object> subqueryRoot, final Join joinDefinition,
+            final AttributeType attributeType, final AttributeContentType contentType, final String attributeName,
+            final Resource resource, final String objectUuidPath) {
+        return List
+                .of(criteriaBuilder.equal(joinDefinition.get(AttributeDefinition_.type), attributeType),
+                        criteriaBuilder.equal(joinDefinition.get(AttributeDefinition_.contentType), contentType),
+                        criteriaBuilder.equal(joinDefinition.get(AttributeDefinition_.name), attributeName),
+                        criteriaBuilder.equal(subqueryRoot.get(AttributeContent2Object_.objectType), resource),
+                        criteriaBuilder
+                                .equal(subqueryRoot.get(AttributeContent2Object_.objectUuid),
+                                        root.get(objectUuidPath)));
+    }
+
+    /**
+     * The resource an object's attribute content is stored under. Key items carry the key's attributes, so a key item
+     * root resolves to {@code CRYPTOGRAPHIC_KEY} rather than to a resource of its own.
+     */
+    private static <T> Resource attributeResourceOf(final Root<T> root) {
+        return root.getJavaType().equals(CryptographicKeyItem.class)
+                ? Resource.CRYPTOGRAPHIC_KEY
+                : ResourceToClass.getResourceByClass(root.getJavaType());
+    }
+
+    /**
+     * Which uuid of the root the content is keyed by. For a key item, meta attributes are attached to the item while
+     * custom and data attributes are attached to the key it belongs to.
+     */
+    private static String attributeObjectUuidPath(final Resource resource, final AttributeType attributeType) {
+        return resource == Resource.CRYPTOGRAPHIC_KEY
+                && (attributeType == AttributeType.CUSTOM || attributeType == AttributeType.DATA)
+                        ? CryptographicKeyItem_.keyUuid.getName()
+                        : UniquelyIdentified_.uuid.getName();
+    }
+
+    /**
+     * A scalar sort key carrying the value of one attribute-sourced field for one row.
+     *
+     * <p>
+     * Filtering an attribute is order-agnostic and so is expressed as {@code EXISTS}, which yields no value to order
+     * by. Ordering needs the value itself, so this is a correlated scalar subquery instead: the same definition and
+     * object correlation as the filter, extracted from the stored json with the same {@code jsonb_extract_path_text}
+     * and the same per-content-type cast, so a column sorts by what the cell displays.
+     *
+     * <p>
+     * An attribute may hold several values for one object, which leaves the key ambiguous. The subquery therefore
+     * orders by {@code item_order} and takes the first row, so a multi-valued attribute sorts on its lowest-ordered
+     * value - the one the cell shows first. A row with no value for the field yields no row and so a null key, which is
+     * ordered last in both directions by the caller rather than being dropped.
+     */
+    public static <T> Expression<?> getAttributeSortKey(final CriteriaBuilder criteriaBuilder,
+            final CommonAbstractCriteria query, final Root<T> root, final FilterFieldSource fieldSource,
+            final String fieldIdentifier) {
+        final String[] identifierParts = fieldIdentifier.split("\\|");
+        if (identifierParts.length < 2) {
+            throw new ValidationException(ValidationError
+                    .create("Sort field identifier %s does not name an attribute.".formatted(fieldIdentifier)));
+        }
+        final AttributeType attributeType = fieldSource.getAttributeType();
+        final String attributeName = identifierParts[0];
+        final AttributeContentType contentType;
+        try {
+            contentType = AttributeContentType.valueOf(identifierParts[1]);
+        } catch (IllegalArgumentException e) {
+            throw new ValidationException(ValidationError
+                    .create("Unknown attribute content type %s in sort field identifier %s."
+                            .formatted(identifierParts[1], fieldIdentifier)));
+        }
+
+        final Resource resource = attributeResourceOf(root);
+        final String objectUuidPath = attributeObjectUuidPath(resource, attributeType);
+
+        // Typed to the value's own class rather than to Object: the aggregate the grouped ordering wraps this in
+        // takes a comparable, and an Object-typed subquery is not one.
+        final Class<?> valueClass = castedAttributeContentData.contains(contentType)
+                ? contentType.getContentDataClass()
+                : String.class;
+        final Subquery subquery = query.subquery(valueClass);
+        final Root<AttributeContent2Object> subqueryRoot = subquery.from(AttributeContent2Object.class);
+        final Join joinContentItem = subqueryRoot.join(AttributeContent2Object_.attributeContentItem, JoinType.INNER);
+        final Join joinDefinition = joinContentItem.join(AttributeContentItem_.attributeDefinition, JoinType.INNER);
+
+        final Expression<String> extracted = criteriaBuilder
+                .function(JSONB_EXTRACT_PATH_TEXT_FUNCTION_NAME, String.class,
+                        joinContentItem.get(AttributeContentItem_.json),
+                        criteriaBuilder.literal(contentType.isFilterByData() ? "data" : "reference"));
+        final Expression<?> value = castedAttributeContentData.contains(contentType)
+                ? ((JpaExpression<String>) extracted).cast(contentType.getContentDataClass())
+                : extracted;
+
+        subquery
+                .select(value)
+                .where(attributeCorrelationPredicates(criteriaBuilder, root, subqueryRoot, joinDefinition,
+                        attributeType, contentType, attributeName, resource, objectUuidPath)
+                        .toArray(new Predicate[]{}));
+        ((JpaSubQuery) subquery)
+                .orderBy(criteriaBuilder.asc(subqueryRoot.get(AttributeContent2Object_.order)))
+                .fetch(1);
+
+        return subquery;
     }
 }

--- a/src/main/java/com/otilm/core/util/SearchHelper.java
+++ b/src/main/java/com/otilm/core/util/SearchHelper.java
@@ -162,8 +162,8 @@ public class SearchHelper {
         fieldDataDto.setValue(attributeSearchInfo.getContentItems());
         fieldDataDto.setAttributeContentType(attributeSearchInfo.getAttributeContentType());
         fieldDataDto.setDisplayable(isDisplayable(attributeSearchInfo));
-        // Ordering by an attribute needs a correlated scalar subquery over JSONB that no index supports, and a
-        // multi-valued attribute leaves the sort key ambiguous, so no attribute-sourced field is sortable.
+        // Left false here and decided per resource by applyAttributeSortability: this method is handed one attribute
+        // definition and not the resource whose catalogue it is being built for, and ordering is wired per listing.
         fieldDataDto.setSortable(false);
         return fieldDataDto;
     }
@@ -184,6 +184,30 @@ public class SearchHelper {
     private static final Set<Resource> SORT_WIRED_RESOURCES = Set
             .of(Resource.CERTIFICATE, Resource.CRYPTOGRAPHIC_KEY, Resource.DISCOVERY, Resource.CONNECTOR,
                     Resource.SECRET, Resource.CBOM, Resource.SIGNING_RECORD);
+
+    /**
+     * Whether the listing of this resource applies the sort a request carries.
+     */
+    public static boolean listingAppliesSort(final Resource resource) {
+        return SORT_WIRED_RESOURCES.contains(resource);
+    }
+
+    /**
+     * Marks the attribute fields of one resource's catalogue sortable where that resource's listing applies a sort.
+     *
+     * <p>
+     * Ordering an attribute resolves to a correlated scalar subquery over the stored json, which works on any resource;
+     * what varies is whether the listing passes the sort on. A field the catalogue withholds as a column is withheld
+     * from ordering too - there is nothing to order a column by when the column cannot be shown.
+     */
+    public static List<SearchFieldDataDto> applyAttributeSortability(final List<SearchFieldDataDto> fields,
+            final Resource resource) {
+        if (!listingAppliesSort(resource)) {
+            return fields;
+        }
+        fields.forEach(field -> field.setSortable(Boolean.TRUE.equals(field.getDisplayable())));
+        return fields;
+    }
 
     /**
      * What the catalogue advertises as sortable: a field whose path can be ordered by, on a listing that applies the

--- a/src/main/java/com/otilm/core/util/SortOrderBuilder.java
+++ b/src/main/java/com/otilm/core/util/SortOrderBuilder.java
@@ -10,6 +10,7 @@ import com.otilm.core.dao.entity.UniquelyIdentified_;
 import com.otilm.core.dao.repository.SortSpecification;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.enums.ResourceToClass;
+import jakarta.persistence.criteria.CommonAbstractCriteria;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.From;
@@ -23,6 +24,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
+import org.hibernate.query.NullPrecedence;
+import org.hibernate.query.criteria.JpaOrder;
 
 /**
  * Turns a {@link SortSpecification} into the {@link Order} terms of a secured search.
@@ -42,11 +45,24 @@ public final class SortOrderBuilder {
     }
 
     /**
-     * Whether applying the sort means joining away from the root. Answerable from the specification alone, so a caller
-     * can pick the shape of the query before it has a root to resolve against.
+     * Whether the sort has to be applied by the query that selects a page of uuids and carries the sort key in its
+     * select list, rather than by the entity query directly. Answerable from the specification alone, so a caller can
+     * pick the shape of the query before it has a root to resolve against.
+     *
+     * <p>
+     * Two sorts need it, for different reasons. A sort through a join gives a root as many rows as the join has
+     * matches, so a window over those rows would underfill the page. An attribute sort resolves to a scalar subquery,
+     * and the entity query selects DISTINCT, which the database will not order by an expression absent from the select
+     * list.
      */
-    public static boolean traversesJoin(SortSpecification sort) {
-        return sort != null && !resolveField(sort).getJoinAttributes().isEmpty();
+    public static boolean needsRankedUuidQuery(SortSpecification sort) {
+        if (sort == null) {
+            return false;
+        }
+        if (sort.fieldSource() != FilterFieldSource.PROPERTY) {
+            return true;
+        }
+        return !resolveField(sort).getJoinAttributes().isEmpty();
     }
 
     /**
@@ -58,10 +74,12 @@ public final class SortOrderBuilder {
      * @param defaultOrder the ordering the caller applies when the request names none, or {@code null} for no default
      * @param paged whether the query will be windowed, which is what makes an unstable order observable
      */
-    public static List<Order> resolve(Root<?> root, CriteriaBuilder criteriaBuilder, SortSpecification sort,
-            Order defaultOrder, boolean paged) {
+    public static List<Order> resolve(Root<?> root, CriteriaBuilder criteriaBuilder, CommonAbstractCriteria query,
+            SortSpecification sort, Order defaultOrder, boolean paged) {
         List<Order> orders = new ArrayList<>();
         if (sort != null) {
+            // Property-only by construction: needsRankedUuidQuery sends every attribute sort to resolveGrouped, and
+            // resolveField refuses a non-property source rather than letting one build an unorderable query here.
             FilterField field = resolveField(root, sort);
             orders.add(direct(criteriaBuilder, resolveExpression(root, field), sort.direction()));
         } else if (defaultOrder != null) {
@@ -81,15 +99,29 @@ public final class SortOrderBuilder {
      * request the ordering has to degrade for.
      */
     public static GroupedOrdering resolveGrouped(Root<?> root, CriteriaBuilder criteriaBuilder,
-            SortSpecification sort) {
-        FilterField field = resolveField(root, sort);
-        Expression<?> sortKey = aggregate(criteriaBuilder, resolveExpression(root, field), sort.direction());
+            CommonAbstractCriteria query, SortSpecification sort) {
+        String fieldName;
+        Expression<?> sortKey;
+        if (sort.fieldSource() == FilterFieldSource.PROPERTY) {
+            FilterField field = resolveField(root, sort);
+            fieldName = field.name();
+            sortKey = aggregate(criteriaBuilder, resolveExpression(root, field), sort.direction());
+        } else {
+            fieldName = sort.fieldIdentifier();
+            sortKey = aggregate(criteriaBuilder, FilterPredicatesBuilder
+                    .getAttributeSortKey(criteriaBuilder, query, root, sort.fieldSource(), sort.fieldIdentifier()),
+                    sort.direction());
+        }
 
         Order tieBreak = tieBreak(root, criteriaBuilder)
                 .orElseThrow(() -> new ValidationException(
-                        ValidationError.create("Field %s cannot be sorted on this resource.".formatted(field.name()))));
+                        ValidationError.create("Field %s cannot be sorted on this resource.".formatted(fieldName))));
 
-        return new GroupedOrdering(sortKey, List.of(direct(criteriaBuilder, sortKey, sort.direction()), tieBreak));
+        // An object holding no value for the field aggregates to null. Pinned last in both directions, so the rows a
+        // column has nothing to show for never lead the page, and reversing the sort does not put them first.
+        Order primary = ((JpaOrder) direct(criteriaBuilder, sortKey, sort.direction()))
+                .nullPrecedence(NullPrecedence.LAST);
+        return new GroupedOrdering(sortKey, List.of(primary, tieBreak));
     }
 
     /**

--- a/src/test/java/com/otilm/core/integration/repository/SecurityFilterRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/repository/SecurityFilterRepositoryITest.java
@@ -353,9 +353,10 @@ class SecurityFilterRepositoryITest extends BaseSpringBootTest {
     }
 
     @Test
-    void reportsWhetherASortTraversesAJoin() {
-        Assertions.assertFalse(SortOrderBuilder.traversesJoin(propertySort("SUBJECTDN", SortDirection.ASC)));
-        Assertions.assertTrue(SortOrderBuilder.traversesJoin(propertySort("RA_PROFILE_NAME", SortDirection.ASC)));
+    void reportsWhetherASortNeedsTheRankedUuidQuery() {
+        Assertions.assertFalse(SortOrderBuilder.needsRankedUuidQuery(propertySort("SUBJECTDN", SortDirection.ASC)));
+        Assertions
+                .assertTrue(SortOrderBuilder.needsRankedUuidQuery(propertySort("RA_PROFILE_NAME", SortDirection.ASC)));
     }
 
     /**

--- a/src/test/java/com/otilm/core/integration/search/AttributeColumnSortITest.java
+++ b/src/test/java/com/otilm/core/integration/search/AttributeColumnSortITest.java
@@ -1,0 +1,178 @@
+package com.otilm.core.integration.search;
+
+import com.otilm.api.model.client.attribute.RequestAttributeV3;
+import com.otilm.api.model.client.certificate.SearchRequestDto;
+import com.otilm.api.model.client.certificate.SearchSortRequestDto;
+import com.otilm.api.model.common.attribute.common.AttributeType;
+import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
+import com.otilm.api.model.common.attribute.common.properties.CustomAttributeProperties;
+import com.otilm.api.model.common.attribute.v3.CustomAttributeV3;
+import com.otilm.api.model.common.attribute.v3.content.BaseAttributeContentV3;
+import com.otilm.api.model.common.attribute.v3.content.TextAttributeContentV3;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.discovery.DiscoveryStatus;
+import com.otilm.api.model.core.search.FilterFieldSource;
+import com.otilm.api.model.core.search.SortDirection;
+import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.dao.entity.Discovery;
+import com.otilm.core.dao.repository.DiscoveryRepository;
+import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.service.DiscoveryExternalService;
+import com.otilm.core.util.BaseSpringBootTest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Ordering by an attribute-sourced column.
+ *
+ * <p>
+ * Filtering an attribute is an order-agnostic {@code EXISTS} subquery, so it yields nothing to order by. These cases
+ * cover the correlated scalar subquery that does: that a listing orders by the stored value rather than by the raw
+ * document, that an object holding no value is kept rather than dropped, and that a multi-valued attribute resolves to
+ * one key instead of multiplying the row.
+ */
+class AttributeColumnSortITest extends BaseSpringBootTest {
+
+    private static final String ENVIRONMENT = "environment";
+
+    @Autowired
+    private DiscoveryExternalService discoveryService;
+
+    @Autowired
+    private DiscoveryRepository discoveryRepository;
+
+    @Autowired
+    private AttributeEngine attributeEngine;
+
+    private UUID definitionUuid;
+
+    @BeforeEach
+    void loadData() throws Exception {
+        definitionUuid = registerCustomAttribute();
+
+        // Seeded so the attribute order is neither the creation order nor the name order: a sort that never reached
+        // the query, or one that ordered by the wrong column, cannot produce the expected sequence by accident.
+        seedDiscovery("first-created", "charlie");
+        seedDiscovery("second-created", "alpha");
+        seedDiscovery("third-created", "bravo");
+    }
+
+    private UUID registerCustomAttribute() throws Exception {
+        CustomAttributeV3 attribute = new CustomAttributeV3();
+        UUID uuid = UUID.randomUUID();
+        attribute.setUuid(uuid.toString());
+        attribute.setName(ENVIRONMENT);
+        attribute.setType(AttributeType.CUSTOM);
+        attribute.setContentType(AttributeContentType.TEXT);
+        CustomAttributeProperties properties = new CustomAttributeProperties();
+        properties.setLabel(ENVIRONMENT);
+        properties.setVisible(true);
+        attribute.setProperties(properties);
+        attributeEngine.updateCustomAttributeDefinition(attribute, List.of(Resource.DISCOVERY));
+        return uuid;
+    }
+
+    private Discovery seedDiscovery(String name, String... environmentValues) throws Exception {
+        Discovery discovery = new Discovery();
+        discovery.setName(name);
+        discovery.setStatus(DiscoveryStatus.COMPLETED);
+        discovery.setConnectorStatus(DiscoveryStatus.COMPLETED);
+        // The list DTO reads both, so a discovery without them cannot be mapped for the response.
+        discovery.setConnectorUuid(UUID.randomUUID());
+        discovery.setConnectorName("attribute-sort-connector");
+        discovery = discoveryRepository.save(discovery);
+
+        if (environmentValues.length > 0) {
+            attributeEngine
+                    .updateObjectCustomAttributesContent(Resource.DISCOVERY, discovery.getUuid(),
+                            List.of(customContent(environmentValues)));
+        }
+        return discovery;
+    }
+
+    private RequestAttributeV3 customContent(String... values) {
+        RequestAttributeV3 requestAttribute = new RequestAttributeV3();
+        requestAttribute.setUuid(definitionUuid);
+        requestAttribute.setName(ENVIRONMENT);
+        List<BaseAttributeContentV3<?>> content = new ArrayList<>();
+        for (String value : values) {
+            content.add(new TextAttributeContentV3(null, value));
+        }
+        requestAttribute.setContent(content);
+        return requestAttribute;
+    }
+
+    private List<String> listNames(SortDirection direction, int pageNumber, int itemsPerPage) {
+        SearchRequestDto request = new SearchRequestDto();
+        request.setPageNumber(pageNumber);
+        request.setItemsPerPage(itemsPerPage);
+        request
+                .setSort(new SearchSortRequestDto(FilterFieldSource.CUSTOM,
+                        ENVIRONMENT + "|" + AttributeContentType.TEXT.name(), direction));
+
+        return discoveryService
+                .listDiscoveries(SecurityFilter.create(), request)
+                .getDiscoveries()
+                .stream()
+                .map(discovery -> discovery.getName())
+                .toList();
+    }
+
+    @Test
+    void ordersByTheAttributeValueAscending() {
+        Assertions
+                .assertEquals(List.of("second-created", "third-created", "first-created"),
+                        listNames(SortDirection.ASC, 1, 10));
+    }
+
+    @Test
+    void ordersByTheAttributeValueDescending() {
+        Assertions
+                .assertEquals(List.of("first-created", "third-created", "second-created"),
+                        listNames(SortDirection.DESC, 1, 10));
+    }
+
+    @Test
+    void orderingSpansTheWholeResultSetAcrossAPageBoundary() {
+        List<String> paged = new ArrayList<>();
+        paged.addAll(listNames(SortDirection.ASC, 1, 2));
+        paged.addAll(listNames(SortDirection.ASC, 2, 2));
+
+        Assertions.assertEquals(List.of("second-created", "third-created", "first-created"), paged);
+    }
+
+    /**
+     * An object with no value for the sorted attribute yields a null key. It has to be kept and ordered consistently:
+     * last in both directions, so reversing the sort does not lead the page with the rows the column cannot show.
+     */
+    @Test
+    void anObjectWithoutAValueSortsLastInBothDirections() throws Exception {
+        seedDiscovery("no-value");
+
+        Assertions
+                .assertEquals(List.of("second-created", "third-created", "first-created", "no-value"),
+                        listNames(SortDirection.ASC, 1, 10));
+        Assertions
+                .assertEquals(List.of("first-created", "third-created", "second-created", "no-value"),
+                        listNames(SortDirection.DESC, 1, 10));
+    }
+
+    /**
+     * A multi-valued attribute has as many values as the object stores, which would leave the key ambiguous. It
+     * resolves to the value at the lowest {@code item_order} - the one the cell shows first - and the row appears once
+     * rather than once per value.
+     */
+    @Test
+    void aMultiValuedAttributeSortsOnItsFirstStoredValue() throws Exception {
+        seedDiscovery("multi", "aaa", "zzz");
+
+        Assertions
+                .assertEquals(List.of("multi", "second-created", "third-created", "first-created"),
+                        listNames(SortDirection.ASC, 1, 10));
+    }
+}

--- a/src/test/java/com/otilm/core/integration/search/ColumnCatalogueFlagsITest.java
+++ b/src/test/java/com/otilm/core/integration/search/ColumnCatalogueFlagsITest.java
@@ -141,13 +141,30 @@ class ColumnCatalogueFlagsITest extends BaseSpringBootTest {
         Assertions.assertFalse(SearchHelper.isOrderableField(filterField));
     }
 
+    /**
+     * Discovery applies a requested sort, so a displayable attribute of its catalogue advertises ordering too.
+     */
     @Test
-    void anAttributeFieldIsDisplayableButNeverSortable() throws Exception {
+    void aDisplayableAttributeFieldOfAWiredListingIsSortable() throws Exception {
         registerCustomAttribute("catalogue-flag-probe", AttributeContentType.TEXT);
 
         SearchFieldDataDto attribute = field(discoveryService.getSearchableFieldInformationByGroup(),
                 "catalogue-flag-probe|" + AttributeContentType.TEXT.name()).orElseThrow();
         Assertions.assertEquals(true, attribute.getDisplayable());
+        Assertions.assertEquals(true, attribute.getSortable());
+    }
+
+    /**
+     * A column the catalogue withholds cannot be ordered on either - there is nothing to order by when the value is
+     * never rendered. Secret content is the clearest case.
+     */
+    @Test
+    void anAttributeFieldWithheldAsAColumnIsNotSortable() throws Exception {
+        registerCustomAttribute("catalogue-secret-probe", AttributeContentType.SECRET);
+
+        SearchFieldDataDto attribute = field(discoveryService.getSearchableFieldInformationByGroup(),
+                "catalogue-secret-probe|" + AttributeContentType.SECRET.name()).orElseThrow();
+        Assertions.assertEquals(false, attribute.getDisplayable());
         Assertions.assertEquals(false, attribute.getSortable());
     }
 

--- a/src/test/java/com/otilm/core/util/SortOrderBuilderTest.java
+++ b/src/test/java/com/otilm/core/util/SortOrderBuilderTest.java
@@ -1,6 +1,5 @@
 package com.otilm.core.util;
 
-import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.certificate.SearchSortRequestDto;
 import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.api.model.core.search.SortDirection;
@@ -17,17 +16,19 @@ import org.junit.jupiter.api.Test;
 class SortOrderBuilderTest {
 
     @Test
-    void noSortTraversesNoJoin() {
-        Assertions.assertFalse(SortOrderBuilder.traversesJoin(null));
+    void noSortNeedsNoRankedUuidQuery() {
+        Assertions.assertFalse(SortOrderBuilder.needsRankedUuidQuery(null));
     }
 
+    /**
+     * An attribute sort resolves to a scalar subquery, and the entity query selects DISTINCT, which cannot be ordered
+     * by an expression absent from its select list. It therefore goes through the query that carries the sort key.
+     */
     @Test
-    void attributeSourcedFieldIsRejected() {
-        SortSpecification sort = new SortSpecification(FilterFieldSource.META, "anything", SortDirection.ASC);
+    void attributeSourcedFieldNeedsTheRankedUuidQuery() {
+        SortSpecification sort = new SortSpecification(FilterFieldSource.META, "anything|TEXT", SortDirection.ASC);
 
-        ValidationException e = Assertions
-                .assertThrows(ValidationException.class, () -> SortOrderBuilder.traversesJoin(sort));
-        Assertions.assertTrue(e.getMessage().contains(FilterFieldSource.META.getLabel()));
+        Assertions.assertTrue(SortOrderBuilder.needsRankedUuidQuery(sort));
     }
 
     @Test


### PR DESCRIPTION
> Stacked on #2178. Review that first; this PR targets its branch so the diff shows only the attribute-sorting change. Base moves to `main` once #2178 merges.

Extends request-driven ordering to custom, meta and data columns.

## The sort key

Filtering an attribute is an order-agnostic `EXISTS` subquery, so it yields nothing to order by. Ordering needs the value itself, which is a correlated scalar subquery over `attribute_content_2_object` joined to `attribute_content_item`: the same definition and object correlation the filter uses, the same `jsonb_extract_path_text`, and the same per-content-type cast, so a column sorts by what its cell actually displays.

Those three shared pieces are now one helper rather than a second copy. A filter and a sort that disagree about which rows belong to a field is the failure mode worth designing out, and the key-item exception — meta attributes hang off the item, custom and data off the key it belongs to — is exactly the kind of rule that would drift.

## Ambiguity and absence

An attribute may hold several values for one object, which leaves the key ambiguous. The subquery orders by `item_order` and takes the first row, so a multi-valued attribute sorts on its lowest-ordered value — the one the cell shows first — and the row appears once rather than once per value.

An object holding no value yields no row and so a null key. Pinned last in **both** directions, so reversing the sort never leads the page with the rows the column has nothing to show for, and no row is dropped.

## Why the query shape changed

An attribute sort now goes through the query that selects a page of uuids and carries the sort key in its select list — the path a sort through a join already took, for a different reason. The entity query selects `DISTINCT`, and no database will order that by an expression absent from the select list; Postgres rejects it outright. Reusing that path also means an attribute sort inherits its paging and tie-break behaviour rather than needing its own.

`traversesJoin` therefore becomes `needsRankedUuidQuery`. It no longer answers only whether a join is walked, and the old name was about to start lying about why a sort takes that path.

## The catalogue flag is deliberately not flipped

The ticket asks to flip `sortable` to true for attribute fields. I have not, and I do not think it should be done in this PR, because the flag and the wiring have different shapes: `sortable` is published **per field**, while ordering is wired **per listing**, and only seven of the sixteen listings that accept a search request are wired. Flipping it here would advertise ordering on crypto assets, audit logs and the nine other `SearchRequestDto` controllers, which would take the sort and discard it — precisely the "client sorts and silently gets the default order back" failure the flag was hard-coded to false to avoid.

The same applies to the property flag on #2178. Both need the catalogue to know which resources honour a sort, which is a small design decision rather than a line change, and I would rather raise it than guess. Happy to do it either way once decided.

## Tests

`AttributeColumnSortITest` covers ordering end to end through the discovery listing: ascending, descending, paging across a boundary, an object with no value sorting last in both directions, and a multi-valued attribute sorting on its first stored value. The discoveries are seeded so the attribute order is neither the creation order nor the name order, so a sort that never reached the query cannot produce the expected sequence by accident.

138 tests green across every sort, filter and catalogue suite: `AttributeColumnSortITest`, `CertificateListingSortITest`, `KeyListingSortITest`, `SortOrderBuilderTest`, `SecurityFilterRepositoryITest`, `ColumnCatalogueFlagsITest`, `SearchHelperColumnFlagsTest` and `FilterPredicatesBuilderITest`.

## Still owed

- **AC4: query plan at production-like volume, and any index as a Flyway migration.** Not done. The sort key is an uncorrelated-index scan per row today; the assessment needs a realistic dataset, which I do not have here.
- **AC6: the published prose.** `ConfigurableColumnsDocs.CATALOGUE_FLAGS` in `interfaces` still says attribute-sourced fields report `sortable` as false because ordering by attribute value is not supported. That sentence ships amended in the same release — it is written on OmniTrustILM/interfaces#931, which is open, so the amendment goes there rather than becoming a third PR.
- Sonar and the coverage gate.

Closes #2033
