### PR TITLE
Make the Mockito and HQL-rendering test shapes hold on both framework lines

### DIFF
--- a/src/test/java/com/otilm/core/integration/service/ConnectorServiceMockITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ConnectorServiceMockITest.java
@@ -32,11 +32,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.mockito.Mockito.any;
@@ -100,8 +102,12 @@ class ConnectorServiceMockITest {
 
     private Endpoint endpoint1, endpoint2, endpoint3;
 
+    private AutoCloseable mocks;
+
     @BeforeEach
     void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
+
         endpoint1 = new Endpoint();
         endpoint1.setUuid(UUID.fromString("abfbc322-29e1-11ed-a261-0242ac120002"));
         endpoint1.setName("endpoint1");
@@ -141,6 +147,11 @@ class ConnectorServiceMockITest {
 
         when(connectorApiFactory.getConnectorApiClient(any(ApiClientConnectorInfo.class)))
                 .thenReturn(connectorApiClient);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mocks.close();
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/util/FilterPredicatesBuilderITest.java
+++ b/src/test/java/com/otilm/core/integration/util/FilterPredicatesBuilderITest.java
@@ -101,6 +101,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.hibernate.query.sqm.ComparisonOperator;
 import org.hibernate.query.sqm.function.SelfRenderingSqmFunction;
+import org.hibernate.query.sqm.tree.expression.SqmLiteral;
 import org.hibernate.query.sqm.tree.predicate.SqmComparisonPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmExistsPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmJunctionPredicate;
@@ -318,6 +319,7 @@ class FilterPredicatesBuilderITest extends BaseSpringBootTest {
         SelfRenderingSqmFunction<?> leftHandExpressionHandExpression = (SelfRenderingSqmFunction<?>) comparisonPredicateTest
                 .getLeftHandExpression();
         Assertions.assertEquals("textregexeq", leftHandExpressionHandExpression.getFunctionName());
+        Assertions.assertInstanceOf(SqmLiteral.class, leftHandExpressionHandExpression.getArguments().getLast());
         Assertions
                 .assertEquals(testValue,
                         unquoted(leftHandExpressionHandExpression.getArguments().getLast().toHqlString()));

--- a/src/test/java/com/otilm/core/integration/util/FilterPredicatesBuilderITest.java
+++ b/src/test/java/com/otilm/core/integration/util/FilterPredicatesBuilderITest.java
@@ -275,7 +275,7 @@ class FilterPredicatesBuilderITest extends BaseSpringBootTest {
         Assertions.assertEquals(ComparisonOperator.EQUAL, ((SqmComparisonPredicate) predicateTest).getSqmOperator());
         Assertions
                 .assertEquals(testValue,
-                        ((SqmComparisonPredicate) predicateTest).getRightHandExpression().toHqlString());
+                        unquoted(((SqmComparisonPredicate) predicateTest).getRightHandExpression().toHqlString()));
     }
 
     @Test
@@ -297,7 +297,7 @@ class FilterPredicatesBuilderITest extends BaseSpringBootTest {
                                 ((SqmComparisonPredicate) predicate).getSqmOperator());
                 Assertions
                         .assertEquals(testValue,
-                                ((SqmComparisonPredicate) predicate).getRightHandExpression().toHqlString());
+                                unquoted(((SqmComparisonPredicate) predicate).getRightHandExpression().toHqlString()));
             } else {
                 Assertions.assertFalse(predicate.isNull().isNegated());
             }
