### PR TITLE
Populate the caller's resource actions in the user profile

### DIFF
--- a/src/main/java/com/otilm/core/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/AuthServiceImpl.java
@@ -4,6 +4,7 @@ import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.model.client.auth.UpdateUserRequestDto;
 import com.otilm.api.model.core.auth.AuthResourceDto;
 import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.auth.ResourceActionsDto;
 import com.otilm.api.model.core.auth.ResourcePermissionsDto;
 import com.otilm.api.model.core.auth.UserDetailDto;
 import com.otilm.api.model.core.auth.UserProfileDetailDto;
@@ -11,6 +12,7 @@ import com.otilm.api.model.core.auth.UserProfileDto;
 import com.otilm.api.model.core.auth.UserProfilePermissionsDto;
 import com.otilm.core.auth.ContextRefreshListener;
 import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.model.auth.ResourceSyncRequestDto;
 import com.otilm.core.security.authn.client.ResourceApiClient;
 import com.otilm.core.security.authn.client.UserManagementApiClient;
 import com.otilm.core.security.authz.AnyPrincipalEndpoint;
@@ -68,8 +70,8 @@ public class AuthServiceImpl implements AuthExternalService {
         UserDetailDto userDetailDto = userManagementApiClient.getUserDetail(userProfileDto.getUser().getUuid());
 
         // load listing permissions
-        return new UserProfileDetailDto(userDetailDto,
-                new UserProfilePermissionsDto(getAllowedResourceListings(userProfileDto)));
+        return new UserProfileDetailDto(userDetailDto, new UserProfilePermissionsDto(
+                getAllowedResourceListings(userProfileDto), getAllowedResourceActions(userProfileDto)));
     }
 
     @Override
@@ -143,6 +145,64 @@ public class AuthServiceImpl implements AuthExternalService {
             }
         }
         return withDefaultListings(allowedListings);
+    }
+
+    /**
+     * The actions the caller holds on each resource as a whole, so a client can gate a control on the action that
+     * actually guards the endpoint instead of inferring it from listing access.
+     * <p>
+     * Object-scoped grants are deliberately left out - see {@link UserProfilePermissionsDto#getAllowedActions()} - so
+     * this is not the union {@link #getAllowedResourceListings} computes for {@code LIST}, and the two fields are not
+     * derivable from each other.
+     */
+    private List<ResourceActionsDto> getAllowedResourceActions(UserProfileDto userProfileDto) {
+        boolean allowAllResources = Boolean.TRUE.equals(userProfileDto.getPermissions().getAllowAllResources());
+        Map<Resource, ResourcePermissionsDto> mappedUserPermissions = allowAllResources
+                ? Map.of()
+                : userProfileDto
+                        .getPermissions()
+                        .getResources()
+                        .stream()
+                        .collect(Collectors
+                                .toMap(resource -> Resource.findByCode(resource.getName()), resource -> resource));
+
+        List<ResourceActionsDto> allowedActions = new ArrayList<>();
+        for (ResourceSyncRequestDto syncResource : contextRefreshListener.getResources()) {
+            Resource resource = Resource.findByCode(syncResource.getName().getCode());
+            ResourcePermissionsDto resourcePermissions = mappedUserPermissions.get(resource);
+            // Filtered out of the catalogue rather than mapped out of the grant: the authorization service may hold an
+            // action code this build no longer declares, and findByCode throws on one, which would fail the whole
+            // profile request over a permission the caller does not even need.
+            List<ResourceAction> actions = syncResource
+                    .getActions()
+                    .stream()
+                    .filter(actionCode -> isActionGranted(actionCode, allowAllResources, resourcePermissions))
+                    .map(ResourceAction::findByCode)
+                    // NONE and ANY are sentinels the auth service rejects as unknown actions, so reporting them would
+                    // name a grant that cannot exist.
+                    .filter(action -> action.getAccessType() != ResourceAction.AccessType.NOT_GRANTABLE)
+                    .sorted(Comparator.comparing(ResourceAction::getCode))
+                    .toList();
+
+            if (!actions.isEmpty()) {
+                allowedActions.add(new ResourceActionsDto(resource, actions));
+            }
+        }
+        return allowedActions.stream().sorted(Comparator.comparing(entry -> entry.getResource().getCode())).toList();
+    }
+
+    private static boolean isActionGranted(String actionCode, boolean allowAllResources,
+            ResourcePermissionsDto resourcePermissions) {
+        if (allowAllResources) {
+            return true;
+        }
+        if (resourcePermissions == null) {
+            return false;
+        }
+        if (Boolean.TRUE.equals(resourcePermissions.getAllowAllActions())) {
+            return true;
+        }
+        return resourcePermissions.getActions() != null && resourcePermissions.getActions().contains(actionCode);
     }
 
     private List<Resource> withDefaultListings(List<Resource> listings) {

--- a/src/main/java/com/otilm/core/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/AuthServiceImpl.java
@@ -101,6 +101,15 @@ public class AuthServiceImpl implements AuthExternalService {
                         certificateFingerprint);
     }
 
