### PR TITLE
Serve the cryptographic asset detail, statistics and sync visibility

### DIFF
--- a/src/main/java/com/otilm/core/api/web/StatisticsControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/StatisticsControllerImpl.java
@@ -53,6 +53,6 @@ public class StatisticsControllerImpl implements StatisticsController {
     @Override
     @AuditLogged(module = Module.CORE, resource = Resource.CRYPTO_ASSET, operation = Operation.STATISTICS)
     public CryptographicAssetStatisticsDto getCryptographicAssetStatistics() {
-        return cryptographicAssetService.getCryptographicAssetStatistics();
+        return cryptographicAssetService.getCryptographicAssetStatistics(SecurityFilter.create());
     }
 }

--- a/src/main/java/com/otilm/core/dao/repository/cbom/CryptoAssetSourceRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/cbom/CryptoAssetSourceRepository.java
@@ -27,6 +27,19 @@ public interface CryptoAssetSourceRepository extends SecurityFilterRepository<Cr
     boolean existsByCbomUuid(UUID cbomUuid);
 
     /**
+     * The detail endpoint's source list: every CBOM's contribution with its document header, oldest contribution first,
+     * uuid as the deterministic tiebreak. The fetch join loads the read-only {@link CryptoAssetSource#getCbom()}
+     * association in the same query, so callers can read header fields without a session.
+     */
+    @Query("""
+            SELECT s FROM CryptoAssetSource s
+            JOIN FETCH s.cbom
+            WHERE s.assetUuid = :assetUuid
+            ORDER BY s.firstSeenAt ASC, s.uuid ASC
+            """)
+    List<CryptoAssetSource> findWithCbomByAssetUuid(@Param("assetUuid") UUID assetUuid);
+
+    /**
      * The assets a CBOM contributes to -- the work list for detaching that CBOM before its row is deleted, since the
      * foreign key is {@code RESTRICT}.
      */

--- a/src/main/java/com/otilm/core/service/CryptographicAssetExternalService.java
+++ b/src/main/java/com/otilm/core/service/CryptographicAssetExternalService.java
@@ -17,10 +17,10 @@ import java.util.List;
  * operations; the sync itself stays on the CBOM services.
  *
  * <p>
