### PR TITLE
Attribute signing records to the authenticated caller

### DIFF
--- a/src/main/java/com/otilm/core/signing/contentsigning/ContentSigningRecordFactory.java
+++ b/src/main/java/com/otilm/core/signing/contentsigning/ContentSigningRecordFactory.java
@@ -9,13 +9,15 @@ import com.otilm.core.signing.record.DeferredSigningRecordInputSource;
 import com.otilm.core.signing.record.SigningRecordInput;
 import com.otilm.core.signing.record.SigningRecordInputSource;
 import com.otilm.core.signing.record.TimestampTokenSerialNumbers;
+import com.otilm.core.util.AuthHelper;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
 /**
- * Builds the signing-record input for a content-signing run.
+ * Builds the signing-record input for a content-signing run. {@code requestedBy} is the identity on the thread that
+ * produced the signature, so the record names who asked for it; it stays unset when that thread carries no identity.
  */
 @Component
 public class ContentSigningRecordFactory {
@@ -47,7 +49,7 @@ public class ContentSigningRecordFactory {
                 .signingProfile(signingProfile)
                 .protocol(protocol)
                 .signingTime(signingTime)
-                .requestedBy(null)
+                .requestedBy(AuthHelper.getActingUserOrNull())
                 .displayName("%s %s".formatted(signingProfile.name(), result.level().getFormatName(profile.family())))
                 .requestMetadataJson(buildRequestMetadataJson(signingProfile, profile, result))
                 .signedDocument(result.signedDocument())

--- a/src/main/java/com/otilm/core/signing/tsa/TimestampSigningRecordFactory.java
+++ b/src/main/java/com/otilm/core/signing/tsa/TimestampSigningRecordFactory.java
@@ -28,9 +28,9 @@ import org.springframework.stereotype.Component;
  * {@code requestMetadataJson}, unconditionally.
  *
  * <p>
- * {@code requestedBy} is the identity on the thread that issued the token: the caller a TSP authenticator put into the
- * SecurityContext, or — for in-process issuance, which has no caller of its own — whoever requested the signature the
- * timestamp is going into. It stays unset when the issuing thread carries no identity.
+ * {@code requestedBy} is the identity on the thread that issued the token. On the TSP path a TSP authenticator put it
+ * into the SecurityContext; in-process issuance has no caller of its own, so the record names whoever requested the
+ * signature the timestamp goes into. It stays unset when the issuing thread carries no identity.
  */
 @Component
 public class TimestampSigningRecordFactory {

--- a/src/main/java/com/otilm/core/signing/tsa/TimestampSigningRecordFactory.java
+++ b/src/main/java/com/otilm/core/signing/tsa/TimestampSigningRecordFactory.java
@@ -9,6 +9,7 @@ import com.otilm.core.signing.record.SigningRecordInput;
 import com.otilm.core.signing.record.SigningRecordInputSource;
 import com.otilm.core.signing.record.TimestampTokenSerialNumbers;
 import com.otilm.core.signing.tsa.messages.TspRequest;
+import com.otilm.core.util.AuthHelper;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -27,8 +28,9 @@ import org.springframework.stereotype.Component;
  * {@code requestMetadataJson}, unconditionally.
  *
  * <p>
- * {@code requestedBy} is left {@code null}: the TSP caller identity is resolved in the protocol layer and is not
- * currently threaded down to the TSA engine, and in-process issuance has no caller identity of its own.
+ * {@code requestedBy} is the identity on the thread that issued the token: the caller a TSP authenticator put into the
+ * SecurityContext, or — for in-process issuance, which has no caller of its own — whoever requested the signature the
+ * timestamp is going into. It stays unset when the issuing thread carries no identity.
  */
 @Component
 public class TimestampSigningRecordFactory {
@@ -63,7 +65,7 @@ public class TimestampSigningRecordFactory {
                 .signingProfile(signingProfile)
                 .protocol(protocol)
                 .signingTime(genTime)
-                .requestedBy(null)
+                .requestedBy(AuthHelper.getActingUserOrNull())
                 .displayName(signingProfile.name() + " #" + serialHex)
                 .requestMetadataJson(buildRequestMetadataJson(signingProfile, request, serialHex))
                 .signedDocument(encodedToken)

--- a/src/main/java/com/otilm/core/util/AuthHelper.java
+++ b/src/main/java/com/otilm/core/util/AuthHelper.java
@@ -251,6 +251,21 @@ public class AuthHelper {
         }
     }
 
+    /**
+     * The acting user's uuid and username, or {@code null} when the thread carries no identifiable user — the
+     * {@link NameAndUuidDto} counterpart of {@link #getActingUserUuidOrNull()}, for callers that persist the username
+     * next to the uuid. Absence has the same two shapes described there, and an anonymous caller is reported as no user
+     * rather than as the literal "anonymousUser" its principal carries.
+     */
+    public static NameAndUuidDto getActingUserOrNull() {
+        try {
+            NameAndUuidDto actingUser = getUserIdentification();
+            return NullUtil.parseUuidOrNull(actingUser.getUuid()) == null ? null : actingUser;
+        } catch (ValidationException | IllegalArgumentException e) {
+            return null;
+        }
+    }
+
     public static UserProfileDto getUserProfile() {
         UserProfileDto userProfileDto;
         try {

--- a/src/main/java/com/otilm/core/util/AuthHelper.java
+++ b/src/main/java/com/otilm/core/util/AuthHelper.java
@@ -244,11 +244,8 @@ public class AuthHelper {
      * users (acme, scep, cmp, localhost) are ordinary auth-service users and are carried like any other.
      */
     public static UUID getActingUserUuidOrNull() {
-        try {
-            return NullUtil.parseUuidOrNull(getUserIdentification().getUuid());
-        } catch (ValidationException | IllegalArgumentException e) {
-            return null;
-        }
+        NameAndUuidDto actingUser = getActingUserOrNull();
+        return actingUser == null ? null : UUID.fromString(actingUser.getUuid());
     }
 
     /**

--- a/src/test/java/com/otilm/core/integration/signing/tsa/TsaServiceImplITest.java
+++ b/src/test/java/com/otilm/core/integration/signing/tsa/TsaServiceImplITest.java
@@ -6,6 +6,7 @@ import com.otilm.api.interfaces.core.tsp.error.TspFailureInfo;
 import com.otilm.api.model.client.cryptography.key.KeyRequestType;
 import com.otilm.api.model.client.signing.profile.SigningProfileDto;
 import com.otilm.api.model.client.signing.profile.record.SigningRecordPersistenceMode;
+import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.common.enums.cryptography.DigestAlgorithm;
 import com.otilm.api.model.common.enums.cryptography.KeyAlgorithm;
 import com.otilm.api.model.core.connector.v2.ConnectorDetailDto;
@@ -17,6 +18,7 @@ import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.repository.signing.TspProfileRepository;
 import com.otilm.core.helpers.CertificateGeneratorHelper;
 import com.otilm.core.helpers.TestCertificateAuthority;
+import com.otilm.core.security.authn.PlatformUserDetails;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
@@ -47,6 +49,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import static com.otilm.core.signing.tsa.messages.TspRequestBuilder.aTspRequest;
 import static com.otilm.core.util.builders.ConnectorRequestDtoBuilder.aV1ConnectorRequest;
@@ -218,6 +221,14 @@ class TsaServiceImplITest extends BaseSpringBootTest {
         return signingProfile;
     }
 
+    private SigningRecordDto theOnlySigningRecord() throws Exception {
+        List<SigningRecordListDto> records = signingRecordService
+                .listSigningRecords(aSearchRequest().build(), SecurityFilter.create())
+                .getItems();
+        assertThat(records).hasSize(1);
+        return signingRecordService.getSigningRecord(SecuredUUID.fromString(records.getFirst().getUuid()));
+    }
+
     // ── processTspRequestForTspProfile ────────────────────────────────────────
 
     @Nested
@@ -317,13 +328,7 @@ class TsaServiceImplITest extends BaseSpringBootTest {
             assertThat(response).isInstanceOf(TspResponse.Granted.class);
             byte[] grantedBytes = ((TspResponse.Granted) response).timestampBytes();
 
-            List<SigningRecordListDto> records = signingRecordService
-                    .listSigningRecords(aSearchRequest().build(), SecurityFilter.create())
-                    .getItems();
-            assertThat(records).hasSize(1);
-
-            SigningRecordDto signingRecord = signingRecordService
-                    .getSigningRecord(SecuredUUID.fromString(records.getFirst().getUuid()));
+            SigningRecordDto signingRecord = theOnlySigningRecord();
             assertThat(signingRecord.getSignedDocument()).isEqualTo(grantedBytes);
             assertThat(signingRecord.getName()).startsWith(profile.getName() + " #");
             assertThat(signingRecord.getSigningTime()).isNotNull();
@@ -334,6 +339,29 @@ class TsaServiceImplITest extends BaseSpringBootTest {
             // The TSP path stores only the self-contained token; signature and dtbs are recoverable from it.
             assertThat(signingRecord.getSignatureValue()).isNull();
             assertThat(signingRecord.getDtbs()).isNull();
+        }
+
+        /**
+         * Without this the operator sees a dash where the requester belongs, and the per-user signing statistics group
+         * the operation under nobody.
+         */
+        @Test
+        void signingRecordNamesTheAuthenticatedCaller_whenTimestampGranted() throws Exception {
+            // given
+            SigningProfileDto profile = createTimestampingSigningProfile("attributed-sp");
+            PlatformUserDetails caller = (PlatformUserDetails) SecurityContextHolder
+                    .getContext()
+                    .getAuthentication()
+                    .getPrincipal();
+
+            // when
+            tsaService.processTspRequestForSigningProfile(profile.getName(), aTspRequest().build());
+
+            // then
+            NameAndUuidDto requestedBy = theOnlySigningRecord().getRequestedBy();
+            assertThat(requestedBy).isNotNull();
+            assertThat(requestedBy.getUuid()).isEqualTo(caller.getUserUuid());
+            assertThat(requestedBy.getName()).isEqualTo("tst-user");
         }
 
         @Test

--- a/src/test/java/com/otilm/core/signing/contentsigning/ContentSigningRecordFactoryTest.java
+++ b/src/test/java/com/otilm/core/signing/contentsigning/ContentSigningRecordFactoryTest.java
@@ -3,15 +3,22 @@ package com.otilm.core.signing.contentsigning;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.otilm.api.model.common.signature.SignatureLevel;
+import com.otilm.api.model.core.logging.enums.AuthMethod;
 import com.otilm.api.model.core.signing.SigningProtocol;
+import com.otilm.core.security.authn.PlatformAuthenticationToken;
+import com.otilm.core.security.authn.PlatformUserDetails;
+import com.otilm.core.security.authn.client.AuthenticationInfo;
 import com.otilm.core.serialization.ObjectMapperFactory;
 import com.otilm.core.signing.record.SigningRecordInput;
 import com.otilm.core.signing.record.SigningRecordInputSource;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import static com.otilm.core.util.builders.ResolvedManagedContentSigningProfileBuilder.aResolvedContentSigningProfile;
 import static com.otilm.core.util.builders.SigningProfileModelBuilder.aSigningProfile;
@@ -24,6 +31,45 @@ import static org.mockito.Mockito.when;
 class ContentSigningRecordFactoryTest {
 
     private final ContentSigningRecordFactory factory = new ContentSigningRecordFactory(ObjectMapperFactory.storage());
+
+    @AfterEach
+    void clearRequester() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Nested
+    class Requester {
+
+        @Test
+        void recordNamesTheUserWhoRequestedTheSignature() {
+            // given
+            UUID requesterUuid = UUID.randomUUID();
+            SecurityContextHolder
+                    .getContext()
+                    .setAuthentication(new PlatformAuthenticationToken(new PlatformUserDetails(new AuthenticationInfo(
+                            AuthMethod.USER_PROXY, requesterUuid.toString(), "operator", List.of()))));
+
+            // when
+            SigningRecordInput input = source(SignatureLevel.SIGNED, List.of()).build();
+
+            // then
+            assertThat(input.getRequestedBy()).isNotNull();
+            assertThat(input.getRequestedBy().getUuid()).isEqualTo(requesterUuid.toString());
+            assertThat(input.getRequestedBy().getName()).isEqualTo("operator");
+        }
+
+        @Test
+        void recordNamesNobodyWhenTheSigningThreadCarriesNoIdentity() {
+            // given
+            SecurityContextHolder.clearContext();
+
+            // when
+            SigningRecordInput input = source(SignatureLevel.SIGNED, List.of()).build();
+
+            // then
+            assertThat(input.getRequestedBy()).isNull();
+        }
+    }
 
     @Nested
     class RecordedArtifacts {

--- a/src/test/java/com/otilm/core/signing/tsa/TimestampSigningRecordFactoryTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/TimestampSigningRecordFactoryTest.java
@@ -4,24 +4,32 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.otilm.api.model.common.enums.cryptography.DigestAlgorithm;
+import com.otilm.api.model.core.logging.enums.AuthMethod;
 import com.otilm.api.model.core.signing.SigningProtocol;
+import com.otilm.core.security.authn.PlatformAuthenticationToken;
+import com.otilm.core.security.authn.PlatformUserDetails;
+import com.otilm.core.security.authn.client.AuthenticationInfo;
 import com.otilm.core.signing.record.SigningRecordInput;
 import com.otilm.core.util.builders.SigningProfileModelBuilder;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import static com.otilm.core.model.signing.SigningRecordPolicyModelBuilder.aSigningRecordPolicy;
 import static com.otilm.core.signing.tsa.messages.TspRequestBuilder.aTspRequest;
 import static com.otilm.core.util.builders.SigningProfileModelBuilder.aSigningProfile;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -47,6 +55,11 @@ class TimestampSigningRecordFactoryTest {
     void setUp() {
         objectMapper = new ObjectMapper();
         factory = new TimestampSigningRecordFactory(objectMapper);
+    }
+
+    @AfterEach
+    void clearCaller() {
+        SecurityContextHolder.clearContext();
     }
 
     /** The record must tell an auditor whether a client asked for the token or the platform issued it itself. */
@@ -175,7 +188,7 @@ class TimestampSigningRecordFactoryTest {
     }
 
     @Test
-    void build_leavesSignatureDtbsAndRequestedByNull() {
+    void build_leavesSignatureAndDtbsNull() {
         // given the TSP path stores only the self-contained token, leaving the other content slots empty
 
         // when
@@ -187,6 +200,43 @@ class TimestampSigningRecordFactoryTest {
         // then
         assertNull(input.getSignature());
         assertNull(input.getDtbs());
+    }
+
+    /**
+     * The TSP authenticators put the caller — for Basic credentials, the ILM user the credential maps to — into the
+     * SecurityContext of the thread that then issues the token, so the record can name who asked for it.
+     */
+    @Test
+    void build_attributesTheRecordToTheAuthenticatedCaller() {
+        // given
+        UUID callerUuid = UUID.randomUUID();
+        authenticateAs(callerUuid, "tsp-client");
+
+        // when
+        SigningRecordInput input = factory
+                .source(aRecordingProfile().build(), aTspRequest().build(), SERIAL, GEN_TIME, ENCODED_TOKEN,
+                        SigningProtocol.TSP)
+                .build();
+
+        // then
+        assertNotNull(input.getRequestedBy());
+        assertEquals(callerUuid.toString(), input.getRequestedBy().getUuid());
+        assertEquals("tsp-client", input.getRequestedBy().getName());
+    }
+
+    @Test
+    void build_leavesRequestedByNull_whenTheIssuingThreadCarriesNoIdentity() {
+        // given
+        SecurityContextHolder.clearContext();
+
+        // when
+        SigningRecordInput input = factory
+                .source(aRecordingProfile().build(), aTspRequest().build(), SERIAL, GEN_TIME, ENCODED_TOKEN,
+                        SigningProtocol.INTERNAL_TSA)
+                .build();
+
+        // then
+        assertNull(input.getRequestedBy());
     }
 
     @Test
@@ -204,6 +254,13 @@ class TimestampSigningRecordFactoryTest {
 
         // then
         assertThrows(IllegalStateException.class, build);
+    }
+
+    private static void authenticateAs(UUID userUuid, String username) {
+        SecurityContextHolder
+                .getContext()
+                .setAuthentication(new PlatformAuthenticationToken(new PlatformUserDetails(
+                        new AuthenticationInfo(AuthMethod.USER_PROXY, userUuid.toString(), username, List.of()))));
     }
 
     private static SigningProfileModelBuilder aRecordingProfile() {

--- a/src/test/java/com/otilm/core/util/AuthHelperTest.java
+++ b/src/test/java/com/otilm/core/util/AuthHelperTest.java
@@ -9,6 +9,7 @@ import com.otilm.core.security.authn.PlatformAnonymousToken;
 import com.otilm.core.security.authn.PlatformAuthenticationToken;
 import com.otilm.core.security.authn.PlatformUserDetails;
 import com.otilm.core.security.authn.client.AuthenticationInfo;
+import com.otilm.core.security.authn.client.PlatformAuthenticationClient;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -28,6 +29,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Contract of the scoped {@code runAsSystem} elevation: the action runs under a system principal, and the caller's
@@ -174,6 +176,27 @@ class AuthHelperTest {
         SecurityContextHolder.clearContext();
 
         assertNull(AuthHelper.getActingUserOrNull());
+    }
+
+    /**
+     * The user-proxy step every TSP authenticator ends in — a Basic credential resolves to a mapped user, and this is
+     * what puts that user where {@link AuthHelper#getActingUserOrNull()} reads it from.
+     */
+    @Test
+    void authenticateAsUser_putsTheResolvedUserInTheSecurityContext() {
+        UUID mappedUser = UUID.randomUUID();
+        PlatformAuthenticationClient authenticationClient = mock(PlatformAuthenticationClient.class);
+        when(authenticationClient.authenticateByUserUuid(mappedUser))
+                .thenReturn(
+                        new AuthenticationInfo(AuthMethod.USER_PROXY, mappedUser.toString(), "mapped-user", List.of()));
+        authHelper.setAuthenticationClient(authenticationClient);
+
+        authHelper.authenticateAsUser(mappedUser);
+
+        NameAndUuidDto actingUser = AuthHelper.getActingUserOrNull();
+        assertNotNull(actingUser);
+        assertEquals(mappedUser.toString(), actingUser.getUuid());
+        assertEquals("mapped-user", actingUser.getName());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/util/AuthHelperTest.java
+++ b/src/test/java/com/otilm/core/util/AuthHelperTest.java
@@ -1,5 +1,6 @@
 package com.otilm.core.util;
 
+import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.core.logging.enums.ActorType;
 import com.otilm.api.model.core.logging.enums.AuthMethod;
 import com.otilm.api.model.core.logging.records.ActorRecord;
@@ -139,6 +140,40 @@ class AuthHelperTest {
                         new AuthenticationInfo(AuthMethod.USER_PROXY, userUuid.toString(), "operator", List.of()))));
 
         assertEquals(userUuid, AuthHelper.getActingUserUuidOrNull());
+    }
+
+    @Test
+    void getActingUserOrNull_returnsTheAuthenticatedUsersUuidAndUsername() {
+        UUID userUuid = UUID.randomUUID();
+        SecurityContextHolder
+                .getContext()
+                .setAuthentication(new PlatformAuthenticationToken(new PlatformUserDetails(
+                        new AuthenticationInfo(AuthMethod.USER_PROXY, userUuid.toString(), "operator", List.of()))));
+
+        NameAndUuidDto actingUser = AuthHelper.getActingUserOrNull();
+
+        assertNotNull(actingUser);
+        assertEquals(userUuid.toString(), actingUser.getUuid());
+        assertEquals("operator", actingUser.getName());
+    }
+
+    /** "anonymousUser" is a placeholder, not an identity, so it must not be persisted as one. */
+    @Test
+    void getActingUserOrNull_returnsNullForAnonymousPrincipal() {
+        AuthenticationInfo anonymous = AuthenticationInfo.getAnonymousAuthenticationInfo();
+        SecurityContextHolder
+                .getContext()
+                .setAuthentication(new PlatformAnonymousToken(UUID.randomUUID().toString(),
+                        new PlatformUserDetails(anonymous), anonymous.getAuthorities()));
+
+        assertNull(AuthHelper.getActingUserOrNull());
+    }
+
+    @Test
+    void getActingUserOrNull_returnsNullWhenNobodyIsAuthenticated() {
+        SecurityContextHolder.clearContext();
+
+        assertNull(AuthHelper.getActingUserOrNull());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/util/AuthHelperTest.java
+++ b/src/test/java/com/otilm/core/util/AuthHelperTest.java
@@ -32,10 +32,13 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
- * Contract of the scoped {@code runAsSystem} elevation: the action runs under a system principal, and the caller's
- * prior context is restored afterwards — on success, on exception, and (critically) leaving NO system principal on a
- * principal-less thread (the async status-poll listener runs pooled with no {@code SecurityContext}). The remote
- * elevation is stubbed so these assertions test only the save/restore discipline, not the auth-service call.
+ * Two {@link AuthHelper} concerns: the scoped {@code runAsSystem} elevation, and resolving the acting user from — and
+ * installing it into — the {@code SecurityContext}.
+ *
+ * <p>
+ * The elevation tests stub the remote call, so they assert only the save/restore discipline: the action runs under a
+ * system principal, the caller's prior context is restored on success and on exception, and no system principal is left
+ * on a principal-less thread (the async status-poll listener runs pooled with no {@code SecurityContext}).
  */
 class AuthHelperTest {
 


### PR DESCRIPTION
Signing records left `requestedBy` unset, so the record detail showed a dash where the requester belongs and the per-user signing statistics grouped every operation under no user.

- `AuthHelper.getActingUserOrNull()` returns the acting user's uuid and username, or `null` for an anonymous or unauthenticated thread.
- `TimestampSigningRecordFactory` and `ContentSigningRecordFactory` populate `requestedBy` from it instead of always writing `null`.

Closes #2096


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signing and timestamp records now identify the authenticated requester by UUID and name when available.
  * Anonymous or unauthenticated requests remain unattributed.

* **Bug Fixes**
  * Corrected requester attribution for content-signing and timestamp records.

* **Tests**
  * Added coverage for authenticated, anonymous, and unauthenticated request scenarios.
  * Added verification that authenticated requester details are preserved across signing and timestamp record creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->