### PR TITLE
Keep the signing volume history when signing records are deleted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Capture entry state before the external call (`final State entryState = entity.g
 
 ## Historical figures must not be derived from deletable rows
 
-A dashboard series, counter, or report that aggregates a table rows get deleted from is rewritten by every deletion — and retention sweeps and delete-after-retrieval mean history changes with nobody touching it. Derive such a figure from a separate append-only aggregate instead, and fold rows into it in the **same statement** that deletes them:
+A dashboard series, counter, or report that aggregates a table whose rows get deleted is rewritten by every one of those deletions — and retention sweeps and delete-after-retrieval mean the history changes with nobody touching it. Derive such a figure from a separate append-only aggregate instead, and fold rows into it in the **same statement** that deletes them:
 
 ```sql
 WITH victim AS MATERIALIZED (SELECT uuid, ... FROM detail WHERE ... LIMIT :limit)
@@ -105,7 +105,7 @@ DELETE FROM detail WHERE uuid IN (SELECT uuid FROM victim)
 
 PostgreSQL runs a data-modifying CTE exactly once and to completion, and every part reads the same snapshot of the materialized `victim` rows, so the roll-up and the delete cover the identical set and commit together: no double counting, no gap, and nothing added to the write path. The statement's own result is still the DELETE's row count, so batch loops keep working. Native, so `@Modifying(flushAutomatically = true)` — Hibernate cannot auto-flush for SQL it does not parse.
 
-**Claim the rows.** Without a locking clause a second deleter sees the same rows in its own snapshot, folds them in too, and then deletes nothing — one row counted twice. Which clause depends on the caller's contract: a keyed delete **waits** (`FOR UPDATE`), because its caller is told the row is gone and skipping would report success for a row the winner might yet roll back; a batch **skips** (`FOR UPDATE ... SKIP LOCKED`), because it has no per-record contract and waiting lets two sweeps picking overlapping victims in different index orders deadlock. Lock only the table you delete from (`FOR UPDATE OF sr`), never the ones you join for the predicate.
+**Claim the rows, and fold them in in key order.** Without a locking clause a second deleter sees the same rows in its own snapshot, folds them in too, and then deletes nothing — one row counted twice. Without an `ORDER BY` on the grouped upsert, two writers carrying rows for the same aggregate keys can take those locks in opposite orders and deadlock. Which clause depends on the caller's contract: a keyed delete **waits** (`FOR UPDATE`), because its caller is told the row is gone and skipping would report success for a row the winner might yet roll back; a batch **skips** (`FOR UPDATE ... SKIP LOCKED`), because it has no per-record contract and waiting lets two sweeps picking overlapping victims in different index orders deadlock. Lock only the table you delete from (`FOR UPDATE OF sr`), never the ones you join for the predicate.
 
 Assemble the figure under one snapshot — `@Transactional(readOnly = true, isolation = Isolation.REPEATABLE_READ)`. Read across the two tables in separate READ COMMITTED statements and a row deleted between them is counted as both live and history.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,9 +95,11 @@ Capture entry state before the external call (`final State entryState = entity.g
 A dashboard series, counter, or report that aggregates a table whose rows get deleted is rewritten by every one of those deletions — and retention sweeps and delete-after-retrieval mean the history changes with nobody touching it. Derive such a figure from a separate append-only aggregate instead, and fold rows into it in the **same statement** that deletes them:
 
 ```sql
-WITH victim AS MATERIALIZED (SELECT uuid, ... FROM detail WHERE ... LIMIT :limit)
+WITH victim AS MATERIALIZED (
+    SELECT uuid, ... FROM detail WHERE ... LIMIT :limit FOR UPDATE OF detail [SKIP LOCKED]
+)
 , rolled AS (
-    INSERT INTO aggregate AS a (...) SELECT ... FROM victim GROUP BY ...
+    INSERT INTO aggregate AS a (...) SELECT ... FROM victim GROUP BY ... ORDER BY <aggregate key>
     ON CONFLICT (...) DO UPDATE SET row_count = a.row_count + EXCLUDED.row_count
 )
 DELETE FROM detail WHERE uuid IN (SELECT uuid FROM victim)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,29 @@ try {
 
 Capture entry state before the external call (`final State entryState = entity.getState();`) so the restoration path has something to restore *to*.
 
+## Historical figures must not be derived from deletable rows
+
+A dashboard series, counter, or report that aggregates a table rows get deleted from is rewritten by every deletion — and retention sweeps and delete-after-retrieval mean history changes with nobody touching it. Derive such a figure from a separate append-only aggregate instead, and fold rows into it in the **same statement** that deletes them:
+
+```sql
+WITH victim AS MATERIALIZED (SELECT uuid, ... FROM detail WHERE ... LIMIT :limit)
+, rolled AS (
+    INSERT INTO aggregate AS a (...) SELECT ... FROM victim GROUP BY ...
+    ON CONFLICT (...) DO UPDATE SET row_count = a.row_count + EXCLUDED.row_count
+)
+DELETE FROM detail WHERE uuid IN (SELECT uuid FROM victim)
+```
+
+PostgreSQL runs a data-modifying CTE exactly once and to completion, and every part reads the same snapshot of the materialized `victim` rows, so the roll-up and the delete cover the identical set and commit together: no double counting, no gap, and nothing added to the write path. The statement's own result is still the DELETE's row count, so batch loops keep working. Native, so `@Modifying(flushAutomatically = true)` — Hibernate cannot auto-flush for SQL it does not parse.
+
+**Claim the rows.** Without a locking clause a second deleter sees the same rows in its own snapshot, folds them in too, and then deletes nothing — one row counted twice. Which clause depends on the caller's contract: a keyed delete **waits** (`FOR UPDATE`), because its caller is told the row is gone and skipping would report success for a row the winner might yet roll back; a batch **skips** (`FOR UPDATE ... SKIP LOCKED`), because it has no per-record contract and waiting lets two sweeps picking overlapping victims in different index orders deadlock. Lock only the table you delete from (`FOR UPDATE OF sr`), never the ones you join for the predicate.
+
+Assemble the figure under one snapshot — `@Transactional(readOnly = true, isolation = Isolation.REPEATABLE_READ)`. Read across the two tables in separate READ COMMITTED statements and a row deleted between them is counted as both live and history.
+
+The aggregate keeps the column its detail rows were access-controlled by, and **no FK to it**: the parent is usually deletable once its detail rows are gone, and the aggregate has to outlive it. Read it back through the parent half of the security filter only — a rolled-up row has no detail identity left for a row-level filter to match on.
+
+Align the live half's window to the aggregate's bucket boundary, not to the exact cutoff. Against an exact cutoff a row inside the first bucket but before the cutoff counts for nothing while live and for one once deleted — deleting it *raises* the figure. Floored on both sides the two are exactly equivalent, and deletion becomes invisible. Say on the API field that the window opens on a bucket boundary.
+
 ## Transactional boundaries live on services, not repositories
 
 Repositories in `com.otilm.core.dao.repository.*` must not carry `@Transactional`. Every guarded write uses a bean-pair: an **orchestrator** (no class-level `@Transactional`; HTTP-bearing methods use `NOT_SUPPORTED` when needed to avoid holding locks across external calls) and a **writer** bean (suffix `Writer`) whose short `@Transactional`(REQUIRED) methods each execute one `@Modifying @Query`. Two beans is mandatory — Spring proxy self-invocation silently skips advice. Writers use REQUIRED so they compose: joining an ambient tx if present, starting one otherwise. `@Modifying @Query` bypasses JPA dirty-checking; set audit columns (`c.updated = CURRENT_TIMESTAMP`) in the SQL.

--- a/src/main/java/com/otilm/core/dao/entity/signing/SigningRecordVolume.java
+++ b/src/main/java/com/otilm/core/dao/entity/signing/SigningRecordVolume.java
@@ -1,0 +1,54 @@
+package com.otilm.core.dao.entity.signing;
+
+import com.otilm.core.dao.entity.UniquelyIdentified;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * How many signings a signing profile performed in one UTC hour, kept after the {@link SigningRecord} rows themselves
+ * are gone. A record proves what a signing contained; this row preserves that the signing happened, which has to
+ * survive the record being deleted by an operator, by retention, or by delete-after-retrieval.
+ *
+ * <p>
+ * Rows are written only by the roll-up-then-delete statements on
+ * {@link com.otilm.core.dao.repository.signing.SigningRecordRepository}: a bucket is created or incremented in the same
+ * statement that removes the records it accounts for, so a count can neither double-count nor drift. Nothing amends a
+ * bucket afterwards and nothing deletes one, which is what makes the history immutable.
+ */
+@Getter
+@Setter
+@Entity
+@Table(name = "signing_record_volume", uniqueConstraints = @UniqueConstraint(name = "uq_signing_record_volume_bucket",
+        columnNames = {"signing_profile_uuid", "bucket_start"}))
+public class SigningRecordVolume extends UniquelyIdentified {
+
+    /**
+     * The signing profile the signings were performed under. Deliberately not a mapped association: a profile becomes
+     * deletable once its records are gone and these counts outlive it, so the reference would be unsatisfiable. The
+     * column stays the access-control anchor — signing history is scoped by signing-profile access.
+     */
+    @Column(name = "signing_profile_uuid", nullable = false)
+    private UUID signingProfileUuid;
+
+    @Column(name = "bucket_start", nullable = false)
+    private Instant bucketStart;
+
+    @Column(name = "signing_count", nullable = false)
+    private long signingCount;
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+}

--- a/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepository.java
@@ -70,6 +70,14 @@ public interface SecurityFilterRepository<T, ID> extends JpaRepository<T, ID> {
             SingularAttribute<?, ?> groupBy, BiFunction<Root<T>, CriteriaBuilder, Expression<?>> groupByExpression,
             TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause);
 
+    /**
+     * Grouped total of an already-aggregated column, for entities whose rows each carry a count rather than being one.
+     * Same grouping and security filtering as the variant above, only summing {@code sumOf} instead of counting rows.
+     */
+    Map<String, Long> sumGroupedUsingSecurityFilter(SecurityFilter filter, SingularAttribute<T, Long> sumOf,
+            BiFunction<Root<T>, CriteriaBuilder, Expression<?>> groupByExpression,
+            TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause);
+
     Long countUsingSecurityFilter(SecurityFilter filter);
 
     Long countUsingSecurityFilter(SecurityFilter filter,

--- a/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepository.java
@@ -72,7 +72,9 @@ public interface SecurityFilterRepository<T, ID> extends JpaRepository<T, ID> {
 
     /**
      * Grouped total of an already-aggregated column, for entities whose rows each carry a count rather than being one.
-     * Same grouping and security filtering as the variant above, only summing {@code sumOf} instead of counting rows.
+     * {@code groupByExpression} is required here, where the grouped count above also accepts a join and attribute.
+     * Unlike that count, this sum carries no DISTINCT: correct only where no predicate can duplicate the root row,
+     * since a join that fans one row out multiplies the count that row carries.
      */
     Map<String, Long> sumGroupedUsingSecurityFilter(SecurityFilter filter, SingularAttribute<T, Long> sumOf,
             BiFunction<Root<T>, CriteriaBuilder, Expression<?>> groupByExpression,

--- a/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepositoryImpl.java
+++ b/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepositoryImpl.java
@@ -251,19 +251,41 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
     public Map<String, Long> countGroupedUsingSecurityFilter(SecurityFilter filter, Attribute<?, ?> join,
             SingularAttribute<?, ?> groupBy, BiFunction<Root<T>, CriteriaBuilder, Expression<?>> groupByExpression,
             TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause) {
+        BiFunction<Root<T>, CriteriaBuilder, Expression<?>> grouping = groupByExpression != null
+                ? groupByExpression
+                : groupingByAttribute(join, groupBy);
+        return aggregateGroupedUsingSecurityFilter(filter, grouping, (root, cb) -> cb.countDistinct(root),
+                additionalWhereClause);
+    }
+
+    /** Groups by {@code groupBy}, read off the root or off a left join to {@code join} when one is given. */
+    private BiFunction<Root<T>, CriteriaBuilder, Expression<?>> groupingByAttribute(Attribute<?, ?> join,
+            SingularAttribute<?, ?> groupBy) {
+        return (root, cb) -> {
+            From<?, ?> from = join == null ? root : root.join(join.getName(), JoinType.LEFT);
+            return from.get(groupBy.getName());
+        };
+    }
+
+    @Override
+    public Map<String, Long> sumGroupedUsingSecurityFilter(SecurityFilter filter, SingularAttribute<T, Long> sumOf,
+            BiFunction<Root<T>, CriteriaBuilder, Expression<?>> groupByExpression,
+            TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause) {
+        return aggregateGroupedUsingSecurityFilter(filter, groupByExpression, (root, cb) -> cb.sum(root.get(sumOf)),
+                additionalWhereClause);
+    }
+
+    private Map<String, Long> aggregateGroupedUsingSecurityFilter(SecurityFilter filter,
+            BiFunction<Root<T>, CriteriaBuilder, Expression<?>> groupByExpression,
+            BiFunction<Root<T>, CriteriaBuilder, Expression<? extends Number>> aggregation,
+            TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause) {
         final Class<T> entity = this.entityInformation.getJavaType();
         final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         CriteriaQuery<AggregateResultDto> cr = cb.createQuery(AggregateResultDto.class);
 
         final Root<T> root = cr.from(entity);
-        Expression<?> groupBySelection;
-        if (groupByExpression != null) {
-            groupBySelection = groupByExpression.apply(root, cb);
-        } else {
-            From from = join == null ? root : root.join(join.getName(), JoinType.LEFT);
-            groupBySelection = from.get(groupBy);
-        }
-        cr.multiselect(groupBySelection, cb.countDistinct(root));
+        Expression<?> groupBySelection = groupByExpression.apply(root, cb);
+        cr.multiselect(groupBySelection, aggregation.apply(root, cb));
         cr.groupBy(groupBySelection);
 
         final List<Predicate> predicates = getPredicates(filter, additionalWhereClause, root, cb, cr);

--- a/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepositoryImpl.java
+++ b/src/main/java/com/otilm/core/dao/repository/SecurityFilterRepositoryImpl.java
@@ -271,6 +271,7 @@ public class SecurityFilterRepositoryImpl<T, ID> extends SimpleJpaRepository<T, 
     public Map<String, Long> sumGroupedUsingSecurityFilter(SecurityFilter filter, SingularAttribute<T, Long> sumOf,
             BiFunction<Root<T>, CriteriaBuilder, Expression<?>> groupByExpression,
             TriFunction<Root<T>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause) {
+        Objects.requireNonNull(groupByExpression, "groupByExpression");
         return aggregateGroupedUsingSecurityFilter(filter, groupByExpression, (root, cb) -> cb.sum(root.get(sumOf)),
                 additionalWhereClause);
     }

--- a/src/main/java/com/otilm/core/dao/repository/signing/SigningRecordRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/signing/SigningRecordRepository.java
@@ -8,45 +8,53 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import static com.otilm.core.dao.repository.signing.SigningRecordRollupSql.CLAIM_VICTIMS;
+import static com.otilm.core.dao.repository.signing.SigningRecordRollupSql.ROLL_UP_THEN_DELETE;
+import static com.otilm.core.dao.repository.signing.SigningRecordRollupSql.SKIP_CONTENDED_ROWS;
+import static com.otilm.core.dao.repository.signing.SigningRecordRollupSql.WAIT_FOR_CONTENDED_ROWS;
+
+/**
+ * Every statement here that removes signing records rolls them into {@code signing_record_volume} first; see
+ * {@link SigningRecordRollupSql}. They are native because a data-modifying CTE has no JPQL equivalent, and native
+ * statements are opaque to Hibernate's auto-flush, hence {@code flushAutomatically}.
+ */
 @Repository
 public interface SigningRecordRepository extends SecurityFilterRepository<SigningRecord, UUID> {
     boolean existsBySigningProfileUuidAndSigningProfileVersion(UUID signingProfileUuid, int version);
 
     boolean existsBySigningProfileUuid(UUID signingProfileUuid);
 
-    @Modifying
-    @Query("DELETE FROM SigningRecord sr WHERE sr.uuid = :uuid")
+    @Modifying(flushAutomatically = true)
+    @Query(value = CLAIM_VICTIMS + """
+            SELECT sr.uuid, sr.signing_profile_uuid, sr.signing_time
+            FROM {h-schema}signing_record sr
+            WHERE sr.uuid = :uuid
+            """ + WAIT_FOR_CONTENDED_ROWS + ROLL_UP_THEN_DELETE, nativeQuery = true)
     int deleteByUuid(@Param("uuid") UUID uuid);
 
-    @Modifying
-    @Query(value = """
-            DELETE FROM {h-schema}signing_record
-            WHERE ctid IN (
-                SELECT sr.ctid
-                FROM {h-schema}signing_record sr
-                JOIN {h-schema}signing_profile_version spv
-                  ON sr.signing_profile_uuid = spv.signing_profile_uuid
-                 AND sr.signing_profile_version = spv.version
-                WHERE spv.retention_days IS NOT NULL
-                  AND sr.signing_time < NOW() - make_interval(days => spv.retention_days)
-                LIMIT :limit
-            )
-            """, nativeQuery = true)
+    @Modifying(flushAutomatically = true)
+    @Query(value = CLAIM_VICTIMS + """
+            SELECT sr.uuid, sr.signing_profile_uuid, sr.signing_time
+            FROM {h-schema}signing_record sr
+            JOIN {h-schema}signing_profile_version spv
+              ON sr.signing_profile_uuid = spv.signing_profile_uuid
+             AND sr.signing_profile_version = spv.version
+            WHERE spv.retention_days IS NOT NULL
+              AND sr.signing_time < NOW() - make_interval(days => spv.retention_days)
+            LIMIT :limit
+            """ + SKIP_CONTENDED_ROWS + ROLL_UP_THEN_DELETE, nativeQuery = true)
     int deleteExpiredByRetention(@Param("limit") int limit);
 
-    @Modifying
-    @Query(value = """
-            DELETE FROM {h-schema}signing_record
-            WHERE ctid IN (
-                SELECT sr.ctid
-                FROM {h-schema}signing_record sr
-                JOIN {h-schema}signing_profile_version spv
-                  ON sr.signing_profile_uuid = spv.signing_profile_uuid
-                 AND sr.signing_profile_version = spv.version
-                WHERE spv.delete_after_retrieval = true
-                  AND sr.signed_document_retrieved_at IS NOT NULL
-                LIMIT :limit
-            )
-            """, nativeQuery = true)
+    @Modifying(flushAutomatically = true)
+    @Query(value = CLAIM_VICTIMS + """
+            SELECT sr.uuid, sr.signing_profile_uuid, sr.signing_time
+            FROM {h-schema}signing_record sr
+            JOIN {h-schema}signing_profile_version spv
+              ON sr.signing_profile_uuid = spv.signing_profile_uuid
+             AND sr.signing_profile_version = spv.version
+            WHERE spv.delete_after_retrieval = true
+              AND sr.signed_document_retrieved_at IS NOT NULL
+            LIMIT :limit
+            """ + SKIP_CONTENDED_ROWS + ROLL_UP_THEN_DELETE, nativeQuery = true)
     int deleteRetrievedAndFlagged(@Param("limit") int limit);
 }

--- a/src/main/java/com/otilm/core/dao/repository/signing/SigningRecordRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/signing/SigningRecordRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import static com.otilm.core.dao.repository.signing.SigningRecordRollupSql.CLAIM_VICTIMS;
+import static com.otilm.core.dao.repository.signing.SigningRecordRollupSql.OPEN_VICTIM_CTE;
 import static com.otilm.core.dao.repository.signing.SigningRecordRollupSql.ROLL_UP_THEN_DELETE;
 import static com.otilm.core.dao.repository.signing.SigningRecordRollupSql.SKIP_CONTENDED_ROWS;
 import static com.otilm.core.dao.repository.signing.SigningRecordRollupSql.WAIT_FOR_CONTENDED_ROWS;
@@ -25,7 +25,7 @@ public interface SigningRecordRepository extends SecurityFilterRepository<Signin
     boolean existsBySigningProfileUuid(UUID signingProfileUuid);
 
     @Modifying(flushAutomatically = true)
-    @Query(value = CLAIM_VICTIMS + """
+    @Query(value = OPEN_VICTIM_CTE + """
             SELECT sr.uuid, sr.signing_profile_uuid, sr.signing_time
             FROM {h-schema}signing_record sr
             WHERE sr.uuid = :uuid
@@ -33,7 +33,7 @@ public interface SigningRecordRepository extends SecurityFilterRepository<Signin
     int deleteByUuid(@Param("uuid") UUID uuid);
 
     @Modifying(flushAutomatically = true)
-    @Query(value = CLAIM_VICTIMS + """
+    @Query(value = OPEN_VICTIM_CTE + """
             SELECT sr.uuid, sr.signing_profile_uuid, sr.signing_time
             FROM {h-schema}signing_record sr
             JOIN {h-schema}signing_profile_version spv
@@ -46,7 +46,7 @@ public interface SigningRecordRepository extends SecurityFilterRepository<Signin
     int deleteExpiredByRetention(@Param("limit") int limit);
 
     @Modifying(flushAutomatically = true)
-    @Query(value = CLAIM_VICTIMS + """
+    @Query(value = OPEN_VICTIM_CTE + """
             SELECT sr.uuid, sr.signing_profile_uuid, sr.signing_time
             FROM {h-schema}signing_record sr
             JOIN {h-schema}signing_profile_version spv

--- a/src/main/java/com/otilm/core/dao/repository/signing/SigningRecordRollupSql.java
+++ b/src/main/java/com/otilm/core/dao/repository/signing/SigningRecordRollupSql.java
@@ -46,19 +46,26 @@ final class SigningRecordRollupSql {
     /**
      * Rolls the claimed rows into their UTC hourly buckets and deletes them. Only {@code signing_record} rows are
      * locked, so a claim never holds up the signing profile version the batch selectors join.
+     *
+     * <p>
+     * The buckets are inserted in key order. Two sweeps running at once can each carry rows for the same profile and
+     * hour, and an unordered grouped upsert would let them take those bucket locks in opposite orders and deadlock.
      */
     static final String ROLL_UP_THEN_DELETE = """
+            )
+            , bucket AS (
+                SELECT victim.signing_profile_uuid AS signing_profile_uuid,
+                       date_trunc('hour', victim.signing_time AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' AS bucket_start,
+                       count(*) AS signing_count
+                FROM victim
+                GROUP BY 1, 2
             )
             , rolled AS (
                 INSERT INTO {h-schema}signing_record_volume AS srv
                     (uuid, signing_profile_uuid, bucket_start, signing_count)
-                SELECT gen_random_uuid(),
-                       victim.signing_profile_uuid,
-                       date_trunc('hour', victim.signing_time AT TIME ZONE 'UTC') AT TIME ZONE 'UTC',
-                       count(*)
-                FROM victim
-                GROUP BY victim.signing_profile_uuid,
-                         date_trunc('hour', victim.signing_time AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+                SELECT gen_random_uuid(), bucket.signing_profile_uuid, bucket.bucket_start, bucket.signing_count
+                FROM bucket
+                ORDER BY bucket.signing_profile_uuid, bucket.bucket_start
                 ON CONFLICT (signing_profile_uuid, bucket_start)
                 DO UPDATE SET signing_count = srv.signing_count + EXCLUDED.signing_count
             )

--- a/src/main/java/com/otilm/core/dao/repository/signing/SigningRecordRollupSql.java
+++ b/src/main/java/com/otilm/core/dao/repository/signing/SigningRecordRollupSql.java
@@ -1,0 +1,70 @@
+package com.otilm.core.dao.repository.signing;
+
+/**
+ * The two halves every statement that removes signing records is wrapped in, so that removing a record never removes
+ * the fact that the signing happened.
+ *
+ * <p>
+ * A statement opens with {@link #CLAIM_VICTIMS}, selects the rows it is about to delete, claims them with
+ * {@link #WAIT_FOR_CONTENDED_ROWS} or {@link #SKIP_CONTENDED_ROWS}, and closes with {@link #ROLL_UP_THEN_DELETE}, which
+ * folds those rows into {@code signing_record_volume} and then deletes them. PostgreSQL runs a data-modifying CTE
+ * exactly once and to completion, and every part of the statement reads the same snapshot of the materialized
+ * {@code victim} rows, so the roll-up and the delete cover the identical set and commit together. The statement's own
+ * result is the DELETE's row count, so callers still learn how many records were removed.
+ *
+ * <p>
+ * Claiming the rows is what keeps the count exact when two delete paths reach the same record at once — an operator
+ * deleting by hand while a retention or delete-after-retrieval sweep is mid-flight. Unclaimed, the loser would still
+ * see the record in its own snapshot, roll it up, and then delete nothing, counting one signing twice. Claimed, the
+ * roll-up covers exactly the rows the statement goes on to remove.
+ */
+final class SigningRecordRollupSql {
+
+    /**
+     * Opens the {@code victim} CTE; the caller appends the SELECT naming the rows to delete, which must alias
+     * {@code signing_record} as {@code sr} and project {@code uuid}, {@code signing_profile_uuid} and
+     * {@code signing_time}. Materialized because both halves of the statement read it and must see the same rows — a
+     * re-evaluated {@code LIMIT} could pick a different set.
+     */
+    static final String CLAIM_VICTIMS = "WITH victim AS MATERIALIZED (";
+
+    /**
+     * Waits for a row another statement holds, then re-reads it: one the winner deleted is not returned. For the keyed
+     * delete, whose caller is told the record is gone — skipping a contended row would report success for a record the
+     * winner might yet roll back. It locks a single row, so it can wait for a cycle but never form one.
+     */
+    static final String WAIT_FOR_CONTENDED_ROWS = "FOR UPDATE OF sr\n";
+
+    /**
+     * Leaves a row another statement holds where it is. For the batch sweeps, which have no per-record contract —
+     * whatever a sweep passes over is taken by the statement holding it or by the next sweep. Waiting instead would let
+     * two sweeps that pick overlapping victims in different index orders deadlock, or let one open transaction stall a
+     * sweep while it holds the cluster-wide sweep lock.
+     */
+    static final String SKIP_CONTENDED_ROWS = "FOR UPDATE OF sr SKIP LOCKED\n";
+
+    /**
+     * Rolls the claimed rows into their UTC hourly buckets and deletes them. Only {@code signing_record} rows are
+     * locked, so a claim never holds up the signing profile version the batch selectors join.
+     */
+    static final String ROLL_UP_THEN_DELETE = """
+            )
+            , rolled AS (
+                INSERT INTO {h-schema}signing_record_volume AS srv
+                    (uuid, signing_profile_uuid, bucket_start, signing_count)
+                SELECT gen_random_uuid(),
+                       victim.signing_profile_uuid,
+                       date_trunc('hour', victim.signing_time AT TIME ZONE 'UTC') AT TIME ZONE 'UTC',
+                       count(*)
+                FROM victim
+                GROUP BY victim.signing_profile_uuid,
+                         date_trunc('hour', victim.signing_time AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+                ON CONFLICT (signing_profile_uuid, bucket_start)
+                DO UPDATE SET signing_count = srv.signing_count + EXCLUDED.signing_count
+            )
+            DELETE FROM {h-schema}signing_record WHERE uuid IN (SELECT uuid FROM victim)
+            """;
+
+    private SigningRecordRollupSql() {
+    }
+}

--- a/src/main/java/com/otilm/core/dao/repository/signing/SigningRecordRollupSql.java
+++ b/src/main/java/com/otilm/core/dao/repository/signing/SigningRecordRollupSql.java
@@ -1,22 +1,18 @@
 package com.otilm.core.dao.repository.signing;
 
 /**
- * The two halves every statement that removes signing records is wrapped in, so that removing a record never removes
+ * The SQL fragments every statement that removes signing records is wrapped in, so that deleting a record never deletes
  * the fact that the signing happened.
  *
  * <p>
- * A statement opens with {@link #CLAIM_VICTIMS}, selects the rows it is about to delete, claims them with
- * {@link #WAIT_FOR_CONTENDED_ROWS} or {@link #SKIP_CONTENDED_ROWS}, and closes with {@link #ROLL_UP_THEN_DELETE}, which
- * folds those rows into {@code signing_record_volume} and then deletes them. PostgreSQL runs a data-modifying CTE
- * exactly once and to completion, and every part of the statement reads the same snapshot of the materialized
- * {@code victim} rows, so the roll-up and the delete cover the identical set and commit together. The statement's own
- * result is the DELETE's row count, so callers still learn how many records were removed.
+ * A statement is assembled as {@link #OPEN_VICTIM_CTE}, the caller's SELECT naming the rows to delete,
+ * {@link #WAIT_FOR_CONTENDED_ROWS} or {@link #SKIP_CONTENDED_ROWS}, and {@link #ROLL_UP_THEN_DELETE}. Each fragment
+ * that follows the SELECT opens with its own newline, so the joins never depend on how the caller ended it.
  *
  * <p>
- * Claiming the rows is what keeps the count exact when two delete paths reach the same record at once — an operator
- * deleting by hand while a retention or delete-after-retrieval sweep is mid-flight. Unclaimed, the loser would still
- * see the record in its own snapshot, roll it up, and then delete nothing, counting one signing twice. Claimed, the
- * roll-up covers exactly the rows the statement goes on to remove.
+ * PostgreSQL runs a data-modifying CTE exactly once and to completion, and every part of the statement reads the same
+ * snapshot of the materialized {@code victim} rows, so the roll-up and the delete cover the identical set and commit
+ * together. The statement's own result is the DELETE's row count, so callers still learn how many records were removed.
  */
 final class SigningRecordRollupSql {
 
@@ -26,14 +22,14 @@ final class SigningRecordRollupSql {
      * {@code signing_time}. Materialized because both halves of the statement read it and must see the same rows — a
      * re-evaluated {@code LIMIT} could pick a different set.
      */
-    static final String CLAIM_VICTIMS = "WITH victim AS MATERIALIZED (";
+    static final String OPEN_VICTIM_CTE = "WITH victim AS MATERIALIZED (";
 
     /**
      * Waits for a row another statement holds, then re-reads it: one the winner deleted is not returned. For the keyed
      * delete, whose caller is told the record is gone — skipping a contended row would report success for a record the
      * winner might yet roll back. It locks a single row, so it can wait for a cycle but never form one.
      */
-    static final String WAIT_FOR_CONTENDED_ROWS = "FOR UPDATE OF sr\n";
+    static final String WAIT_FOR_CONTENDED_ROWS = "\nFOR UPDATE OF sr\n";
 
     /**
      * Leaves a row another statement holds where it is. For the batch sweeps, which have no per-record contract —
@@ -41,7 +37,7 @@ final class SigningRecordRollupSql {
      * two sweeps that pick overlapping victims in different index orders deadlock, or let one open transaction stall a
      * sweep while it holds the cluster-wide sweep lock.
      */
-    static final String SKIP_CONTENDED_ROWS = "FOR UPDATE OF sr SKIP LOCKED\n";
+    static final String SKIP_CONTENDED_ROWS = "\nFOR UPDATE OF sr SKIP LOCKED\n";
 
     /**
      * Rolls the claimed rows into their UTC hourly buckets and deletes them. Only {@code signing_record} rows are

--- a/src/main/java/com/otilm/core/dao/repository/signing/SigningRecordVolumeRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/signing/SigningRecordVolumeRepository.java
@@ -1,0 +1,14 @@
+package com.otilm.core.dao.repository.signing;
+
+import com.otilm.core.dao.entity.signing.SigningRecordVolume;
+import com.otilm.core.dao.repository.SecurityFilterRepository;
+import java.util.UUID;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Read access to the rolled-up signing history. The buckets themselves are written by the roll-up-then-delete
+ * statements on {@link SigningRecordRepository}, never through this repository.
+ */
+@Repository
+public interface SigningRecordVolumeRepository extends SecurityFilterRepository<SigningRecordVolume, UUID> {
+}

--- a/src/main/java/com/otilm/core/service/impl/SigningRecordServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SigningRecordServiceImpl.java
@@ -237,7 +237,6 @@ public class SigningRecordServiceImpl implements SigningRecordExternalService, S
         return cutoff.truncatedTo(ChronoUnit.HOURS);
     }
 
-    /** Bucketed counts of the records still held in {@code signing_record}. */
     private Map<String, Long> retainedVolume(SecurityFilter filter, Bucket bucket, Instant from) {
         return signingRecordRepository
                 .countGroupedUsingSecurityFilter(filter, null, null,

--- a/src/main/java/com/otilm/core/service/impl/SigningRecordServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SigningRecordServiceImpl.java
@@ -4,6 +4,7 @@ import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.model.client.certificate.SearchRequestDto;
 import com.otilm.api.model.client.dashboard.SigningRecordStatisticsDto;
 import com.otilm.api.model.client.dashboard.SigningRecordStatisticsPeriod;
+import com.otilm.api.model.client.dashboard.SigningRecordStatisticsPeriod.Bucket;
 import com.otilm.api.model.client.signing.profile.scheme.ManagedSigningType;
 import com.otilm.api.model.client.signing.profile.scheme.SigningScheme;
 import com.otilm.api.model.common.BulkActionMessageDto;
@@ -23,9 +24,11 @@ import com.otilm.core.dao.entity.signing.SigningProfileVersion;
 import com.otilm.core.dao.entity.signing.SigningProfileVersion_;
 import com.otilm.core.dao.entity.signing.SigningProfile_;
 import com.otilm.core.dao.entity.signing.SigningRecord;
+import com.otilm.core.dao.entity.signing.SigningRecordVolume_;
 import com.otilm.core.dao.entity.signing.SigningRecord_;
 import com.otilm.core.dao.repository.signing.SigningProfileRepository;
 import com.otilm.core.dao.repository.signing.SigningRecordRepository;
+import com.otilm.core.dao.repository.signing.SigningRecordVolumeRepository;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.mapper.signing.SigningRecordMapper;
 import com.otilm.core.mapper.workflows.PaginationResponseMapper;
@@ -46,48 +49,45 @@ import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.function.TriFunction;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class SigningRecordServiceImpl implements SigningRecordExternalService, SigningRecordInternalService {
 
     private static final String SIGNING_PROFILE_PARENT_REF = "signingProfileUuid";
     private static final int TOP_REQUESTERS = 10;
     private static final String SCHEME_PAIR_SEPARATOR = "::";
 
+    /** Postgres {@code to_char} patterns producing the same key as {@link SigningRecordStatisticsCalculator}. */
+    private static final String BUCKET_HOUR_FORMAT = "YYYY-MM-DD\"T\"HH24:00:00\"Z\"";
+    private static final String BUCKET_DAY_FORMAT = "YYYY-MM-DD\"T\"00:00:00\"Z\"";
+
     private final SigningRecordRepository signingRecordRepository;
+    private final SigningRecordVolumeRepository signingRecordVolumeRepository;
     private final SigningRecordWriter signingRecordWriter;
     private final SigningProfileRepository signingProfileRepository;
     private final AttributeEngine attributeEngine;
     private final AttributeColumnProjector attributeColumnProjector;
     private final ListingSortResolver listingSortResolver;
     private final AuthorizationEnforcer authorizationEnforcer;
-
-    public SigningRecordServiceImpl(SigningRecordRepository signingRecordRepository,
-            SigningRecordWriter signingRecordWriter, SigningProfileRepository signingProfileRepository,
-            AttributeEngine attributeEngine, AttributeColumnProjector attributeColumnProjector,
-            ListingSortResolver listingSortResolver, AuthorizationEnforcer authorizationEnforcer) {
-        this.signingRecordRepository = signingRecordRepository;
-        this.signingRecordWriter = signingRecordWriter;
-        this.signingProfileRepository = signingProfileRepository;
-        this.attributeEngine = attributeEngine;
-        this.attributeColumnProjector = attributeColumnProjector;
-        this.listingSortResolver = listingSortResolver;
-        this.authorizationEnforcer = authorizationEnforcer;
-    }
 
     @Override
     @ExternalAuthorization(resource = Resource.SIGNING_RECORD, action = ResourceAction.LIST)
@@ -128,10 +128,15 @@ public class SigningRecordServiceImpl implements SigningRecordExternalService, S
         return listRecords(request, filter, signingProfileUuid);
     }
 
+    /**
+     * Read under one snapshot: the signing figures are assembled from two tables, and a record deleted between the two
+     * queries would otherwise be counted both as retained and as history. {@code REPEATABLE_READ} costs nothing here —
+     * the transaction only reads, so it cannot fail to serialize.
+     */
     @Override
     @ExternalAuthorization(resource = Resource.SIGNING_RECORD, action = ResourceAction.LIST,
             parentResource = Resource.SIGNING_PROFILE, parentAction = ResourceAction.LIST)
-    @Transactional(readOnly = true)
+    @Transactional(readOnly = true, isolation = Isolation.REPEATABLE_READ)
     public SigningRecordStatisticsDto getSigningRecordStatistics(SigningRecordStatisticsPeriod period,
             SecurityFilter filter) {
         filter.setParentRefProperty(SIGNING_PROFILE_PARENT_REF);
@@ -139,12 +144,8 @@ public class SigningRecordServiceImpl implements SigningRecordExternalService, S
 
         SigningRecordStatisticsDto dto = new SigningRecordStatisticsDto();
         dto.setTotalRetained(signingRecordRepository.countUsingSecurityFilter(filter));
-        dto
-                .setCountLast24h(signingRecordRepository
-                        .countUsingSecurityFilter(filter, signedSince(now.minus(Duration.ofDays(1)))));
-        dto
-                .setCountLast7d(signingRecordRepository
-                        .countUsingSecurityFilter(filter, signedSince(now.minus(Duration.ofDays(7)))));
+        dto.setCountLast24h(signingsSince(filter, now.minus(Duration.ofDays(1))));
+        dto.setCountLast7d(signingsSince(filter, now.minus(Duration.ofDays(7))));
 
         Map<String, Long> byProfile = signingRecordRepository
                 .countGroupedUsingSecurityFilter(filter, SigningRecord_.signingProfile, SigningProfile_.name, null,
@@ -205,22 +206,79 @@ public class SigningRecordServiceImpl implements SigningRecordExternalService, S
         return cb.concat(cb.concat(scheme, SCHEME_PAIR_SEPARATOR), managedType);
     }
 
+    /**
+     * The signing volume series: records still retained, plus the rolled-up counts of records already deleted. Both
+     * halves are keyed identically, so summing them per bucket reconstructs what was signed regardless of what has
+     * since been removed.
+     */
     private Map<String, Long> volumeOverTime(SecurityFilter filter, SigningRecordStatisticsPeriod period, Instant now) {
-        Instant from = now.minus(period.getWindow());
-        String truncUnit = period.getBucket() == SigningRecordStatisticsPeriod.Bucket.HOUR ? "hour" : "day";
-        String format = period.getBucket() == SigningRecordStatisticsPeriod.Bucket.HOUR
-                ? "YYYY-MM-DD\"T\"HH24:00:00\"Z\""
-                : "YYYY-MM-DD\"T\"00:00:00\"Z\"";
-        Map<String, Long> sparse = signingRecordRepository
-                .countGroupedUsingSecurityFilter(filter, null, null, (root, cb) -> {
-                    Expression<?> atUtc = cb
-                            .function("timezone", java.sql.Timestamp.class, cb.literal("UTC"),
-                                    root.get(SigningRecord_.signingTime));
-                    Expression<?> truncated = cb
-                            .function("date_trunc", java.sql.Timestamp.class, cb.literal(truncUnit), atUtc);
-                    return cb.function("to_char", String.class, truncated, cb.literal(format));
-                }, signedSince(from));
-        return SigningRecordStatisticsCalculator.denseBuckets(from, now, period.getBucket(), sparse);
+        Instant from = windowStart(now.minus(period.getWindow()));
+        Bucket bucket = period.getBucket();
+        Map<String, Long> sparse = SigningRecordStatisticsCalculator
+                .sumByBucket(retainedVolume(filter, bucket, from), deletedVolume(filter, bucket, from));
+        return SigningRecordStatisticsCalculator.denseBuckets(from, now, bucket, sparse);
+    }
+
+    /** Signings performed since {@code cutoff}, whether or not their records still exist. */
+    private Long signingsSince(SecurityFilter filter, Instant cutoff) {
+        Instant from = windowStart(cutoff);
+        long retained = signingRecordRepository.countUsingSecurityFilter(filter, signedSince(from));
+        long deleted = deletedVolume(filter, Bucket.HOUR, from).values().stream().mapToLong(Long::longValue).sum();
+        return retained + deleted;
+    }
+
+    /**
+     * Start of the hour {@code cutoff} falls in. History is bucketed by the hour, so the retained half of a figure has
+     * to start on the same boundary: only then does a signing contribute the same count before and after its record is
+     * deleted. Against the exact cutoff, a signing in that first hour but before the cutoff would count for nothing
+     * while retained and for one once deleted — deletion would raise the number.
+     */
+    private static Instant windowStart(Instant cutoff) {
+        return cutoff.truncatedTo(ChronoUnit.HOURS);
+    }
+
+    /** Bucketed counts of the records still held in {@code signing_record}. */
+    private Map<String, Long> retainedVolume(SecurityFilter filter, Bucket bucket, Instant from) {
+        return signingRecordRepository
+                .countGroupedUsingSecurityFilter(filter, null, null,
+                        (root, cb) -> bucketKey(cb, root.get(SigningRecord_.signingTime), bucket), signedSince(from));
+    }
+
+    /**
+     * Bucketed counts of the records that have since been deleted. History is stored hourly, so a daily series sums
+     * whole hours out of it. {@code from} is expected on an hour boundary; see {@link #windowStart}.
+     */
+    private Map<String, Long> deletedVolume(SecurityFilter filter, Bucket bucket, Instant from) {
+        return signingRecordVolumeRepository
+                .sumGroupedUsingSecurityFilter(signingProfileScope(filter), SigningRecordVolume_.signingCount,
+                        (root, cb) -> bucketKey(cb, root.get(SigningRecordVolume_.bucketStart), bucket),
+                        (root, cb, cq) -> cb.greaterThanOrEqualTo(root.get(SigningRecordVolume_.bucketStart), from));
+    }
+
+    /**
+     * {@code to_char(date_trunc(unit, <instant> AT TIME ZONE 'UTC'), format)} — the canonical UTC bucket key of
+     * {@link SigningRecordStatisticsCalculator#bucketKey}, expressed in SQL so both halves of the series key alike.
+     */
+    private static Expression<String> bucketKey(CriteriaBuilder cb, Expression<Instant> instant, Bucket bucket) {
+        Expression<?> atUtc = cb.function("timezone", Timestamp.class, cb.literal("UTC"), instant);
+        Expression<?> truncated = cb
+                .function("date_trunc", Timestamp.class, cb.literal(bucket == Bucket.HOUR ? "hour" : "day"), atUtc);
+        return cb
+                .function("to_char", String.class, truncated,
+                        cb.literal(bucket == Bucket.HOUR ? BUCKET_HOUR_FORMAT : BUCKET_DAY_FORMAT));
+    }
+
+    /**
+     * The signing-profile half of {@code filter}. Signing-record visibility follows signing-profile access, and a
+     * rolled-up bucket has no record identity left for a record-level filter to match on, so only the parent filter
+     * carries over to the history rows. Nothing is lost with it: {@link Resource#SIGNING_RECORD} declares no
+     * object-level access, so the record half of the filter never narrows anything on its own.
+     */
+    private static SecurityFilter signingProfileScope(SecurityFilter filter) {
+        SecurityFilter scope = SecurityFilter.create();
+        scope.setParentResourceFilter(filter.getParentResourceFilter());
+        scope.setParentRefProperty(SIGNING_PROFILE_PARENT_REF);
+        return scope;
     }
 
     private TriFunction<Root<SigningRecord>, CriteriaBuilder, CriteriaQuery<?>, Predicate> signedSince(Instant cutoff) {

--- a/src/main/java/com/otilm/core/service/impl/SigningRecordServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SigningRecordServiceImpl.java
@@ -130,8 +130,8 @@ public class SigningRecordServiceImpl implements SigningRecordExternalService, S
 
     /**
      * Read under one snapshot: the signing figures are assembled from two tables, and a record deleted between the two
-     * queries would otherwise be counted both as retained and as history. {@code REPEATABLE_READ} costs nothing here —
-     * the transaction only reads, so it cannot fail to serialize.
+     * queries would otherwise be counted both as retained and as history. The transaction only reads, so the snapshot
+     * cannot fail to serialize; it does hold the vacuum horizon for the length of the read.
      */
     @Override
     @ExternalAuthorization(resource = Resource.SIGNING_RECORD, action = ResourceAction.LIST,
@@ -270,8 +270,8 @@ public class SigningRecordServiceImpl implements SigningRecordExternalService, S
     /**
      * The signing-profile half of {@code filter}. Signing-record visibility follows signing-profile access, and a
      * rolled-up bucket has no record identity left for a record-level filter to match on, so only the parent filter
-     * carries over to the history rows. Nothing is lost with it: {@link Resource#SIGNING_RECORD} declares no
-     * object-level access, so the record half of the filter never narrows anything on its own.
+     * carries over to the history rows. Nothing is lost with it while the authorization policy grants no object-level
+     * access on signing records, which is what {@link Resource#SIGNING_RECORD} declaring none asks of it.
      */
     private static SecurityFilter signingProfileScope(SecurityFilter filter) {
         SecurityFilter scope = SecurityFilter.create();

--- a/src/main/java/com/otilm/core/service/impl/SigningRecordStatisticsCalculator.java
+++ b/src/main/java/com/otilm/core/service/impl/SigningRecordStatisticsCalculator.java
@@ -51,6 +51,16 @@ final class SigningRecordStatisticsCalculator {
     }
 
     /**
+     * Adds two sparse bucket→count maps. The signing volume in a bucket is the records still retained plus those
+     * already deleted, and either half may be missing a bucket the other has.
+     */
+    static Map<String, Long> sumByBucket(Map<String, Long> retained, Map<String, Long> deleted) {
+        Map<String, Long> combined = new LinkedHashMap<>(retained);
+        deleted.forEach((bucket, count) -> combined.merge(bucket, count, Long::sum));
+        return combined;
+    }
+
+    /**
      * Expands a sparse bucket→count map into a dense, ordered series covering every bucket from {@code fromInclusive}
      * to {@code toInclusive}, filling gaps with zero. Sparse keys must already be formatted by {@link #bucketKey}.
      */

--- a/src/main/resources/db/migration/V202609051000__signing_record_volume.sql
+++ b/src/main/resources/db/migration/V202609051000__signing_record_volume.sql
@@ -1,0 +1,23 @@
+-- Immutable signing history. A signing_record row proves what a signing contained; this table preserves that the
+-- signing happened, which has to survive the record being deleted by an operator, by retention, or by
+-- delete-after-retrieval. Rows are written only by the roll-up-then-delete statements on SigningRecordRepository:
+-- a bucket is created or incremented in the same statement that removes the records it accounts for.
+CREATE TABLE "signing_record_volume"
+(
+    "uuid"                 UUID        NOT NULL,
+    -- No FK to signing_profile: a profile becomes deletable once its records are gone and these counts outlive it,
+    -- so the reference would be unsatisfiable. The column stays the access-control anchor -- signing history is
+    -- scoped by signing-profile access, exactly as the records were.
+    "signing_profile_uuid" UUID        NOT NULL,
+    -- Start of the UTC hour the signings fall in. Hourly is the finest granularity the dashboard renders, and daily
+    -- series are summed from it.
+    "bucket_start"         TIMESTAMPTZ NOT NULL,
+    "signing_count"        BIGINT      NOT NULL,
+    PRIMARY KEY ("uuid"),
+    -- Target of the ON CONFLICT that increments an existing bucket.
+    CONSTRAINT "uq_signing_record_volume_bucket" UNIQUE ("signing_profile_uuid", "bucket_start")
+);
+
+-- The dashboard series scans a window across every profile the caller may see; the unique constraint's index leads
+-- with the profile, so it cannot serve a bare window scan.
+CREATE INDEX "idx_srv_bucket_start" ON "signing_record_volume" ("bucket_start");

--- a/src/test/java/com/otilm/core/integration/dao/repository/signing/SigningRecordRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/dao/repository/signing/SigningRecordRepositoryITest.java
@@ -390,10 +390,10 @@ class SigningRecordRepositoryITest extends BaseSpringBootTest {
      * nothing up, so a statement that rolls up rows it did not remove shows up here as a bucket that should not exist.
      *
      * <p>
-     * The delete is confirmed stuck rather than assumed stuck: it has started, and a moment later it still has not
-     * returned, which for a statement whose only obstacle is the held row means it is waiting on it. Letting the
-     * competing transaction go early would leave the delete nothing to find, and the assertions would then pass over an
-     * interleaving this test never produced.
+     * The delete is confirmed stuck rather than assumed stuck: its transaction is open and its connection in hand, so
+     * issuing the statement is all that is left, and a moment later it still has not returned — for a statement whose
+     * only obstacle is the held row, that means it is waiting on it. Letting the competing transaction go early would
+     * leave the delete nothing to find, and the assertions would then pass over an interleaving never produced.
      */
     private int deleteBehindAnInFlightDelete(SigningRecord signingRecord) throws Exception {
         ExecutorService waiting = Executors.newSingleThreadExecutor();
@@ -403,13 +403,13 @@ class SigningRecordRepositoryITest extends BaseSpringBootTest {
                 delete.setObject(1, signingRecord.getUuid());
                 delete.executeUpdate();
             }
-            CountDownLatch started = new CountDownLatch(1);
-            Future<Integer> blocked = waiting.submit(() -> {
-                started.countDown();
-                return doInTransaction(() -> repository.deleteByUuid(signingRecord.getUuid()));
-            });
-            assertTrue(started.await(BLOCKED_DELETE_TIMEOUT.toSeconds(), TimeUnit.SECONDS),
-                    "the delete under test never started");
+            CountDownLatch transactionOpen = new CountDownLatch(1);
+            Future<Integer> blocked = waiting.submit(() -> doInTransaction(() -> {
+                transactionOpen.countDown();
+                return repository.deleteByUuid(signingRecord.getUuid());
+            }));
+            assertTrue(transactionOpen.await(BLOCKED_DELETE_TIMEOUT.toSeconds(), TimeUnit.SECONDS),
+                    "the delete under test never opened its transaction");
             assertThrows(TimeoutException.class,
                     () -> blocked.get(BLOCK_CONFIRMATION.toMillis(), TimeUnit.MILLISECONDS),
                     "the delete under test should be waiting for the row the competing transaction holds");

--- a/src/test/java/com/otilm/core/integration/dao/repository/signing/SigningRecordRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/dao/repository/signing/SigningRecordRepositoryITest.java
@@ -16,6 +16,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
@@ -412,11 +413,29 @@ class SigningRecordRepositoryITest extends BaseSpringBootTest {
                     "the delete under test never opened its transaction");
             assertThrows(TimeoutException.class,
                     () -> blocked.get(BLOCK_CONFIRMATION.toMillis(), TimeUnit.MILLISECONDS),
+                    "the delete under test should not have returned while the row is held");
+            assertTrue(aSessionIsBlockedByAnother(),
                     "the delete under test should be waiting for the row the competing transaction holds");
             inFlight.commit();
             return blocked.get(BLOCKED_DELETE_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
         } finally {
             waiting.shutdownNow();
+        }
+    }
+
+    /**
+     * Whether PostgreSQL reports a session in this database blocked by another. Asked once, after the timeout above has
+     * established that the delete has not returned, so being stuck is confirmed by the server rather than inferred from
+     * how fast the box happens to be.
+     */
+    private boolean aSessionIsBlockedByAnother() throws SQLException {
+        try (Connection probe = testDataSource.getConnection(); PreparedStatement blocked = probe.prepareStatement("""
+                SELECT count(*) FROM pg_stat_activity
+                WHERE datname = current_database()
+                  AND pid <> pg_backend_pid()
+                  AND cardinality(pg_blocking_pids(pid)) > 0
+                """); ResultSet result = blocked.executeQuery()) {
+            return result.next() && result.getInt(1) > 0;
         }
     }
 

--- a/src/test/java/com/otilm/core/integration/dao/repository/signing/SigningRecordRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/dao/repository/signing/SigningRecordRepositoryITest.java
@@ -6,14 +6,29 @@ import com.otilm.api.model.core.signing.SigningProtocol;
 import com.otilm.core.dao.entity.signing.SigningProfile;
 import com.otilm.core.dao.entity.signing.SigningProfileVersion;
 import com.otilm.core.dao.entity.signing.SigningRecord;
+import com.otilm.core.dao.entity.signing.SigningRecordVolume;
 import com.otilm.core.dao.repository.signing.SigningProfileRepository;
 import com.otilm.core.dao.repository.signing.SigningProfileVersionRepository;
 import com.otilm.core.dao.repository.signing.SigningRecordRepository;
+import com.otilm.core.dao.repository.signing.SigningRecordVolumeRepository;
 import com.otilm.core.util.BaseSpringBootTest;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.IntSupplier;
+import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,9 +42,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SigningRecordRepositoryITest extends BaseSpringBootTest {
 
     private static final int BATCH_LIMIT_LARGER_THAN_FIXTURES = 1000;
+    private static final Duration BLOCKED_DELETE_TIMEOUT = Duration.ofSeconds(20);
+    private static final Duration POLL_INTERVAL = Duration.ofMillis(50);
 
     @Autowired
     private SigningRecordRepository repository;
+
+    @Autowired
+    private SigningRecordVolumeRepository volumeRepository;
 
     @Autowired
     private SigningProfileRepository signingProfileRepository;
@@ -39,6 +59,12 @@ class SigningRecordRepositoryITest extends BaseSpringBootTest {
 
     @Autowired
     private PlatformTransactionManager transactionManager;
+
+    @Autowired
+    private DataSource testDataSource;
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     /**
      * Wraps the {@code @Modifying} native delete queries, which require an active transaction. Fixtures are committed
@@ -202,6 +228,249 @@ class SigningRecordRepositoryITest extends BaseSpringBootTest {
         // then
         assertEquals(0, deleted);
         assertTrue(repository.existsById(pending.getUuid()));
+    }
+
+    @Test
+    void deleteByUuid_rollsTheRecordIntoItsHourlyBucket() {
+        // given
+        var signedAt = Instant.parse("2026-03-01T12:34:56Z");
+        SigningProfile profile = insertProfile("rollup-single");
+        insertProfileVersion(profile, 1);
+        SigningRecord signingRecord = insertRecordSignedAt(profile, 1, signedAt);
+
+        // when
+        int deleted = doInTransaction(() -> repository.deleteByUuid(signingRecord.getUuid()));
+
+        // then
+        assertEquals(1, deleted);
+        assertFalse(repository.existsById(signingRecord.getUuid()));
+        assertEquals(1, countIn(profile, "2026-03-01T12:00:00Z"));
+    }
+
+    @Test
+    void deleteByUuid_accumulatesRecordsSignedInTheSameHour() {
+        // given
+        SigningProfile profile = insertProfile("rollup-accumulate");
+        insertProfileVersion(profile, 1);
+        SigningRecord first = insertRecordSignedAt(profile, 1, Instant.parse("2026-03-01T12:00:00Z"));
+        SigningRecord second = insertRecordSignedAt(profile, 1, Instant.parse("2026-03-01T12:59:59Z"));
+
+        // when
+        doInTransaction(() -> repository.deleteByUuid(first.getUuid()));
+        doInTransaction(() -> repository.deleteByUuid(second.getUuid()));
+
+        // then
+        assertEquals(1, volumeRepository.count());
+        assertEquals(2, countIn(profile, "2026-03-01T12:00:00Z"));
+    }
+
+    @Test
+    void deleteByUuid_keepsSeparateBucketsPerHourAndProfile() {
+        // given
+        SigningProfile profile = insertProfile("rollup-split");
+        SigningProfile otherProfile = insertProfile("rollup-split-other");
+        insertProfileVersion(profile, 1);
+        insertProfileVersion(otherProfile, 1);
+        SigningRecord noon = insertRecordSignedAt(profile, 1, Instant.parse("2026-03-01T12:10:00Z"));
+        SigningRecord onePm = insertRecordSignedAt(profile, 1, Instant.parse("2026-03-01T13:10:00Z"));
+        SigningRecord elsewhere = insertRecordSignedAt(otherProfile, 1, Instant.parse("2026-03-01T12:20:00Z"));
+
+        // when
+        doInTransaction(() -> repository.deleteByUuid(noon.getUuid()));
+        doInTransaction(() -> repository.deleteByUuid(onePm.getUuid()));
+        doInTransaction(() -> repository.deleteByUuid(elsewhere.getUuid()));
+
+        // then
+        assertEquals(1, countIn(profile, "2026-03-01T12:00:00Z"));
+        assertEquals(1, countIn(profile, "2026-03-01T13:00:00Z"));
+        assertEquals(1, countIn(otherProfile, "2026-03-01T12:00:00Z"));
+    }
+
+    @Test
+    void deleteExpiredByRetention_rollsUpEveryRecordItRemoves() {
+        // given
+        var retentionDays = 7;
+        var expiredHour = Instant.now().minus(Duration.ofDays(10)).truncatedTo(ChronoUnit.HOURS);
+        SigningProfile profile = insertProfile("rollup-retention");
+        insertProfileVersion(profile, 1, retentionDays, false);
+        insertRecordSignedAt(profile, 1, expiredHour);
+        insertRecordSignedAt(profile, 1, expiredHour.plus(Duration.ofMinutes(30)));
+
+        // when
+        int deleted = doInTransaction(() -> repository.deleteExpiredByRetention(BATCH_LIMIT_LARGER_THAN_FIXTURES));
+
+        // then
+        assertEquals(2, deleted);
+        assertEquals(2, countIn(profile, expiredHour));
+    }
+
+    @Test
+    void deleteExpiredByRetention_rollsUpOnlyTheRecordsWithinTheBatchLimit() {
+        // given
+        var oneOfTwo = 1;
+        var retentionDays = 7;
+        var expiredHour = Instant.now().minus(Duration.ofDays(10)).truncatedTo(ChronoUnit.HOURS);
+        SigningProfile profile = insertProfile("rollup-retention-limit");
+        insertProfileVersion(profile, 1, retentionDays, false);
+        insertRecordSignedAt(profile, 1, expiredHour);
+        insertRecordSignedAt(profile, 1, expiredHour);
+
+        // when
+        int deleted = doInTransaction(() -> repository.deleteExpiredByRetention(oneOfTwo));
+
+        // then
+        assertEquals(oneOfTwo, deleted);
+        assertEquals(oneOfTwo, countIn(profile, expiredHour));
+        assertEquals(1, repository.count());
+    }
+
+    @Test
+    void deleteRetrievedAndFlagged_rollsUpEveryRecordItRemoves() {
+        // given
+        var signedAt = Instant.parse("2026-04-02T08:15:00Z");
+        SigningProfile profile = insertProfile("rollup-retrieved");
+        insertProfileVersion(profile, 1, null, true);
+        insertRecord(profile, 1, Instant.now(), signedAt);
+
+        // when
+        int deleted = doInTransaction(() -> repository.deleteRetrievedAndFlagged(BATCH_LIMIT_LARGER_THAN_FIXTURES));
+
+        // then
+        assertEquals(1, deleted);
+        assertEquals(1, countIn(profile, "2026-04-02T08:00:00Z"));
+    }
+
+    @Test
+    void deleteByUuid_countsTheSigningOnceWhenAnotherDeletePathRemovesTheRecordFirst() throws Exception {
+        // given
+        SigningProfile profile = insertProfile("rollup-contested");
+        insertProfileVersion(profile, 1);
+        SigningRecord contested = insertRecordSignedAt(profile, 1, Instant.parse("2026-05-01T09:30:00Z"));
+
+        // when
+        int deleted = deleteBehindAnInFlightDelete(contested);
+
+        // then
+        assertEquals(0, deleted);
+        assertFalse(repository.existsById(contested.getUuid()));
+        assertEquals(0, volumeRepository.count());
+    }
+
+    /**
+     * Runs the keyed delete against a record another connection has already deleted but not yet committed, releasing
+     * that connection only once the keyed delete is waiting on the row. The competing delete does not roll anything up,
+     * so a statement that rolls up rows it did not remove shows up here as a bucket that should not exist.
+     */
+    private int deleteBehindAnInFlightDelete(SigningRecord signingRecord) throws Exception {
+        ExecutorService waiting = Executors.newSingleThreadExecutor();
+        try (Connection inFlight = testDataSource.getConnection()) {
+            inFlight.setAutoCommit(false);
+            try (PreparedStatement delete = inFlight.prepareStatement("DELETE FROM signing_record WHERE uuid = ?")) {
+                delete.setObject(1, signingRecord.getUuid());
+                delete.executeUpdate();
+            }
+            Future<Integer> blocked = waiting
+                    .submit(() -> doInTransaction(() -> repository.deleteByUuid(signingRecord.getUuid())));
+            awaitBackendWaitingOnALock();
+            inFlight.commit();
+            return blocked.get(BLOCKED_DELETE_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+        } finally {
+            waiting.shutdownNow();
+        }
+    }
+
+    /**
+     * Polls until a backend is blocked on a lock, so the delete under test is known to be waiting before the competing
+     * transaction commits. Gives up quietly at the bound: the assertions hold either way, this only makes the
+     * interleaving the test is after the one that actually happens.
+     */
+    private void awaitBackendWaitingOnALock() throws SQLException, InterruptedException {
+        Instant deadline = Instant.now().plus(BLOCKED_DELETE_TIMEOUT);
+        while (Instant.now().isBefore(deadline)) {
+            try (Connection probe = testDataSource.getConnection();
+                    PreparedStatement waiting = probe
+                            .prepareStatement("SELECT count(*) FROM pg_stat_activity WHERE wait_event_type = 'Lock'");
+                    ResultSet result = waiting.executeQuery()) {
+                if (result.next() && result.getInt(1) > 0) {
+                    return;
+                }
+            }
+            Thread.sleep(POLL_INTERVAL.toMillis());
+        }
+    }
+
+    @Test
+    void deleteExpiredByRetention_leavesAContendedRecordToTheStatementHoldingIt() throws SQLException {
+        // given
+        var retentionDays = 7;
+        var expiredHour = Instant.now().minus(Duration.ofDays(10)).truncatedTo(ChronoUnit.HOURS);
+        SigningProfile profile = insertProfile("rollup-retention-contended");
+        insertProfileVersion(profile, 1, retentionDays, false);
+        SigningRecord contested = insertRecordSignedAt(profile, 1, expiredHour);
+
+        // when
+        int deleted = whileHeldElsewhere(contested,
+                () -> doInTransaction(() -> repository.deleteExpiredByRetention(BATCH_LIMIT_LARGER_THAN_FIXTURES)));
+
+        // then
+        assertEquals(0, deleted);
+        assertEquals(0, volumeRepository.count());
+        assertTrue(repository.existsById(contested.getUuid()));
+    }
+
+    /**
+     * Runs {@code sweep} while a second connection holds {@code signingRecord} under {@code FOR UPDATE}. A batch that
+     * waited for contended rows instead of skipping them would block here until the test's own claim is released, which
+     * only happens afterwards.
+     */
+    private int whileHeldElsewhere(SigningRecord signingRecord, IntSupplier sweep) throws SQLException {
+        try (Connection holder = testDataSource.getConnection()) {
+            holder.setAutoCommit(false);
+            try (PreparedStatement select = holder
+                    .prepareStatement("SELECT uuid FROM signing_record WHERE uuid = ? FOR UPDATE")) {
+                select.setObject(1, signingRecord.getUuid());
+                select.executeQuery().close();
+            }
+            try {
+                return Objects.requireNonNull(transactionTemplate.execute(status -> {
+                    entityManager.createNativeQuery("SET LOCAL lock_timeout = '5s'").executeUpdate();
+                    return sweep.getAsInt();
+                }));
+            } finally {
+                holder.rollback();
+            }
+        }
+    }
+
+    @Test
+    void deleteQueries_recordNothingWhenTheyRemoveNothing() {
+        // given
+        var withinRetentionWindow = Instant.now();
+        SigningProfile profile = insertProfile("rollup-noop");
+        insertProfileVersion(profile, 1, 30, false);
+        insertRecordSignedAt(profile, 1, withinRetentionWindow);
+
+        // when
+        doInTransaction(() -> repository.deleteExpiredByRetention(BATCH_LIMIT_LARGER_THAN_FIXTURES));
+        doInTransaction(() -> repository.deleteRetrievedAndFlagged(BATCH_LIMIT_LARGER_THAN_FIXTURES));
+        doInTransaction(() -> repository.deleteByUuid(UUID.randomUUID()));
+
+        // then
+        assertEquals(0, volumeRepository.count());
+    }
+
+    private long countIn(SigningProfile profile, String bucketStart) {
+        return countIn(profile, Instant.parse(bucketStart));
+    }
+
+    private long countIn(SigningProfile profile, Instant bucketStart) {
+        return volumeRepository
+                .findAll()
+                .stream()
+                .filter(volume -> volume.getSigningProfileUuid().equals(profile.getUuid()))
+                .filter(volume -> volume.getBucketStart().equals(bucketStart))
+                .mapToLong(SigningRecordVolume::getSigningCount)
+                .sum();
     }
 
     private SigningProfile insertProfile(String name) {

--- a/src/test/java/com/otilm/core/integration/dao/repository/signing/SigningRecordRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/dao/repository/signing/SigningRecordRepositoryITest.java
@@ -305,6 +305,32 @@ class SigningRecordRepositoryITest extends BaseSpringBootTest {
     }
 
     @Test
+    void deleteExpiredByRetention_rollsUpEveryBucketOneBatchSpans() {
+        // given one batch covering two profiles across two hours
+        var retentionDays = 7;
+        var firstHour = Instant.now().minus(Duration.ofDays(10)).truncatedTo(ChronoUnit.HOURS);
+        var secondHour = firstHour.plus(Duration.ofHours(1));
+        SigningProfile profile = insertProfile("rollup-batch-spread");
+        SigningProfile otherProfile = insertProfile("rollup-batch-spread-other");
+        insertProfileVersion(profile, 1, retentionDays, false);
+        insertProfileVersion(otherProfile, 1, retentionDays, false);
+        insertRecordSignedAt(profile, 1, firstHour);
+        insertRecordSignedAt(profile, 1, firstHour.plus(Duration.ofMinutes(20)));
+        insertRecordSignedAt(profile, 1, secondHour);
+        insertRecordSignedAt(otherProfile, 1, firstHour);
+
+        // when
+        int deleted = doInTransaction(() -> repository.deleteExpiredByRetention(BATCH_LIMIT_LARGER_THAN_FIXTURES));
+
+        // then
+        assertEquals(4, deleted);
+        assertEquals(3, volumeRepository.count());
+        assertEquals(2, countIn(profile, firstHour));
+        assertEquals(1, countIn(profile, secondHour));
+        assertEquals(1, countIn(otherProfile, firstHour));
+    }
+
+    @Test
     void deleteExpiredByRetention_rollsUpOnlyTheRecordsWithinTheBatchLimit() {
         // given
         var oneOfTwo = 1;

--- a/src/test/java/com/otilm/core/integration/dao/repository/signing/SigningRecordRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/dao/repository/signing/SigningRecordRepositoryITest.java
@@ -16,17 +16,18 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.IntSupplier;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,13 +38,14 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SigningRecordRepositoryITest extends BaseSpringBootTest {
 
     private static final int BATCH_LIMIT_LARGER_THAN_FIXTURES = 1000;
     private static final Duration BLOCKED_DELETE_TIMEOUT = Duration.ofSeconds(20);
-    private static final Duration POLL_INTERVAL = Duration.ofMillis(50);
+    private static final Duration BLOCK_CONFIRMATION = Duration.ofSeconds(1);
 
     @Autowired
     private SigningRecordRepository repository;
@@ -384,8 +386,14 @@ class SigningRecordRepositoryITest extends BaseSpringBootTest {
 
     /**
      * Runs the keyed delete against a record another connection has already deleted but not yet committed, releasing
-     * that connection only once the keyed delete is waiting on the row. The competing delete does not roll anything up,
-     * so a statement that rolls up rows it did not remove shows up here as a bucket that should not exist.
+     * that connection only once the keyed delete is confirmed to be waiting on the row. The competing delete rolls
+     * nothing up, so a statement that rolls up rows it did not remove shows up here as a bucket that should not exist.
+     *
+     * <p>
+     * The delete is confirmed stuck rather than assumed stuck: it has started, and a moment later it still has not
+     * returned, which for a statement whose only obstacle is the held row means it is waiting on it. Letting the
+     * competing transaction go early would leave the delete nothing to find, and the assertions would then pass over an
+     * interleaving this test never produced.
      */
     private int deleteBehindAnInFlightDelete(SigningRecord signingRecord) throws Exception {
         ExecutorService waiting = Executors.newSingleThreadExecutor();
@@ -395,41 +403,20 @@ class SigningRecordRepositoryITest extends BaseSpringBootTest {
                 delete.setObject(1, signingRecord.getUuid());
                 delete.executeUpdate();
             }
-            Future<Integer> blocked = waiting
-                    .submit(() -> doInTransaction(() -> repository.deleteByUuid(signingRecord.getUuid())));
-            awaitDeleteBlockedOnTheRecord();
+            CountDownLatch started = new CountDownLatch(1);
+            Future<Integer> blocked = waiting.submit(() -> {
+                started.countDown();
+                return doInTransaction(() -> repository.deleteByUuid(signingRecord.getUuid()));
+            });
+            assertTrue(started.await(BLOCKED_DELETE_TIMEOUT.toSeconds(), TimeUnit.SECONDS),
+                    "the delete under test never started");
+            assertThrows(TimeoutException.class,
+                    () -> blocked.get(BLOCK_CONFIRMATION.toMillis(), TimeUnit.MILLISECONDS),
+                    "the delete under test should be waiting for the row the competing transaction holds");
             inFlight.commit();
             return blocked.get(BLOCKED_DELETE_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
         } finally {
             waiting.shutdownNow();
-        }
-    }
-
-    /**
-     * Polls until the delete under test is blocked on the record, so the competing transaction only commits once it is
-     * waiting. {@code pg_stat_activity} spans the cluster, so the predicate has to name this database, exclude the
-     * probe itself, and require the stalled statement to be one touching {@code signing_record} — matched against any
-     * waiter, the probe would release the competitor before the delete had begun, and every assertion would still hold
-     * over an interleaving the test never produced. Gives up quietly at the bound; the assertions hold either way, this
-     * only makes the interleaving the one that actually happens.
-     */
-    private void awaitDeleteBlockedOnTheRecord() throws SQLException, InterruptedException {
-        Instant deadline = Instant.now().plus(BLOCKED_DELETE_TIMEOUT);
-        while (Instant.now().isBefore(deadline)) {
-            try (Connection probe = testDataSource.getConnection();
-                    PreparedStatement waiting = probe.prepareStatement("""
-                            SELECT count(*) FROM pg_stat_activity
-                            WHERE wait_event_type = 'Lock'
-                              AND datname = current_database()
-                              AND pid <> pg_backend_pid()
-                              AND query ILIKE '%signing_record%'
-                            """);
-                    ResultSet result = waiting.executeQuery()) {
-                if (result.next() && result.getInt(1) > 0) {
-                    return;
-                }
-            }
-            Thread.sleep(POLL_INTERVAL.toMillis());
         }
     }
 

--- a/src/test/java/com/otilm/core/integration/dao/repository/signing/SigningRecordRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/dao/repository/signing/SigningRecordRepositoryITest.java
@@ -397,7 +397,7 @@ class SigningRecordRepositoryITest extends BaseSpringBootTest {
             }
             Future<Integer> blocked = waiting
                     .submit(() -> doInTransaction(() -> repository.deleteByUuid(signingRecord.getUuid())));
-            awaitBackendWaitingOnALock();
+            awaitDeleteBlockedOnTheRecord();
             inFlight.commit();
             return blocked.get(BLOCKED_DELETE_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
         } finally {
@@ -406,16 +406,24 @@ class SigningRecordRepositoryITest extends BaseSpringBootTest {
     }
 
     /**
-     * Polls until a backend is blocked on a lock, so the delete under test is known to be waiting before the competing
-     * transaction commits. Gives up quietly at the bound: the assertions hold either way, this only makes the
-     * interleaving the test is after the one that actually happens.
+     * Polls until the delete under test is blocked on the record, so the competing transaction only commits once it is
+     * waiting. {@code pg_stat_activity} spans the cluster, so the predicate has to name this database, exclude the
+     * probe itself, and require the stalled statement to be one touching {@code signing_record} — matched against any
+     * waiter, the probe would release the competitor before the delete had begun, and every assertion would still hold
+     * over an interleaving the test never produced. Gives up quietly at the bound; the assertions hold either way, this
+     * only makes the interleaving the one that actually happens.
      */
-    private void awaitBackendWaitingOnALock() throws SQLException, InterruptedException {
+    private void awaitDeleteBlockedOnTheRecord() throws SQLException, InterruptedException {
         Instant deadline = Instant.now().plus(BLOCKED_DELETE_TIMEOUT);
         while (Instant.now().isBefore(deadline)) {
             try (Connection probe = testDataSource.getConnection();
-                    PreparedStatement waiting = probe
-                            .prepareStatement("SELECT count(*) FROM pg_stat_activity WHERE wait_event_type = 'Lock'");
+                    PreparedStatement waiting = probe.prepareStatement("""
+                            SELECT count(*) FROM pg_stat_activity
+                            WHERE wait_event_type = 'Lock'
+                              AND datname = current_database()
+                              AND pid <> pg_backend_pid()
+                              AND query ILIKE '%signing_record%'
+                            """);
                     ResultSet result = waiting.executeQuery()) {
                 if (result.next() && result.getInt(1) > 0) {
                     return;

--- a/src/test/java/com/otilm/core/integration/service/SigningRecordServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/SigningRecordServiceITest.java
@@ -2,6 +2,8 @@ package com.otilm.core.integration.service;
 
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.model.client.certificate.SearchRequestDto;
+import com.otilm.api.model.client.dashboard.SigningRecordStatisticsDto;
+import com.otilm.api.model.client.dashboard.SigningRecordStatisticsPeriod;
 import com.otilm.api.model.client.signing.profile.SigningProfileDto;
 import com.otilm.api.model.common.BulkActionMessageDto;
 import com.otilm.api.model.common.PaginationResponseDto;
@@ -17,6 +19,7 @@ import com.otilm.core.dao.entity.signing.SigningRecord;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.security.authz.opa.dto.OpaObjectAccessResult;
 import com.otilm.core.service.SigningProfileExternalService;
 import com.otilm.core.service.SigningRecordExternalService;
 import com.otilm.core.service.SigningRecordInternalService;
@@ -26,9 +29,13 @@ import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.builders.SearchRequestDtoBuilder;
 import com.otilm.core.util.mocks.ConnectorMockFactory;
 import com.otilm.core.util.mocks.SignerConnectorMock;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +54,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.when;
 
 /**
  * Drives {@link SigningRecordExternalService} end to end: signing profiles are created through
@@ -63,6 +73,18 @@ class SigningRecordServiceITest extends BaseSpringBootTest {
     private static final String ALPHA_RECORD_V1 = "alpha-record-v1";
     private static final String ALPHA_RECORD_V2 = "alpha-record-v2";
     private static final String BETA_RECORD_V1 = "beta-record-v1";
+
+    /**
+     * The bucket key the volume series is expected to use, spelled out here rather than borrowed from the production
+     * formatter so the test pins the wire format rather than mirroring whatever it becomes.
+     */
+    private static final DateTimeFormatter HOUR_BUCKET_KEY = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd'T'HH:00:00'Z'")
+            .withZone(ZoneOffset.UTC);
+
+    private static final DateTimeFormatter DAY_BUCKET_KEY = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd'T'00:00:00'Z'")
+            .withZone(ZoneOffset.UTC);
 
     @Autowired
     private SigningRecordExternalService signingRecordService;
@@ -507,6 +529,194 @@ class SigningRecordServiceITest extends BaseSpringBootTest {
                     signingRecordService
                             .listSigningRecords(SearchRequestDtoBuilder.all(), SecurityFilter.create())
                             .getTotalItems());
+        }
+    }
+
+    /**
+     * Signing history is immutable: how much was signed in a period must read the same before and after the records
+     * describing it are deleted. What is currently <em>retained</em> is a separate figure and does follow the
+     * deletions.
+     */
+    @Nested
+    class StatisticsTests {
+
+        @Test
+        void volumeOverTimeKeepsTheSigningAfterItsRecordIsDeleted() throws NotFoundException {
+            // given
+            Instant signedAt = hoursAgo(2);
+            SigningRecord signingRecord = insertRecordSignedAt(signedAt);
+            assertEquals(1L, volumeIn(signedAt));
+
+            // when
+            signingRecordService.deleteSigningRecord(SecuredUUID.fromUUID(signingRecord.getUuid()));
+
+            // then
+            assertEquals(1L, volumeIn(signedAt));
+        }
+
+        @Test
+        void volumeOverTimeSumsRetainedAndDeletedSigningsOfTheSameBucket() throws NotFoundException {
+            // given
+            Instant signedAt = hoursAgo(2);
+            SigningRecord deleted = insertRecordSignedAt(signedAt);
+            insertRecordSignedAt(signedAt.plusSeconds(60));
+
+            // when
+            signingRecordService.deleteSigningRecord(SecuredUUID.fromUUID(deleted.getUuid()));
+
+            // then
+            assertEquals(2L, volumeIn(signedAt));
+        }
+
+        @Test
+        void volumeOverTimeCountsADeletedSigningOnce() throws NotFoundException {
+            // given
+            Instant signedAt = hoursAgo(2);
+            SigningRecord signingRecord = insertRecordSignedAt(signedAt);
+
+            // when
+            signingRecordService.deleteSigningRecord(SecuredUUID.fromUUID(signingRecord.getUuid()));
+
+            // then
+            assertEquals(1L, totalVolume());
+        }
+
+        @Test
+        void windowCountsKeepTheSigningAfterItsRecordIsDeleted() throws NotFoundException {
+            // given
+            SigningRecord signingRecord = insertRecordSignedAt(hoursAgo(2));
+
+            // when
+            signingRecordService.deleteSigningRecord(SecuredUUID.fromUUID(signingRecord.getUuid()));
+
+            // then
+            SigningRecordStatisticsDto statistics = statistics();
+            assertEquals(1L, statistics.getCountLast24h());
+            assertEquals(1L, statistics.getCountLast7d());
+        }
+
+        @Test
+        void dailySeriesSumsTheHourlyHistoryOfADeletedDay() throws NotFoundException {
+            // given
+            Instant earlier = hoursIntoTheDayBeforeYesterday(3);
+            Instant later = hoursIntoTheDayBeforeYesterday(21);
+            SigningRecord morning = insertRecordSignedAt(earlier);
+            SigningRecord evening = insertRecordSignedAt(later);
+
+            // when
+            signingRecordService.deleteSigningRecord(SecuredUUID.fromUUID(morning.getUuid()));
+            signingRecordService.deleteSigningRecord(SecuredUUID.fromUUID(evening.getUuid()));
+
+            // then
+            Map<String, Long> daily = statistics(SigningRecordStatisticsPeriod.LAST_7D).getVolumeOverTime();
+            assertEquals(2L, daily.get(DAY_BUCKET_KEY.format(earlier)));
+        }
+
+        @Test
+        void windowCountsAreUnchangedByDeletingASigningAtTheWindowEdge() throws NotFoundException {
+            // given a signing in the very hour the 24h cutoff falls in, where an exact and an hour-aligned window
+            // disagree about whether it belongs
+            SigningRecord signingRecord = insertRecordSignedAt(
+                    Instant.now().minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.HOURS));
+            long before = statistics().getCountLast24h();
+
+            // when
+            signingRecordService.deleteSigningRecord(SecuredUUID.fromUUID(signingRecord.getUuid()));
+
+            // then
+            assertEquals(1L, before);
+            assertEquals(before, statistics().getCountLast24h());
+        }
+
+        @Test
+        void volumeOverTimeOfDeletedSigningsStaysScopedToTheProfilesTheCallerMaySee() throws Exception {
+            // given
+            Instant signedAt = hoursAgo(2);
+            SigningProfileDto otherProfile = createSigningProfile("out-of-scope-profile");
+            SigningRecord mine = insertRecordSignedAt(defaultProfile, signedAt);
+            SigningRecord theirs = insertRecordSignedAt(otherProfile, signedAt);
+            signingRecordService.deleteSigningRecord(SecuredUUID.fromUUID(mine.getUuid()));
+            signingRecordService.deleteSigningRecord(SecuredUUID.fromUUID(theirs.getUuid()));
+            assertEquals(2L, volumeIn(signedAt));
+
+            // when
+            allowOnlySigningProfile(defaultProfile);
+
+            // then
+            assertEquals(1L, volumeIn(signedAt));
+        }
+
+        @Test
+        void totalRetainedDropsWhenTheRecordIsDeleted() throws NotFoundException {
+            // given
+            SigningRecord signingRecord = insertRecordSignedAt(hoursAgo(2));
+            assertEquals(1L, statistics().getTotalRetained());
+
+            // when
+            signingRecordService.deleteSigningRecord(SecuredUUID.fromUUID(signingRecord.getUuid()));
+
+            // then
+            assertEquals(0L, statistics().getTotalRetained());
+        }
+
+        private SigningRecord insertRecordSignedAt(Instant signingTime) {
+            return insertRecordSignedAt(defaultProfile, signingTime);
+        }
+
+        private SigningRecord insertRecordSignedAt(SigningProfileDto profile, Instant signingTime) {
+            SigningRecord signingRecord = aSigningRecord()
+                    .withSigningProfile(profile)
+                    .withSigningTime(signingTime)
+                    .build();
+            signingRecordWriter.insert(signingRecord);
+            return signingRecord;
+        }
+
+        /**
+         * Narrows the OPA object-access vote for signing profiles to {@code allowed}, the way it comes back for an
+         * operator scoped to a subset of them. The vote for signing records themselves stays unrestricted, so what the
+         * assertion measures is the signing-profile scope alone.
+         */
+        private void allowOnlySigningProfile(SigningProfileDto allowed) {
+            OpaObjectAccessResult scoped = new OpaObjectAccessResult();
+            scoped.setActionAllowedForGroupOfObjects(false);
+            scoped.setAllowedObjects(List.of(allowed.getUuid()));
+            scoped.setForbiddenObjects(List.of());
+            when(opaClient
+                    .checkObjectAccess(any(),
+                            argThat(request -> request != null && request.getProperties() != null
+                                    && Resource.SIGNING_PROFILE.getCode().equals(request.getProperties().get("name"))),
+                            any(), any()))
+                    .thenReturn(scoped);
+        }
+
+        /** Well inside the 24h window and clear of both its edges, so the assertions do not race the clock. */
+        private Instant hoursAgo(int hours) {
+            return Instant.now().minus(Duration.ofHours(hours)).truncatedTo(ChronoUnit.HOURS).plusSeconds(1800);
+        }
+
+        /**
+         * {@code hour} o'clock UTC on the day before yesterday — a whole day inside the 7-day window, so a daily bucket
+         * built from it is neither the partial leading day nor today.
+         */
+        private Instant hoursIntoTheDayBeforeYesterday(int hour) {
+            return Instant.now().minus(Duration.ofDays(2)).truncatedTo(ChronoUnit.DAYS).plus(Duration.ofHours(hour));
+        }
+
+        private long volumeIn(Instant bucket) {
+            return statistics().getVolumeOverTime().get(HOUR_BUCKET_KEY.format(bucket));
+        }
+
+        private long totalVolume() {
+            return statistics().getVolumeOverTime().values().stream().mapToLong(Long::longValue).sum();
+        }
+
+        private SigningRecordStatisticsDto statistics() {
+            return statistics(SigningRecordStatisticsPeriod.LAST_24H);
+        }
+
+        private SigningRecordStatisticsDto statistics(SigningRecordStatisticsPeriod period) {
+            return signingRecordService.getSigningRecordStatistics(period, SecurityFilter.create());
         }
     }
 

--- a/src/test/java/com/otilm/core/integration/service/SigningRecordServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/SigningRecordServiceITest.java
@@ -717,7 +717,7 @@ class SigningRecordServiceITest extends BaseSpringBootTest {
             return Instant.now().minus(Duration.ofDays(2)).truncatedTo(ChronoUnit.DAYS).plus(Duration.ofHours(hour));
         }
 
-        private long volumeIn(Instant bucket) {
+        private Long volumeIn(Instant bucket) {
             return statistics().getVolumeOverTime().get(HOUR_BUCKET_KEY.format(bucket));
         }
 

--- a/src/test/java/com/otilm/core/integration/service/SigningRecordServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/SigningRecordServiceITest.java
@@ -613,6 +613,20 @@ class SigningRecordServiceITest extends BaseSpringBootTest {
         }
 
         @Test
+        void windowCountsExcludeADeletedSigningOlderThanTheWindow() throws NotFoundException {
+            // given
+            SigningRecord signingRecord = insertRecordSignedAt(Instant.now().minus(Duration.ofDays(3)));
+
+            // when
+            signingRecordService.deleteSigningRecord(SecuredUUID.fromUUID(signingRecord.getUuid()));
+
+            // then
+            SigningRecordStatisticsDto statistics = statistics();
+            assertEquals(0L, statistics.getCountLast24h());
+            assertEquals(1L, statistics.getCountLast7d());
+        }
+
+        @Test
         void windowCountsAreUnchangedByDeletingASigningAtTheWindowEdge() throws NotFoundException {
             // given a signing in the very hour the 24h cutoff falls in, where an exact and an hour-aligned window
             // disagree about whether it belongs

--- a/src/test/java/com/otilm/core/service/impl/SigningRecordStatisticsCalculatorTest.java
+++ b/src/test/java/com/otilm/core/service/impl/SigningRecordStatisticsCalculatorTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 class SigningRecordStatisticsCalculatorTest {
 
@@ -55,6 +56,35 @@ class SigningRecordStatisticsCalculatorTest {
         Map<String, Long> all = Map.of("alice", 1L, "bob", 2L);
 
         assertThat(SigningRecordStatisticsCalculator.topRequesters(all, 10)).hasSize(2);
+    }
+
+    @Test
+    void sumByBucket_addsCountsOfBucketsPresentInBothHalves() {
+        Map<String, Long> retained = Map.of("2026-06-11T09:00:00Z", 3L);
+        Map<String, Long> deleted = Map.of("2026-06-11T09:00:00Z", 4L);
+
+        assertThat(SigningRecordStatisticsCalculator.sumByBucket(retained, deleted))
+                .containsExactly(entry("2026-06-11T09:00:00Z", 7L));
+    }
+
+    @Test
+    void sumByBucket_keepsBucketsPresentInOnlyOneHalf() {
+        Map<String, Long> retained = Map.of("2026-06-11T09:00:00Z", 3L);
+        Map<String, Long> deleted = Map.of("2026-06-11T08:00:00Z", 5L);
+
+        assertThat(SigningRecordStatisticsCalculator.sumByBucket(retained, deleted))
+                .containsOnly(entry("2026-06-11T08:00:00Z", 5L), entry("2026-06-11T09:00:00Z", 3L));
+    }
+
+    @Test
+    void sumByBucket_leavesTheHalvesUntouched() {
+        Map<String, Long> retained = new LinkedHashMap<>(Map.of("2026-06-11T09:00:00Z", 3L));
+        Map<String, Long> deleted = new LinkedHashMap<>(Map.of("2026-06-11T09:00:00Z", 4L));
+
+        SigningRecordStatisticsCalculator.sumByBucket(retained, deleted);
+
+        assertThat(retained).containsExactly(entry("2026-06-11T09:00:00Z", 3L));
+        assertThat(deleted).containsExactly(entry("2026-06-11T09:00:00Z", 4L));
     }
 
     @Test


### PR DESCRIPTION
Closes #2097

- Add `signing_record_volume`, an append-only count of signings per signing profile per UTC hour, with no foreign key to `signing_profile` so the counts outlive the profile.
- Fold signing records into that table in the same statement that deletes them, claiming the rows first so two delete paths reaching one record cannot count it twice.
- Read the signing volume series and the 24h and 7d counts as the retained records plus that history; the retained total and the breakdown maps continue to describe what is currently retained.
- Read the statistics under one snapshot, and open both window halves on an hour boundary, so deleting a record cannot change either count.
- Add `sumGroupedUsingSecurityFilter` to `SecurityFilterRepository` for the grouped read of the new table.

Schema descriptions for the three changed figures are in OmniTrustILM/interfaces#957; merge that first so the published spec matches.