### PR TITLE
Fix the project link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ILM Core
 
-> This repository is part of the open source project ILM. You can find more information about the project at the [ILM](https://github.com/ILM/ILM) repository, including the contribution guide.
+> This repository is part of the open source project ILM. You can find more information about the project at the [ILM](https://github.com/OmniTrustILM/ilm) repository, including the contribution guide.
 
 `Core` provides the basic functionality for the ILM platform. It implements the logic for the certificate lifecycle management and handles all related tasks. You can think about it as a brain of the ILM platform.
 


### PR DESCRIPTION
The link pointed to a repository path left over from the rename and returned 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README link to point to the current ILM repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->