### PR TITLE
Let a root author delete a thread whose replies are all their own

### DIFF
--- a/src/main/java/com/otilm/core/dao/repository/CommentRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CommentRepository.java
@@ -27,7 +27,7 @@ public interface CommentRepository extends SecurityFilterRepository<Comment, UUI
     @Query("SELECT c.parentUuid, COUNT(c) FROM Comment c WHERE c.parentUuid IN :rootUuids GROUP BY c.parentUuid")
     List<Object[]> countRepliesByRoots(@Param("rootUuids") Collection<UUID> rootUuids);
 
-    boolean existsByParentUuid(UUID parentUuid);
+    boolean existsByParentUuidAndAuthorUuidNot(UUID parentUuid, UUID authorUuid);
 
     boolean existsByResourceAndObjectUuid(Resource resource, UUID objectUuid);
 

--- a/src/main/java/com/otilm/core/dao/repository/CommentRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CommentRepository.java
@@ -2,7 +2,6 @@ package com.otilm.core.dao.repository;
 
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.core.dao.entity.Comment;
-import jakarta.persistence.LockModeType;
 import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.List;
@@ -10,7 +9,6 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -31,8 +29,9 @@ public interface CommentRepository extends SecurityFilterRepository<Comment, UUI
 
     boolean existsByResourceAndObjectUuid(Resource resource, UUID objectUuid);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT c FROM Comment c WHERE c.uuid = :uuid")
+    // Spelled out because Hibernate renders a pessimistic write lock as FOR NO KEY UPDATE on PostgreSQL, which does
+    // not conflict with the key-share lock a reply's insert holds on its parent row; only FOR UPDATE does.
+    @Query(value = "SELECT * FROM {h-schema}comment WHERE uuid = :uuid FOR UPDATE", nativeQuery = true)
     Optional<Comment> findWithLockByUuid(@Param("uuid") UUID uuid);
 
     @Query("SELECT DISTINCT c.authorUuid FROM Comment c WHERE c.uuid = :rootUuid OR c.parentUuid = :rootUuid")

--- a/src/main/java/com/otilm/core/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CommentServiceImpl.java
@@ -224,11 +224,12 @@ public class CommentServiceImpl implements CommentExternalService, CommentIntern
         // A root author must not be able to erase other users' words: once another user has replied, only the host
         // object's owner or an update holder may delete the root (the delete cascades to the replies). Replies the
         // author wrote themselves stand in nobody's way. The writer re-checks under a row lock, so a reply racing
-        // in between this check and the delete still blocks a deletion that relies on sole authorship.
+        // in between this check and the delete still blocks a deletion that relies on sole authorship - which is
+        // why the cascade privilege is decided on its own: an author who also holds it must not be held to sole
+        // authorship by a reply that lands in between.
         boolean authorDeletesOwnThread = isAuthor
                 && !commentRepository.existsByParentUuidAndAuthorUuidNot(uuid, comment.getAuthorUuid());
-        boolean mayCascade = !authorDeletesOwnThread
-                && (isHostObjectOwner(comment, actor) || holdsHostObjectUpdate(comment));
+        boolean mayCascade = isHostObjectOwner(comment, actor) || holdsHostObjectUpdate(comment);
         if (!(authorDeletesOwnThread || mayCascade)) {
             throw deletionDenied(uuid, comment);
         }

--- a/src/main/java/com/otilm/core/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CommentServiceImpl.java
@@ -221,18 +221,19 @@ public class CommentServiceImpl implements CommentExternalService, CommentIntern
             return;
         }
 
-        // A root author must not be able to erase other users' words: once a root has replies, only the host
-        // object's owner or an update holder may delete it (the delete cascades to the replies). The writer
-        // re-checks for replies under a row lock, so ones racing in between this check and the delete still
-        // block a non-cascading deletion.
-        boolean authorDeletesOwnReplylessRoot = isAuthor && !commentRepository.existsByParentUuid(uuid);
-        boolean mayCascade = !authorDeletesOwnReplylessRoot
+        // A root author must not be able to erase other users' words: once another user has replied, only the host
+        // object's owner or an update holder may delete the root (the delete cascades to the replies). Replies the
+        // author wrote themselves stand in nobody's way. The writer re-checks under a row lock, so a reply racing
+        // in between this check and the delete still blocks a deletion that relies on sole authorship.
+        boolean authorDeletesOwnThread = isAuthor
+                && !commentRepository.existsByParentUuidAndAuthorUuidNot(uuid, comment.getAuthorUuid());
+        boolean mayCascade = !authorDeletesOwnThread
                 && (isHostObjectOwner(comment, actor) || holdsHostObjectUpdate(comment));