- * Every operation currently rejects with {@link com.otilm.api.exception.NotSupportedException}: the API contract is
- * ratified (interfaces#909, interfaces#913) but the inventory projection and its persistence are not built yet. The
- * authorization annotations on the implementation are live, so the resource and its actions reach the auth service
- * before the data does and the endpoints answer 403 to an unpermitted caller rather than 501.
+ * The ratified contract (interfaces#909, interfaces#913) is fully served: list, detail, the searchable-field
+ * definitions and the dashboard statistics are all real reads. The authorization annotations on the implementation are
+ * what gate every operation, so the resource and its actions reach the auth service before the data does and an
+ * unpermitted caller is refused with 403.
  */
 public interface CryptographicAssetExternalService {
 

--- a/src/main/java/com/otilm/core/service/CryptographicAssetExternalService.java
+++ b/src/main/java/com/otilm/core/service/CryptographicAssetExternalService.java
@@ -55,7 +55,9 @@ public interface CryptographicAssetExternalService {
      * Count badges, distribution maps and the sync-completeness block for the inventory dashboard. Shares the list
      * permission with {@link #listCryptographicAssets} rather than carrying a gate of its own.
      *
+     * @param filter security filter narrowing the asset-side counts to the caller's permitted objects; the
+     * document-level completeness block is scoped separately, by CBOM object access
      * @return the dashboard statistics
      */
-    CryptographicAssetStatisticsDto getCryptographicAssetStatistics();
+    CryptographicAssetStatisticsDto getCryptographicAssetStatistics(SecurityFilter filter);
 }

--- a/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
@@ -39,6 +39,7 @@ import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.ObjectFilterAspect;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.security.authz.SecurityResourceFilter;
 import com.otilm.core.service.CryptographicAssetExternalService;
 import com.otilm.core.service.ResourceExtensionService;
 import com.otilm.core.util.FilterPredicatesBuilder;
@@ -52,9 +53,11 @@ import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Subquery;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -81,6 +84,11 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
 
     /** Top-N cap on the served algorithm-family distribution; the badge pair carries the overflow. */
     private static final int TOP_ALGORITHM_FAMILIES = 10;
+
+    // Per-source evidence is already bounded at 50 occurrences / 64KB by OccurrenceEvidenceCapper; the asset-level
+    // fan-out -- one row per contributing CBOM -- is not. 100 x ~70KB bounds the response while sourceCbomCount
+    // keeps carrying the true total, the same served-vs-true pattern occurrenceCount already uses.
+    private static final int MAX_SERVED_SOURCES = 100;
 
     // The OpenAPI schema documents 1000 as the maximum items per page; this is where it is actually enforced.
     private static final int MAX_ITEMS_PER_PAGE = 1000;
@@ -149,7 +157,40 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
                 .findByUuid(uuid)
                 .orElseThrow(() -> new NotFoundException(CryptoAsset.class, uuid));
         List<CryptoAssetSource> sources = cryptoAssetSourceRepository.findWithCbomByAssetUuid(asset.getUuid());
-        return toDetailDto(asset, sources);
+        return toDetailDto(asset, sources, visibleCbomUuids(asset.getUuid()));
+    }
+
+    /**
+     * The CBOM documents whose content the caller may read, scoped by the caller's own {@code cboms:list} object access
+     * -- serial numbers and payloads belong to the CBOM resource, the same rule
+     * {@link #cbomSerialNumbersScopedToCaller} applies to the source-CBOM value list. Narrowed to the documents that
+     * actually contribute to this asset, mirroring {@link #hasContributedAssets}, so the EXISTS subquery stays cheap.
+     */
+    private Set<UUID> visibleCbomUuids(UUID assetUuid) {
+        SecurityFilter cbomFilter = SecurityFilter.create();
+        objectFilterAspect.populateSecurityFilter(Resource.CBOM, ResourceAction.LIST, null, null, cbomFilter);
+        // Unpaged: Pageable.unpaged() throws from window()'s getOffset()/getPageSize(), unsupported on that
+        // sentinel. A null Pageable and null order is this codebase's own idiom for "every matching uuid, no
+        // paging, no particular order" -- see CryptographicKeyServiceImpl#filterKeyItemsBySecurityFilter and
+        // CertificateServiceImpl#bulkDeleteCertificateBatch.
+        return new HashSet<>(
+                cbomRepository.findUuidsUsingSecurityFilter(cbomFilter, contributesToAsset(assetUuid), null, null));
+    }
+
+    /**
+     * {@link #hasContributedAssets}, narrowed to one asset: the EXISTS subquery a per-detail visibility scope needs.
+     */
+    private static TriFunction<Root<Cbom>, CriteriaBuilder, CriteriaQuery<?>, Predicate> contributesToAsset(
+            UUID assetUuid) {
+        return (root, cb, query) -> {
+            Subquery<Integer> contributed = query.subquery(Integer.class);
+            Root<CryptoAssetSource> source = contributed.from(CryptoAssetSource.class);
+            contributed
+                    .select(cb.literal(1))
+                    .where(cb.equal(source.get(CryptoAssetSource_.cbomUuid), root.get(UniquelyIdentified_.uuid)),
+                            cb.equal(source.get(CryptoAssetSource_.assetUuid), assetUuid));
+            return cb.exists(contributed);
+        };
     }
 
     /**
@@ -232,6 +273,13 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
             CryptographicAssetStatisticsDto dto = CryptographicAssetStatisticsCalculator
                     .assemble(totalAssets.get(), byType.get(), byVerdict.get(), byFamily.get(), TOP_ALGORITHM_FAMILIES,
                             sourceCbomCount.get(), bySyncState.get(), lastCompletedSyncAt.get());
+            if (deniesEverything(cbomFilter)) {
+                // A permission-shaped zero reads as "nothing has ever synced"; omitting the document-derived block
+                // instead states plainly that access, not the estate, is why nothing is served. Asset-side
+                // statistics above are untouched -- they are scoped by the independent CRYPTO_ASSET gate.
+                dto.setSourceCbomCount(null);
+                dto.setSyncCompleteness(null);
+            }
             log.debug("Cryptographic asset statistics calculated in {} ms", (System.nanoTime() - start) / 1_000_000L);
             return dto;
         } catch (InterruptedException e) {
@@ -242,6 +290,19 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
             // request rather than silently serve zeros that no longer reconcile with the list.
             throw new IllegalStateException("Cryptographic asset statistics aggregation failed", e.getCause());
         }
+    }
+
+    /**
+     * Whether the populated filter denies every object of its resource outright: {@code areOnlySpecificObjectsAllowed}
+     * true with an empty allow-list -- the shape {@code ObjectFilterAspect#getResourceFilter} builds from an OPA "not
+     * allowed for the whole group of objects" vote that also names no individually allowed uuid, which is what
+     * {@code BaseSpringBootTest.denyObjectAccess} stubs. A partial restriction (some uuids allowed, or the whole group
+     * allowed with some forbidden) does not match this and keeps serving scoped counts as before.
+     */
+    private static boolean deniesEverything(SecurityFilter filter) {
+        SecurityResourceFilter resourceFilter = filter.getResourceFilter();
+        return resourceFilter != null && resourceFilter.areOnlySpecificObjectsAllowed()
+                && resourceFilter.getAllowedObjects().isEmpty();
     }
 
     /** A document contributed to the inventory when at least one asset-source row points at it. */
@@ -424,21 +485,65 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
         return dto;
     }
 
-    private static CryptographicAssetDetailDto toDetailDto(CryptoAsset asset, List<CryptoAssetSource> sources) {
+    private static CryptographicAssetDetailDto toDetailDto(CryptoAsset asset, List<CryptoAssetSource> sources,
+            Set<UUID> visibleCbomUuids) {
         CryptographicAssetDetailDto dto = new CryptographicAssetDetailDto();
         dto.setUuid(asset.getUuid());
         dto.setName(servedName(asset.getName(), asset.getOid(), asset.getIdentityGuard()));
         dto.setType(asset.getAssetType());
         dto.setPqcVerdict(servedVerdict(asset.getPqcVerdict()));
+        // GLOBAL badges: computed over every loaded row, before the CBOM visibility filter below, so they keep
+        // reconciling with the list (scoped by CRYPTO_ASSET, not CBOM) exactly as the list endpoint serves them --
+        // the visibility gate below is on per-document CONTENT, not on whether a document contributed.
         dto.setSourceCbomCount(asset.getSourceCount());
         dto.setOccurrenceCount(sources.stream().mapToLong(CryptoAssetSource::getOccurrenceCount).sum());
         dto.setQuarantined(quarantined(asset.getIdentityGuard()));
         dto.setVerdict(toVerdictDto(asset));
         dto.setNormalizedFields(toNormalizedFieldsDto(asset));
-        dto.setElectedPayload(asset.getMergedCryptoProperties());
-        dto.setSources(sources.stream().map(CryptographicAssetServiceImpl::toSourceDto).toList());
+        dto.setElectedPayload(servedElectedPayload(asset, sources, visibleCbomUuids));
+        dto.setSources(servedSources(sources, visibleCbomUuids));
         dto.setOids(toOidDtos(asset));
         return dto;
+    }
+
+    /**
+     * Serial numbers, versions and payloads belong to the CBOM resource -- same rule as
+     * {@link #cbomSerialNumbersScopedToCaller} -- so a source is served only for a CBOM the caller may see. Visible
+     * rows are then capped at {@link #MAX_SERVED_SOURCES}, oldest-first: {@code sources} already arrives in that order
+     * (see {@code CryptoAssetSourceRepository#findWithCbomByAssetUuid}), so filtering before limiting keeps it.
+     */
+    private static List<CryptographicAssetSourceDto> servedSources(List<CryptoAssetSource> sources,
+            Set<UUID> visibleCbomUuids) {
+        return sources
+                .stream()
+                .filter(source -> visibleCbomUuids.contains(source.getCbomUuid()))
+                .limit(MAX_SERVED_SOURCES)
+                .map(CryptographicAssetServiceImpl::toSourceDto)
+                .toList();
+    }
+
+    /**
+     * The elected payload is one document's payload verbatim -- {@code asset.getMergedCryptoProperties()} is not
+     * synthesised, it is the electing source's own content -- so unlike the row-level badges (counts) it is gated by
+     * that ONE document's visibility, the same rule {@link #servedSources} applies per row. Election itself stays
+     * global and deterministic: an invisible electing source suppresses the payload rather than re-electing among
+     * whatever the caller can see, which would make the served payload depend on who is asking.
+     */
+    private static Map<String, Object> servedElectedPayload(CryptoAsset asset, List<CryptoAssetSource> sources,
+            Set<UUID> visibleCbomUuids) {
+        UUID electingSourceUuid = asset.getPropertiesSourceUuid();
+        if (electingSourceUuid == null) {
+            return null;
+        }
+        // A pointer naming a row absent from the loaded list (should not happen, but is not this method's invariant
+        // to enforce) is treated the same as an invisible one: no visible row, no payload.
+        boolean electingDocumentVisible = sources
+                .stream()
+                .filter(source -> electingSourceUuid.equals(source.getUuid()))
+                .findFirst()
+                .map(source -> visibleCbomUuids.contains(source.getCbomUuid()))
+                .orElse(false);
+        return electingDocumentVisible ? asset.getMergedCryptoProperties() : null;
     }
 
     /**
@@ -500,11 +605,37 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
     /** Stored evidence is the capped producer occurrence array; the keys are CycloneDX occurrence field names. */
     private static CryptographicAssetEvidenceDto toEvidenceDto(Map<String, Object> occurrence) {
         CryptographicAssetEvidenceDto dto = new CryptographicAssetEvidenceDto();
-        dto.setLocation(occurrence.get("location") instanceof String location ? location : null);
-        dto.setLine(occurrence.get("line") instanceof Number line ? line.intValue() : null);
-        dto.setOffset(occurrence.get("offset") instanceof Number offset ? offset.intValue() : null);
-        dto.setSymbol(occurrence.get("symbol") instanceof String symbol ? symbol : null);
+        dto.setLocation(asServedText(occurrence.get("location")));
+        dto.setLine(asServedInteger(occurrence.get("line")));
+        dto.setOffset(asServedInteger(occurrence.get("offset")));
+        dto.setSymbol(asServedText(occurrence.get("symbol")));
         return dto;
+    }
+
+    /** A producer occasionally emits a numeric evidence field as a string; the value still names a real position. */
+    private static Integer asServedInteger(Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String text) {
+            try {
+                return Integer.valueOf(text.trim());
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /** A locator or symbol served verbatim when textual, or in its decimal form when a producer emitted a number. */
+    private static String asServedText(Object value) {
+        if (value instanceof String text) {
+            return text;
+        }
+        if (value instanceof Number number) {
+            return String.valueOf(number);
+        }
+        return null;
     }
 
     private static List<CryptographicAssetOidDto> toOidDtos(CryptoAsset asset) {

--- a/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
@@ -1,7 +1,6 @@
 package com.otilm.core.service.impl;
 
 import com.otilm.api.exception.NotFoundException;
-import com.otilm.api.exception.NotSupportedException;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.certificate.SearchFilterRequestDto;
 import com.otilm.api.model.client.certificate.SearchRequestDto;
@@ -11,17 +10,27 @@ import com.otilm.api.model.common.PaginationResponseDto;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.cryptoasset.CryptographicAssetDetailDto;
 import com.otilm.api.model.core.cryptoasset.CryptographicAssetDto;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetEvidenceDto;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetNormalizedFieldsDto;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetOidDto;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetSourceDto;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetVerdictDto;
 import com.otilm.api.model.core.cryptoasset.PqcVerdict;
 import com.otilm.api.model.core.scheduler.PaginationRequestDto;
 import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
 import com.otilm.api.model.core.search.SearchFieldDataDto;
 import com.otilm.core.comparator.SearchFieldDataComparator;
+import com.otilm.core.dao.entity.Cbom;
 import com.otilm.core.dao.entity.Cbom_;
+import com.otilm.core.dao.entity.UniquelyIdentified_;
 import com.otilm.core.dao.entity.cbom.CryptoAsset;
+import com.otilm.core.dao.entity.cbom.CryptoAssetSource;
+import com.otilm.core.dao.entity.cbom.CryptoAssetSource_;
 import com.otilm.core.dao.entity.cbom.CryptoAsset_;
 import com.otilm.core.dao.repository.CbomRepository;
 import com.otilm.core.dao.repository.cbom.CryptoAssetRepository;
+import com.otilm.core.dao.repository.cbom.CryptoAssetSourceRepository;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.model.cbom.CryptoAssetIdentityGuard;
@@ -40,39 +49,45 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.function.TriFunction;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.concurrent.DelegatingSecurityContextExecutorService;
 import org.springframework.stereotype.Service;
 
 /**
- * Serves the ratified cryptographic asset inventory contract. List and searchable-fields are real reads over the
- * deduplicated cross-CBOM asset projection; detail, statistics and sync visibility remain {@link NotSupportedException}
- * refusals until core#2145 builds them. The service also serves the per-object listing behind {@code @AuthEndpoint} --
- * the role editor's object picker.
- *
- * <p>
- * {@link NotSupportedException} maps to HTTP 501 in {@code ExceptionHandlingAdvice}, so a permitted caller learns a
- * still-refused operation is not implemented while an unpermitted caller is refused with 403 by the authorization
- * aspect ahead of this body.
+ * Serves the ratified cryptographic asset inventory contract: list, detail, searchable-fields and the dashboard
+ * statistics are all real reads over the deduplicated cross-CBOM asset projection. The service also serves the
+ * per-object listing behind {@code @AuthEndpoint} -- the role editor's object picker.
  */
 @Service(Resource.Codes.CRYPTO_ASSET)
+@Slf4j
 public class CryptographicAssetServiceImpl implements CryptographicAssetExternalService, ResourceExtensionService {
 
-    private static final String NOT_IMPLEMENTED = "Cryptographic asset inventory is not implemented yet";
+    /** Top-N cap on the served algorithm-family distribution; the badge pair carries the overflow. */
+    private static final int TOP_ALGORITHM_FAMILIES = 10;
 
     // The OpenAPI schema documents 1000 as the maximum items per page; this is where it is actually enforced.
     private static final int MAX_ITEMS_PER_PAGE = 1000;
 
     private CryptoAssetRepository cryptoAssetRepository;
+
+    private CryptoAssetSourceRepository cryptoAssetSourceRepository;
 
     private CbomRepository cbomRepository;
 
@@ -81,6 +96,11 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
     @Autowired
     public void setCryptoAssetRepository(CryptoAssetRepository cryptoAssetRepository) {
         this.cryptoAssetRepository = cryptoAssetRepository;
+    }
+
+    @Autowired
+    public void setCryptoAssetSourceRepository(CryptoAssetSourceRepository cryptoAssetSourceRepository) {
+        this.cryptoAssetSourceRepository = cryptoAssetSourceRepository;
     }
 
     @Autowired
@@ -125,7 +145,11 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
     @Override
     @ExternalAuthorization(resource = Resource.CRYPTO_ASSET, action = ResourceAction.DETAIL)
     public CryptographicAssetDetailDto getCryptographicAsset(SecuredUUID uuid) throws NotFoundException {
-        throw new NotSupportedException(NOT_IMPLEMENTED);
+        CryptoAsset asset = cryptoAssetRepository
+                .findByUuid(uuid)
+                .orElseThrow(() -> new NotFoundException(CryptoAsset.class, uuid));
+        List<CryptoAssetSource> sources = cryptoAssetSourceRepository.findWithCbomByAssetUuid(asset.getUuid());
+        return toDetailDto(asset, sources);
     }
 
     /**
@@ -176,7 +200,69 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
     @Override
     @ExternalAuthorization(resource = Resource.CRYPTO_ASSET, action = ResourceAction.LIST)
     public CryptographicAssetStatisticsDto getCryptographicAssetStatistics() {
-        throw new NotSupportedException(NOT_IMPLEMENTED);
+        // No SecurityFilter parameter reaches this method (the contract takes none), so both scopes are built
+        // by hand: assets under the caller's CRYPTO_ASSET LIST scope -- which is what makes these numbers
+        // reconcile with the list -- and the document-level completeness block under the CBOM LIST scope.
+        SecurityFilter assetFilter = SecurityFilter.create();
+        objectFilterAspect.populateSecurityFilter(Resource.CRYPTO_ASSET, ResourceAction.LIST, null, null, assetFilter);
+        SecurityFilter cbomFilter = SecurityFilter.create();
+        objectFilterAspect.populateSecurityFilter(Resource.CBOM, ResourceAction.LIST, null, null, cbomFilter);
+        long start = System.nanoTime();
+        try (ExecutorService executor = new DelegatingSecurityContextExecutorService(
+                Executors.newVirtualThreadPerTaskExecutor())) {
+            Future<Long> totalAssets = executor
+                    .submit(() -> cryptoAssetRepository.countRowsUsingSecurityFilter(assetFilter, null));
+            Future<Map<String, Long>> byType = executor
+                    .submit(() -> cryptoAssetRepository
+                            .countGroupedUsingSecurityFilter(assetFilter, null, CryptoAsset_.assetType, null, null));
+            Future<Map<String, Long>> byVerdict = executor
+                    .submit(() -> cryptoAssetRepository
+                            .countGroupedUsingSecurityFilter(assetFilter, null, CryptoAsset_.pqcVerdict, null, null));
+            Future<Map<String, Long>> byFamily = executor
+                    .submit(() -> cryptoAssetRepository
+                            .countGroupedUsingSecurityFilter(assetFilter, null, CryptoAsset_.algorithmFamily, null,
+                                    null));
+            Future<Long> sourceCbomCount = executor
+                    .submit(() -> cbomRepository
+                            .countUsingSecurityFilter(cbomFilter, CryptographicAssetServiceImpl::hasContributedAssets));
+            Future<Map<String, Long>> bySyncState = executor
+                    .submit(() -> cbomRepository
+                            .countGroupedUsingSecurityFilter(cbomFilter, null, Cbom_.assetSyncState, null, null));
+            Future<OffsetDateTime> lastCompletedSyncAt = executor.submit(() -> lastCompletedSyncAt(cbomFilter));
+            CryptographicAssetStatisticsDto dto = CryptographicAssetStatisticsCalculator
+                    .assemble(totalAssets.get(), byType.get(), byVerdict.get(), byFamily.get(), TOP_ALGORITHM_FAMILIES,
+                            sourceCbomCount.get(), bySyncState.get(), lastCompletedSyncAt.get());
+            log.debug("Cryptographic asset statistics calculated in {} ms", (System.nanoTime() - start) / 1_000_000L);
+            return dto;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Cryptographic asset statistics aggregation was interrupted", e);
+        } catch (ExecutionException e) {
+            // Unlike the mixed dashboard, this endpoint serves one resource: a failed aggregate must fail the
+            // request rather than silently serve zeros that no longer reconcile with the list.
+            throw new IllegalStateException("Cryptographic asset statistics aggregation failed", e.getCause());
+        }
+    }
+
+    /** A document contributed to the inventory when at least one asset-source row points at it. */
+    private static Predicate hasContributedAssets(Root<Cbom> root, CriteriaBuilder cb, CriteriaQuery<?> query) {
+        Subquery<Integer> contributed = query.subquery(Integer.class);
+        Root<CryptoAssetSource> source = contributed.from(CryptoAssetSource.class);
+        contributed
+                .select(cb.literal(1))
+                .where(cb.equal(source.get(CryptoAssetSource_.cbomUuid), root.get(UniquelyIdentified_.uuid)));
+        return cb.exists(contributed);
+    }
+
+    private OffsetDateTime lastCompletedSyncAt(SecurityFilter cbomFilter) {
+        List<UUID> newest = cbomRepository
+                .findUuidsUsingSecurityFilter(cbomFilter,
+                        (root, cb, query) -> cb.isNotNull(root.get(Cbom_.assetsSyncedAt)), PageRequest.of(0, 1),
+                        (root, cb) -> cb.desc(root.get(Cbom_.assetsSyncedAt)));
+        if (newest.isEmpty()) {
+            return null;
+        }
+        return cbomRepository.findById(newest.getFirst()).map(Cbom::getAssetsSyncedAt).orElse(null);
     }
 
     @Override
@@ -294,10 +380,33 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
 
     /** The in-memory twin of {@link #displayLabel}; the list orders by that expression and serves this value. */
     private static String servedName(CryptoAssetListRow row) {
-        if (row.name() != null) {
-            return row.name();
+        return servedName(row.name(), row.oid(), row.identityGuard());
+    }
+
+    private static String servedName(String name, String oid, CryptoAssetIdentityGuard guard) {
+        if (name != null) {
+            return name;
         }
-        return row.identityGuard() == CryptoAssetIdentityGuard.REFUTED_OID ? null : row.oid();
+        return guard == CryptoAssetIdentityGuard.REFUTED_OID ? null : oid;
+    }
+
+    /**
+     * A never-evaluated asset is served as UNKNOWN, the ratified "the rules cannot classify this asset" verdict,
+     * because the contract marks the field required.
+     */
+    private static PqcVerdict servedVerdict(PqcVerdict stored) {
+        return stored == null ? PqcVerdict.UNKNOWN : stored;
+    }
+
+    /**
+     * The contract's sentence -- "sources make contradicting claims ... quarantined pending reconciliation" --
+     * describes exactly one guard: REFUTED_CERTIFICATE_DIGEST (contradicting claims, reconciliation queue).
+     * BARE_CN_SUBJECT is a permanent DN-scope split with, by the ratified addendum, no reconciliation path at all, and
+     * REFUTED_OID is one component contradicting itself; flagging either would advertise an operator queue that can
+     * never drain. Widening this needs the flag re-worded in interfaces, not a wider test here.
+     */
+    private static boolean quarantined(CryptoAssetIdentityGuard guard) {
+        return guard == CryptoAssetIdentityGuard.REFUTED_CERTIFICATE_DIGEST;
     }
 
     private static CryptographicAssetDto toDto(CryptoAssetListRow row) {
@@ -310,15 +419,101 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
         dto.setType(row.assetType());
         dto.setSourceCbomCount(row.sourceCount());
         dto.setOccurrenceCount(row.occurrenceCount());
-        // A never-evaluated asset is served as UNKNOWN, the ratified "the rules cannot classify this asset"
-        // verdict, because the contract marks the field required.
-        dto.setPqcVerdict(row.pqcVerdict() == null ? PqcVerdict.UNKNOWN : row.pqcVerdict());
-        // The contract's sentence -- "sources make contradicting claims ... quarantined pending reconciliation" --
-        // describes exactly one guard: REFUTED_CERTIFICATE_DIGEST (contradicting claims, reconciliation queue).
-        // BARE_CN_SUBJECT is a permanent DN-scope split with, by the ratified addendum, no reconciliation path at
-        // all, and REFUTED_OID is one component contradicting itself; flagging either would advertise an operator
-        // queue that can never drain. Widening this needs the flag re-worded in interfaces, not a wider test here.
-        dto.setQuarantined(row.identityGuard() == CryptoAssetIdentityGuard.REFUTED_CERTIFICATE_DIGEST);
+        dto.setPqcVerdict(servedVerdict(row.pqcVerdict()));
+        dto.setQuarantined(quarantined(row.identityGuard()));
         return dto;
+    }
+
+    private static CryptographicAssetDetailDto toDetailDto(CryptoAsset asset, List<CryptoAssetSource> sources) {
+        CryptographicAssetDetailDto dto = new CryptographicAssetDetailDto();
+        dto.setUuid(asset.getUuid());
+        dto.setName(servedName(asset.getName(), asset.getOid(), asset.getIdentityGuard()));
+        dto.setType(asset.getAssetType());
+        dto.setPqcVerdict(servedVerdict(asset.getPqcVerdict()));
+        dto.setSourceCbomCount(asset.getSourceCount());
+        dto.setOccurrenceCount(sources.stream().mapToLong(CryptoAssetSource::getOccurrenceCount).sum());
+        dto.setQuarantined(quarantined(asset.getIdentityGuard()));
+        dto.setVerdict(toVerdictDto(asset));
+        dto.setNormalizedFields(toNormalizedFieldsDto(asset));
+        dto.setElectedPayload(asset.getMergedCryptoProperties());
+        dto.setSources(sources.stream().map(CryptographicAssetServiceImpl::toSourceDto).toList());
+        dto.setOids(toOidDtos(asset));
+        return dto;
+    }
+
+    /**
+     * Verdict provenance exists only once a rule set has evaluated the asset; until core#2151 populates verdicts, a
+     * fabricated all-default block would present "never evaluated" as a decision, so the block is omitted and the
+     * row-level verdict alone says UNKNOWN.
+     */
+    private static CryptographicAssetVerdictDto toVerdictDto(CryptoAsset asset) {
+        if (asset.getPqcEvaluatedAt() == null) {
+            return null;
+        }
+        CryptographicAssetVerdictDto dto = new CryptographicAssetVerdictDto();
+        dto.setRuleSetVersion(asset.getPqcRulesetVersion() == null ? 0 : asset.getPqcRulesetVersion());
+        dto.setRuleId(asset.getPqcRuleId());
+        dto.setReason(asset.getPqcReason());
+        dto.setEvaluatedFields(asset.getPqcEvaluatedFields());
+        dto.setDecidedAt(asset.getPqcDecidedAt());
+        dto.setEvaluatedAt(asset.getPqcEvaluatedAt());
+        return dto;
+    }
+
+    private static CryptographicAssetNormalizedFieldsDto toNormalizedFieldsDto(CryptoAsset asset) {
+        if (asset.getAlgorithmFamily() == null && asset.getPrimitive() == null && asset.getParameterSet() == null
+                && asset.getCurve() == null && asset.getMode() == null && asset.getPadding() == null
+                && asset.getVariant() == null) {
+            return null;
+        }
+        CryptographicAssetNormalizedFieldsDto dto = new CryptographicAssetNormalizedFieldsDto();
+        dto.setAlgorithmFamily(asset.getAlgorithmFamily());
+        dto.setPrimitive(asset.getPrimitive());
+        dto.setParameterSet(asset.getParameterSet());
+        dto.setCurve(asset.getCurve());
+        dto.setMode(asset.getMode());
+        dto.setPadding(asset.getPadding());
+        dto.setVariant(asset.getVariant());
+        return dto;
+    }
+
+    private static CryptographicAssetSourceDto toSourceDto(CryptoAssetSource source) {
+        Cbom cbom = source.getCbom();
+        CryptographicAssetSourceDto dto = new CryptographicAssetSourceDto();
+        dto.setCbomUuid(source.getCbomUuid());
+        dto.setSerialNumber(cbom.getSerialNumber());
+        dto.setVersion(cbom.getVersion());
+        dto.setOccurrenceCount(source.getOccurrenceCount());
+        dto.setSource(cbom.getSource());
+        dto.setPayload(source.getOriginalCryptoProperties());
+        dto.setEvidence(toEvidenceDtos(source.getEvidence()));
+        return dto;
+    }
+
+    private static List<CryptographicAssetEvidenceDto> toEvidenceDtos(List<Map<String, Object>> stored) {
+        if (stored == null) {
+            return null;
+        }
+        return stored.stream().map(CryptographicAssetServiceImpl::toEvidenceDto).toList();
+    }
+
+    /** Stored evidence is the capped producer occurrence array; the keys are CycloneDX occurrence field names. */
+    private static CryptographicAssetEvidenceDto toEvidenceDto(Map<String, Object> occurrence) {
+        CryptographicAssetEvidenceDto dto = new CryptographicAssetEvidenceDto();
+        dto.setLocation(occurrence.get("location") instanceof String location ? location : null);
+        dto.setLine(occurrence.get("line") instanceof Number line ? line.intValue() : null);
+        dto.setOffset(occurrence.get("offset") instanceof Number offset ? offset.intValue() : null);
+        dto.setSymbol(occurrence.get("symbol") instanceof String symbol ? symbol : null);
+        return dto;
+    }
+
+    private static List<CryptographicAssetOidDto> toOidDtos(CryptoAsset asset) {
+        if (asset.getOid() == null) {
+            return List.of();
+        }
+        CryptographicAssetOidDto dto = new CryptographicAssetOidDto();
+        dto.setOid(asset.getOid());
+        dto.setRefuted(asset.getIdentityGuard() == CryptoAssetIdentityGuard.REFUTED_OID);
+        return List.of(dto);
     }
 }

--- a/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
@@ -240,29 +240,28 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
 
     @Override
     @ExternalAuthorization(resource = Resource.CRYPTO_ASSET, action = ResourceAction.LIST)
-    public CryptographicAssetStatisticsDto getCryptographicAssetStatistics() {
-        // No SecurityFilter parameter reaches this method (the contract takes none), so both scopes are built
-        // by hand: assets under the caller's CRYPTO_ASSET LIST scope -- which is what makes these numbers
-        // reconcile with the list -- and the document-level completeness block under the CBOM LIST scope.
-        SecurityFilter assetFilter = SecurityFilter.create();
-        objectFilterAspect.populateSecurityFilter(Resource.CRYPTO_ASSET, ResourceAction.LIST, null, null, assetFilter);
+    public CryptographicAssetStatisticsDto getCryptographicAssetStatistics(SecurityFilter filter) {
+        // The annotation aspect populates `filter` under the caller's CRYPTO_ASSET LIST scope before this method
+        // runs -- the same mechanism listCryptographicAssets uses -- which is what makes these numbers reconcile
+        // with the list. The document-level completeness block is a second, cross-resource scope the aspect
+        // cannot populate from one annotation, so only that half is still built by hand, same as
+        // cbomSerialNumbersScopedToCaller and the detail endpoint's visibleCbomUuids.
         SecurityFilter cbomFilter = SecurityFilter.create();
         objectFilterAspect.populateSecurityFilter(Resource.CBOM, ResourceAction.LIST, null, null, cbomFilter);
         long start = System.nanoTime();
         try (ExecutorService executor = new DelegatingSecurityContextExecutorService(
                 Executors.newVirtualThreadPerTaskExecutor())) {
             Future<Long> totalAssets = executor
-                    .submit(() -> cryptoAssetRepository.countRowsUsingSecurityFilter(assetFilter, null));
+                    .submit(() -> cryptoAssetRepository.countRowsUsingSecurityFilter(filter, null));
             Future<Map<String, Long>> byType = executor
                     .submit(() -> cryptoAssetRepository
-                            .countGroupedUsingSecurityFilter(assetFilter, null, CryptoAsset_.assetType, null, null));
+                            .countGroupedUsingSecurityFilter(filter, null, CryptoAsset_.assetType, null, null));
             Future<Map<String, Long>> byVerdict = executor
                     .submit(() -> cryptoAssetRepository
-                            .countGroupedUsingSecurityFilter(assetFilter, null, CryptoAsset_.pqcVerdict, null, null));
+                            .countGroupedUsingSecurityFilter(filter, null, CryptoAsset_.pqcVerdict, null, null));
             Future<Map<String, Long>> byFamily = executor
                     .submit(() -> cryptoAssetRepository
-                            .countGroupedUsingSecurityFilter(assetFilter, null, CryptoAsset_.algorithmFamily, null,
-                                    null));
+                            .countGroupedUsingSecurityFilter(filter, null, CryptoAsset_.algorithmFamily, null, null));
             Future<Long> sourceCbomCount = executor
                     .submit(() -> cbomRepository
                             .countUsingSecurityFilter(cbomFilter, CryptographicAssetServiceImpl::hasContributedAssets));
@@ -605,7 +604,9 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
     /** Stored evidence is the capped producer occurrence array; the keys are CycloneDX occurrence field names. */
     private static CryptographicAssetEvidenceDto toEvidenceDto(Map<String, Object> occurrence) {
         CryptographicAssetEvidenceDto dto = new CryptographicAssetEvidenceDto();
-        dto.setLocation(asServedText(occurrence.get("location")));
+        // location is contract-REQUIRED; the write side (OccurrenceEvidenceCapper#sanitizeLocation) already
+        // established "" as the absent-location representation, so the read side must not serve null here either.
+        dto.setLocation(Objects.requireNonNullElse(asServedText(occurrence.get("location")), ""));
         dto.setLine(asServedInteger(occurrence.get("line")));
         dto.setOffset(asServedInteger(occurrence.get("offset")));
         dto.setSymbol(asServedText(occurrence.get("symbol")));

--- a/src/main/java/com/otilm/core/service/impl/CryptographicAssetStatisticsCalculator.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicAssetStatisticsCalculator.java
@@ -1,0 +1,89 @@
+package com.otilm.core.service.impl;
+
+import com.otilm.api.model.client.dashboard.CryptographicAssetStatisticsDto;
+import com.otilm.api.model.client.dashboard.CryptographicAssetSyncCompletenessDto;
+import com.otilm.api.model.core.cbom.CbomAssetSyncState;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetType;
+import com.otilm.api.model.core.cryptoasset.PqcVerdict;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Pure transformations behind the cryptographic asset statistics, kept free of Spring and persistence so they can be
+ * unit-tested directly. The SQL aggregation lives in the service; this class only reshapes its results.
+ */
+final class CryptographicAssetStatisticsCalculator {
+
+    /**
+     * The literal {@code SecurityFilterRepositoryImpl.countGroupedUsingSecurityFilter} substitutes for a NULL group
+     * key. For verdicts it means "never evaluated" and folds into {@code unknown}; for families it is the contract's
+     * unassignedAssetCount and never occupies a top-N slot.
+     */
+    static final String UNASSIGNED_KEY = "Unassigned";
+
+    private CryptographicAssetStatisticsCalculator() {
+    }
+
+    static CryptographicAssetStatisticsDto assemble(long totalAssets, Map<String, Long> byType,
+            Map<String, Long> byVerdict, Map<String, Long> byFamily, int topFamilies, long sourceCbomCount,
+            Map<String, Long> cbomBySyncState, OffsetDateTime lastCompletedSyncAt) {
+        CryptographicAssetStatisticsDto dto = new CryptographicAssetStatisticsDto();
+        dto.setTotalAssets(totalAssets);
+        dto.setSourceCbomCount(sourceCbomCount);
+        dto.setStatByType(dense(byType, typeCodes(), null));
+        dto.setStatByPqcVerdict(dense(byVerdict, verdictCodes(), PqcVerdict.UNKNOWN.getCode()));
+        Map<String, Long> families = new HashMap<>(byFamily);
+        Long unassigned = families.remove(UNASSIGNED_KEY);
+        dto.setUnassignedAssetCount(unassigned == null ? 0L : unassigned);
+        dto.setDistinctAlgorithmFamilyCount((long) families.size());
+        dto.setStatByAlgorithmFamily(top(families, topFamilies));
+        CryptographicAssetSyncCompletenessDto completeness = new CryptographicAssetSyncCompletenessDto();
+        completeness.setCbomStatBySyncState(dense(cbomBySyncState, syncStateCodes(), null));
+        completeness.setLastCompletedSyncAt(lastCompletedSyncAt);
+        dto.setSyncCompleteness(completeness);
+        return dto;
+    }
+
+    /** Every code present with 0 when none, in enum declaration order; a NULL bucket folds into foldNullInto. */
+    private static Map<String, Long> dense(Map<String, Long> sparse, List<String> codes, String foldNullInto) {
+        Map<String, Long> result = new LinkedHashMap<>();
+        for (String code : codes) {
+            result.put(code, sparse.getOrDefault(code, 0L));
+        }
+        Long nullBucket = sparse.get(UNASSIGNED_KEY);
+        if (nullBucket != null && foldNullInto != null) {
+            result.merge(foldNullInto, nullBucket, Long::sum);
+        }
+        return result;
+    }
+
+    /** Highest counts first, count ties broken on ascending key so pagination of the chart is stable. */
+    private static Map<String, Long> top(Map<String, Long> all, int limit) {
+        return all
+                .entrySet()
+                .stream()
+                .sorted(Map.Entry
+                        .<String, Long>comparingByValue(Comparator.reverseOrder())
+                        .thenComparing(Map.Entry.comparingByKey()))
+                .limit(limit)
+                .collect(LinkedHashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), LinkedHashMap::putAll);
+    }
+
+    private static List<String> typeCodes() {
+        return Arrays.stream(CryptographicAssetType.values()).map(CryptographicAssetType::getCode).toList();
+    }
+
+    private static List<String> verdictCodes() {
+        return Arrays.stream(PqcVerdict.values()).map(PqcVerdict::getCode).toList();
+    }
+
+    private static List<String> syncStateCodes() {
+        return Arrays.stream(CbomAssetSyncState.values()).map(CbomAssetSyncState::getCode).toList();
+    }
+}

--- a/src/main/java/com/otilm/core/service/impl/CryptographicAssetStatisticsCalculator.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicAssetStatisticsCalculator.java
@@ -24,6 +24,12 @@ final class CryptographicAssetStatisticsCalculator {
      * The literal {@code SecurityFilterRepositoryImpl.countGroupedUsingSecurityFilter} substitutes for a NULL group
      * key. For verdicts it means "never evaluated" and folds into {@code unknown}; for families it is the contract's
      * unassignedAssetCount and never occupies a top-N slot.
+     *
+     * <p>
+     * The literal is duplicated from {@code SecurityFilterRepositoryImpl}'s NULL group-key substitution, not shared
+     * with it. Collision with a genuine stored family is prevented by {@code CryptoAssetIdentityFields#fold()}
+     * lowercasing producer text before storage, so a stored "unassigned" coexists with this sentinel while a stored
+     * "Unassigned" can never occur.
      */
     static final String UNASSIGNED_KEY = "Unassigned";
 
@@ -50,15 +56,29 @@ final class CryptographicAssetStatisticsCalculator {
         return dto;
     }
 
-    /** Every code present with 0 when none, in enum declaration order; a NULL bucket folds into foldNullInto. */
+    /**
+     * Every code present with 0 when none, in enum declaration order; a NULL bucket folds into {@code foldNullInto}
+     * when one is given. Any other key -- one {@code codes} does not list, or the sentinel when nothing folds it -- is
+     * not a bucket this dense map has room for, and is not dropped silently: a discarded bucket is a chart that
+     * silently lies, so it fails the request instead.
+     */
     private static Map<String, Long> dense(Map<String, Long> sparse, List<String> codes, String foldNullInto) {
         Map<String, Long> result = new LinkedHashMap<>();
         for (String code : codes) {
             result.put(code, sparse.getOrDefault(code, 0L));
         }
-        Long nullBucket = sparse.get(UNASSIGNED_KEY);
-        if (nullBucket != null && foldNullInto != null) {
-            result.merge(foldNullInto, nullBucket, Long::sum);
+        for (Map.Entry<String, Long> entry : sparse.entrySet()) {
+            String key = entry.getKey();
+            if (codes.contains(key)) {
+                continue;
+            }
+            if (key.equals(UNASSIGNED_KEY) && foldNullInto != null) {
+                result.merge(foldNullInto, entry.getValue(), Long::sum);
+                continue;
+            }
+            throw new IllegalStateException("Unmapped statistics group key \"%s\": expected one of %s%s"
+                    .formatted(key, codes,
+                            foldNullInto != null ? " or the \"%s\" sentinel".formatted(UNASSIGNED_KEY) : ""));
         }
         return result;
     }

--- a/src/main/java/com/otilm/core/service/writer/cbom/CryptoAssetSourceWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/cbom/CryptoAssetSourceWriter.java
@@ -8,6 +8,7 @@ import com.otilm.core.dao.repository.cbom.CryptoAssetSourceRepository;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -80,9 +81,15 @@ public class CryptoAssetSourceWriter {
         sourceRepository
                 .upsertSource(UUID.randomUUID(), assetUuid, cbomUuid, JsonColumnText.render(cryptoProperties),
                         digest.leafCount(), digest.hash(),
-                        JsonColumnText.render(OccurrenceEvidenceCapper.cap(occurrences)),
-                        occurrences == null ? 0 : occurrences.size(), seenAt);
+                        JsonColumnText.render(OccurrenceEvidenceCapper.cap(occurrences)), occurrenceCount(occurrences),
+                        seenAt);
         assetRepository.recomputeMergeFromSources(assetUuid);
+    }
+
+    // A JSON-null array element carries no evidence -- OccurrenceEvidenceCapper#cap filters it out before capping --
+    // so counting it here would let occurrence_count overstate what cap() considers an occurrence.
+    private static int occurrenceCount(List<Map<String, Object>> occurrences) {
+        return occurrences == null ? 0 : (int) occurrences.stream().filter(Objects::nonNull).count();
     }
 
     /**

--- a/src/test/java/com/otilm/core/integration/api/web/CryptographicAssetAuthorizationHttpITest.java
+++ b/src/test/java/com/otilm/core/integration/api/web/CryptographicAssetAuthorizationHttpITest.java
@@ -2,13 +2,19 @@ package com.otilm.core.integration.api.web;
 
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.cryptoasset.CryptographicAssetType;
+import com.otilm.api.model.core.cryptoasset.PqcVerdict;
 import com.otilm.core.cbom.asset.AssetRowKeys;
 import com.otilm.core.cbom.asset.CryptoAssetIdentityFields;
 import com.otilm.core.dao.entity.Cbom;
 import com.otilm.core.dao.repository.CbomRepository;
 import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.service.writer.cbom.CryptoAssetSourceWriter;
 import com.otilm.core.service.writer.cbom.CryptoAssetWriter;
 import com.otilm.core.util.BaseSpringBootTest;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,13 +29,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * {@code @ExternalAuthorization} over HTTP for the cryptographic asset inventory's list and searchable-fields
- * endpoints, mirroring {@link ExternalAuthorizationHttpITest}'s style: the real security filter chain, the
- * method-security advisor, and {@code ExceptionHandlingAdvice.handleAccessDeniedException}.
+ * {@code @ExternalAuthorization} over HTTP for the cryptographic asset inventory's list, searchable-fields, detail and
+ * statistics endpoints, mirroring {@link ExternalAuthorizationHttpITest}'s style: the real security filter chain, the
+ * method-security advisor, and {@code ExceptionHandlingAdvice.handleAccessDeniedException}. Detail additionally pins
+ * the not-found path (a 404, not a leak) and the wire shape of its own core#2145 contract.
  *
  * <p>
- * The permitted-path assertions also carry the wire-level identity-key criterion: neither endpoint's raw response ever
- * mentions it.
+ * The permitted-path assertions also carry the wire-level identity-key criterion: none of the four endpoints' raw
+ * responses ever mentions it.
  */
 @AutoConfigureMockMvc
 class CryptographicAssetAuthorizationHttpITest extends BaseSpringBootTest {
@@ -37,6 +44,10 @@ class CryptographicAssetAuthorizationHttpITest extends BaseSpringBootTest {
     private static final String LIST_ENDPOINT = "/v1/cryptoAssets";
 
     private static final String SEARCHABLE_FIELDS_ENDPOINT = "/v1/cryptoAssets/search";
+
+    private static final String DETAIL_ENDPOINT = "/v1/cryptoAssets/";
+
+    private static final String STATISTICS_ENDPOINT = "/v1/statistics/cryptoAssets";
 
     // The same detection rule IdentityKeyExposureFence uses, applied to the live wire response. A bare "identity"
     // substring is not it: CBOM_ASSET_RULESET_VERSION's own label is "Identity Rule Set Version" -- "identity" as an
@@ -51,15 +62,20 @@ class CryptographicAssetAuthorizationHttpITest extends BaseSpringBootTest {
     private CryptoAssetWriter assetWriter;
 
     @Autowired
+    private CryptoAssetSourceWriter sourceWriter;
+
+    @Autowired
     private CbomRepository cbomRepository;
 
     private CryptoAssetIdentityFields seededFields;
+
+    private UUID seededUuid;
 
     @BeforeEach
     void seedAsset() {
         seededFields = new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ECDSA", "1.2.840.10045.4.3.2",
                 "ecdsa", "signature", "P-256", "secp256r1", null, null, null);
-        assetWriter.upsertIdentity(AssetRowKeys.forFields(seededFields), seededFields, null);
+        seededUuid = assetWriter.upsertIdentity(AssetRowKeys.forFields(seededFields), seededFields, null);
     }
 
     @Test
@@ -97,9 +113,8 @@ class CryptographicAssetAuthorizationHttpITest extends BaseSpringBootTest {
         // The name pattern catches field names; a wire leak would realistically be the VALUE. The calculator can
         // recompute this row's exact key from the same fixture input, so assert the strongest possible fact: the
         // literal key appears in neither raw response.
-        String exactIdentityKey = AssetRowKeys.forFields(seededFields);
-        assertThat(listResponse).doesNotContain(exactIdentityKey);
-        assertThat(searchableFieldsResponse).doesNotContain(exactIdentityKey);
+        assertThat(listResponse).doesNotContain(theSeededKeyLiteral());
+        assertThat(searchableFieldsResponse).doesNotContain(theSeededKeyLiteral());
     }
 
     @Test
@@ -141,5 +156,122 @@ class CryptographicAssetAuthorizationHttpITest extends BaseSpringBootTest {
         assertThat(scoped)
                 .describedAs("the fields themselves still serve; only the cross-resource value list is scoped")
                 .contains("CBOM_ASSET_SOURCE_CBOM");
+    }
+
+    @Test
+    void deniesDetailWhenTheDetailActionIsDenied() throws Exception {
+        UUID assetUuid = seedOneAsset();
+        denyResourceAccess(Resource.CRYPTO_ASSET, ResourceAction.DETAIL);
+
+        mockMvc
+                .perform(get(DETAIL_ENDPOINT + assetUuid))
+                .andExpectAll(status().isForbidden(), jsonPath("$.code").value("ACCESS_DENIED"));
+    }
+
+    @Test
+    void deniesStatisticsWhenTheListActionIsDenied() throws Exception {
+        denyResourceAccess(Resource.CRYPTO_ASSET, ResourceAction.LIST);
+
+        mockMvc
+                .perform(get(STATISTICS_ENDPOINT))
+                .andExpectAll(status().isForbidden(), jsonPath("$.code").value("ACCESS_DENIED"));
+    }
+
+    @Test
+    void detailNotFoundIsA404NotALeak() throws Exception {
+        String body = mockMvc
+                .perform(get(DETAIL_ENDPOINT + UUID.randomUUID()))
+                .andExpect(status().isNotFound())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertThat(body).doesNotContainPattern(IDENTITY_KEY);
+    }
+
+    /**
+     * The permitted-path identity-key criterion, extended to detail and statistics. Seeding a source payload, capped
+     * evidence and an evaluated verdict puts every map-typed channel either response carries -- the elected payload,
+     * the per-source original, the verdict's evaluated fields, and the statistics group-by maps -- onto the wire, so
+     * the two assertions below (the vocabulary regex and the literal recomputed key) are checking something real rather
+     * than passing vacuously over a near-empty response.
+     */
+    @Test
+    void neitherDetailNorStatisticsResponseCarriesTheIdentityKey() throws Exception {
+        UUID assetUuid = seedAssetWithSourcesPayloadsAndVerdict();
+
+        String detailBody = mockMvc
+                .perform(get(DETAIL_ENDPOINT + assetUuid))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        String statisticsBody = mockMvc
+                .perform(get(STATISTICS_ENDPOINT))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        // same two assertions the list test makes: the vocabulary regex AND the literal recomputed key value
+        assertThat(detailBody).doesNotContainPattern(IDENTITY_KEY).doesNotContain(theSeededKeyLiteral());
+        assertThat(statisticsBody).doesNotContainPattern(IDENTITY_KEY).doesNotContain(theSeededKeyLiteral());
+    }
+
+    /**
+     * The JSON property names on detail are the contract, not just the Java getters -- this pins {@code
+     * electedPayload}, a per-source {@code payload} and {@code serialNumber}, a per-OID {@code refuted} flag and
+     * {@code verdict.ruleId} on the wire. The same row is read before and after it earns a verdict, so the negative
+     * half of the contract is pinned too: {@code NON_NULL} omits the {@code verdict} field entirely rather than serving
+     * it as {@code null}.
+     */
+    @Test
+    void servesDetailWireShapeAndOmitsVerdictUntilEvaluated() throws Exception {
+        UUID assetUuid = seedOneAsset();
+
+        mockMvc
+                .perform(get(DETAIL_ENDPOINT + assetUuid))
+                .andExpectAll(status().isOk(), jsonPath("$.verdict").doesNotExist());
+
+        seedAssetWithSourcesPayloadsAndVerdict();
+
+        mockMvc
+                .perform(get(DETAIL_ENDPOINT + assetUuid))
+                .andExpectAll(status().isOk(), jsonPath("$.electedPayload").exists(),
+                        jsonPath("$.sources[0].payload").exists(), jsonPath("$.sources[0].serialNumber").exists(),
+                        jsonPath("$.oids[0].refuted").exists(), jsonPath("$.verdict.ruleId").exists());
+    }
+
+    private UUID seedOneAsset() {
+        return seededUuid;
+    }
+
+    /**
+     * Extends the row {@link #seedAsset()} already created with a source (a payload map and capped evidence) and an
+     * evaluated verdict (whose own {@code evaluatedFields} is a map too), reusing the same {@link #seededFields} so
+     * {@link #theSeededKeyLiteral()} still names the row under test.
+     */
+    private UUID seedAssetWithSourcesPayloadsAndVerdict() {
+        Cbom cbom = newCbom("urn:uuid:fence-source");
+        Map<String, Object> payload = Map.of("name", "ecdsa", "curve", "P-256");
+        sourceWriter
+                .upsertSource(seededUuid, cbom.getUuid(), payload,
+                        List.of(Map.of("location", "src/fence.c", "line", 1)), OffsetDateTime.now());
+        assetWriter
+                .applyPqcVerdict(seededUuid, PqcVerdict.NOT_READY, "fence-rule", "fence reason", 1,
+                        Map.of("checked", "field"));
+        return seededUuid;
+    }
+
+    /** The seeded row's exact identity key, recomputed the same way {@link CryptoAssetWriter} would have. */
+    private String theSeededKeyLiteral() {
+        return AssetRowKeys.forFields(seededFields);
+    }
+
+    private Cbom newCbom(String serialNumber) {
+        Cbom cbom = new Cbom();
+        cbom.setSerialNumber(serialNumber);
+        cbom.setVersion(1);
+        cbom.setSpecVersion("1.7");
+        return cbomRepository.save(cbom);
     }
 }

--- a/src/test/java/com/otilm/core/integration/api/web/CryptographicAssetControllerITest.java
+++ b/src/test/java/com/otilm/core/integration/api/web/CryptographicAssetControllerITest.java
@@ -1,32 +1,33 @@
 package com.otilm.core.integration.api.web;
 
-import com.otilm.api.exception.NotSupportedException;
+import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.interfaces.core.web.CryptographicAssetController;
 import com.otilm.api.interfaces.core.web.StatisticsController;
 import com.otilm.api.model.client.certificate.SearchRequestDto;
+import com.otilm.api.model.client.dashboard.CryptographicAssetStatisticsDto;
 import com.otilm.api.model.common.PaginationResponseDto;
 import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetDetailDto;
 import com.otilm.api.model.core.cryptoasset.CryptographicAssetDto;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetType;
 import com.otilm.core.auth.ContextRefreshListener;
+import com.otilm.core.cbom.asset.AssetRowKeys;
+import com.otilm.core.cbom.asset.CryptoAssetIdentityFields;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.model.auth.ResourceSyncRequestDto;
+import com.otilm.core.service.writer.cbom.CryptoAssetWriter;
 import com.otilm.core.util.BaseSpringBootTest;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * The cryptographic asset inventory endpoints exist so the contract ratified in interfaces#909 is served by a real
- * bean. The read model now serves list and searchable-fields as real reads over the deduplicated cross-CBOM asset
- * projection; detail and statistics stay {@link NotSupportedException} refusals (HTTP 501) until core#2145 builds them.
- * The resource still reaches the auth service with its list and detail actions, so roles can be defined against it
- * independently of which operations are implemented.
- *
- * <p>
- * When detail and statistics are implemented, the refusal assertions below are what should fail first.
+ * bean, and core#2145 finished the job: list, searchable-fields, detail and statistics are all real reads over the
+ * deduplicated cross-CBOM asset projection now, with no operation left refusing. The resource still reaches the auth
+ * service with its list and detail actions, so roles can be defined against it independently of which operations exist.
  */
 class CryptographicAssetControllerITest extends BaseSpringBootTest {
 
@@ -39,8 +40,11 @@ class CryptographicAssetControllerITest extends BaseSpringBootTest {
     @Autowired
     private ContextRefreshListener contextRefreshListener;
 
+    @Autowired
+    private CryptoAssetWriter assetWriter;
+
     @Test
-    void listAndSearchableFieldsAreServedWhileDetailAndStatisticsRefuse() {
+    void everyInventoryOperationIsServed() throws NotFoundException {
         PaginationResponseDto<CryptographicAssetDto> page = cryptographicAssetController
                 .listCryptographicAssets(new SearchRequestDto());
         assertThat(page.getItems()).isEmpty();
@@ -48,11 +52,15 @@ class CryptographicAssetControllerITest extends BaseSpringBootTest {
 
         assertThat(cryptographicAssetController.getSearchableFieldInformation()).isNotEmpty();
 
-        UUID anyUuid = UUID.randomUUID();
-        assertThatThrownBy(() -> cryptographicAssetController.getCryptographicAsset(anyUuid))
-                .isInstanceOf(NotSupportedException.class);
-        assertThatThrownBy(() -> statisticsController.getCryptographicAssetStatistics())
-                .isInstanceOf(NotSupportedException.class);
+        UUID seededUuid = seedOneAsset();
+        CryptographicAssetDetailDto detail = cryptographicAssetController.getCryptographicAsset(seededUuid);
+        assertThat(detail.getUuid()).isEqualTo(seededUuid);
+
+        CryptographicAssetStatisticsDto statistics = statisticsController.getCryptographicAssetStatistics();
+        assertThat(statistics).isNotNull();
+        // BaseSpringBootTest truncates before each test and this method seeds exactly one asset above, so the count
+        // is deterministic, not merely non-negative.
+        assertThat(statistics.getTotalAssets()).isEqualTo(1L);
     }
 
     @Test
@@ -68,5 +76,11 @@ class CryptographicAssetControllerITest extends BaseSpringBootTest {
         assertThat(synced.getListObjectsEndpoint())
                 .describedAs("the one auth-sync behaviour @AuthEndpoint adds: the advertised object listing route")
                 .isEqualTo("/v1/cryptoAssets");
+    }
+
+    private UUID seedOneAsset() {
+        CryptoAssetIdentityFields fields = new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM,
+                "aes-256-gcm", null, null, null, null, null, null, null, null);
+        return assetWriter.upsertIdentity(AssetRowKeys.forFields(fields), fields, null);
     }
 }

--- a/src/test/java/com/otilm/core/integration/cbom/CryptoAssetInventoryITest.java
+++ b/src/test/java/com/otilm/core/integration/cbom/CryptoAssetInventoryITest.java
@@ -356,6 +356,30 @@ class CryptoAssetInventoryITest extends BaseSpringBootTest {
         assertThat(String.valueOf(stored.getEvidence())).doesNotContain(SECRET_MARKER);
     }
 
+    /**
+     * F6: {@code cap()} filters JSON-null array elements out before it ever counts an occurrence, so a null carries no
+     * evidence and must not inflate {@code occurrence_count} either -- the stored count has to keep agreeing with what
+     * capping considered real.
+     */
+    @Test
+    void occurrenceCountExcludesJsonNullArrayElements() {
+        UUID assetUuid = upsert(rsa2048(), null);
+        List<Map<String, Object>> occurrencesWithNulls = new ArrayList<>();
+        occurrencesWithNulls.add(Map.of("location", "src/a.java"));
+        occurrencesWithNulls.add(null);
+        occurrencesWithNulls.add(null);
+
+        sourceWriter
+                .upsertSource(assetUuid, leanCbom.getUuid(), Map.of("primitive", "signature"), occurrencesWithNulls,
+                        OffsetDateTime.now());
+
+        CryptoAssetSource stored = source(assetUuid, leanCbom.getUuid());
+        assertThat(stored.getOccurrenceCount())
+                .describedAs("a JSON-null array element carries no evidence and must not inflate the true count")
+                .isEqualTo(1);
+        assertThat(stored.getEvidence()).hasSize(1);
+    }
+
     // ---- foreign-key behaviour ----
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/CbomServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CbomServiceITest.java
@@ -14,6 +14,7 @@ import com.otilm.api.model.common.BulkActionMessageDto;
 import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.common.PaginationResponseDto;
 import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.cbom.CbomAssetSyncState;
 import com.otilm.api.model.core.cbom.CbomDetailDto;
 import com.otilm.api.model.core.cbom.CbomDto;
 import com.otilm.api.model.core.cbom.CbomUploadRequestDto;
@@ -40,10 +41,12 @@ import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.CbomExternalService;
 import com.otilm.core.service.CbomInternalService;
+import com.otilm.core.service.writer.cbom.CbomAssetSyncStateWriter;
 import com.otilm.core.settings.SettingsCache;
 import com.otilm.core.tasks.CbomSyncTask;
 import com.otilm.core.util.BaseSpringBootTest;
 import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -108,6 +111,9 @@ class CbomServiceITest extends BaseSpringBootTest {
 
     @Autowired
     private CbomRepository cbomRepository;
+
+    @Autowired
+    private CbomAssetSyncStateWriter syncStateWriter;
 
     @Autowired
     private ScheduledJobHistoryRepository scheduledJobHistoryRepository;
@@ -179,6 +185,37 @@ class CbomServiceITest extends BaseSpringBootTest {
     }
 
     @Test
+    void listServesTheAssetSyncStateFields() {
+        // Given
+        Cbom cbom = new Cbom();
+        cbom.setSerialNumber("urn:uuid:sync-state-list");
+        cbom.setTimestamp(OffsetDateTime.now());
+        cbom.setVersion(1);
+        cbom.setSpecVersion("1.6");
+        cbom = cbomRepository.save(cbom);
+
+        // Truncated to microseconds: the DB column stores microsecond precision, so a nanosecond-precision
+        // `now()` would round on the way back out and break the round-trip equality below.
+        OffsetDateTime syncedAt = OffsetDateTime.now().minusMinutes(5).truncatedTo(ChronoUnit.MICROS);
+
+        SecurityFilter filter = new SecurityFilter();
+        SearchRequestDto search = new SearchRequestDto();
+
+        // When / Then - freshly-seeded row reads as PENDING with no synced timestamp
+        PaginationResponseDto<CbomDto> beforeSync = cbomService.listCboms(filter, search);
+        assertEquals(CbomAssetSyncState.PENDING, beforeSync.getItems().getFirst().getAssetSyncState());
+        assertNull(beforeSync.getItems().getFirst().getAssetSyncedAt());
+
+        // When
+        syncStateWriter.markSynced(cbom.getUuid(), syncedAt);
+
+        // Then
+        PaginationResponseDto<CbomDto> afterSync = cbomService.listCboms(filter, search);
+        assertEquals(CbomAssetSyncState.SYNCED, afterSync.getItems().getFirst().getAssetSyncState());
+        assertEquals(syncedAt.toInstant(), afterSync.getItems().getFirst().getAssetSyncedAt().toInstant());
+    }
+
+    @Test
     void testGetCbomDetail_Success() throws Exception {
         // Given
         SecuredUUID uuid = SecuredUUID.fromString("807d4ff9-8bcf-4dd4-9239-3a8f2a177710");
@@ -231,6 +268,61 @@ class CbomServiceITest extends BaseSpringBootTest {
                 .verify(WireMock
                         .getRequestedFor(WireMock.urlPathMatching("/api/v1/bom/.*"))
                         .withQueryParam("version", WireMock.equalTo(Integer.toString(version))));
+    }
+
+    @Test
+    void detailServesTheAssetSyncStateFields() throws Exception {
+        // Given
+        SecuredUUID uuid = SecuredUUID.fromString("807d4ff9-8bcf-4dd4-9239-3a8f2a177710");
+        String serialNumber = "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79";
+        int version = 1;
+
+        Cbom cbom = new Cbom();
+        cbom.setUuid(uuid.getValue());
+        cbom.setSerialNumber(serialNumber);
+        cbom.setVersion(version);
+        cbom.setSpecVersion("1.6");
+        cbom.setTimestamp(OffsetDateTime.now());
+        cbomRepository.save(cbom);
+
+        String responseBody = """
+                {
+                "$schema": "https://cyclonedx.org/schema/bom-1.6.schema.json",
+                "bomFormat": "CycloneDX",
+                "specVersion": "1.6",
+                "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+                "version": 1,
+                "metadata": {},
+                "components": []
+                }
+                """;
+
+        mockServer
+                .stubFor(WireMock
+                        .get(WireMock.urlPathMatching("/api/v1/bom/.*"))
+                        .withQueryParam("version", WireMock.equalTo(Integer.toString(version)))
+                        .willReturn(WireMock
+                                .aResponse()
+                                .withStatus(200)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(responseBody)));
+
+        // Truncated to microseconds: the DB column stores microsecond precision, so a nanosecond-precision
+        // `now()` would round on the way back out and break the round-trip equality below.
+        OffsetDateTime syncedAt = OffsetDateTime.now().minusMinutes(5).truncatedTo(ChronoUnit.MICROS);
+
+        // When / Then - freshly-seeded row reads as PENDING with no synced timestamp
+        CbomDetailDto beforeSync = cbomService.getCbomDetail(uuid);
+        assertEquals(CbomAssetSyncState.PENDING, beforeSync.getAssetSyncState());
+        assertNull(beforeSync.getAssetSyncedAt());
+
+        // When
+        syncStateWriter.markSynced(uuid.getValue(), syncedAt);
+
+        // Then
+        CbomDetailDto afterSync = cbomService.getCbomDetail(uuid);
+        assertEquals(CbomAssetSyncState.SYNCED, afterSync.getAssetSyncState());
+        assertEquals(syncedAt.toInstant(), afterSync.getAssetSyncedAt().toInstant());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/CryptographicAssetDetailITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicAssetDetailITest.java
@@ -1,7 +1,9 @@
 package com.otilm.core.integration.service;
 
 import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.cryptoasset.CryptographicAssetDetailDto;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetEvidenceDto;
 import com.otilm.api.model.core.cryptoasset.CryptographicAssetSourceDto;
 import com.otilm.api.model.core.cryptoasset.CryptographicAssetType;
 import com.otilm.api.model.core.cryptoasset.PqcVerdict;
@@ -9,10 +11,14 @@ import com.otilm.core.cbom.asset.AssetRowKeys;
 import com.otilm.core.cbom.asset.CryptoAssetIdentityFields;
 import com.otilm.core.cbom.asset.OccurrenceEvidenceCapper;
 import com.otilm.core.dao.entity.Cbom;
+import com.otilm.core.dao.entity.cbom.CryptoAssetSource;
 import com.otilm.core.dao.repository.CbomRepository;
 import com.otilm.core.dao.repository.cbom.CryptoAssetRepository;
+import com.otilm.core.dao.repository.cbom.CryptoAssetSourceRepository;
+import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.model.cbom.CryptoAssetIdentityGuard;
 import com.otilm.core.security.authz.SecuredUUID;
+import com.otilm.core.security.authz.opa.dto.OpaObjectAccessResult;
 import com.otilm.core.service.CryptographicAssetExternalService;
 import com.otilm.core.service.writer.cbom.CryptoAssetSourceWriter;
 import com.otilm.core.service.writer.cbom.CryptoAssetWriter;
@@ -24,11 +30,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
 /**
  * The detail operation ({@link CryptographicAssetExternalService#getCryptographicAsset}) end to end, through the
@@ -54,6 +62,9 @@ class CryptographicAssetDetailITest extends BaseSpringBootTest {
 
     @Autowired
     private CryptoAssetRepository cryptoAssetRepository;
+
+    @Autowired
+    private CryptoAssetSourceRepository cryptoAssetSourceRepository;
 
     /**
      * The detail endpoint's distinguishing obligation (core#2145 AC): the elected representative payload is one
@@ -206,6 +217,196 @@ class CryptographicAssetDetailITest extends BaseSpringBootTest {
         assertThat(source.getEvidence().get(0).getLine()).isEqualTo(0);
     }
 
+    /**
+     * F5: producers occasionally emit a numeric evidence field as a string, or a textual one as a number; the DTO must
+     * still serve the value rather than let a type mismatch drop it silently.
+     *
+     * <p>
+     * Seeded by saving the source row directly rather than through {@link CryptoAssetSourceWriter}:
+     * {@code OccurrenceEvidenceCapper#sanitizeLocation} forces a non-string {@code location} to {@code ""} at write
+     * time, so a stored numeric location can only be reached this way -- which is the point: this proves
+     * {@code toEvidenceDto}'s own coercion against whatever shape is actually in the column, independent of what
+     * today's writer happens to produce.
+     */
+    @Test
+    void evidenceFieldsCoerceNumericStringsAndNumbers() throws NotFoundException {
+        UUID assetUuid = upsert(fields("AES-EVIDENCE-COERCE"), null);
+        Cbom cbom = newCbom("urn:uuid:evidence-coerce");
+        Map<String, Object> occurrence = new HashMap<>();
+        occurrence.put("location", 123);
+        occurrence.put("line", "42");
+        occurrence.put("offset", 7);
+        CryptoAssetSource source = new CryptoAssetSource();
+        source.setAssetUuid(assetUuid);
+        source.setCbomUuid(cbom.getUuid());
+        source.setOccurrenceCount(1);
+        source.setPropertiesLeafCount(0);
+        source.setFirstSeenAt(NOW);
+        source.setLastSeenAt(NOW);
+        source.setEvidence(List.of(occurrence));
+        cryptoAssetSourceRepository.save(source);
+
+        CryptographicAssetDetailDto detail = cryptographicAssetService
+                .getCryptographicAsset(SecuredUUID.fromUUID(assetUuid));
+
+        CryptographicAssetEvidenceDto evidence = detail.getSources().get(0).getEvidence().get(0);
+        assertThat(evidence.getLocation()).isEqualTo("123");
+        assertThat(evidence.getLine()).isEqualTo(42);
+        assertThat(evidence.getOffset()).isEqualTo(7);
+    }
+
+    /**
+     * F1: sources belong to the CBOM resource -- a caller denied CBOM object access must not read a contributing
+     * document's serialNumber, version, source or payload through the detail endpoint, even though cryptoAssets:detail
+     * itself is granted. The row-level badges stay global: they reconcile with the list, which is scoped by
+     * CRYPTO_ASSET, not CBOM. electedPayload is one document's payload verbatim, so it is gated the same way sources[]
+     * is, even though it is served from the asset row rather than a source row.
+     */
+    @Test
+    void deniedCbomAccessHidesSourcesButKeepsGlobalBadges() throws NotFoundException {
+        UUID assetUuid = upsert(fields("AES-CBOM-SCOPE"), null);
+        Cbom cbomA = newCbom("urn:uuid:scope-a");
+        Cbom cbomB = newCbom("urn:uuid:scope-b");
+        sourceWriter
+                .upsertSource(assetUuid, cbomA.getUuid(), Map.of("name", "AES-CBOM-SCOPE"), occurrences("a.c", 1), NOW);
+        sourceWriter
+                .upsertSource(assetUuid, cbomB.getUuid(), Map.of("name", "AES-CBOM-SCOPE"), occurrences("b.c", 2),
+                        NOW.plusSeconds(1));
+
+        denyObjectAccess(Resource.CBOM, ResourceAction.LIST);
+
+        CryptographicAssetDetailDto detail = cryptographicAssetService
+                .getCryptographicAsset(SecuredUUID.fromUUID(assetUuid));
+
+        assertThat(detail.getSources()).isEmpty();
+        assertThat(detail.getSourceCbomCount()).isEqualTo(2);
+        assertThat(detail.getOccurrenceCount()).isEqualTo(2L);
+        assertThat(detail.getElectedPayload())
+                .describedAs("the electing document is hidden by the same denial that empties sources[]")
+                .isNull();
+    }
+
+    /**
+     * F1's positive twin for electedPayload: a partial restriction that still leaves the ELECTING document visible
+     * serves the payload normally.
+     */
+    @Test
+    void partialCbomRestrictionServesElectedPayloadWhenTheElectingDocumentIsVisible() throws NotFoundException {
+        UUID assetUuid = upsert(fields("AES-CBOM-ELECT-VISIBLE"), null);
+        Cbom richCbom = newCbom("urn:uuid:elect-visible-rich");
+        Cbom leanCbom = newCbom("urn:uuid:elect-visible-lean");
+        Map<String, Object> richPayload = Map.of("name", "AES-CBOM-ELECT-VISIBLE", "primitive", "ae", "mode", "gcm");
+        Map<String, Object> leanPayload = Map.of("name", "AES-CBOM-ELECT-VISIBLE");
+        sourceWriter.upsertSource(assetUuid, richCbom.getUuid(), richPayload, occurrences("rich.c", 1), NOW);
+        sourceWriter
+                .upsertSource(assetUuid, leanCbom.getUuid(), leanPayload, occurrences("lean.c", 2), NOW.plusSeconds(1));
+
+        forbidCbomObjects(List.of(leanCbom.getUuid()));
+
+        CryptographicAssetDetailDto detail = cryptographicAssetService
+                .getCryptographicAsset(SecuredUUID.fromUUID(assetUuid));
+
+        assertThat(detail.getSources()).hasSize(1);
+        assertThat(detail.getSources().get(0).getCbomUuid()).isEqualTo(richCbom.getUuid());
+        assertThat(detail.getElectedPayload())
+                .describedAs("the richest source elects and its document is visible, so the payload is served")
+                .isEqualTo(richPayload);
+    }
+
+    /**
+     * F1's sharp case for electedPayload: the electing (richest) document is HIDDEN while a different, non-electing
+     * document is visible. sources[] serves exactly the visible row, but electedPayload must not re-elect among what
+     * the caller can see -- election is global and deterministic, not per-caller -- so it is omitted rather than
+     * silently substituting the visible document's own payload.
+     */
+    @Test
+    void partialCbomRestrictionOmitsElectedPayloadWhenTheElectingDocumentIsHidden() throws NotFoundException {
+        UUID assetUuid = upsert(fields("AES-CBOM-ELECT-HIDDEN"), null);
+        Cbom richCbom = newCbom("urn:uuid:elect-hidden-rich");
+        Cbom leanCbom = newCbom("urn:uuid:elect-hidden-lean");
+        Map<String, Object> richPayload = Map.of("name", "AES-CBOM-ELECT-HIDDEN", "primitive", "ae", "mode", "gcm");
+        Map<String, Object> leanPayload = Map.of("name", "AES-CBOM-ELECT-HIDDEN");
+        sourceWriter.upsertSource(assetUuid, richCbom.getUuid(), richPayload, occurrences("rich.c", 1), NOW);
+        sourceWriter
+                .upsertSource(assetUuid, leanCbom.getUuid(), leanPayload, occurrences("lean.c", 2), NOW.plusSeconds(1));
+
+        forbidCbomObjects(List.of(richCbom.getUuid()));
+
+        CryptographicAssetDetailDto detail = cryptographicAssetService
+                .getCryptographicAsset(SecuredUUID.fromUUID(assetUuid));
+
+        assertThat(detail.getSources()).hasSize(1);
+        assertThat(detail.getSources().get(0).getCbomUuid())
+                .describedAs("the visible (non-electing) document still serves its own row")
+                .isEqualTo(leanCbom.getUuid());
+        assertThat(detail.getSources().get(0).getPayload()).isEqualTo(leanPayload);
+        assertThat(detail.getElectedPayload())
+                .describedAs("must not re-elect onto the visible document's payload -- election is global, not scoped")
+                .isNull();
+    }
+
+    /**
+     * F1's partial-restriction twin: a caller who can see A but not B gets exactly A's row, while the global badges
+     * still count both.
+     */
+    @Test
+    void partialCbomRestrictionServesOnlyTheVisibleSource() throws NotFoundException {
+        UUID assetUuid = upsert(fields("AES-CBOM-PARTIAL"), null);
+        Cbom cbomA = newCbom("urn:uuid:partial-a");
+        Cbom cbomB = newCbom("urn:uuid:partial-b");
+        sourceWriter
+                .upsertSource(assetUuid, cbomA.getUuid(), Map.of("name", "AES-CBOM-PARTIAL"), occurrences("a.c", 1),
+                        NOW);
+        sourceWriter
+                .upsertSource(assetUuid, cbomB.getUuid(), Map.of("name", "AES-CBOM-PARTIAL"), occurrences("b.c", 2),
+                        NOW.plusSeconds(1));
+
+        forbidCbomObjects(List.of(cbomB.getUuid()));
+
+        CryptographicAssetDetailDto detail = cryptographicAssetService
+                .getCryptographicAsset(SecuredUUID.fromUUID(assetUuid));
+
+        assertThat(detail.getSources()).hasSize(1);
+        assertThat(detail.getSources().get(0).getCbomUuid()).isEqualTo(cbomA.getUuid());
+        assertThat(detail.getSourceCbomCount()).isEqualTo(2);
+        assertThat(detail.getOccurrenceCount()).isEqualTo(2L);
+    }
+
+    /**
+     * F3: the asset-level source fan-out has no cap of its own -- one row per contributing CBOM, unlike the per-source
+     * evidence {@link OccurrenceEvidenceCapper} already bounds. 101 lightweight documents is enough to prove the served
+     * list stays bounded while sourceCbomCount and occurrenceCount keep the true totals.
+     */
+    @Test
+    void capsServedSourcesButKeepsTheTrueTotals() throws NotFoundException {
+        UUID assetUuid = upsert(fields("AES-SOURCE-CAP"), null);
+        int total = 101;
+        List<UUID> cbomUuidsOldestFirst = new ArrayList<>();
+        for (int i = 0; i < total; i++) {
+            Cbom cbom = newCbom("urn:uuid:source-cap-" + i);
+            cbomUuidsOldestFirst.add(cbom.getUuid());
+            sourceWriter
+                    .upsertSource(assetUuid, cbom.getUuid(), Map.of("name", "AES-SOURCE-CAP"),
+                            occurrences("f" + i + ".c", i), NOW.plusSeconds(i));
+        }
+
+        CryptographicAssetDetailDto detail = cryptographicAssetService
+                .getCryptographicAsset(SecuredUUID.fromUUID(assetUuid));
+
+        assertThat(detail.getSources()).hasSize(100);
+        assertThat(detail.getSourceCbomCount()).isEqualTo(total);
+        assertThat(detail.getOccurrenceCount()).isEqualTo((long) total);
+        List<UUID> servedCbomUuids = detail
+                .getSources()
+                .stream()
+                .map(CryptographicAssetSourceDto::getCbomUuid)
+                .toList();
+        assertThat(servedCbomUuids)
+                .describedAs("the cap keeps the oldest-seeded row and drops the newest -- firstSeenAt-ascending order")
+                .contains(cbomUuidsOldestFirst.get(0))
+                .doesNotContain(cbomUuidsOldestFirst.get(100));
+    }
+
     @Test
     void normalizedFieldsAbsentWhenNothingDerivable() throws NotFoundException {
         UUID assetUuid = upsert(fields("AES"), null);
@@ -264,5 +465,26 @@ class CryptographicAssetDetailITest extends BaseSpringBootTest {
         cbom.setVersion(1);
         cbom.setSpecVersion("1.7");
         return cbomRepository.save(cbom);
+    }
+
+    /**
+     * Stubs the OPA object-access vote for {@code cboms:list} so every uuid in {@code forbidden} is denied while the
+     * rest of the CBOM estate stays visible -- the CBOM twin of
+     * {@code CryptographicAssetStatisticsITest#forbidCryptoAssetObjects}, needed here because {@link #denyObjectAccess}
+     * denies everything and F1's partial-restriction case needs a real, known-size visible subset.
+     */
+    private void forbidCbomObjects(List<UUID> forbidden) {
+        OpaObjectAccessResult partial = new OpaObjectAccessResult();
+        partial.setActionAllowedForGroupOfObjects(true);
+        partial.setAllowedObjects(List.of());
+        partial.setForbiddenObjects(forbidden.stream().map(UUID::toString).toList());
+        when(opaClient
+                .checkObjectAccess(Mockito.any(),
+                        Mockito
+                                .argThat(req -> req != null && req.getProperties() != null
+                                        && Resource.CBOM.getCode().equals(req.getProperties().get("name"))
+                                        && ResourceAction.LIST.getCode().equals(req.getProperties().get("action"))),
+                        Mockito.any(), Mockito.any()))
+                .thenReturn(partial);
     }
 }

--- a/src/test/java/com/otilm/core/integration/service/CryptographicAssetDetailITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicAssetDetailITest.java
@@ -1,0 +1,268 @@
+package com.otilm.core.integration.service;
+
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetDetailDto;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetSourceDto;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetType;
+import com.otilm.api.model.core.cryptoasset.PqcVerdict;
+import com.otilm.core.cbom.asset.AssetRowKeys;
+import com.otilm.core.cbom.asset.CryptoAssetIdentityFields;
+import com.otilm.core.cbom.asset.OccurrenceEvidenceCapper;
+import com.otilm.core.dao.entity.Cbom;
+import com.otilm.core.dao.repository.CbomRepository;
+import com.otilm.core.dao.repository.cbom.CryptoAssetRepository;
+import com.otilm.core.model.cbom.CryptoAssetIdentityGuard;
+import com.otilm.core.security.authz.SecuredUUID;
+import com.otilm.core.service.CryptographicAssetExternalService;
+import com.otilm.core.service.writer.cbom.CryptoAssetSourceWriter;
+import com.otilm.core.service.writer.cbom.CryptoAssetWriter;
+import com.otilm.core.util.BaseSpringBootTest;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The detail operation ({@link CryptographicAssetExternalService#getCryptographicAsset}) end to end, through the
+ * service interface: the elected-payload-beside-originals contract that is core#2145's own acceptance criterion,
+ * verdict provenance, refuted-OID flagging, capped-evidence-with-true-count, normalized-field presence, and the
+ * not-found path.
+ */
+class CryptographicAssetDetailITest extends BaseSpringBootTest {
+
+    private static final OffsetDateTime NOW = OffsetDateTime.now();
+
+    @Autowired
+    private CryptographicAssetExternalService cryptographicAssetService;
+
+    @Autowired
+    private CryptoAssetWriter assetWriter;
+
+    @Autowired
+    private CryptoAssetSourceWriter sourceWriter;
+
+    @Autowired
+    private CbomRepository cbomRepository;
+
+    @Autowired
+    private CryptoAssetRepository cryptoAssetRepository;
+
+    /**
+     * The detail endpoint's distinguishing obligation (core#2145 AC): the elected representative payload is one
+     * source's payload verbatim, served BESIDE every source's original -- a sparse but crucial observation can lose the
+     * election to a richer generic one, and the original must remain readable on the wire when it does.
+     */
+    @Test
+    void servesElectedPayloadBesideDisagreeingPerSourceOriginals() throws NotFoundException {
+        UUID assetUuid = upsert(fields("AES-128-GCM"), null);
+        Cbom rich = newCbom("urn:uuid:rich");
+        Cbom sparse = newCbom("urn:uuid:sparse");
+        Map<String, Object> richPayload = Map.of("name", "AES-128-GCM", "primitive", "ae", "mode", "gcm");
+        Map<String, Object> sparsePayload = Map.of("name", "AES-128-GCM", "nistQuantumSecurityLevel", 1);
+        sourceWriter.upsertSource(assetUuid, rich.getUuid(), richPayload, occurrences("lib/a.c", 10), NOW);
+        sourceWriter
+                .upsertSource(assetUuid, sparse.getUuid(), sparsePayload, occurrences("lib/b.c", 20),
+                        NOW.plusSeconds(5));
+
+        CryptographicAssetDetailDto detail = cryptographicAssetService
+                .getCryptographicAsset(SecuredUUID.fromUUID(assetUuid));
+
+        // election is by leaf count: the rich payload wins and is served verbatim
+        assertEquals(richPayload, detail.getElectedPayload());
+        // both originals are served beside it, in first-seen order, disagreement intact
+        assertEquals(2, detail.getSources().size());
+        assertEquals(richPayload, detail.getSources().get(0).getPayload());
+        assertEquals(sparsePayload, detail.getSources().get(1).getPayload());
+        assertEquals(sparse.getUuid(), detail.getSources().get(1).getCbomUuid());
+        assertEquals("urn:uuid:sparse", detail.getSources().get(1).getSerialNumber());
+        // the aggregate is the sum across sources: each occurrences() call above seeds exactly one occurrence, so 1 + 1
+        assertEquals(2L, detail.getOccurrenceCount());
+    }
+
+    @Test
+    void rowFieldsMatchTheListContract() throws NotFoundException {
+        UUID assetUuid = upsert(fieldsWithOid("AES-256-GCM", "oid-aes-256-gcm"), null);
+        Cbom cbom = newCbom("urn:uuid:contract");
+        List<Map<String, Object>> threeOccurrences = List
+                .of(new HashMap<>(Map.of("location", "src/a.c", "line", 1)),
+                        new HashMap<>(Map.of("location", "src/b.c", "line", 2)),
+                        new HashMap<>(Map.of("location", "src/c.c", "line", 3)));
+        sourceWriter.upsertSource(assetUuid, cbom.getUuid(), Map.of("name", "AES-256-GCM"), threeOccurrences, NOW);
+        assetWriter.applyPqcVerdict(assetUuid, PqcVerdict.READY, "rule", "reason", 1, Map.of());
+
+        CryptographicAssetDetailDto detail = cryptographicAssetService
+                .getCryptographicAsset(SecuredUUID.fromUUID(assetUuid));
+
+        assertThat(detail.getUuid()).isEqualTo(assetUuid);
+        assertThat(detail.getName()).isEqualTo("aes-256-gcm");
+        assertThat(detail.getType()).isEqualTo(CryptographicAssetType.ALGORITHM);
+        assertThat(detail.getPqcVerdict()).isEqualTo(PqcVerdict.READY);
+        assertThat(detail.getSourceCbomCount()).isEqualTo(1);
+        assertThat(detail.getOccurrenceCount()).isEqualTo(3);
+        assertThat(detail.isQuarantined()).isFalse();
+    }
+
+    @Test
+    void servesVerdictProvenanceWhenEvaluated() throws NotFoundException {
+        UUID assetUuid = upsert(fields("RSA-2048"), null);
+        assetWriter
+                .applyPqcVerdict(assetUuid, PqcVerdict.NOT_READY, "shor-breakable", "RSA is Shor-breakable", 3,
+                        Map.of());
+
+        CryptographicAssetDetailDto detail = cryptographicAssetService
+                .getCryptographicAsset(SecuredUUID.fromUUID(assetUuid));
+
+        assertThat(detail.getVerdict()).isNotNull();
+        assertThat(detail.getVerdict().getRuleId()).isEqualTo("shor-breakable");
+        assertThat(detail.getVerdict().getReason()).isEqualTo("RSA is Shor-breakable");
+        assertThat(detail.getVerdict().getRuleSetVersion()).isEqualTo(3);
+        assertThat(detail.getVerdict().getDecidedAt()).isNotNull();
+        assertThat(detail.getVerdict().getEvaluatedAt()).isNotNull();
+        assertThat(detail.getPqcVerdict()).isEqualTo(PqcVerdict.NOT_READY);
+    }
+
+    @Test
+    void omitsVerdictProvenanceWhenNeverEvaluated() throws NotFoundException {
+        UUID assetUuid = upsert(fields("ChaCha20-Poly1305"), null);
+
+        CryptographicAssetDetailDto detail = cryptographicAssetService
+                .getCryptographicAsset(SecuredUUID.fromUUID(assetUuid));
+
+        assertThat(detail.getVerdict()).isNull();
+        assertThat(detail.getPqcVerdict())
+                .describedAs("never evaluated -> UNKNOWN, not null")
+                .isEqualTo(PqcVerdict.UNKNOWN);
+        // the zero-source wire shape: no sources, no elected payload, zero aggregate occurrences
+        assertThat(detail.getSources()).isEmpty();
+        assertThat(detail.getElectedPayload()).isNull();
+        assertThat(detail.getOccurrenceCount()).isZero();
+    }
+
+    /**
+     * A refuted OID must never be served as fact -- the row's own display name and the per-OID flag both have to say so
+     * -- while an unrefuted twin serves its OID as the name fallback exactly like the list contract does.
+     */
+    @Test
+    void flagsARefutedOidAndSuppressesItAsName() throws NotFoundException {
+        UUID refuted = upsert(fieldsWithOid(null, "1.2.840.113549.1.1.1"), CryptoAssetIdentityGuard.REFUTED_OID);
+        UUID notRefuted = upsert(fieldsWithOid(null, "1.2.840.113549.1.1.2"), null);
+
+        CryptographicAssetDetailDto refutedDetail = cryptographicAssetService
+                .getCryptographicAsset(SecuredUUID.fromUUID(refuted));
+        assertThat(refutedDetail.getOids()).hasSize(1);
+        assertThat(refutedDetail.getOids().get(0).getOid()).isEqualTo("1.2.840.113549.1.1.1");
+        assertThat(refutedDetail.getOids().get(0).isRefuted()).isTrue();
+        assertThat(refutedDetail.getName()).describedAs("the refuted OID is never served as the display name").isNull();
+        assertThat(cryptoAssetRepository.findByUuid(SecuredUUID.fromUUID(refuted)).orElseThrow().getIdentityGuard())
+                .isEqualTo(CryptoAssetIdentityGuard.REFUTED_OID);
+
+        CryptographicAssetDetailDto notRefutedDetail = cryptographicAssetService
+                .getCryptographicAsset(SecuredUUID.fromUUID(notRefuted));
+        assertThat(notRefutedDetail.getOids()).hasSize(1);
+        assertThat(notRefutedDetail.getOids().get(0).isRefuted()).isFalse();
+        assertThat(notRefutedDetail.getName())
+                .describedAs("no name recorded -> the OID is the display fallback")
+                .isEqualTo("1.2.840.113549.1.1.2");
+    }
+
+    @Test
+    void servesEmptyOidListWhenNoOidRecorded() throws NotFoundException {
+        UUID assetUuid = upsert(fields("AES-GCM"), null);
+
+        CryptographicAssetDetailDto detail = cryptographicAssetService
+                .getCryptographicAsset(SecuredUUID.fromUUID(assetUuid));
+
+        assertThat(detail.getOids()).isEmpty();
+    }
+
+    @Test
+    void servesCappedEvidenceWithTrueCount() throws NotFoundException {
+        UUID assetUuid = upsert(fields("AES-GCM"), null);
+        Cbom cbom = newCbom("urn:uuid:capped");
+        List<Map<String, Object>> manyOccurrences = new ArrayList<>();
+        for (int i = 0; i < 55; i++) {
+            manyOccurrences.add(Map.of("location", "src/f" + i + ".c", "line", i));
+        }
+        sourceWriter.upsertSource(assetUuid, cbom.getUuid(), Map.of("name", "AES-GCM"), manyOccurrences, NOW);
+
+        CryptographicAssetDetailDto detail = cryptographicAssetService
+                .getCryptographicAsset(SecuredUUID.fromUUID(assetUuid));
+
+        assertThat(detail.getSources()).hasSize(1);
+        CryptographicAssetSourceDto source = detail.getSources().get(0);
+        assertThat(source.getEvidence())
+                .describedAs("evidence is capped even though every occurrence was reported")
+                .hasSize(OccurrenceEvidenceCapper.MAX_OCCURRENCES);
+        assertThat(source.getOccurrenceCount()).describedAs("the true, unclipped count is still served").isEqualTo(55);
+        assertThat(source.getEvidence().get(0).getLocation()).isEqualTo("src/f0.c");
+        assertThat(source.getEvidence().get(0).getLine()).isEqualTo(0);
+    }
+
+    @Test
+    void normalizedFieldsAbsentWhenNothingDerivable() throws NotFoundException {
+        UUID assetUuid = upsert(fields("AES"), null);
+
+        CryptographicAssetDetailDto detail = cryptographicAssetService
+                .getCryptographicAsset(SecuredUUID.fromUUID(assetUuid));
+
+        assertThat(detail.getNormalizedFields()).isNull();
+    }
+
+    @Test
+    void normalizedFieldsCarryTheDerivedColumns() throws NotFoundException {
+        UUID assetUuid = upsert(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ECDSA", null, "ecdsa",
+                "signature", "P-256", "secp256r1", null, null, null), null);
+
+        CryptographicAssetDetailDto detail = cryptographicAssetService
+                .getCryptographicAsset(SecuredUUID.fromUUID(assetUuid));
+
+        assertThat(detail.getNormalizedFields()).isNotNull();
+        assertThat(detail.getNormalizedFields().getAlgorithmFamily()).isEqualTo("ecdsa");
+        assertThat(detail.getNormalizedFields().getPrimitive()).isEqualTo("signature");
+        assertThat(detail.getNormalizedFields().getParameterSet()).isEqualTo("p-256");
+        assertThat(detail.getNormalizedFields().getCurve()).isEqualTo("secp256r1");
+    }
+
+    @Test
+    void throwsNotFoundForAnUnknownUuid() {
+        assertThatThrownBy(
+                () -> cryptographicAssetService.getCryptographicAsset(SecuredUUID.fromUUID(UUID.randomUUID())))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ---- helpers ----
+
+    private static CryptoAssetIdentityFields fields(String name) {
+        return new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, name, null, null, null, null, null, null,
+                null, null);
+    }
+
+    private static CryptoAssetIdentityFields fieldsWithOid(String name, String oid) {
+        return new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, name, oid, null, null, null, null, null,
+                null, null);
+    }
+
+    private static List<Map<String, Object>> occurrences(String location, int line) {
+        return List.of(new HashMap<>(Map.of("location", location, "line", line)));
+    }
+
+    private UUID upsert(CryptoAssetIdentityFields fields, CryptoAssetIdentityGuard guard) {
+        return assetWriter.upsertIdentity(AssetRowKeys.forFields(fields), fields, guard);
+    }
+
+    private Cbom newCbom(String serialNumber) {
+        Cbom cbom = new Cbom();
+        cbom.setSerialNumber(serialNumber);
+        cbom.setVersion(1);
+        cbom.setSpecVersion("1.7");
+        return cbomRepository.save(cbom);
+    }
+}

--- a/src/test/java/com/otilm/core/integration/service/CryptographicAssetDetailITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicAssetDetailITest.java
@@ -219,7 +219,8 @@ class CryptographicAssetDetailITest extends BaseSpringBootTest {
 
     /**
      * F5: producers occasionally emit a numeric evidence field as a string, or a textual one as a number; the DTO must
-     * still serve the value rather than let a type mismatch drop it silently.
+     * still serve the value rather than let a type mismatch drop it silently. location is additionally
+     * contract-REQUIRED, so an occurrence that lacks it entirely must still serve {@code ""}, never {@code null}.
      *
      * <p>
      * Seeded by saving the source row directly rather than through {@link CryptoAssetSourceWriter}:
@@ -236,23 +237,29 @@ class CryptographicAssetDetailITest extends BaseSpringBootTest {
         occurrence.put("location", 123);
         occurrence.put("line", "42");
         occurrence.put("offset", 7);
+        Map<String, Object> occurrenceWithoutLocation = new HashMap<>();
+        occurrenceWithoutLocation.put("line", 1);
         CryptoAssetSource source = new CryptoAssetSource();
         source.setAssetUuid(assetUuid);
         source.setCbomUuid(cbom.getUuid());
-        source.setOccurrenceCount(1);
+        source.setOccurrenceCount(2);
         source.setPropertiesLeafCount(0);
         source.setFirstSeenAt(NOW);
         source.setLastSeenAt(NOW);
-        source.setEvidence(List.of(occurrence));
+        source.setEvidence(List.of(occurrence, occurrenceWithoutLocation));
         cryptoAssetSourceRepository.save(source);
 
         CryptographicAssetDetailDto detail = cryptographicAssetService
                 .getCryptographicAsset(SecuredUUID.fromUUID(assetUuid));
 
-        CryptographicAssetEvidenceDto evidence = detail.getSources().get(0).getEvidence().get(0);
+        List<CryptographicAssetEvidenceDto> servedEvidence = detail.getSources().get(0).getEvidence();
+        CryptographicAssetEvidenceDto evidence = servedEvidence.get(0);
         assertThat(evidence.getLocation()).isEqualTo("123");
         assertThat(evidence.getLine()).isEqualTo(42);
         assertThat(evidence.getOffset()).isEqualTo(7);
+        assertThat(servedEvidence.get(1).getLocation())
+                .describedAs("location is REQUIRED; an occurrence with no location key must not serve null")
+                .isEqualTo("");
     }
 
     /**

--- a/src/test/java/com/otilm/core/integration/service/CryptographicAssetStatisticsITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicAssetStatisticsITest.java
@@ -1,0 +1,290 @@
+package com.otilm.core.integration.service;
+
+import com.otilm.api.model.client.certificate.SearchRequestDto;
+import com.otilm.api.model.client.dashboard.CryptographicAssetStatisticsDto;
+import com.otilm.api.model.common.PaginationResponseDto;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetDto;
+import com.otilm.api.model.core.cryptoasset.CryptographicAssetType;
+import com.otilm.api.model.core.cryptoasset.PqcVerdict;
+import com.otilm.core.cbom.asset.AssetRowKeys;
+import com.otilm.core.cbom.asset.CryptoAssetIdentityFields;
+import com.otilm.core.dao.entity.Cbom;
+import com.otilm.core.dao.repository.CbomRepository;
+import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.model.cbom.CryptoAssetIdentityGuard;
+import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.security.authz.opa.dto.OpaObjectAccessResult;
+import com.otilm.core.service.CryptographicAssetExternalService;
+import com.otilm.core.service.writer.cbom.CbomAssetSyncStateWriter;
+import com.otilm.core.service.writer.cbom.CryptoAssetSourceWriter;
+import com.otilm.core.service.writer.cbom.CryptoAssetWriter;
+import com.otilm.core.util.BaseSpringBootTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * The statistics operation ({@link CryptographicAssetExternalService#getCryptographicAssetStatistics}) end to end,
+ * through the service interface: densify-and-fold over real rows, the core#2145 acceptance criteria that the badges
+ * reconcile with the list under identical permission filtering and that the completeness block reflects partial sync,
+ * the top-N family cutoff, and the independence of the two security gates -- CRYPTO_ASSET for the inventory badges,
+ * CBOM for the completeness block.
+ *
+ * <p>
+ * Deliberately not {@code @Transactional}: {@link CbomAssetSyncStateWriter} and the crypto-asset writers commit their
+ * own transactions, and the statistics query fans out across virtual threads that must see those commits rather than an
+ * uncommitted outer transaction visible only to this thread.
+ */
+class CryptographicAssetStatisticsITest extends BaseSpringBootTest {
+
+    @Autowired
+    private CryptographicAssetExternalService cryptographicAssetService;
+
+    @Autowired
+    private CryptoAssetWriter assetWriter;
+
+    @Autowired
+    private CryptoAssetSourceWriter sourceWriter;
+
+    @Autowired
+    private CbomRepository cbomRepository;
+
+    @Autowired
+    private CbomAssetSyncStateWriter syncStateWriter;
+
+    @Test
+    void countsDensifyAndFoldExactlyAsServed() {
+        // 2 algorithms (one NOT_READY verdict, one never evaluated), 1 certificate with a family, 1 protocol without
+        UUID a1 = seedTyped(CryptographicAssetType.ALGORITHM, "RSA-2048");
+        seedTyped(CryptographicAssetType.ALGORITHM, "AES-128");
+        seedTypedWithFamily(CryptographicAssetType.CERTIFICATE, "leaf", "RSA");
+        seedTyped(CryptographicAssetType.PROTOCOL, "TLS-1.3");
+        applyVerdict(a1, PqcVerdict.NOT_READY);
+
+        CryptographicAssetStatisticsDto dto = cryptographicAssetService.getCryptographicAssetStatistics();
+
+        assertEquals(4L, dto.getTotalAssets());
+        assertEquals(2L, dto.getStatByType().get("algorithm"));
+        assertEquals(1L, dto.getStatByType().get("certificate"));
+        assertEquals(0L, dto.getStatByType().get("unroutable")); // densified
+        assertEquals(1L, dto.getStatByPqcVerdict().get("notReady"));
+        assertEquals(3L, dto.getStatByPqcVerdict().get("unknown")); // NULL verdicts fold into unknown
+        // algorithmFamily is producer text and folds like every other identity field, so "RSA" is stored/served as
+        // "rsa" -- see CryptoAssetIdentityFields#normalized.
+        assertEquals(1L, dto.getStatByAlgorithmFamily().get("rsa"));
+        assertEquals(1L, dto.getDistinctAlgorithmFamilyCount());
+        assertEquals(3L, dto.getUnassignedAssetCount());
+    }
+
+    /**
+     * The core#2145 AC: the badges reconcile with the list under identical permission filtering, both unrestricted and
+     * with a subset of the inventory forbidden by OPA.
+     */
+    @Test
+    void statisticsReconcileWithTheListUnderIdenticalPermissionFiltering() {
+        UUID a1 = seedTyped(CryptographicAssetType.ALGORITHM, "alg-1");
+        UUID a2 = seedTyped(CryptographicAssetType.ALGORITHM, "alg-2");
+        UUID a3 = seedTyped(CryptographicAssetType.CERTIFICATE, "cert-1");
+        UUID a4 = seedTyped(CryptographicAssetType.CERTIFICATE, "cert-2");
+        seedTyped(CryptographicAssetType.PROTOCOL, "proto-1");
+        applyVerdict(a1, PqcVerdict.READY);
+        applyVerdict(a3, PqcVerdict.NOT_READY);
+
+        assertStatisticsReconcileWithTheList(5);
+
+        // Forbid a subset (2 of the 5 seeded assets); calling the list service method here goes through the same
+        // @ExternalAuthorization with a fresh SecurityFilter.create(), so the OPA mock applies the identical
+        // restriction to both reads -- which is the point of the assertion.
+        forbidCryptoAssetObjects(List.of(a2, a4));
+        assertStatisticsReconcileWithTheList(3);
+    }
+
+    /**
+     * The core#2145 AC: the completeness block reflects a partially-synced inventory, and its timestamp advances as
+     * later syncs complete.
+     */
+    @Test
+    void completenessBlockIsCorrectUnderPartialSync() {
+        Cbom a = newCbom("urn:uuid:completeness-a");
+        Cbom b = newCbom("urn:uuid:completeness-b");
+        Cbom c = newCbom("urn:uuid:completeness-c");
+        Cbom d = newCbom("urn:uuid:completeness-d");
+        // a is left PENDING (the entity default)
+        syncStateWriter.markInProgress(b.getUuid());
+        OffsetDateTime t1 = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS);
+        syncStateWriter.markSynced(c.getUuid(), t1);
+        syncStateWriter.markFailed(d.getUuid(), "boom");
+        UUID contributor = seedTyped(CryptographicAssetType.ALGORITHM, "contributor");
+        sourceWriter
+                .upsertSource(contributor, c.getUuid(), Map.of("name", "contributor"),
+                        List.of(Map.of("location", "a.c")), OffsetDateTime.now());
+
+        CryptographicAssetStatisticsDto dto = cryptographicAssetService.getCryptographicAssetStatistics();
+
+        Map<String, Long> bySyncState = dto.getSyncCompleteness().getCbomStatBySyncState();
+        assertThat(bySyncState.get("pending")).isEqualTo(1L);
+        assertThat(bySyncState.get("inProgress")).isEqualTo(1L);
+        assertThat(bySyncState.get("synced")).isEqualTo(1L);
+        assertThat(bySyncState.get("failed")).isEqualTo(1L);
+        assertThat(dto.getSyncCompleteness().getLastCompletedSyncAt()).isEqualTo(t1);
+        assertThat(dto.getSourceCbomCount())
+                .describedAs("only c has a source row, so only c contributed")
+                .isEqualTo(1L);
+
+        OffsetDateTime t2later = t1.plusSeconds(30);
+        syncStateWriter.markSynced(d.getUuid(), t2later);
+        CryptographicAssetStatisticsDto after = cryptographicAssetService.getCryptographicAssetStatistics();
+        assertThat(after.getSyncCompleteness().getLastCompletedSyncAt()).isEqualTo(t2later);
+    }
+
+    @Test
+    void sourceCbomCountCountsContributingDocumentsOnce() {
+        UUID assetA = seedTyped(CryptographicAssetType.ALGORITHM, "source-count-a");
+        UUID assetB = seedTyped(CryptographicAssetType.ALGORITHM, "source-count-b");
+        Cbom contributing = newCbom("urn:uuid:source-count-contributing");
+        newCbom("urn:uuid:source-count-untouched"); // no source rows -- must count zero
+        sourceWriter
+                .upsertSource(assetA, contributing.getUuid(), Map.of("name", "source-count-a"),
+                        List.of(Map.of("location", "a.c")), OffsetDateTime.now());
+        sourceWriter
+                .upsertSource(assetB, contributing.getUuid(), Map.of("name", "source-count-b"),
+                        List.of(Map.of("location", "b.c")), OffsetDateTime.now());
+
+        CryptographicAssetStatisticsDto dto = cryptographicAssetService.getCryptographicAssetStatistics();
+
+        assertThat(dto.getSourceCbomCount())
+                .describedAs("one cbom sourcing two assets counts once; the untouched cbom counts zero")
+                .isEqualTo(1L);
+    }
+
+    @Test
+    void emptyInventoryServesZeroesNotNulls() {
+        CryptographicAssetStatisticsDto dto = cryptographicAssetService.getCryptographicAssetStatistics();
+
+        assertThat(dto.getTotalAssets()).isZero();
+        assertThat(dto.getStatByType()).hasSize(5);
+        assertThat(dto.getStatByType().values()).containsOnly(0L);
+        assertThat(dto.getStatByPqcVerdict()).hasSize(4);
+        assertThat(dto.getStatByPqcVerdict().values()).containsOnly(0L);
+        assertThat(dto.getUnassignedAssetCount()).isZero();
+        assertThat(dto.getDistinctAlgorithmFamilyCount()).isZero();
+        assertThat(dto.getStatByAlgorithmFamily()).isEmpty();
+        assertThat(dto.getSourceCbomCount()).isZero();
+        assertThat(dto.getSyncCompleteness().getCbomStatBySyncState()).hasSize(4);
+        assertThat(dto.getSyncCompleteness().getCbomStatBySyncState().values()).containsOnly(0L);
+        assertThat(dto.getSyncCompleteness().getLastCompletedSyncAt()).isNull();
+    }
+
+    @Test
+    void familyTopNAndOverflowOverRealRows() {
+        for (int i = 1; i <= 12; i++) {
+            seedTypedWithFamily(CryptographicAssetType.ALGORITHM, "family-top-n-" + i, "family-" + i);
+        }
+
+        CryptographicAssetStatisticsDto dto = cryptographicAssetService.getCryptographicAssetStatistics();
+
+        assertThat(dto.getStatByAlgorithmFamily()).hasSize(10);
+        assertThat(dto.getDistinctAlgorithmFamilyCount()).isEqualTo(12L);
+    }
+
+    /**
+     * The two security gates are independent: CRYPTO_ASSET scopes the inventory badges, CBOM scopes the completeness
+     * block, and forbidding one must not perturb the other.
+     */
+    @Test
+    void cbomRestrictionsScopeTheCompletenessBlockOnly() {
+        UUID asset1 = seedTyped(CryptographicAssetType.ALGORITHM, "cbom-restricted-1");
+        seedTyped(CryptographicAssetType.CERTIFICATE, "cbom-restricted-2");
+        Cbom cbom = newCbom("urn:uuid:cbom-restricted");
+        syncStateWriter.markSynced(cbom.getUuid(), OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS));
+        sourceWriter
+                .upsertSource(asset1, cbom.getUuid(), Map.of("name", "cbom-restricted-1"),
+                        List.of(Map.of("location", "a.c")), OffsetDateTime.now());
+
+        denyObjectAccess(Resource.CBOM, ResourceAction.LIST);
+
+        CryptographicAssetStatisticsDto dto = cryptographicAssetService.getCryptographicAssetStatistics();
+
+        assertThat(dto.getSyncCompleteness().getCbomStatBySyncState().values()).containsOnly(0L);
+        assertThat(dto.getSourceCbomCount()).isZero();
+        assertThat(dto.getSyncCompleteness().getLastCompletedSyncAt()).isNull();
+        assertThat(dto.getTotalAssets())
+                .describedAs("asset scope is CRYPTO_ASSET, document scope is CBOM -- the two gates are independent")
+                .isEqualTo(2L);
+    }
+
+    // ---- helpers ----
+
+    private void assertStatisticsReconcileWithTheList(long expectedTotalAssets) {
+        CryptographicAssetStatisticsDto dto = cryptographicAssetService.getCryptographicAssetStatistics();
+        PaginationResponseDto<CryptographicAssetDto> page = cryptographicAssetService
+                .listCryptographicAssets(SecurityFilter.create(), new SearchRequestDto());
+
+        // The absolute count, not just the relational equalities below: if the OPA stub ever silently stopped
+        // matching, both dto and page would agree on the (wrong) unrestricted total and every assertion here would
+        // still pass.
+        assertThat(dto.getTotalAssets()).isEqualTo(expectedTotalAssets);
+        assertThat(dto.getTotalAssets()).isEqualTo(page.getTotalItems());
+        assertThat(dto.getStatByType().values().stream().mapToLong(Long::longValue).sum())
+                .isEqualTo(dto.getTotalAssets());
+        assertThat(dto.getStatByPqcVerdict().values().stream().mapToLong(Long::longValue).sum())
+                .isEqualTo(dto.getTotalAssets());
+    }
+
+    /**
+     * Stubs the OPA object-access vote for {@code cryptoAssets:list} so every uuid in {@code forbidden} is denied while
+     * the rest of the inventory stays allowed -- unlike {@link #denyObjectAccess} (denies everything) and
+     * {@link #restrictObjectAccess} (allows only one unrelated random uuid), this leaves a real, known-size subset of
+     * the seeded rows visible so the reconciliation assertion is meaningful under partial restriction.
+     */
+    private void forbidCryptoAssetObjects(List<UUID> forbidden) {
+        OpaObjectAccessResult partial = new OpaObjectAccessResult();
+        partial.setActionAllowedForGroupOfObjects(true);
+        partial.setAllowedObjects(List.of());
+        partial.setForbiddenObjects(forbidden.stream().map(UUID::toString).toList());
+        when(opaClient
+                .checkObjectAccess(Mockito.any(),
+                        Mockito
+                                .argThat(req -> req != null && req.getProperties() != null
+                                        && Resource.CRYPTO_ASSET.getCode().equals(req.getProperties().get("name"))
+                                        && ResourceAction.LIST.getCode().equals(req.getProperties().get("action"))),
+                        Mockito.any(), Mockito.any()))
+                .thenReturn(partial);
+    }
+
+    private UUID seedTyped(CryptographicAssetType type, String name) {
+        return upsert(new CryptoAssetIdentityFields(type, name, null, null, null, null, null, null, null, null), null);
+    }
+
+    private UUID seedTypedWithFamily(CryptographicAssetType type, String name, String family) {
+        return upsert(new CryptoAssetIdentityFields(type, name, null, family, null, null, null, null, null, null),
+                null);
+    }
+
+    private void applyVerdict(UUID assetUuid, PqcVerdict verdict) {
+        assetWriter.applyPqcVerdict(assetUuid, verdict, "rule", "reason", 1, Map.of());
+    }
+
+    private UUID upsert(CryptoAssetIdentityFields fields, CryptoAssetIdentityGuard guard) {
+        return assetWriter.upsertIdentity(AssetRowKeys.forFields(fields), fields, guard);
+    }
+
+    private Cbom newCbom(String serialNumber) {
+        Cbom cbom = new Cbom();
+        cbom.setSerialNumber(serialNumber);
+        cbom.setVersion(1);
+        cbom.setSpecVersion("1.7");
+        return cbomRepository.save(cbom);
+    }
+}

--- a/src/test/java/com/otilm/core/integration/service/CryptographicAssetStatisticsITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicAssetStatisticsITest.java
@@ -200,10 +200,12 @@ class CryptographicAssetStatisticsITest extends BaseSpringBootTest {
 
     /**
      * The two security gates are independent: CRYPTO_ASSET scopes the inventory badges, CBOM scopes the completeness
-     * block, and forbidding one must not perturb the other.
+     * block, and forbidding one must not perturb the other. F2: a CBOM access denial that is total is a
+     * permission-shaped zero, not a fact about the estate, so the document-derived fields are omitted entirely rather
+     * than served as zeroes that read as "nothing has ever synced".
      */
     @Test
-    void cbomRestrictionsScopeTheCompletenessBlockOnly() {
+    void cbomDenialOmitsTheCompletenessBlock() {
         UUID asset1 = seedTyped(CryptographicAssetType.ALGORITHM, "cbom-restricted-1");
         seedTyped(CryptographicAssetType.CERTIFICATE, "cbom-restricted-2");
         Cbom cbom = newCbom("urn:uuid:cbom-restricted");
@@ -216,12 +218,43 @@ class CryptographicAssetStatisticsITest extends BaseSpringBootTest {
 
         CryptographicAssetStatisticsDto dto = cryptographicAssetService.getCryptographicAssetStatistics();
 
-        assertThat(dto.getSyncCompleteness().getCbomStatBySyncState().values()).containsOnly(0L);
-        assertThat(dto.getSourceCbomCount()).isZero();
-        assertThat(dto.getSyncCompleteness().getLastCompletedSyncAt()).isNull();
+        assertThat(dto.getSourceCbomCount())
+                .describedAs("a permission-shaped zero would read as a never-synced estate; omit instead")
+                .isNull();
+        assertThat(dto.getSyncCompleteness()).isNull();
         assertThat(dto.getTotalAssets())
                 .describedAs("asset scope is CRYPTO_ASSET, document scope is CBOM -- the two gates are independent")
                 .isEqualTo(2L);
+    }
+
+    /**
+     * F2's partial-restriction twin: a caller who can see one of two cboms still gets the scoped counts, not the
+     * omission -- omission is reserved for a total denial.
+     */
+    @Test
+    void partialCbomRestrictionStillServesScopedCounts() {
+        UUID asset1 = seedTyped(CryptographicAssetType.ALGORITHM, "cbom-partial-1");
+        Cbom visible = newCbom("urn:uuid:cbom-partial-visible");
+        Cbom hidden = newCbom("urn:uuid:cbom-partial-hidden");
+        OffsetDateTime syncedAt = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS);
+        syncStateWriter.markSynced(visible.getUuid(), syncedAt);
+        syncStateWriter.markSynced(hidden.getUuid(), syncedAt);
+        sourceWriter
+                .upsertSource(asset1, visible.getUuid(), Map.of("name", "cbom-partial-1"),
+                        List.of(Map.of("location", "a.c")), OffsetDateTime.now());
+
+        forbidCbomObjects(List.of(hidden.getUuid()));
+
+        CryptographicAssetStatisticsDto dto = cryptographicAssetService.getCryptographicAssetStatistics();
+
+        assertThat(dto.getSourceCbomCount())
+                .describedAs("only the visible cbom is counted; a partial restriction is not deniesEverything")
+                .isEqualTo(1L);
+        assertThat(dto.getSyncCompleteness()).isNotNull();
+        assertThat(
+                dto.getSyncCompleteness().getCbomStatBySyncState().values().stream().mapToLong(Long::longValue).sum())
+                .describedAs("only the visible cbom is in scope, even though both are synced")
+                .isEqualTo(1L);
     }
 
     // ---- helpers ----
@@ -258,6 +291,26 @@ class CryptographicAssetStatisticsITest extends BaseSpringBootTest {
                         Mockito
                                 .argThat(req -> req != null && req.getProperties() != null
                                         && Resource.CRYPTO_ASSET.getCode().equals(req.getProperties().get("name"))
+                                        && ResourceAction.LIST.getCode().equals(req.getProperties().get("action"))),
+                        Mockito.any(), Mockito.any()))
+                .thenReturn(partial);
+    }
+
+    /**
+     * The CBOM twin of {@link #forbidCryptoAssetObjects}: stubs the OPA object-access vote for {@code cboms:list} so
+     * every uuid in {@code forbidden} is denied while the rest of the CBOM estate stays visible -- a PARTIAL
+     * restriction, as opposed to {@link #denyObjectAccess} which denies the whole resource.
+     */
+    private void forbidCbomObjects(List<UUID> forbidden) {
+        OpaObjectAccessResult partial = new OpaObjectAccessResult();
+        partial.setActionAllowedForGroupOfObjects(true);
+        partial.setAllowedObjects(List.of());
+        partial.setForbiddenObjects(forbidden.stream().map(UUID::toString).toList());
+        when(opaClient
+                .checkObjectAccess(Mockito.any(),
+                        Mockito
+                                .argThat(req -> req != null && req.getProperties() != null
+                                        && Resource.CBOM.getCode().equals(req.getProperties().get("name"))
                                         && ResourceAction.LIST.getCode().equals(req.getProperties().get("action"))),
                         Mockito.any(), Mockito.any()))
                 .thenReturn(partial);

--- a/src/test/java/com/otilm/core/integration/service/CryptographicAssetStatisticsITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicAssetStatisticsITest.java
@@ -72,7 +72,8 @@ class CryptographicAssetStatisticsITest extends BaseSpringBootTest {
         seedTyped(CryptographicAssetType.PROTOCOL, "TLS-1.3");
         applyVerdict(a1, PqcVerdict.NOT_READY);
 
-        CryptographicAssetStatisticsDto dto = cryptographicAssetService.getCryptographicAssetStatistics();
+        CryptographicAssetStatisticsDto dto = cryptographicAssetService
+                .getCryptographicAssetStatistics(SecurityFilter.create());
 
         assertEquals(4L, dto.getTotalAssets());
         assertEquals(2L, dto.getStatByType().get("algorithm"));
@@ -130,7 +131,8 @@ class CryptographicAssetStatisticsITest extends BaseSpringBootTest {
                 .upsertSource(contributor, c.getUuid(), Map.of("name", "contributor"),
                         List.of(Map.of("location", "a.c")), OffsetDateTime.now());
 
-        CryptographicAssetStatisticsDto dto = cryptographicAssetService.getCryptographicAssetStatistics();
+        CryptographicAssetStatisticsDto dto = cryptographicAssetService
+                .getCryptographicAssetStatistics(SecurityFilter.create());
 
         Map<String, Long> bySyncState = dto.getSyncCompleteness().getCbomStatBySyncState();
         assertThat(bySyncState.get("pending")).isEqualTo(1L);
@@ -144,7 +146,8 @@ class CryptographicAssetStatisticsITest extends BaseSpringBootTest {
 
         OffsetDateTime t2later = t1.plusSeconds(30);
         syncStateWriter.markSynced(d.getUuid(), t2later);
-        CryptographicAssetStatisticsDto after = cryptographicAssetService.getCryptographicAssetStatistics();
+        CryptographicAssetStatisticsDto after = cryptographicAssetService
+                .getCryptographicAssetStatistics(SecurityFilter.create());
         assertThat(after.getSyncCompleteness().getLastCompletedSyncAt()).isEqualTo(t2later);
     }
 
@@ -161,7 +164,8 @@ class CryptographicAssetStatisticsITest extends BaseSpringBootTest {
                 .upsertSource(assetB, contributing.getUuid(), Map.of("name", "source-count-b"),
                         List.of(Map.of("location", "b.c")), OffsetDateTime.now());
 
-        CryptographicAssetStatisticsDto dto = cryptographicAssetService.getCryptographicAssetStatistics();
+        CryptographicAssetStatisticsDto dto = cryptographicAssetService
+                .getCryptographicAssetStatistics(SecurityFilter.create());
 
         assertThat(dto.getSourceCbomCount())
                 .describedAs("one cbom sourcing two assets counts once; the untouched cbom counts zero")
@@ -170,7 +174,8 @@ class CryptographicAssetStatisticsITest extends BaseSpringBootTest {
 
     @Test
     void emptyInventoryServesZeroesNotNulls() {
-        CryptographicAssetStatisticsDto dto = cryptographicAssetService.getCryptographicAssetStatistics();
+        CryptographicAssetStatisticsDto dto = cryptographicAssetService
+                .getCryptographicAssetStatistics(SecurityFilter.create());
 
         assertThat(dto.getTotalAssets()).isZero();
         assertThat(dto.getStatByType()).hasSize(5);
@@ -192,7 +197,8 @@ class CryptographicAssetStatisticsITest extends BaseSpringBootTest {
             seedTypedWithFamily(CryptographicAssetType.ALGORITHM, "family-top-n-" + i, "family-" + i);
         }
 
-        CryptographicAssetStatisticsDto dto = cryptographicAssetService.getCryptographicAssetStatistics();
+        CryptographicAssetStatisticsDto dto = cryptographicAssetService
+                .getCryptographicAssetStatistics(SecurityFilter.create());
 
         assertThat(dto.getStatByAlgorithmFamily()).hasSize(10);
         assertThat(dto.getDistinctAlgorithmFamilyCount()).isEqualTo(12L);
@@ -216,7 +222,8 @@ class CryptographicAssetStatisticsITest extends BaseSpringBootTest {
 
         denyObjectAccess(Resource.CBOM, ResourceAction.LIST);
 
-        CryptographicAssetStatisticsDto dto = cryptographicAssetService.getCryptographicAssetStatistics();
+        CryptographicAssetStatisticsDto dto = cryptographicAssetService
+                .getCryptographicAssetStatistics(SecurityFilter.create());
 
         assertThat(dto.getSourceCbomCount())
                 .describedAs("a permission-shaped zero would read as a never-synced estate; omit instead")
@@ -245,7 +252,8 @@ class CryptographicAssetStatisticsITest extends BaseSpringBootTest {
 
         forbidCbomObjects(List.of(hidden.getUuid()));
 
-        CryptographicAssetStatisticsDto dto = cryptographicAssetService.getCryptographicAssetStatistics();
+        CryptographicAssetStatisticsDto dto = cryptographicAssetService
+                .getCryptographicAssetStatistics(SecurityFilter.create());
 
         assertThat(dto.getSourceCbomCount())
                 .describedAs("only the visible cbom is counted; a partial restriction is not deniesEverything")
@@ -260,7 +268,8 @@ class CryptographicAssetStatisticsITest extends BaseSpringBootTest {
     // ---- helpers ----
 
     private void assertStatisticsReconcileWithTheList(long expectedTotalAssets) {
-        CryptographicAssetStatisticsDto dto = cryptographicAssetService.getCryptographicAssetStatistics();
+        CryptographicAssetStatisticsDto dto = cryptographicAssetService
+                .getCryptographicAssetStatistics(SecurityFilter.create());
         PaginationResponseDto<CryptographicAssetDto> page = cryptographicAssetService
                 .listCryptographicAssets(SecurityFilter.create(), new SearchRequestDto());
 

--- a/src/test/java/com/otilm/core/service/impl/CryptographicAssetStatisticsCalculatorTest.java
+++ b/src/test/java/com/otilm/core/service/impl/CryptographicAssetStatisticsCalculatorTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CryptographicAssetStatisticsCalculatorTest {
 
@@ -79,6 +80,38 @@ class CryptographicAssetStatisticsCalculatorTest {
                 .assemble(0, Map.of(), Map.of(), Map.of(), 10, 0, Map.of(), null)
                 .getSyncCompleteness()
                 .getLastCompletedSyncAt());
+    }
+
+    /**
+     * F4: a key dense() has no declared code for is not a bucket it can silently drop -- a discarded bucket is a chart
+     * that lies.
+     */
+    @Test
+    void anUnmappedTypeKeyThrows() {
+        assertThrows(IllegalStateException.class, () -> CryptographicAssetStatisticsCalculator
+                .assemble(1, Map.of("bogus-type", 1L), Map.of(), Map.of(), 10, 0, Map.of(), null));
+    }
+
+    /**
+     * F4: statByType folds nothing (asset_type is NOT NULL, so densifying it never names a foldNullInto target). An
+     * Unassigned bucket appearing there means the invariant that every stored type is a real enum code broke, and that
+     * must fail loud rather than serve a silently-zeroed extra bucket.
+     */
+    @Test
+    void theUnassignedSentinelWithNoFoldTargetThrowsForType() {
+        assertThrows(IllegalStateException.class,
+                () -> CryptographicAssetStatisticsCalculator
+                        .assemble(1, Map.of(CryptographicAssetStatisticsCalculator.UNASSIGNED_KEY, 1L), Map.of(),
+                                Map.of(), 10, 0, Map.of(), null));
+    }
+
+    /** F4: the same rule for cbomStatBySyncState -- asset_sync_state is NOT NULL too. */
+    @Test
+    void theUnassignedSentinelWithNoFoldTargetThrowsForSyncState() {
+        assertThrows(IllegalStateException.class,
+                () -> CryptographicAssetStatisticsCalculator
+                        .assemble(0, Map.of(), Map.of(), Map.of(), 10, 0,
+                                Map.of(CryptographicAssetStatisticsCalculator.UNASSIGNED_KEY, 1L), null));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/impl/CryptographicAssetStatisticsCalculatorTest.java
+++ b/src/test/java/com/otilm/core/service/impl/CryptographicAssetStatisticsCalculatorTest.java
@@ -1,0 +1,95 @@
+package com.otilm.core.service.impl;
+
+import com.otilm.api.model.client.dashboard.CryptographicAssetStatisticsDto;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class CryptographicAssetStatisticsCalculatorTest {
+
+    @Test
+    void densifiesEveryEnumCodeWithZero() {
+        CryptographicAssetStatisticsDto dto = CryptographicAssetStatisticsCalculator
+                .assemble(3, Map.of("algorithm", 3L), Map.of(), Map.of(), 10, 0, Map.of(), null);
+        assertEquals(Map
+                .of("algorithm", 3L, "certificate", 0L, "protocol", 0L, "related-crypto-material", 0L, "unroutable",
+                        0L),
+                dto.getStatByType());
+        assertEquals(Map.of("ready", 0L, "notReady", 0L, "notApplicable", 0L, "unknown", 0L),
+                dto.getStatByPqcVerdict());
+        assertEquals(Map.of("pending", 0L, "inProgress", 0L, "synced", 0L, "failed", 0L),
+                dto.getSyncCompleteness().getCbomStatBySyncState());
+    }
+
+    @Test
+    void foldsTheUnassignedVerdictBucketIntoUnknown() {
+        // countGroupedUsingSecurityFilter maps a NULL pqc_verdict group key to "Unassigned"; a never-evaluated
+        // asset is served as unknown everywhere else, so the fold keeps statistics reconciled with the list
+        CryptographicAssetStatisticsDto dto = CryptographicAssetStatisticsCalculator
+                .assemble(5, Map.of(), Map.of("Unassigned", 3L, "unknown", 1L, "ready", 1L), Map.of(), 10, 0, Map.of(),
+                        null);
+        assertEquals(4L, dto.getStatByPqcVerdict().get("unknown"));
+        assertEquals(1L, dto.getStatByPqcVerdict().get("ready"));
+    }
+
+    @Test
+    void familyTopNKeepsHighestCountsAndReportsOverflowAndUnassigned() {
+        Map<String, Long> families = new HashMap<>();
+        for (int i = 1; i <= 12; i++) {
+            families.put("family-" + String.format("%02d", i), (long) i);
+        }
+        families.put("Unassigned", 99L);
+        CryptographicAssetStatisticsDto dto = CryptographicAssetStatisticsCalculator
+                .assemble(0, Map.of(), Map.of(), families, 10, 0, Map.of(), null);
+        assertEquals(10, dto.getStatByAlgorithmFamily().size());
+        assertFalse(dto.getStatByAlgorithmFamily().containsKey("Unassigned"));
+        assertFalse(dto.getStatByAlgorithmFamily().containsKey("family-01")); // the two smallest overflow
+        assertFalse(dto.getStatByAlgorithmFamily().containsKey("family-02"));
+        assertEquals(List.of("family-12", "family-11"),
+                dto.getStatByAlgorithmFamily().keySet().stream().limit(2).toList());
+        assertEquals(12L, dto.getDistinctAlgorithmFamilyCount());
+        assertEquals(99L, dto.getUnassignedAssetCount());
+    }
+
+    @Test
+    void familyTiesBreakOnKeyForDeterminism() {
+        // two families with equal counts → ascending key order between them
+        Map<String, Long> families = Map.of("zebra", 5L, "apple", 5L, "banana", 3L);
+        CryptographicAssetStatisticsDto dto = CryptographicAssetStatisticsCalculator
+                .assemble(0, Map.of(), Map.of(), families, 10, 0, Map.of(), null);
+        assertEquals(3, dto.getStatByAlgorithmFamily().size());
+        assertEquals(List.of("apple", "zebra", "banana"), dto.getStatByAlgorithmFamily().keySet().stream().toList());
+    }
+
+    @Test
+    void badgesAndTimestampPassThrough() {
+        OffsetDateTime syncedAt = OffsetDateTime.parse("2026-08-30T12:00:00Z");
+        CryptographicAssetStatisticsDto dto = CryptographicAssetStatisticsCalculator
+                .assemble(7, Map.of(), Map.of(), Map.of(), 10, 4, Map.of("synced", 4L), syncedAt);
+        assertEquals(7L, dto.getTotalAssets());
+        assertEquals(4L, dto.getSourceCbomCount());
+        assertEquals(syncedAt, dto.getSyncCompleteness().getLastCompletedSyncAt());
+        assertNull(CryptographicAssetStatisticsCalculator
+                .assemble(0, Map.of(), Map.of(), Map.of(), 10, 0, Map.of(), null)
+                .getSyncCompleteness()
+                .getLastCompletedSyncAt());
+    }
+
+    @Test
+    void fewerFamiliesThanTheLimitAreAllServed() {
+        // 3 families, limit 10 → all 3 present, distinct == 3
+        Map<String, Long> families = Map.of("family-a", 2L, "family-b", 5L, "family-c", 1L);
+        CryptographicAssetStatisticsDto dto = CryptographicAssetStatisticsCalculator
+                .assemble(0, Map.of(), Map.of(), families, 10, 0, Map.of(), null);
+        assertEquals(3, dto.getStatByAlgorithmFamily().size());
+        assertEquals(3L, dto.getDistinctAlgorithmFamilyCount());
+        assertEquals(List.of("family-b", "family-a", "family-c"),
+                dto.getStatByAlgorithmFamily().keySet().stream().toList());
+    }
+}


### PR DESCRIPTION
Closes #2145. Second half of the read surface on top of #2167's plumbing: fills the two `NotSupportedException` stubs and pins the CBOM sync-state fields to the wire.

## What

- **Detail** `GET /v1/cryptoAssets/{uuid}`: elected representative payload served verbatim beside every source's original (never merged), verdict provenance block, normalized fields, per-source capped evidence with true pre-cap `occurrenceCount`, OIDs with the `refuted` flag, sources fetch-joined to their CBOM headers in first-seen order.
- **Statistics** `GET /v1/statistics/cryptoAssets`: seven security-scoped aggregates on virtual threads (`DelegatingSecurityContextExecutorService`), reshaped by a pure package-private calculator — dense enum maps, null-bucket folds, top-10 families with `distinctAlgorithmFamilyCount`/`unassignedAssetCount` overflow badges, sync-completeness block. Gated by CRYPTO_ASSET LIST (deliberately shares the list permission). Aggregation failures fail the request rather than serve zeros that no longer reconcile.
- **Sync visibility**: `assetSyncState`/`assetSyncedAt` were already mapped on the CBOM DTOs; new tests pin them on list and detail.

## Acceptance criteria

- Detail complete; source links resolve (`cbomUuid` + `serialNumber`/`version`): `CryptographicAssetDetailITest`.
- Per-source originals beside the elected payload, disagreement covered: `servesElectedPayloadBesideDisagreeingPerSourceOriginals`.
- Refuted OID renders flagged and is never served as the display name: `flagsARefutedOidAndSuppressesItAsName`.
- Statistics reconcile exactly with list totals under identical permission filtering (asserted with absolute counts under an OPA object restriction) and the completeness block is correct under partial sync: `CryptographicAssetStatisticsITest`.
- No response carries the identity key: ArchUnit fence + wire-level regex and recomputed-literal assertions on list, detail, statistics and the 404 body.
- 403 without permission on every operation, server-side: `CryptographicAssetAuthorizationHttpITest`.
- Coverage on new code 0.9095 by the Sonar line+branch formula (gate 0.80).

## Map-typed payload hand-check (AC, recorded)

The lexical exposure fence cannot see a key travelling as runtime data, so the four map channels were traced by hand to their write paths:

1. `electedPayload` ← `merged_crypto_properties` ← `recomputeMergeFromSources` elects one source's stored payload verbatim → reduces to channel 2.
2. `sources[].payload` ← `original_crypto_properties` ← `CryptoAssetSourceWriter.upsertSource`, producer-derived and redaction-enveloped; no production caller exists yet (sync lands with core#2073), today fixture-only.
3. `verdict.evaluatedFields` ← `applyPqcVerdict` — written by core#2151, not here; fixture-only today. The write-side allowlist raised on core#2151 is the fix; this surface serves the column verbatim and is the backstop.
4. `CbomDetailDto.content` — pre-existing external-fetch channel, untouched by this diff.

## Coordination notes for reviewers

- PR #2173 (core#2165 items 3 and 12: credential-strip-before-cap, redaction envelope) is still open. This endpoint serves stored values, so rows ingested before those pipeline fixes land keep their pre-fix shapes until re-ingest — flagged on the issue as a pre-ship coordination point.
- Contract friction, follow-up filed: the detail DTO marks `verdict` REQUIRED, but a never-evaluated asset serves no fabricated provenance block (row-level `pqcVerdict` = `unknown`); OmniTrustILM/interfaces#938 flips it to NOT_REQUIRED.

## Verification

All four CI profile groups + full `mvn verify`: 6319 tests, 0 failures (2 pre-existing environmental `ProxyPropertiesTest` DNS errors, unrelated). Spotless/Checkstyle clean. Adversarial whole-branch review ran before this PR; its one finding (a reconciliation test that could pass vacuously) is fixed in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)