### PR TITLE
Drop the tertiary brand colour from branding persistence

### DIFF
--- a/src/main/java/com/otilm/core/service/impl/BrandingServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/BrandingServiceImpl.java
@@ -42,7 +42,6 @@ public class BrandingServiceImpl implements BrandingExternalService {
 
         publicBranding.setPrimaryColor(branding.getPrimaryColor());
         publicBranding.setSecondaryColor(branding.getSecondaryColor());
-        publicBranding.setTertiaryColor(branding.getTertiaryColor());
         publicBranding.setBackgroundColor(branding.getBackgroundColor());
         publicBranding.setTextColor(branding.getTextColor());
         publicBranding.setLightLogo(branding.getLightLogo());
@@ -58,9 +57,9 @@ public class BrandingServiceImpl implements BrandingExternalService {
      */
     private static boolean isConfigured(BrandingSettingsDto branding) {
         return Stream
-                .of(branding.getPrimaryColor(), branding.getSecondaryColor(), branding.getTertiaryColor(),
-                        branding.getBackgroundColor(), branding.getTextColor(), branding.getLightLogo(),
-                        branding.getDarkLogo(), branding.getDefaultTheme())
+                .of(branding.getPrimaryColor(), branding.getSecondaryColor(), branding.getBackgroundColor(),
+                        branding.getTextColor(), branding.getLightLogo(), branding.getDarkLogo(),
+                        branding.getDefaultTheme())
                 .anyMatch(Objects::nonNull);
     }
 }

--- a/src/main/java/com/otilm/core/service/impl/SettingServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SettingServiceImpl.java
@@ -247,9 +247,6 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
                 .put("secondaryColor", new BrandingField(BrandingSettingsUpdateDto::getSecondaryColor,
                         BrandingSettingsDto::setSecondaryColor));
         fields
-                .put("tertiaryColor", new BrandingField(BrandingSettingsUpdateDto::getTertiaryColor,
-                        BrandingSettingsDto::setTertiaryColor));
-        fields
                 .put("backgroundColor", new BrandingField(BrandingSettingsUpdateDto::getBackgroundColor,
                         BrandingSettingsDto::setBackgroundColor));
         fields

--- a/src/main/java/com/otilm/core/settings/branding/BrandingSettingsValidator.java
+++ b/src/main/java/com/otilm/core/settings/branding/BrandingSettingsValidator.java
@@ -29,7 +29,6 @@ public final class BrandingSettingsValidator {
         Map<String, Function<BrandingSettingsUpdateDto, String>> accessors = new LinkedHashMap<>();
         accessors.put("primaryColor", BrandingSettingsUpdateDto::getPrimaryColor);
         accessors.put("secondaryColor", BrandingSettingsUpdateDto::getSecondaryColor);
-        accessors.put("tertiaryColor", BrandingSettingsUpdateDto::getTertiaryColor);
         accessors.put("backgroundColor", BrandingSettingsUpdateDto::getBackgroundColor);
         accessors.put("textColor", BrandingSettingsUpdateDto::getTextColor);
         return Map.copyOf(accessors);
@@ -53,7 +52,6 @@ public final class BrandingSettingsValidator {
         BrandingSettingsUpdateDto stored = new BrandingSettingsUpdateDto();
         stored.setPrimaryColor(branding.getPrimaryColor());
         stored.setSecondaryColor(branding.getSecondaryColor());
-        stored.setTertiaryColor(branding.getTertiaryColor());
         stored.setBackgroundColor(branding.getBackgroundColor());
         stored.setTextColor(branding.getTextColor());
         stored.setDefaultTheme(branding.getDefaultTheme());

--- a/src/test/java/com/otilm/core/integration/api/web/PublicBrandingControllerITest.java
+++ b/src/test/java/com/otilm/core/integration/api/web/PublicBrandingControllerITest.java
@@ -61,8 +61,8 @@ class PublicBrandingControllerITest extends BaseSpringBootTestNoAuth {
      * {@code PublicBrandingDto} omits it when unset rather than sending it as null.
      */
     private static final Set<String> ALWAYS_PRESENT_KEYS = Set
-            .of("configured", "primaryColor", "secondaryColor", "tertiaryColor", "backgroundColor", "textColor",
-                    "lightLogo", "darkLogo");
+            .of("configured", "primaryColor", "secondaryColor", "backgroundColor", "textColor", "lightLogo",
+                    "darkLogo");
 
     /** Everything the anonymous response is allowed to carry. A key outside this set is a leak, not a feature. */
     private static final Set<String> PERMITTED_KEYS = Stream

--- a/src/test/java/com/otilm/core/integration/service/BrandingSettingsITest.java
+++ b/src/test/java/com/otilm/core/integration/service/BrandingSettingsITest.java
@@ -56,6 +56,15 @@ class BrandingSettingsITest extends BaseSpringBootTest {
         return branding;
     }
 
+    private void storeBrandingRow(String name, String value) {
+        Setting setting = new Setting();
+        setting.setSection(SettingsSection.PLATFORM);
+        setting.setCategory(SettingsSectionCategory.PLATFORM_BRANDING.getCode());
+        setting.setName(name);
+        setting.setValue(value);
+        settingRepository.save(setting);
+    }
+
     @Test
     void anUnbrandedPlatformReportsBrandingWithEveryFieldUnset() {
         BrandingSettingsDto branding = settingService.getBrandingSettings();
@@ -180,16 +189,48 @@ class BrandingSettingsITest extends BaseSpringBootTest {
     /** The platform settings read is on the hot path for every page render, so it must not fail over one bad value. */
     @Test
     void anUnknownStoredThemeIsIgnoredRatherThanFailingTheRead() {
-        Setting theme = new Setting();
-        theme.setSection(SettingsSection.PLATFORM);
-        theme.setCategory(SettingsSectionCategory.PLATFORM_BRANDING.getCode());
-        theme.setName("defaultTheme");
-        theme.setValue("midnight");
-        settingRepository.save(theme);
+        storeBrandingRow("defaultTheme", "midnight");
 
         BrandingSettingsDto branding = settingService.getBrandingSettings();
 
         Assertions.assertNull(branding.getDefaultTheme());
+    }
+
+    /**
+     * Branding is stored one field per row, so a platform that was branded before a field was dropped from the contract
+     * keeps a row the mapping no longer has a field for. The read walks the known fields rather than the stored rows,
+     * so the leftover is never looked at and the rest of the brand comes back intact.
+     */
+    @Test
+    void aStoredFieldTheMappingNoLongerKnowsIsIgnoredOnRead() {
+        storeBrandingRow("tertiaryColor", "#FF6900");
+        storeBrandingRow("primaryColor", PRIMARY);
+        storeBrandingRow("defaultTheme", BrandingTheme.DARK.getCode());
+
+        BrandingSettingsDto branding = settingService.getBrandingSettings();
+
+        Assertions.assertEquals(PRIMARY, branding.getPrimaryColor());
+        Assertions.assertEquals(BrandingTheme.DARK, branding.getDefaultTheme());
+        Assertions.assertNull(branding.getSecondaryColor());
+        Assertions.assertEquals(PRIMARY, settingService.getPlatformSettings().getBranding().getPrimaryColor());
+    }
+
+    /**
+     * The write walks the same known fields, so an unrecognised row is neither rewritten nor deleted by an update. It
+     * is left where it is, unread by anything, while the fields the operator did submit are written as usual.
+     */
+    @Test
+    void aStoredFieldTheMappingNoLongerKnowsIsLeftAloneByAnUpdate() {
+        storeBrandingRow("tertiaryColor", "#FF6900");
+
+        settingService.updateBrandingSettings(update(PRIMARY, SECONDARY, BrandingTheme.LIGHT));
+
+        BrandingSettingsDto branding = settingService.getBrandingSettings();
+        Assertions.assertEquals(PRIMARY, branding.getPrimaryColor());
+        Assertions.assertEquals(SECONDARY, branding.getSecondaryColor());
+        Assertions.assertEquals(BrandingTheme.LIGHT, branding.getDefaultTheme());
+        Assertions.assertEquals(4, storedBranding().size());
+        Assertions.assertTrue(storedBranding().stream().anyMatch(setting -> "tertiaryColor".equals(setting.getName())));
     }
 
     /**

--- a/src/test/java/com/otilm/core/service/impl/BrandingServiceImplTest.java
+++ b/src/test/java/com/otilm/core/service/impl/BrandingServiceImplTest.java
@@ -65,7 +65,6 @@ class BrandingServiceImplTest {
         BrandingSettingsDto settings = new BrandingSettingsDto();
         settings.setPrimaryColor("#0073CF");
         settings.setSecondaryColor("#00B0F0");
-        settings.setTertiaryColor("#7030A0");
         settings.setBackgroundColor("#FFFFFF");
         settings.setTextColor("#171717");
         settings.setLightLogo("data:image/png;base64,light");
@@ -77,7 +76,6 @@ class BrandingServiceImplTest {
         Assertions.assertTrue(branding.isConfigured());
         Assertions.assertEquals("#0073CF", branding.getPrimaryColor());
         Assertions.assertEquals("#00B0F0", branding.getSecondaryColor());
-        Assertions.assertEquals("#7030A0", branding.getTertiaryColor());
         Assertions.assertEquals("#FFFFFF", branding.getBackgroundColor());
         Assertions.assertEquals("#171717", branding.getTextColor());
         Assertions.assertEquals("data:image/png;base64,light", branding.getLightLogo());

--- a/src/test/java/com/otilm/core/settings/branding/BrandingSettingsValidatorTest.java
+++ b/src/test/java/com/otilm/core/settings/branding/BrandingSettingsValidatorTest.java
@@ -16,8 +16,7 @@ class BrandingSettingsValidatorTest {
     private static Stream<BiConsumer<BrandingSettingsUpdateDto, String>> colorSetters() {
         return Stream
                 .of(BrandingSettingsUpdateDto::setPrimaryColor, BrandingSettingsUpdateDto::setSecondaryColor,
-                        BrandingSettingsUpdateDto::setTertiaryColor, BrandingSettingsUpdateDto::setBackgroundColor,
-                        BrandingSettingsUpdateDto::setTextColor);
+                        BrandingSettingsUpdateDto::setBackgroundColor, BrandingSettingsUpdateDto::setTextColor);
     }
 
     /** Every field is optional, so an operator clearing all of their branding at once must not be refused. */
@@ -31,7 +30,6 @@ class BrandingSettingsValidatorTest {
         BrandingSettingsUpdateDto branding = new BrandingSettingsUpdateDto();
         branding.setPrimaryColor("#0073CF");
         branding.setSecondaryColor("#00a3e0");
-        branding.setTertiaryColor("#7B61FF");
         branding.setBackgroundColor("#FFFFFF");
         branding.setTextColor("#171717");
         branding.setDefaultTheme(BrandingTheme.DARK);


### PR DESCRIPTION
Follows OmniTrustILM/interfaces#937, which removes `tertiaryColor` from the branding contract. **Depends on that PR merging first** — the call sites below would not compile against the removed field otherwise.

Core validated the colour in `BrandingSettingsValidator`, persisted it through the `PLATFORM_BRANDING` field mapping in `SettingServiceImpl`, and copied it onto the anonymous response in `BrandingServiceImpl`. Nothing ever read it back, so nothing is lost by removing it.

`isConfigured` loses one of its inputs and keeps its meaning: the remaining colours, both logos and the default theme still answer whether an operator has configured anything, and a brand consisting of tertiary alone was never something a client could render.

No migration. Branding is stored one field per row under `PLATFORM_BRANDING`, and both the read and the write walk the known field mapping rather than the stored rows, so a `tertiaryColor` row left behind by an earlier build is never read and never rewritten. The field also never reached a release: branding persistence landed on `main` after `2.19.1`, so only a platform tracking `main` can hold such a row at all.

## Tests

`PublicBrandingControllerITest` asserts the exact key set of the anonymous response, so the field is removed from that expectation rather than left to pass by omission. `BrandingSettingsValidatorTest` and `BrandingServiceImplTest` drop it from their colour sets. `BrandingSettingsITest` gains two cases for a stored `tertiaryColor` row: the read returns the rest of the brand and ignores it, and an update writes the submitted fields and leaves it untouched.

Closes #2184