-        if (!(authorDeletesOwnReplylessRoot || mayCascade)) {
+        if (!(authorDeletesOwnThread || mayCascade)) {
             throw deletionDenied(uuid, comment);
         }
         recordAuditData(baseEventData(comment, hostObject.getName()));
-        commentWriter.deleteRoot(uuid, mayCascade);
+        commentWriter.deleteRoot(uuid, mayCascade ? null : comment.getAuthorUuid());
     }
 
     private AccessDeniedException deletionDenied(UUID uuid, Comment comment) {

--- a/src/main/java/com/otilm/core/service/writer/CommentWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/CommentWriter.java
@@ -60,14 +60,16 @@ public class CommentWriter {
     /**
      * Locking the root serializes the deletion against concurrent replies: the row lock ({@code FOR UPDATE}) conflicts
      * with the key-share lock a reply insert takes on its parent, so the reply check below cannot be invalidated before
-     * the delete commits — a root author must not erase words the thread gained meanwhile.
+     * the delete commits — a root author must not erase words the thread gained meanwhile. {@code soleAuthor} is the
+     * caller when they may delete only because every comment in the thread is theirs; null when they hold the cascade
+     * privilege and other users' replies go with the root.
      */
     @Transactional
-    public void deleteRoot(UUID uuid, boolean mayCascade) throws NotFoundException {
+    public void deleteRoot(UUID uuid, UUID soleAuthor) throws NotFoundException {
         commentRepository.findWithLockByUuid(uuid).orElseThrow(() -> new NotFoundException(Comment.class, uuid));
-        if (!mayCascade && commentRepository.existsByParentUuid(uuid)) {
-            throw new ValidationException(
-                    "The thread gained replies; only the host object's owner or an update holder may delete it");
+        if (soleAuthor != null && commentRepository.existsByParentUuidAndAuthorUuidNot(uuid, soleAuthor)) {
+            throw new ValidationException("The thread gained replies from other users; only the host object's owner"
+                    + " or an update holder may delete it");
         }
         commentRepository.deleteCommentByUuid(uuid);
     }

--- a/src/test/java/com/otilm/core/integration/dao/repository/CommentRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/dao/repository/CommentRepositoryITest.java
@@ -51,7 +51,9 @@ class CommentRepositoryITest extends BaseSpringBootTest {
             assertThat(row[0]).isEqualTo(root.getUuid());
             assertThat(row[1]).isEqualTo(1L);
         });
-        assertThat(commentRepository.existsByParentUuid(root.getUuid())).isTrue();
+        assertThat(commentRepository.existsByParentUuidAndAuthorUuidNot(root.getUuid(), root.getAuthorUuid())).isTrue();
+        assertThat(commentRepository.existsByParentUuidAndAuthorUuidNot(root.getUuid(), reply.getAuthorUuid()))
+                .isFalse();
     }
 
     @Test
@@ -82,16 +84,17 @@ class CommentRepositoryITest extends BaseSpringBootTest {
     }
 
     @Test
-    void nonCascadingRootDeletionIsBlockedOnceTheThreadHasReplies() {
+    void soleAuthorRootDeletionIsBlockedOnceAnotherUserReplied() {
         UUID objectUuid = UUID.randomUUID();
         Comment root = commentRepository.saveAndFlush(newComment(objectUuid, null));
         commentRepository.saveAndFlush(newComment(objectUuid, root.getUuid()));
 
         UUID rootUuid = root.getUuid();
-        assertThatThrownBy(() -> commentWriter.deleteRoot(rootUuid, false)).isInstanceOf(ValidationException.class);
+        assertThatThrownBy(() -> commentWriter.deleteRoot(rootUuid, root.getAuthorUuid()))
+                .isInstanceOf(ValidationException.class);
         assertThat(commentRepository.count()).isEqualTo(2);
 
-        assertThatCode(() -> commentWriter.deleteRoot(root.getUuid(), true)).doesNotThrowAnyException();
+        assertThatCode(() -> commentWriter.deleteRoot(root.getUuid(), null)).doesNotThrowAnyException();
         assertThat(commentRepository.count()).isZero();
     }
 

--- a/src/test/java/com/otilm/core/integration/service/CommentAuthorizationITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CommentAuthorizationITest.java
@@ -261,6 +261,24 @@ class CommentAuthorizationITest extends BaseSpringBootTest {
     }
 
     @Test
+    void authorWhoOwnsTheHostCascadesOverAnotherUsersReply() throws NotFoundException {
+        UUID objectUuid = hostObjects.create(Resource.RA_PROFILE);
+        UUID authorUuid = authenticateAs("tst-author");
+        grantOwnership(Resource.RA_PROFILE, objectUuid, authorUuid);
+        CommentDto root = post(Resource.RA_PROFILE, objectUuid, null);
+        authenticateAs("tst-replier");
+        post(Resource.RA_PROFILE, objectUuid, root.getUuid());
+
+        authenticateAs("tst-author", authorUuid);
+        restrictObjectAccess(Resource.RA_PROFILE, ResourceAction.UPDATE);
+        denyResourceAccess(Resource.RA_PROFILE, ResourceAction.UPDATE);
+
+        commentService.deleteComment(root.getUuid());
+
+        assertThat(list(Resource.RA_PROFILE, objectUuid).getComments()).isEmpty();
+    }
+
+    @Test
     void ownerDeletesRootWithRepliesCascading() throws NotFoundException {
         UUID objectUuid = hostObjects.create(Resource.RA_PROFILE);
         authenticateAs("tst-author");

--- a/src/test/java/com/otilm/core/integration/service/CommentAuthorizationITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CommentAuthorizationITest.java
@@ -71,7 +71,10 @@ class CommentAuthorizationITest extends BaseSpringBootTest {
     }
 
     private UUID authenticateAs(String username) {
-        UUID userUuid = UUID.randomUUID();
+        return authenticateAs(username, UUID.randomUUID());
+    }
+
+    private UUID authenticateAs(String username, UUID userUuid) {
         UserProfileDto userProfileDto = new UserProfileDto();
         UserDto userDto = new UserDto();
         userDto.setUuid(userUuid.toString());
@@ -226,17 +229,35 @@ class CommentAuthorizationITest extends BaseSpringBootTest {
     }
 
     @Test
-    void rootAuthorCannotDeleteOwnRootOnceReplied() throws NotFoundException {
+    void rootAuthorDeletesOwnThreadWhenEveryReplyIsTheirs() throws NotFoundException {
         UUID objectUuid = hostObjects.create(Resource.RA_PROFILE);
         authenticateAs("tst-author");
         CommentDto root = post(Resource.RA_PROFILE, objectUuid, null);
         post(Resource.RA_PROFILE, objectUuid, root.getUuid());
+        restrictObjectAccess(Resource.RA_PROFILE, ResourceAction.UPDATE);
+        denyResourceAccess(Resource.RA_PROFILE, ResourceAction.UPDATE);
 
+        commentService.deleteComment(root.getUuid());
+
+        assertThat(list(Resource.RA_PROFILE, objectUuid).getComments()).isEmpty();
+    }
+
+    @Test
+    void rootAuthorCannotDeleteOwnRootOnceAnotherUserReplied() throws NotFoundException {
+        UUID objectUuid = hostObjects.create(Resource.RA_PROFILE);
+        UUID authorUuid = authenticateAs("tst-author");
+        CommentDto root = post(Resource.RA_PROFILE, objectUuid, null);
+        post(Resource.RA_PROFILE, objectUuid, root.getUuid());
+        authenticateAs("tst-replier");
+        post(Resource.RA_PROFILE, objectUuid, root.getUuid());
+
+        authenticateAs("tst-author", authorUuid);
         restrictObjectAccess(Resource.RA_PROFILE, ResourceAction.UPDATE);
         denyResourceAccess(Resource.RA_PROFILE, ResourceAction.UPDATE);
 
         UUID rootUuid = root.getUuid();
         assertThatThrownBy(() -> commentService.deleteComment(rootUuid)).isInstanceOf(AccessDeniedException.class);
+        assertThat(list(Resource.RA_PROFILE, objectUuid).getComments().getFirst().getReplyCount()).isEqualTo(2);
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/CommentWriterConcurrencyITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CommentWriterConcurrencyITest.java
@@ -1,6 +1,7 @@
 package com.otilm.core.integration.service;
 
 import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.core.dao.entity.Comment;
 import com.otilm.core.dao.entity.Group;
@@ -119,6 +120,40 @@ class CommentWriterConcurrencyITest extends BaseSpringBootTest {
         assertThat(groupRepository.findByName(group.getName())).isEmpty();
     }
 
+    @Test
+    void soleAuthorDeletionWaitingOnTheRowLockIsRejectedOnceAnotherUsersReplyCommits() throws Exception {
+        Group group = newGroup();
+        Comment root = commentRepository.saveAndFlush(newComment(group.getUuid()));
+        CountDownLatch replied = new CountDownLatch(1);
+        CountDownLatch mayCommitReply = new CountDownLatch(1);
+
+        // Once flushed, the reply's insert holds a key-share lock on the root until it commits
+        Future<Comment> replier = executor.submit(() -> transactionTemplate.execute(status -> {
+            Comment reply = newComment(group.getUuid());
+            reply.setParentUuid(root.getUuid());
+            Comment saved = create(reply);
+            commentRepository.flush();
+            replied.countDown();
+            await(mayCommitReply);
+            return saved;
+        }));
+
+        assertThat(replied.await(10, TimeUnit.SECONDS)).isTrue();
+
+        Future<Object> deleter = executor.submit(() -> transactionTemplate.execute(status -> {
+            deleteRootAsSoleAuthor(root);
+            return null;
+        }));
+
+        awaitLockWaiter("transactionid");
+        mayCommitReply.countDown();
+
+        assertThat(replier.get(10, TimeUnit.SECONDS)).isNotNull();
+        assertThatThrownBy(() -> deleter.get(10, TimeUnit.SECONDS)).hasRootCauseInstanceOf(ValidationException.class);
+        assertThat(commentRepository.findById(root.getUuid())).isPresent();
+        assertThat(commentRepository.existsByParentUuidAndAuthorUuidNot(root.getUuid(), root.getAuthorUuid())).isTrue();
+    }
+
     private Group newGroup() {
         Group group = new Group();
         group.setName("tst-group-" + UUID.randomUUID());
@@ -143,18 +178,31 @@ class CommentWriterConcurrencyITest extends BaseSpringBootTest {
         }
     }
 
-    /**
-     * The interleaving under test only exists while the second worker sits in the advisory-lock wait, so the first
-     * worker must not commit before that wait is observable in pg_locks; timing out here means the lock was never
-     * contended — the serialization itself is broken, not the test.
-     */
+    private void deleteRootAsSoleAuthor(Comment root) {
+        try {
+            commentWriter.deleteRoot(root.getUuid(), root.getAuthorUuid());
+        } catch (NotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
     private void awaitAdvisoryLockWaiter() {
+        awaitLockWaiter("advisory");
+    }
+
+    /**
+     * The interleaving under test only exists while the second worker sits in a lock wait, so the first worker must not
+     * commit before that wait is observable in pg_locks; timing out here means the lock was never contended — the
+     * serialization itself is broken, not the test. A row lock held by another transaction shows up as a wait on that
+     * transaction's id.
+     */
+    private void awaitLockWaiter(String lockType) {
         Awaitility
                 .await()
                 .atMost(Duration.ofSeconds(10))
                 .until(() -> jdbcTemplate
-                        .queryForObject("SELECT count(*) FROM pg_locks WHERE locktype = 'advisory' AND NOT granted",
-                                Long.class) > 0);
+                        .queryForObject("SELECT count(*) FROM pg_locks WHERE locktype = ? AND NOT granted", Long.class,
+                                lockType) > 0);
     }
 
     private static void await(CountDownLatch latch) {


### PR DESCRIPTION
Closes #2198

A thread root's author could not delete it once it had any replies, including replies they wrote themselves (Epic: OmniTrustILM/ilm#246). The rule exists so an author cannot erase other users' words; it was checked as "has any replies".

## What's here

- `CommentRepository` — `existsByParentUuid` becomes `existsByParentUuidAndAuthorUuidNot`; nothing else used the old predicate.
- `CommentServiceImpl.deleteComment` — the author may delete their root when no reply by somebody else exists. The cascade privilege (host owner or update holder) is decided on its own, so a privileged author is never held to sole authorship by a reply that lands in between; the writer is told to cascade for every privileged caller and given the author otherwise.
- `CommentWriter.deleteRoot` — takes the sole author instead of a boolean and re-checks the same predicate under the row lock, so a reply from another user racing in between still blocks the deletion. The 422 message now says the thread gained replies from other users.
- `CommentRepository.findWithLockByUuid` — a native `FOR UPDATE`. Hibernate renders a pessimistic write lock as `FOR NO KEY UPDATE` on PostgreSQL, which does not conflict with the key-share lock a reply's insert holds on its parent, so the re-check was never actually serialized against replies (pre-existing since #2105; found by the new concurrency test).
- Tests — the test that pinned the old denial is replaced by one where the author deletes a thread holding their own reply, one where another user's reply still blocks with the reply count intact afterwards, and one where an author who owns the host cascades over another user's reply. The repository test covers the predicate both ways. `CommentWriterConcurrencyITest` gains an interleaving: another user's reply holds its key-share lock while the sole-author deletion waits on the row lock; once the reply commits the deletion is rejected and the whole thread is preserved.

## Notes for reviewers

- Own replies are deleted along with the root, which is the expected behaviour in the issue: every comment in the thread is the caller's.
- Independent of OmniTrustILM/core#2200 and OmniTrustILM/core#2197; branched off current main.