@@ -313,14 +313,14 @@ class FilterPredicatesBuilderITest extends BaseSpringBootTest {
         Assertions.assertInstanceOf(SqmComparisonPredicate.class, predicateTest);
         SqmComparisonPredicate comparisonPredicateTest = (SqmComparisonPredicate) predicateTest;
         Assertions.assertEquals(ComparisonOperator.EQUAL, comparisonPredicateTest.getSqmOperator());
-        Assertions.assertEquals("true", comparisonPredicateTest.getRightHandExpression().toHqlString());
+        Assertions.assertEquals("true", unquoted(comparisonPredicateTest.getRightHandExpression().toHqlString()));
         Assertions.assertInstanceOf(SelfRenderingSqmFunction.class, comparisonPredicateTest.getLeftHandExpression());
         SelfRenderingSqmFunction<?> leftHandExpressionHandExpression = (SelfRenderingSqmFunction<?>) comparisonPredicateTest
                 .getLeftHandExpression();
         Assertions.assertEquals("textregexeq", leftHandExpressionHandExpression.getFunctionName());
         Assertions
-                .assertEquals("'" + testValue + "'",
-                        leftHandExpressionHandExpression.getArguments().getLast().toHqlString());
+                .assertEquals(testValue,
+                        unquoted(leftHandExpressionHandExpression.getArguments().getLast().toHqlString()));
     }
 
     @Test
@@ -346,7 +346,8 @@ class FilterPredicatesBuilderITest extends BaseSpringBootTest {
             if (predicate instanceof SqmLikePredicate) {
                 Assertions.assertTrue(predicate.isNegated());
                 Assertions
-                        .assertEquals("%" + testValue + "%", ((SqmLikePredicate) predicate).getPattern().toHqlString());
+                        .assertEquals("%" + testValue + "%",
+                                unquoted(((SqmLikePredicate) predicate).getPattern().toHqlString()));
             } else {
                 Assertions.assertFalse(predicate.isNull().isNegated());
             }
@@ -402,7 +403,7 @@ class FilterPredicatesBuilderITest extends BaseSpringBootTest {
                         ((SqmComparisonPredicate) predicateTest).getSqmOperator());
         Assertions
                 .assertEquals(getFormattedDate(),
-                        ((SqmComparisonPredicate) predicateTest).getRightHandExpression().toHqlString());
+                        unquoted(((SqmComparisonPredicate) predicateTest).getRightHandExpression().toHqlString()));
     }
 
     @Test
@@ -415,7 +416,7 @@ class FilterPredicatesBuilderITest extends BaseSpringBootTest {
                 .assertEquals(ComparisonOperator.LESS_THAN, ((SqmComparisonPredicate) predicateTest).getSqmOperator());
         Assertions
                 .assertEquals(getFormattedDate(),
-                        ((SqmComparisonPredicate) predicateTest).getRightHandExpression().toHqlString());
+                        unquoted(((SqmComparisonPredicate) predicateTest).getRightHandExpression().toHqlString()));
     }
 
     @NotNull
@@ -2156,9 +2157,18 @@ class FilterPredicatesBuilderITest extends BaseSpringBootTest {
                 .collect(Collectors.toSet());
     }
 
