### PR TITLE
Pin embedded Tomcat to 10.1.59 for the authentication-bypass CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,9 @@
 
     <properties>
         <archunit.version>1.4.2</archunit.version>
+        <!-- CVE-2026-65182, CVE-2026-65905, CVE-2026-68525 (auth/constraint bypasses in embedded Tomcat).
+             Remove when the parent BOM manages at least this version. -->
+        <tomcat.version>10.1.58</tomcat.version>
         <log-schema.version>1.1</log-schema.version>
         <hsqldb.version>2.7.3</hsqldb.version>
         <nimbus-jose-jwt.version>10.8</nimbus-jose-jwt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,9 @@
     <properties>
         <archunit.version>1.4.2</archunit.version>
         <!-- CVE-2026-65182, CVE-2026-65905, CVE-2026-68525 (auth/constraint bypasses in embedded Tomcat).
+             The announced fix version 10.1.58 was never published; 10.1.59 is its released successor.
              Remove when the parent BOM manages at least this version. -->
-        <tomcat.version>10.1.58</tomcat.version>
+        <tomcat.version>10.1.59</tomcat.version>
         <log-schema.version>1.1</log-schema.version>
         <hsqldb.version>2.7.3</hsqldb.version>
         <nimbus-jose-jwt.version>10.8</nimbus-jose-jwt.version>


### PR DESCRIPTION
## TLDR

Trivy fails every core image build (`test / Build amd64|arm64`, e.g. on #2189) on three CRITICAL CVEs in `tomcat-embed-core 10.1.55`, the version the parent BOM chain manages. This pins `tomcat.version` to **10.1.59** in core's pom until the BOM catches up (the announced fix version 10.1.58 failed its release vote and never reached Maven Central - 10.1.59 is the published successor carrying the same fixes; all three embed artifacts verified present). Like-for-like patch pin, no other changes.

| CVE | Issue |
|---|---|
| CVE-2026-65182 | Security constraint bypass via improper access control |
| CVE-2026-65905 | Authentication bypass via limited replay in the DIGEST authenticator |
| CVE-2026-68525 | Unauthorized resource access via FORM authentication bypass |

Note: the equivalent pin in the dependencies BOM (dependencies#152) was withdrawn - that repo's main carries the new major core has not adopted; this pin moves with core's own release train instead. Verified locally that the property overrides the managed version (help:evaluate resolves the pin); artifact resolution verified by CI.