+    /** Shared by both permission-derived fields, so a change to how a grant is looked up reaches each of them. */
+    private static Map<Resource, ResourcePermissionsDto> mapPermissionsByResource(UserProfileDto userProfileDto) {
+        return userProfileDto
+                .getPermissions()
+                .getResources()
+                .stream()
+                .collect(Collectors.toMap(resource -> Resource.findByCode(resource.getName()), resource -> resource));
+    }
+
     private List<Resource> getAllowedResourceListings(UserProfileDto userProfileDto) {
         List<Resource> allowedListings;
         List<Resource> allListings = contextRefreshListener
@@ -115,11 +124,7 @@ public class AuthServiceImpl implements AuthExternalService {
             return withDefaultListings(allListings);
         }
 
-        Map<Resource, ResourcePermissionsDto> mappedUserPermissions = userProfileDto
-                .getPermissions()
-                .getResources()
-                .stream()
-                .collect(Collectors.toMap(resource -> Resource.findByCode(resource.getName()), resource -> resource));
+        Map<Resource, ResourcePermissionsDto> mappedUserPermissions = mapPermissionsByResource(userProfileDto);
         ResourcePermissionsDto groupPermissions = mappedUserPermissions.get(Resource.GROUP);
         boolean hasGroupMembersPermissions = groupPermissions != null
                 && (groupPermissions.getAllowAllActions() || groupPermissions
@@ -147,24 +152,12 @@ public class AuthServiceImpl implements AuthExternalService {
         return withDefaultListings(allowedListings);
     }
 
-    /**
-     * The actions the caller holds on each resource as a whole, so a client can gate a control on the action that
-     * actually guards the endpoint instead of inferring it from listing access.
-     * <p>
-     * Object-scoped grants are deliberately left out - see {@link UserProfilePermissionsDto#getAllowedActions()} - so
-     * this is not the union {@link #getAllowedResourceListings} computes for {@code LIST}, and the two fields are not
-     * derivable from each other.
-     */
+    /** See {@link UserProfilePermissionsDto#getAllowedActions()} for the contract this computes. */
     private List<ResourceActionsDto> getAllowedResourceActions(UserProfileDto userProfileDto) {
         boolean allowAllResources = Boolean.TRUE.equals(userProfileDto.getPermissions().getAllowAllResources());
         Map<Resource, ResourcePermissionsDto> mappedUserPermissions = allowAllResources
                 ? Map.of()
-                : userProfileDto
-                        .getPermissions()
-                        .getResources()
-                        .stream()
-                        .collect(Collectors
-                                .toMap(resource -> Resource.findByCode(resource.getName()), resource -> resource));
+                : mapPermissionsByResource(userProfileDto);
 
         List<ResourceActionsDto> allowedActions = new ArrayList<>();
         for (ResourceSyncRequestDto syncResource : contextRefreshListener.getResources()) {
@@ -178,8 +171,10 @@ public class AuthServiceImpl implements AuthExternalService {
                     .stream()
                     .filter(actionCode -> isActionGranted(actionCode, allowAllResources, resourcePermissions))
                     .map(ResourceAction::findByCode)
-                    // NONE and ANY are sentinels the auth service rejects as unknown actions, so reporting them would
-                    // name a grant that cannot exist.
+                    // ANY reaches the catalogue from the annotations but is skipped by the auth service at sync, so a
+                    // grant on it cannot exist. NONE is not skipped and would be stored as a real action; it only
+                    // stays out of the catalogue because every annotated endpoint passes an explicit action rather
+                    // than leaving the NONE default in place.
                     .filter(action -> action.getAccessType() != ResourceAction.AccessType.NOT_GRANTABLE)
                     .sorted(Comparator.comparing(ResourceAction::getCode))
                     .toList();

--- a/src/test/java/com/otilm/core/integration/service/AuthServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/AuthServiceITest.java
@@ -7,6 +7,7 @@ import com.otilm.api.model.client.auth.UpdateUserRequestDto;
 import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.core.auth.AuthResourceDto;
 import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.auth.ResourceActionsDto;
 import com.otilm.api.model.core.auth.UserDetailDto;
 import com.otilm.api.model.core.auth.UserProfileDetailDto;
 import com.otilm.api.model.core.logging.enums.AuthMethod;
@@ -130,6 +131,84 @@ class AuthServiceITest extends BaseSpringBootTest {
         Assertions
                 .assertEquals(1, allowedListings.stream().filter(r -> r == Resource.DASHBOARD).count(),
                         "DASHBOARD must appear exactly once");
+    }
+
+    /**
+     * The branding gate this field was added for: the localhost role holds SETTINGS with detail, list and update, and
+     * UPDATE_BRANDING is deliberately not among them, so a client reading the profile can keep the Appearance tab off
+     * the screen instead of offering a save the authorization service will refuse.
+     */
+    @Test
+    void testAuthProfileAllowedActions() {
+        injectLocalhostUserProfileToContext();
+
+        UserProfileDetailDto userProfileDto = authService.getAuthProfile();
+
+        Assertions
+                .assertEquals(List.of(ResourceAction.DETAIL, ResourceAction.LIST, ResourceAction.UPDATE),
+                        allowedActionsFor(userProfileDto, Resource.SETTINGS));
+        Assertions
+                .assertFalse(
+                        allowedActionsFor(userProfileDto, Resource.SETTINGS).contains(ResourceAction.UPDATE_BRANDING),
+                        "SETTINGS granted update must not imply UPDATE_BRANDING");
+        Assertions
+                .assertEquals(List.of(ResourceAction.CREATE, ResourceAction.DETAIL),
+                        allowedActionsFor(userProfileDto, Resource.CERTIFICATE));
+        Assertions
+                .assertTrue(allowedActionsFor(userProfileDto, Resource.CONNECTOR).isEmpty(),
+                        "a resource the role grants nothing on must be omitted, not reported empty");
+    }
+
+    /**
+     * Object-scoped grants are deliberately not folded in: the changed profile allows MEMBERS on one group object only,
+     * and an action held on one object says nothing about the next. Reporting it here would let a client enable a
+     * control the server refuses everywhere but that single object.
+     */
+    @Test
+    void testAuthProfileAllowedActionsExcludeObjectScopedGrants() {
+        injectLocalhostUserProfileChangedToContext();
+
+        UserProfileDetailDto userProfileDto = authService.getAuthProfile();
+
+        Assertions
+                .assertEquals(List.of(ResourceAction.CREATE, ResourceAction.DETAIL, ResourceAction.LIST),
+                        allowedActionsFor(userProfileDto, Resource.GROUP));
+        // The same grant does put GROUP in allowedListings, which is the union the two fields deliberately differ on.
+        Assertions
+                .assertTrue(userProfileDto.getPermissions().getAllowedListings().contains(Resource.GROUP),
+                        "allowedListings keeps its own semantics");
+    }
+
+    @Test
+    void testAuthProfileAllowedActionsAllowAllResources() {
+        injectAllowAllResourcesUserProfileToContext();
+
+        UserProfileDetailDto userProfileDto = authService.getAuthProfile();
+
+        Assertions
+                .assertTrue(
+                        allowedActionsFor(userProfileDto, Resource.SETTINGS).contains(ResourceAction.UPDATE_BRANDING),
+                        "a role holding every resource must hold UPDATE_BRANDING");
+        Assertions
+                .assertTrue(
+                        userProfileDto
+                                .getPermissions()
+                                .getAllowedActions()
+                                .stream()
+                                .flatMap(entry -> entry.getActions().stream())
+                                .noneMatch(action -> action.getAccessType() == ResourceAction.AccessType.NOT_GRANTABLE),
+                        "NONE and ANY are sentinels the auth service rejects and must never be reported");
+    }
+
+    private static List<ResourceAction> allowedActionsFor(UserProfileDetailDto userProfileDto, Resource resource) {
+        return userProfileDto
+                .getPermissions()
+                .getAllowedActions()
+                .stream()
+                .filter(entry -> entry.getResource() == resource)
+                .map(ResourceActionsDto::getActions)
+                .findFirst()
+                .orElseGet(List::of);
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/AuthServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/AuthServiceITest.java
@@ -23,6 +23,8 @@ import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.WireMockPorts;
 import java.security.cert.CertificateException;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -133,11 +135,6 @@ class AuthServiceITest extends BaseSpringBootTest {
                         "DASHBOARD must appear exactly once");
     }
 
-    /**
-     * The branding gate this field was added for: the localhost role holds SETTINGS with detail, list and update, and
-     * UPDATE_BRANDING is deliberately not among them, so a client reading the profile can keep the Appearance tab off
-     * the screen instead of offering a save the authorization service will refuse.
-     */
     @Test
     void testAuthProfileAllowedActions() {
         injectLocalhostUserProfileToContext();
@@ -155,28 +152,34 @@ class AuthServiceITest extends BaseSpringBootTest {
                 .assertEquals(List.of(ResourceAction.CREATE, ResourceAction.DETAIL),
                         allowedActionsFor(userProfileDto, Resource.CERTIFICATE));
         Assertions
-                .assertTrue(allowedActionsFor(userProfileDto, Resource.CONNECTOR).isEmpty(),
-                        "a resource the role grants nothing on must be omitted, not reported empty");
+                .assertTrue(
+                        userProfileDto
+                                .getPermissions()
+                                .getAllowedActions()
+                                .stream()
+                                .noneMatch(entry -> entry.getResource() == Resource.CONNECTOR),
+                        "a resource the role grants nothing on must be omitted, not reported with an empty list");
     }
 
-    /**
-     * Object-scoped grants are deliberately not folded in: the changed profile allows MEMBERS on one group object only,
-     * and an action held on one object says nothing about the next. Reporting it here would let a client enable a
-     * control the server refuses everywhere but that single object.
-     */
     @Test
     void testAuthProfileAllowedActionsExcludeObjectScopedGrants() {
         injectLocalhostUserProfileChangedToContext();
 
         UserProfileDetailDto userProfileDto = authService.getAuthProfile();
 
+        // The profile allows MEMBERS on a single group object; folding that in would report an action the server
+        // refuses on every other group.
         Assertions
                 .assertEquals(List.of(ResourceAction.CREATE, ResourceAction.DETAIL, ResourceAction.LIST),
                         allowedActionsFor(userProfileDto, Resource.GROUP));
-        // The same grant does put GROUP in allowedListings, which is the union the two fields deliberately differ on.
+        // CERTIFICATE is the contrast between the two fields: it is listed through hasOwner() rather than through a
+        // granted action, so it reaches allowedListings while LIST stays out of its actions.
         Assertions
-                .assertTrue(userProfileDto.getPermissions().getAllowedListings().contains(Resource.GROUP),
-                        "allowedListings keeps its own semantics");
+                .assertTrue(userProfileDto.getPermissions().getAllowedListings().contains(Resource.CERTIFICATE),
+                        "CERTIFICATE is listed through the owner rule");
+        Assertions
+                .assertEquals(List.of(ResourceAction.CREATE, ResourceAction.DETAIL),
+                        allowedActionsFor(userProfileDto, Resource.CERTIFICATE));
     }
 
     @Test
@@ -186,18 +189,27 @@ class AuthServiceITest extends BaseSpringBootTest {
         UserProfileDetailDto userProfileDto = authService.getAuthProfile();
 
         Assertions
+                .assertEquals(grantableCataloguePairs(), reportedPairs(userProfileDto),
+                        "a role holding every resource must be reported every grantable action in the catalogue");
+        Assertions
                 .assertTrue(
                         allowedActionsFor(userProfileDto, Resource.SETTINGS).contains(ResourceAction.UPDATE_BRANDING),
                         "a role holding every resource must hold UPDATE_BRANDING");
+    }
+
+    /**
+     * The authorization service keeps a grant on an action code this build may no longer declare, and findByCode throws
+     * on one, so the profile request has to survive it rather than fail over a permission nobody asked for.
+     */
+    @Test
+    void testAuthProfileAllowedActionsIgnoreUndeclaredActionCodes() {
+        injectUndeclaredActionCodeUserProfileToContext();
+
+        UserProfileDetailDto userProfileDto = authService.getAuthProfile();
+
         Assertions
-                .assertTrue(
-                        userProfileDto
-                                .getPermissions()
-                                .getAllowedActions()
-                                .stream()
-                                .flatMap(entry -> entry.getActions().stream())
-                                .noneMatch(action -> action.getAccessType() == ResourceAction.AccessType.NOT_GRANTABLE),
-                        "NONE and ANY are sentinels the auth service rejects and must never be reported");
+                .assertEquals(List.of(ResourceAction.CREATE, ResourceAction.DETAIL),
+                        allowedActionsFor(userProfileDto, Resource.CERTIFICATE));
     }
 
     private static List<ResourceAction> allowedActionsFor(UserProfileDetailDto userProfileDto, Resource resource) {
@@ -209,6 +221,32 @@ class AuthServiceITest extends BaseSpringBootTest {
                 .map(ResourceActionsDto::getActions)
                 .findFirst()
                 .orElseGet(List::of);
+    }
+
+    /** Every resource/action pair the annotation scan produced, minus the sentinels no grant can name. */
+    private Set<String> grantableCataloguePairs() {
+        return contextRefreshListener
+                .getResources()
+                .stream()
+                .flatMap(syncResource -> syncResource
+                        .getActions()
+                        .stream()
+                        .filter(actionCode -> !ResourceAction.ANY.getCode().equals(actionCode)
+                                && !ResourceAction.NONE.getCode().equals(actionCode))
+                        .map(actionCode -> syncResource.getName().getCode() + ":" + actionCode))
+                .collect(Collectors.toSet());
+    }
+
+    private static Set<String> reportedPairs(UserProfileDetailDto userProfileDto) {
+        return userProfileDto
+                .getPermissions()
+                .getAllowedActions()
+                .stream()
+                .flatMap(entry -> entry
+                        .getActions()
+                        .stream()
+                        .map(action -> entry.getResource().getCode() + ":" + action.getCode()))
+                .collect(Collectors.toSet());
     }
 
     @Test
@@ -338,6 +376,44 @@ class AuthServiceITest extends BaseSpringBootTest {
                 """;
 
         // inject other user profile
+        AuthenticationInfo info = new AuthenticationInfo(AuthMethod.USER_PROXY, "616be97b-0bd0-434c-a582-2d4dee5d0b41",
+                "localhost", List.of(), userProfileData);
+        SecurityContextHolder
+                .getContext()
+                .setAuthentication(new PlatformAuthenticationToken(new PlatformUserDetails(info)));
+    }
+
+    private void injectUndeclaredActionCodeUserProfileToContext() {
+        String userProfileData = """
+                {
+                    "user": {
+                        "uuid": "616be97b-0bd0-434c-a582-2d4dee5d0b41",
+                        "username": "localhost",
+                        "description": "System user for localhost operations",
+                        "groups": [],
+                        "enabled": true,
+                        "systemUser": true,
+                        "createdAt": "2024-12-02T10:52:54.36424+00:00",
+                        "updatedAt": "2024-12-02T10:52:54.364241+00:00"
+                    },
+                    "roles": [{
+                            "uuid": "9db01d1f-fb62-4be8-b344-a852e82edf80",
+                            "name": "localhost"
+                        }
+                    ],
+                    "permissions": {
+                        "allowAllResources": false,
+                        "resources": [{
+                                "name": "certificates",
+                                "allowAllActions": false,
+                                "actions": ["create", "detail", "actionThisBuildNoLongerDeclares"],
+                                "objects": []
+                            }
+                        ]
+                    }
+                }
+                """;
+
         AuthenticationInfo info = new AuthenticationInfo(AuthMethod.USER_PROXY, "616be97b-0bd0-434c-a582-2d4dee5d0b41",
                 "localhost", List.of(), userProfileData);
         SecurityContextHolder


### PR DESCRIPTION
Fills in the contract added by OmniTrustILM/interfaces#936, which adds `allowedActions` to `UserProfilePermissionsDto`. **Depends on that PR merging first** — `@AllArgsConstructor` means the constructor signature changes.

`getAuthProfile` reported `allowedListings` only, so a client could tell which resources it may list and nothing else. `UPDATE_BRANDING`, `GET_SECRET_CONTENT` and `UPDATE_SOURCE_VAULT_PROFILE` guard endpoints that `UPDATE` does not reach, leaving a client no way to know whether a control it was about to offer would be refused.

Nothing new is fetched. The per-resource permissions already come in on `AuthHelper.getUserProfile()`, and the action catalogue is already held by `ContextRefreshListener` for the auth-service sync.

## Two details that decide correctness

**Actions are filtered out of the catalogue, not mapped out of the grant.** The authorization service can hold an action code this build no longer declares — after a rename, or a downgrade — and `ResourceAction.findByCode` throws a `ValidationException` on one. Mapping the grant directly would fail the entire profile request, and therefore every page load, over a permission the caller does not even need. Intersecting with the catalogue means only codes this build declares can reach `findByCode`.

**`NONE` and `ANY` are never reported.** Both are `AccessType.NOT_GRANTABLE`; the auth service rejects them as unknown actions, so reporting them would name a grant that cannot exist. `registerResourceActions` guards `Resource.NONE` for the parent resource but not the action, so the sentinel can reach the catalogue.

## Semantics

Resource-level grants only, per the contract on the field. Object-scoped grants stay out, so this is not the union `getAllowedResourceListings` computes for `LIST` — an action held on one object says nothing about the next. Resources with no granted action are omitted rather than reported empty, and the output is ordered by resource code so the response is stable.

## Tests

Three added to `AuthServiceITest`, using the fixtures already there:

- The `localhost` role holds `settings` with `detail`, `list` and `update`. `UPDATE_BRANDING` is asserted absent, which is the case the field was added for.
- The changed profile allows `members` on one group object only; that grant is asserted absent from `allowedActions` while `GROUP` stays in `allowedListings`, pinning the deliberate difference between the two fields.
- The `allowAllResources` role is asserted to hold `UPDATE_BRANDING`, and no `NOT_GRANTABLE` action anywhere in the response.

Closes #2183