+    /**
+     * Strips the quoting Hibernate applies inconsistently across versions.
+     */
+    private static String unquoted(final String hqlString) {
+        return hqlString.length() > 1 && hqlString.startsWith("'") && hqlString.endsWith("'")
+                ? hqlString.substring(1, hqlString.length() - 1)
+                : hqlString;
+    }
+
     private void testLikePredicate(final Predicate predicate, final String value) {
         Assertions.assertInstanceOf(SqmLikePredicate.class, predicate);
-        Assertions.assertEquals(value, ((SqmLikePredicate) predicate).getPattern().toHqlString());
+        Assertions.assertEquals(value, unquoted(((SqmLikePredicate) predicate).getPattern().toHqlString()));
     }
 
     private SearchFilterRequestDto prepareDummyFilterRequest(final FilterConditionOperator condition) {


### PR DESCRIPTION
Closes #2202.

**Two test classes assert on framework details that Spring Boot 4 and Hibernate 7 spell
differently. Both are made version-neutral here, on the 3.5 line, so they never become
migration churn.**

No production code changes. Both classes pass on `main` today and keep passing; the point of
the change is that they also pass on the 4.1 baseline, where they currently contribute 8
failures and 3 errors.

## `FilterPredicatesBuilderITest` — 8 tests

The assertions compare the rendered HQL of a predicate's operand. What changed is
[HHH-17002](https://hibernate.atlassian.net/browse/HHH-17002) (query-plan caching for
`CriteriaQuery`), fixVersion **7.0.0.CR1**, never backported to 6.6. On 6.6.53 a value bind
appended the raw value and only a `String` literal was quoted; from 7.0 binds and literals
share one `SqmLiteral.appendHqlString`. For a non-null value with a non-null `JavaType`, that
quotes everything except `Number`, `Boolean` and `Enum`; `null` renders as `null`.

| Expression | 6.6.53 | 7.4.5 |
|---|---|---|
| `cb.equal(path, "test")` right-hand — `String` value bind | `test` | `'test'` |
| `cb.equal(expr, true)` right-hand — `Boolean` value bind | `true` | `true` |
| `cb.literal("test")` — `String` literal | `'test'` | `'test'` |
| `cb.literal(<LocalDateTime>)` — non-`String` literal | `2026-…` | `'2026-…'` |

The two forms already disagreed on 6.6, which is why one assertion in this file expected
`'test'` **with** quotes while the other seven expected `test` **without**. The test was
pinning the rendered spelling of whichever internal form Hibernate happened to pick, which is
what breaks across the versions.

Five of the eight sites are value binds (278, 300, 316, 350, 2171) and three are literals
(323, 406, 419). The bind at 316 carries a `Boolean`, which both versions render unquoted, so
the helper is inert there. 406 and 419 are the sites that could have broken and do not — a
temporal rendered as `{ts '…'}` would survive the helper untouched, but 7.4.5 has no temporal
`appendHqlString` override, so `LocalDateTime` takes the generic quoted branch.

All eight `toHqlString()` sites now go through `unquoted(...)`, which strips one surrounding
pair of quotes, so no assertion depends on the rendered spelling. Node *shape* is a different
property and is deliberately kept: `unquoted()` would otherwise stop telling a literal apart
from a value bind at the MATCHES site, so that site now asserts its argument is a
`SqmLiteral`.

`toHqlString()` appears in this one test file and nowhere in `src/main`.

## `ConnectorServiceMockITest` — 3 tests

A `@SpringBootTest` using plain `@Mock` and `@InjectMocks`, with no
`@ExtendWith(MockitoExtension.class)` and no `openMocks` call. Boot 3 opened those annotations
through `org.springframework.boot.test.mock.mockito.MockitoTestExecutionListener`. Boot 4
removes that listener along with the `@MockBean` package, so the fields stay null:

```
NullPointerException: Cannot invoke "ConnectorServiceImpl.setConnectorAdapters(java.util.Map)"
  because "this.connectorService" is null
```

The test now opens the annotations itself and closes them in `@AfterEach`.

**This is the only test in the repo relying on that implicit behaviour.** 80 test files use
plain `@Mock` or `@InjectMocks`; the other 79 already declare `MockitoExtension` or call
`openMocks`. So this is a one-off, not the first of a sweep.

## Verification

The same commit was run against both framework lines — the 4.1 result is from applying this
commit to `refactor/2016-spring-boot-4.1-baseline`, not from inspection:

| Line | `FilterPredicatesBuilderITest` | `ConnectorServiceMockITest` |
|---|---|---|
| `main` — Boot 3.5, Hibernate 6.6.53 | 52 tests, 0 failures | 3 tests, 0 failures |
| 4.1 baseline — Boot 4.1.1, Hibernate 7.4.5 | 52 tests, 0 failures | 3 tests, 0 failures |

## Scope

Preparation for the Spring Boot 4.1 migration, carved out of #2017, which recorded the first
as RC#4 and attributed the second nowhere. Removes 11 failures from the integration branch
before it is cut — the same pattern as #2149.

What remains in #2017 is RC#8, the follow-on locking defect (HHH-20744). That one cannot be
prepared on 3.5, because it does not reproduce there.

