### PR TITLE
Mirror attribute visibility as a column so every read path shares one predicate

### DIFF
--- a/src/main/java/com/otilm/core/attribute/engine/AttributeColumnProjector.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeColumnProjector.java
@@ -215,11 +215,8 @@ public class AttributeColumnProjector {
 
         for (ProjectedAttributeContent content : stored) {
             // Encrypted content is ciphertext that only its own decryption path can read, and a listing does not take
-            // that path. An attribute whose definition says it is not visible is not to be shown to a user, which is
-            // what a column does with it. The catalogue withholds both kinds of field; a row that reaches here anyway
-            // is dropped, because the flag it withheld them with is a hint on a response the caller is free to ignore.
-            if (content.encryptedContent() != null || WITHHELD_CONTENT_TYPES.contains(content.contentType())
-                    || !AttributeDefinitionProperties.isVisible(content.definition())) {
+            // that path. The query already excludes a definition marked not visible.
+            if (content.encryptedContent() != null || WITHHELD_CONTENT_TYPES.contains(content.contentType())) {
                 continue;
             }
             RequestedColumn column = matchRequested(requested, content);

--- a/src/main/java/com/otilm/core/attribute/engine/records/ProjectedAttributeContent.java
+++ b/src/main/java/com/otilm/core/attribute/engine/records/ProjectedAttributeContent.java
@@ -2,7 +2,6 @@ package com.otilm.core.attribute.engine.records;
 
 import com.otilm.api.model.common.attribute.common.AttributeContent;
 import com.otilm.api.model.common.attribute.common.AttributeType;
-import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 
 import java.util.UUID;
@@ -17,11 +16,7 @@ import java.util.UUID;
  *
  * @param encryptedContent set when the item is stored as ciphertext; such content is never projected, and the field is
  * carried only so the projection can recognise and skip it
- * @param definition the attribute the item is content of. Carried for the {@code visible} flag on its properties, which
- * lives inside the definition document rather than in a column of its own, so it cannot be a predicate on the query
- * that loads these rows
  */
 public record ProjectedAttributeContent(UUID objectUuid, AttributeType attributeType, String attributeName,
-        AttributeContentType contentType, AttributeContent contentItem, String encryptedContent,
-        BaseAttribute definition) {
+        AttributeContentType contentType, AttributeContent contentItem, String encryptedContent) {
 }

--- a/src/main/java/com/otilm/core/dao/entity/AttributeDefinition.java
+++ b/src/main/java/com/otilm/core/dao/entity/AttributeDefinition.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -93,6 +94,7 @@ public class AttributeDefinition extends UniquelyIdentified implements ObjectAcc
      * visibility from one column rather than three readings of the document. Written only by {@link #setDefinition},
      * which is what keeps the two in step.
      */
+    @Setter(AccessLevel.NONE)
     @Column(name = "visible", nullable = false)
     private boolean visible = true;
 

--- a/src/main/java/com/otilm/core/dao/entity/AttributeDefinition.java
+++ b/src/main/java/com/otilm/core/dao/entity/AttributeDefinition.java
@@ -17,6 +17,7 @@ import com.otilm.api.model.common.attribute.common.properties.CustomAttributePro
 import com.otilm.api.model.common.attribute.common.properties.MetadataAttributeProperties;
 import com.otilm.api.model.common.attribute.v2.MetadataAttributeV2;
 import com.otilm.api.model.common.attribute.v3.CustomAttributeV3;
+import com.otilm.core.attribute.engine.AttributeDefinitionProperties;
 import com.otilm.core.attribute.engine.AttributeVersionHelper;
 import com.otilm.core.util.ObjectAccessControlMapper;
 import jakarta.persistence.Column;
@@ -87,6 +88,14 @@ public class AttributeDefinition extends UniquelyIdentified implements ObjectAcc
     @Column(name = "read_only")
     private Boolean readOnly;
 
+    /**
+     * Mirrors {@code properties.visible} of the stored definition, so projection, ordering and filtering answer
+     * visibility from one column rather than three readings of the document. Written only by {@link #setDefinition},
+     * which is what keeps the two in step.
+     */
+    @Column(name = "visible", nullable = false)
+    private boolean visible = true;
+
     @Column(name = "version", nullable = false)
     private int version;
 
@@ -132,6 +141,15 @@ public class AttributeDefinition extends UniquelyIdentified implements ObjectAcc
     @Column(name = "encrypted_data", length = Integer.MAX_VALUE)
     @JdbcTypeCode(SqlTypes.ARRAY)
     private List<String> encryptedData;
+
+    /**
+     * Replaces the definition and re-derives {@link #visible} from it. Overridden rather than left to Lombok because a
+     * definition written without refreshing the column would let a filter read a visibility the projection does not.
+     */
+    public void setDefinition(BaseAttribute definition) {
+        this.definition = definition;
+        this.visible = AttributeDefinitionProperties.isVisible(definition);
+    }
 
     public void setConnector(Connector connector) {
         this.connector = connector;

--- a/src/main/java/com/otilm/core/dao/repository/AttributeContent2ObjectRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/AttributeContent2ObjectRepository.java
@@ -108,17 +108,16 @@ public interface AttributeContent2ObjectRepository extends SecurityFilterReposit
      * restricted custom attribute by naming it as a column.
      *
      * <p>
-     * Selects the definition document alongside the content because the {@code visible} flag lives in it rather than in
-     * a column, and an attribute whose definition says it is not to be shown to a user must not be projected into a
-     * column. The catalogue queries above select the same document for the same reason.
+     * Excludes a definition marked not visible, so an attribute the catalogue withholds is never loaded only to be
+     * dropped afterwards.
      */
     @Query("""
             SELECT new com.otilm.core.attribute.engine.records.ProjectedAttributeContent(
-                aco.objectUuid, ad.type, ad.name, ad.contentType, aci.json, aci.encryptedData, ad.definition)
+                aco.objectUuid, ad.type, ad.name, ad.contentType, aci.json, aci.encryptedData)
                 FROM AttributeContent2Object aco
                 JOIN AttributeContentItem aci ON aci.uuid = aco.attributeContentItemUuid
                 JOIN AttributeDefinition ad ON ad.uuid = aci.attributeDefinitionUuid
-                WHERE ad.type IN (:attributeTypes) AND ad.name IN (:attributeNames)
+                WHERE ad.type IN (:attributeTypes) AND ad.name IN (:attributeNames) AND ad.visible = true
                     AND aco.objectType = :objectType AND aco.objectUuid IN (:objectUuids)
                     AND (ad.type <> :customType
                         OR (ad.enabled = true

--- a/src/main/java/com/otilm/core/dao/repository/AttributeDefinitionRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/AttributeDefinitionRepository.java
@@ -65,13 +65,13 @@ public interface AttributeDefinitionRepository extends SecurityFilterRepository<
      */
     @Query("""
             SELECT DISTINCT new com.otilm.core.model.SearchFieldObject(
-                ad.name, ad.contentType, ad.type, ad.label, ad.definition)
+                ad.name, ad.contentType, ad.type, ad.label, ad.visible, ad.definition)
                 FROM AttributeDefinition ad
                 LEFT JOIN AttributeRelation ar ON ar.attributeDefinitionUuid = ad.uuid
                 WHERE ad.type IN ?2 AND ar.resource = ?1
             UNION
             SELECT DISTINCT new com.otilm.core.model.SearchFieldObject(
-                ad.name, ad.contentType, ad.type, ad.label, ad.definition)
+                ad.name, ad.contentType, ad.type, ad.label, ad.visible, ad.definition)
                 FROM AttributeDefinition ad
                 WHERE ad.type IN ?2 AND ad.uuid IN (
                     SELECT aci.attributeDefinitionUuid
@@ -92,13 +92,13 @@ public interface AttributeDefinitionRepository extends SecurityFilterRepository<
      */
     @Query("""
             SELECT DISTINCT new com.otilm.core.model.SearchFieldObject(
-                ad.name, ad.contentType, ad.type, ad.label, ad.definition)
+                ad.name, ad.contentType, ad.type, ad.label, ad.visible, ad.definition)
                 FROM AttributeDefinition ad
                 LEFT JOIN AttributeRelation ar ON ar.attributeDefinitionUuid = ad.uuid
                 WHERE ad.type IN ?2 AND ar.resource = ?1 AND ad.contentType IN ?3
             UNION
             SELECT DISTINCT new com.otilm.core.model.SearchFieldObject(
-                ad.name, ad.contentType, ad.type, ad.label, ad.definition)
+                ad.name, ad.contentType, ad.type, ad.label, ad.visible, ad.definition)
                 FROM AttributeDefinition ad
                 WHERE ad.type IN ?2 AND ad.contentType IN ?3 AND ad.uuid IN (
                     SELECT aci.attributeDefinitionUuid

--- a/src/main/java/com/otilm/core/model/SearchFieldObject.java
+++ b/src/main/java/com/otilm/core/model/SearchFieldObject.java
@@ -8,7 +8,6 @@ import com.otilm.api.model.common.attribute.common.DataAttribute;
 import com.otilm.api.model.common.attribute.common.MetadataAttribute;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.common.content.data.ProtectionLevel;
-import com.otilm.core.attribute.engine.AttributeDefinitionProperties;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -33,10 +32,7 @@ public class SearchFieldObject {
 
     private ProtectionLevel protectionLevel;
 
-    /**
-     * Whether the definition says its values may be shown to a user. Read here rather than at each use, because the
-     * flag lives on the properties of whichever attribute shape the definition holds.
-     */
+    /** Whether the definition says its values may be shown to a user, as mirrored on the definition row. */
     private boolean visible = true;
 
     private List<String> contentItems;
@@ -53,12 +49,12 @@ public class SearchFieldObject {
     }
 
     public SearchFieldObject(String attributeName, AttributeContentType attributeContentType,
-            AttributeType attributeType, String label, BaseAttribute attributeDefinition) {
+            AttributeType attributeType, String label, boolean visible, BaseAttribute attributeDefinition) {
         this.attributeName = attributeName;
         this.attributeContentType = attributeContentType;
         this.attributeType = attributeType;
         this.label = label;
-        this.visible = AttributeDefinitionProperties.isVisible(attributeDefinition);
+        this.visible = visible;
 
         if (attributeType == AttributeType.CUSTOM || attributeType == AttributeType.DATA) {
             if (attributeDefinition instanceof CustomAttribute customAttribute) {

--- a/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
+++ b/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
@@ -89,11 +89,6 @@ public class FilterPredicatesBuilder {
             .of(AttributeContentType.INTEGER, AttributeContentType.FLOAT, AttributeContentType.DATE,
                     AttributeContentType.TIME, AttributeContentType.DATETIME);
     private static final String JSONB_EXTRACT_PATH_TEXT_FUNCTION_NAME = "jsonb_extract_path_text";
-
-    /** The path within a stored attribute definition at which its visibility lives. */
-    private static final String DEFINITION_PROPERTIES_KEY = "properties";
-
-    private static final String VISIBLE_KEY = "visible";
     private static final String TEXTREGEXEQ_FUNCTION_NAME = "textregexeq";
     private static final String ARRAY_CONTAINS_FUNCTION_NAME = PostgresFunctionContributor.ARRAY_CONTAINS;
 
@@ -1309,17 +1304,11 @@ public class FilterPredicatesBuilder {
     }
 
     /**
-     * Whether the definition behind a content row says its attribute may be shown to a user. Read out of the stored
-     * definition document with {@code jsonb_extract_path_text}, since visibility is a property of the serialized
-     * attribute rather than a column; absent counts as visible, as it does in {@code AttributeDefinitionProperties}.
+     * Whether the definition behind a content row says its attribute may be shown to a user. Reads the mirrored column,
+     * so this cannot fall open on a document whose shape has moved.
      */
     private static Predicate definitionIsVisible(final CriteriaBuilder criteriaBuilder, final Join joinDefinition) {
-        final Expression<String> visible = criteriaBuilder
-                .function(JSONB_EXTRACT_PATH_TEXT_FUNCTION_NAME, String.class,
-                        joinDefinition.get(AttributeDefinition_.definition),
-                        criteriaBuilder.literal(DEFINITION_PROPERTIES_KEY), criteriaBuilder.literal(VISIBLE_KEY));
-        return criteriaBuilder
-                .or(criteriaBuilder.isNull(visible), criteriaBuilder.notEqual(visible, Boolean.FALSE.toString()));
+        return criteriaBuilder.isTrue(joinDefinition.get(AttributeDefinition_.visible));
     }
 
     /**
@@ -1340,6 +1329,10 @@ public class FilterPredicatesBuilder {
         // Only custom definitions carry a permission model and a visibility the platform enforces. On a data or
         // metadata definition `visible` is a connector's display hint, and the nullable `enabled` column is unset,
         // so applying either would drop rows a listing is meant to return.
+        //
+        // The projection and the catalogue do withhold a hidden data or metadata field, because those decide what is
+        // rendered and a display hint governs that. Filtering is not rendering, so such a value stays answerable here
+        // by design: the split is deliberate, not an oversight the projection predicate was meant to close.
         if (attributeType != AttributeType.CUSTOM) {
             return predicates;
         }

--- a/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
+++ b/src/main/java/com/otilm/core/util/FilterPredicatesBuilder.java
@@ -1218,9 +1218,10 @@ public class FilterPredicatesBuilder {
      *
      * <p>
      * Ordering reads a value, so it is gated like the projection that renders one: encrypted content is skipped, a
-     * disabled custom definition is skipped, and the caller's custom-attribute permissions narrow which definitions are
-     * readable at all. Whether the field may be ordered on - visible, not secret, not a code block - is settled before
-     * this by {@code ListingSortResolver} against the resource's published catalogue.
+     * definition marked not visible is skipped whatever its attribute type, a disabled custom definition is skipped,
+     * and the caller's custom-attribute permissions narrow which definitions are readable at all. That the field may be
+     * ordered on at all - not secret, not a code block, and visible in at least one of the definitions it collapses -
+     * is settled before this by {@code ListingSortResolver} against the resource's published catalogue.
      */
     public static <T> Expression<?> getAttributeSortKey(final CriteriaBuilder criteriaBuilder,
             final CommonAbstractCriteria query, final Root<T> root, final SortSpecification sort) {
@@ -1281,6 +1282,11 @@ public class FilterPredicatesBuilder {
         predicates
                 .addAll(attributeReadabilityPredicates(criteriaBuilder, joinContentItem, joinDefinition, attributeType,
                         contentFilterSource, true));
+        // A hidden definition must supply no sort key either: the order of a page is part of what it shows, and the
+        // projection filling its cells keeps only visible definitions. Custom is narrowed for every reader already.
+        if (attributeType != AttributeType.CUSTOM) {
+            predicates.add(definitionIsVisible(criteriaBuilder, joinDefinition));
+        }
 
         subquery.select(value).where(predicates.toArray(new Predicate[]{}));
         ((JpaSubQuery) subquery)
@@ -1330,9 +1336,8 @@ public class FilterPredicatesBuilder {
         // metadata definition `visible` is a connector's display hint, and the nullable `enabled` column is unset,
         // so applying either would drop rows a listing is meant to return.
         //
-        // The projection and the catalogue do withhold a hidden data or metadata field, because those decide what is
-        // rendered and a display hint governs that. Filtering is not rendering, so such a value stays answerable here
-        // by design: the split is deliberate, not an oversight the projection predicate was meant to close.
+        // A display hint governs what is rendered, so the projection and the ordering that arranges it withhold a
+        // hidden data or metadata value while a filter still matches it.
         if (attributeType != AttributeType.CUSTOM) {
             return predicates;
         }

--- a/src/main/java/com/otilm/core/util/SearchHelper.java
+++ b/src/main/java/com/otilm/core/util/SearchHelper.java
@@ -323,6 +323,7 @@ public class SearchHelper {
             .thenComparing(SearchFieldObject::getLabel, Comparator.nullsLast(Comparator.naturalOrder()))
             .thenComparing(SearchFieldObject::isList)
             .thenComparing(SearchFieldObject::isMultiSelect)
+            .thenComparing(SearchFieldObject::isVisible)
             .thenComparing(SearchFieldObject::getProtectionLevel, Comparator.nullsLast(Comparator.naturalOrder()))
             .thenComparing(field -> field.getContentItems() == null ? null : String.join("\0", field.getContentItems()),
                     Comparator.nullsLast(Comparator.naturalOrder()));
@@ -352,6 +353,11 @@ public class SearchHelper {
         // matchable.
         if (other.getProtectionLevel() != ProtectionLevel.ENCRYPTED) {
             merged.setProtectionLevel(other.getProtectionLevel());
+        }
+        // Projection and the filter predicates keep the content of every visible definition, so the collapsed field is
+        // shown whenever any definition behind it is visible.
+        if (other.isVisible()) {
+            merged.setVisible(true);
         }
         // A fixed-choice list input is only correct if every definition is a list; otherwise free-form input must
         // survive the merge, since a list rendering would make the free-form definitions' values un-enterable.

--- a/src/main/java/com/otilm/core/util/SearchHelper.java
+++ b/src/main/java/com/otilm/core/util/SearchHelper.java
@@ -1,5 +1,6 @@
 package com.otilm.core.util;
 
+import com.otilm.api.model.common.attribute.common.AttributeType;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.common.content.data.ProtectionLevel;
 import com.otilm.api.model.common.enums.BitMaskEnum;
@@ -161,7 +162,8 @@ public class SearchHelper {
         // filter the listing then refuses.
         if (attributeSearchInfo.getProtectionLevel() == ProtectionLevel.ENCRYPTED
                 || AttributeColumnProjector.WITHHELD_CONTENT_TYPES
-                        .contains(attributeSearchInfo.getAttributeContentType())) {
+                        .contains(attributeSearchInfo.getAttributeContentType())
+                || hasNoMatchableContent(attributeSearchInfo)) {
             conditionOperators = List.of(FilterConditionOperator.EMPTY, FilterConditionOperator.NOT_EMPTY);
         }
         fieldDataDto.setConditions(conditionOperators);
@@ -277,6 +279,23 @@ public class SearchHelper {
         return !AttributeColumnProjector.WITHHELD_CONTENT_TYPES.contains(attributeSearchInfo.getAttributeContentType())
                 && attributeSearchInfo.getProtectionLevel() != ProtectionLevel.ENCRYPTED
                 && attributeSearchInfo.isVisible();
+    }
+
+    /**
+     * Whether no value of this field is matchable, so the conditions published for it are the presence pair alone.
+     *
+     * <p>
+     * A custom definition marked not visible is excluded from every query that reads its content, filters included, so
+     * a value condition on it could only ever return nothing - and a published condition is one a saved list view
+     * accepts, not merely a hint. A presence condition survives because it needs no value to answer: with the content
+     * unreadable the field is empty everywhere, which is what the column beside it renders.
+     *
+     * <p>
+     * A data or metadata definition carries the same flag as a connector's display hint that filtering does not apply,
+     * so its values stay matchable and its conditions stay whole.
+     */
+    private static boolean hasNoMatchableContent(final SearchFieldObject attributeSearchInfo) {
+        return attributeSearchInfo.getAttributeType() == AttributeType.CUSTOM && !attributeSearchInfo.isVisible();
     }
 
     private static SearchFieldTypeEnum retrieveSearchFieldTypeEnumByContentType(

--- a/src/main/resources/db/migration/V202609071200__attribute_definition_visible.sql
+++ b/src/main/resources/db/migration/V202609071200__attribute_definition_visible.sql
@@ -1,0 +1,7 @@
+-- Mirrors properties.visible out of the stored definition document so projection, ordering and
+-- filtering share one predicate. Absent in the document means visible, which is the column default.
+ALTER TABLE attribute_definition ADD COLUMN visible BOOLEAN NOT NULL DEFAULT TRUE;
+
+UPDATE attribute_definition
+SET visible = FALSE
+WHERE definition -> 'properties' ->> 'visible' = 'false';

--- a/src/test/java/com/otilm/core/attribute/engine/ProjectedContentWithholdingTest.java
+++ b/src/test/java/com/otilm/core/attribute/engine/ProjectedContentWithholdingTest.java
@@ -1,0 +1,109 @@
+package com.otilm.core.attribute.engine;
+
+import com.otilm.api.model.client.certificate.SearchColumnRequestDto;
+import com.otilm.api.model.common.attribute.common.AttributeType;
+import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
+import com.otilm.api.model.common.attribute.v3.content.BaseAttributeContentV3;
+import com.otilm.api.model.common.attribute.v3.content.StringAttributeContentV3;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.search.AttributeProjectable;
+import com.otilm.api.model.core.search.FilterFieldSource;
+import com.otilm.core.attribute.engine.AttributeEngine.CustomAttributeContentFilter;
+import com.otilm.core.attribute.engine.records.ProjectedAttributeContent;
+import com.otilm.core.dao.repository.AttributeContent2ObjectRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Which loaded content rows reach a column: a row of ciphertext, and a row of a content type no list cell renders, are
+ * dropped even when the query returns them.
+ */
+class ProjectedContentWithholdingTest {
+
+    private static final UUID OBJECT_UUID = UUID.randomUUID();
+
+    private static final String ATTRIBUTE_NAME = "environment";
+
+    private static final String FIELD_IDENTIFIER = ATTRIBUTE_NAME + "|STRING";
+
+    private AttributeContent2ObjectRepository attributeContent2ObjectRepository;
+
+    private AttributeColumnProjector projector;
+
+    @BeforeEach
+    void setUp() {
+        attributeContent2ObjectRepository = mock(AttributeContent2ObjectRepository.class);
+        projector = new AttributeColumnProjector(attributeContent2ObjectRepository);
+    }
+
+    @Test
+    void anOrdinaryRowIsProjected() {
+        Map<FilterFieldSource, Map<String, List<BaseAttributeContentV3<?>>>> values = project(
+                row(AttributeContentType.STRING, null, "production"));
+
+        assertEquals(Set.of(FilterFieldSource.CUSTOM), values.keySet());
+        List<BaseAttributeContentV3<?>> projected = values.get(FilterFieldSource.CUSTOM).get(FIELD_IDENTIFIER);
+        assertEquals(1, projected.size());
+        assertEquals("production", projected.getFirst().getData());
+    }
+
+    @Test
+    void aRowStoredAsCiphertextIsNotProjected() {
+        assertNull(project(row(AttributeContentType.STRING, "ciphertext", "production")));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = AttributeContentType.class, names = {"SECRET", "CODEBLOCK"})
+    void aRowOfAWithheldContentTypeIsNotProjected(AttributeContentType withheld) {
+        assertNull(project(row(withheld, null, "production")));
+    }
+
+    private Map<FilterFieldSource, Map<String, List<BaseAttributeContentV3<?>>>> project(
+            ProjectedAttributeContent stored) {
+        when(attributeContent2ObjectRepository
+                .getProjectedAttributesContent(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(List.of(stored));
+        Entry entry = new Entry();
+
+        projector
+                .project(Resource.DISCOVERY,
+                        List.of(new SearchColumnRequestDto(FilterFieldSource.CUSTOM, FIELD_IDENTIFIER)), List.of(entry),
+                        listed -> OBJECT_UUID, () -> new CustomAttributeContentFilter(null, null));
+
+        return entry.getAttributeValues();
+    }
+
+    private static ProjectedAttributeContent row(AttributeContentType contentType, String encryptedContent,
+            String value) {
+        return new ProjectedAttributeContent(OBJECT_UUID, AttributeType.CUSTOM, ATTRIBUTE_NAME, contentType,
+                new StringAttributeContentV3(value), encryptedContent);
+    }
+
+    private static final class Entry implements AttributeProjectable {
+
+        private Map<FilterFieldSource, Map<String, List<BaseAttributeContentV3<?>>>> attributeValues;
+
+        @Override
+        public Map<FilterFieldSource, Map<String, List<BaseAttributeContentV3<?>>>> getAttributeValues() {
+            return attributeValues;
+        }
+
+        @Override
+        public void setAttributeValues(
+                Map<FilterFieldSource, Map<String, List<BaseAttributeContentV3<?>>>> attributeValues) {
+            this.attributeValues = attributeValues;
+        }
+    }
+}

--- a/src/test/java/com/otilm/core/attribute/engine/ProjectedContentWithholdingTest.java
+++ b/src/test/java/com/otilm/core/attribute/engine/ProjectedContentWithholdingTest.java
@@ -11,6 +11,7 @@ import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.core.attribute.engine.AttributeEngine.CustomAttributeContentFilter;
 import com.otilm.core.attribute.engine.records.ProjectedAttributeContent;
 import com.otilm.core.dao.repository.AttributeContent2ObjectRepository;
+import com.otilm.core.model.AttributeFieldIdentifier;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,7 +37,8 @@ class ProjectedContentWithholdingTest {
 
     private static final String ATTRIBUTE_NAME = "environment";
 
-    private static final String FIELD_IDENTIFIER = ATTRIBUTE_NAME + "|STRING";
+    private static final String FIELD_IDENTIFIER = ATTRIBUTE_NAME + AttributeFieldIdentifier.SEPARATOR
+            + AttributeContentType.STRING.name();
 
     private AttributeContent2ObjectRepository attributeContent2ObjectRepository;
 

--- a/src/test/java/com/otilm/core/integration/search/AttributeColumnProjectionITest.java
+++ b/src/test/java/com/otilm/core/integration/search/AttributeColumnProjectionITest.java
@@ -274,7 +274,7 @@ class AttributeColumnProjectionITest extends BaseSpringBootTest {
     void aHiddenAttributeColumnProjectsNoValues() throws Exception {
         // The definition says its values are not to be shown to a user, which is what a column does with them. The
         // catalogue withholds such a field, but that flag is a hint on a response the caller is free to ignore, so
-        // the projection drops the values again on the way out.
+        // the projection query excludes the definition and its values are never loaded.
         UUID hiddenUuid = registerCustomAttribute("helper-only", "Helper only", false);
         Discovery hidden = saveDiscovery("discovery-hidden-attribute");
         attributeEngine

--- a/src/test/java/com/otilm/core/integration/search/HiddenAttributeAgreementITest.java
+++ b/src/test/java/com/otilm/core/integration/search/HiddenAttributeAgreementITest.java
@@ -1,0 +1,201 @@
+package com.otilm.core.integration.search;
+
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.client.attribute.RequestAttributeV3;
+import com.otilm.api.model.client.certificate.DiscoveryResponseDto;
+import com.otilm.api.model.client.certificate.SearchColumnRequestDto;
+import com.otilm.api.model.client.certificate.SearchFilterRequestDto;
+import com.otilm.api.model.client.certificate.SearchRequestDto;
+import com.otilm.api.model.client.certificate.SearchSortRequestDto;
+import com.otilm.api.model.client.connector.v2.ConnectorVersion;
+import com.otilm.api.model.client.discovery.DiscoveryListDto;
+import com.otilm.api.model.common.attribute.common.AttributeType;
+import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
+import com.otilm.api.model.common.attribute.common.properties.CustomAttributeProperties;
+import com.otilm.api.model.common.attribute.v3.CustomAttributeV3;
+import com.otilm.api.model.common.attribute.v3.content.BaseAttributeContentV3;
+import com.otilm.api.model.common.attribute.v3.content.TextAttributeContentV3;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.connector.AuthType;
+import com.otilm.api.model.core.connector.ConnectorStatus;
+import com.otilm.api.model.core.discovery.DiscoveryStatus;
+import com.otilm.api.model.core.search.FilterConditionOperator;
+import com.otilm.api.model.core.search.FilterFieldSource;
+import com.otilm.api.model.core.search.SearchFieldDataDto;
+import com.otilm.api.model.core.search.SortDirection;
+import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.dao.entity.Connector;
+import com.otilm.core.dao.entity.Discovery;
+import com.otilm.core.dao.repository.ConnectorRepository;
+import com.otilm.core.dao.repository.DiscoveryRepository;
+import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.service.DiscoveryExternalService;
+import com.otilm.core.util.BaseSpringBootTest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.otilm.core.integration.search.CatalogueFields.field;
+import static com.otilm.core.util.builders.SearchFilterRequestDtoBuilder.aCustomAttributeFilter;
+
+/**
+ * One hidden custom attribute read through every path that has to answer whether its values may be shown: the
+ * catalogue, the column projection, an ordering and a filter. All four resolve it from the mirrored column, and this
+ * pins that they agree.
+ */
+class HiddenAttributeAgreementITest extends BaseSpringBootTest {
+
+    private static final String HIDDEN = "internal-routing";
+    private static final String VISIBLE = "environment";
+
+    @Autowired
+    private DiscoveryRepository discoveryRepository;
+
+    @Autowired
+    private ConnectorRepository connectorRepository;
+
+    @Autowired
+    private DiscoveryExternalService discoveryService;
+
+    @Autowired
+    private AttributeEngine attributeEngine;
+
+    private Discovery alpha;
+    private Discovery beta;
+
+    @BeforeEach
+    void loadData() throws Exception {
+        Connector connector = saveConnector();
+        alpha = saveDiscovery(connector, "discovery-alpha");
+        beta = saveDiscovery(connector, "discovery-beta");
+
+        UUID hiddenUuid = registerCustomAttribute(HIDDEN, false);
+        UUID visibleUuid = registerCustomAttribute(VISIBLE, true);
+
+        storeContent(alpha, hiddenUuid, HIDDEN, "aaa");
+        storeContent(beta, hiddenUuid, HIDDEN, "zzz");
+        storeContent(alpha, visibleUuid, VISIBLE, "production");
+    }
+
+    @Test
+    void theCatalogueOffersTheHiddenFieldNeitherAsAColumnNorForOrdering() {
+        SearchFieldDataDto hidden = field(discoveryService.getSearchableFieldInformationByGroup(), identifier(HIDDEN))
+                .orElseThrow();
+
+        Assertions.assertEquals(false, hidden.getDisplayable());
+        Assertions.assertEquals(false, hidden.getSortable());
+    }
+
+    @Test
+    void theCatalogueStillOffersAVisibleFieldBesideIt() {
+        SearchFieldDataDto visible = field(discoveryService.getSearchableFieldInformationByGroup(), identifier(VISIBLE))
+                .orElseThrow();
+
+        Assertions.assertEquals(true, visible.getDisplayable());
+        Assertions.assertEquals(true, visible.getSortable());
+    }
+
+    @Test
+    void aColumnOnTheHiddenFieldProjectsNothing() {
+        SearchRequestDto request = new SearchRequestDto();
+        request.setColumns(List.of(new SearchColumnRequestDto(FilterFieldSource.CUSTOM, identifier(HIDDEN))));
+
+        List<DiscoveryListDto> discoveries = list(request);
+
+        // Both fixtures on the page, so the per-entry assertion below is not vacuous. Unsorted, hence order-free.
+        Assertions.assertEquals(List.of(alpha.getName(), beta.getName()), names(request).stream().sorted().toList());
+        for (DiscoveryListDto discovery : discoveries) {
+            Assertions.assertNull(discovery.getAttributeValues());
+        }
+    }
+
+    @Test
+    void anOrderingOnTheHiddenFieldIsRefused() {
+        SearchRequestDto request = new SearchRequestDto();
+        request.setSort(new SearchSortRequestDto(FilterFieldSource.CUSTOM, identifier(HIDDEN), SortDirection.ASC));
+
+        Assertions.assertThrows(ValidationException.class, () -> names(request));
+    }
+
+    @Test
+    void anOrderingOnTheVisibleFieldIsApplied() {
+        SearchRequestDto request = new SearchRequestDto();
+        request.setSort(new SearchSortRequestDto(FilterFieldSource.CUSTOM, identifier(VISIBLE), SortDirection.ASC));
+
+        Assertions.assertEquals(List.of(alpha.getName(), beta.getName()), names(request));
+    }
+
+    @Test
+    void aFilterOnTheHiddenFieldMatchesNothing() {
+        SearchRequestDto request = new SearchRequestDto();
+        SearchFilterRequestDto filter = aCustomAttributeFilter(HIDDEN, AttributeContentType.TEXT,
+                FilterConditionOperator.EQUALS, "aaa");
+        request.setFilters(List.of(filter));
+
+        Assertions.assertEquals(List.of(), names(request));
+    }
+
+    private List<String> names(SearchRequestDto request) {
+        return list(request).stream().map(DiscoveryListDto::getName).toList();
+    }
+
+    private List<DiscoveryListDto> list(SearchRequestDto request) {
+        DiscoveryResponseDto response = discoveryService.listDiscoveries(SecurityFilter.create(), request);
+        return response.getDiscoveries();
+    }
+
+    private static String identifier(String attributeName) {
+        return attributeName + "|" + AttributeContentType.TEXT.name();
+    }
+
+    private UUID registerCustomAttribute(String name, boolean visible) throws Exception {
+        CustomAttributeV3 attribute = new CustomAttributeV3();
+        attribute.setUuid(UUID.randomUUID().toString());
+        attribute.setName(name);
+        attribute.setType(AttributeType.CUSTOM);
+        attribute.setContentType(AttributeContentType.TEXT);
+        CustomAttributeProperties properties = new CustomAttributeProperties();
+        properties.setLabel(name);
+        properties.setVisible(visible);
+        attribute.setProperties(properties);
+        attributeEngine.updateCustomAttributeDefinition(attribute, List.of(Resource.DISCOVERY));
+        return UUID.fromString(attribute.getUuid());
+    }
+
+    private void storeContent(Discovery discovery, UUID definitionUuid, String name, String value) throws Exception {
+        RequestAttributeV3 requestAttribute = new RequestAttributeV3();
+        requestAttribute.setUuid(definitionUuid);
+        requestAttribute.setName(name);
+        List<BaseAttributeContentV3<?>> content = new ArrayList<>();
+        content.add(new TextAttributeContentV3(null, value));
+        requestAttribute.setContent(content);
+        attributeEngine
+                .updateObjectCustomAttributesContent(Resource.DISCOVERY, discovery.getUuid(),
+                        List.of(requestAttribute));
+    }
+
+    private Connector saveConnector() {
+        Connector saved = new Connector();
+        saved.setName("hidden-attribute-connector");
+        saved.setUrl("http://localhost:0/hidden-attribute");
+        saved.setVersion(ConnectorVersion.V2);
+        saved.setStatus(ConnectorStatus.CONNECTED);
+        saved.setAuthType(AuthType.NONE);
+        return connectorRepository.save(saved);
+    }
+
+    private Discovery saveDiscovery(Connector connector, String name) {
+        Discovery discovery = new Discovery();
+        discovery.setName(name);
+        discovery.setConnectorUuid(connector.getUuid());
+        discovery.setConnectorName(connector.getName());
+        discovery.setStatus(DiscoveryStatus.COMPLETED);
+        discovery.setConnectorStatus(DiscoveryStatus.COMPLETED);
+        discovery.setKind("test-kind");
+        return discoveryRepository.save(discovery);
+    }
+}

--- a/src/test/java/com/otilm/core/integration/search/HiddenAttributeAgreementITest.java
+++ b/src/test/java/com/otilm/core/integration/search/HiddenAttributeAgreementITest.java
@@ -12,8 +12,11 @@ import com.otilm.api.model.client.discovery.DiscoveryListDto;
 import com.otilm.api.model.common.attribute.common.AttributeType;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.common.properties.CustomAttributeProperties;
+import com.otilm.api.model.common.attribute.common.properties.MetadataAttributeProperties;
 import com.otilm.api.model.common.attribute.v3.CustomAttributeV3;
+import com.otilm.api.model.common.attribute.v3.MetadataAttributeV3;
 import com.otilm.api.model.common.attribute.v3.content.BaseAttributeContentV3;
+import com.otilm.api.model.common.attribute.v3.content.StringAttributeContentV3;
 import com.otilm.api.model.common.attribute.v3.content.TextAttributeContentV3;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.connector.AuthType;
@@ -24,6 +27,7 @@ import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.api.model.core.search.SearchFieldDataDto;
 import com.otilm.api.model.core.search.SortDirection;
 import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.dao.entity.Connector;
 import com.otilm.core.dao.entity.Discovery;
 import com.otilm.core.dao.repository.ConnectorRepository;
@@ -41,16 +45,25 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static com.otilm.core.integration.search.CatalogueFields.field;
 import static com.otilm.core.util.builders.SearchFilterRequestDtoBuilder.aCustomAttributeFilter;
+import static com.otilm.core.util.builders.SearchFilterRequestDtoBuilder.aMetaAttributeFilter;
 
 /**
  * One hidden custom attribute read through every path that has to answer whether its values may be shown: the
  * catalogue, the column projection, an ordering and a filter. All four resolve it from the mirrored column, and this
  * pins that they agree.
+ *
+ * <p>
+ * The metadata cases beside them pin the one place the paths diverge: a metadata definition carries the flag as a
+ * connector display hint, so it withholds a column and a sort key but leaves the values filterable.
  */
 class HiddenAttributeAgreementITest extends BaseSpringBootTest {
 
     private static final String HIDDEN = "internal-routing";
     private static final String VISIBLE = "environment";
+
+    /** Registered twice, once hidden and once visible, which is what collapses into one catalogue field. */
+    private static final String DUPLICATED_META = "connector-region";
+    private static final String HIDDEN_META = "connector-internal";
 
     @Autowired
     private DiscoveryRepository discoveryRepository;
@@ -64,12 +77,13 @@ class HiddenAttributeAgreementITest extends BaseSpringBootTest {
     @Autowired
     private AttributeEngine attributeEngine;
 
+    private Connector connector;
     private Discovery alpha;
     private Discovery beta;
 
     @BeforeEach
     void loadData() throws Exception {
-        Connector connector = saveConnector();
+        connector = saveConnector();
         alpha = saveDiscovery(connector, "discovery-alpha");
         beta = saveDiscovery(connector, "discovery-beta");
 
@@ -79,6 +93,12 @@ class HiddenAttributeAgreementITest extends BaseSpringBootTest {
         storeContent(alpha, hiddenUuid, HIDDEN, "aaa");
         storeContent(beta, hiddenUuid, HIDDEN, "zzz");
         storeContent(alpha, visibleUuid, VISIBLE, "production");
+
+        // The lower value sits behind the hidden definition, so an ordering that reads it puts alpha first -
+        // which is also the fixture order, so the expected sequence cannot arise from a sort that never ran.
+        storeMetadata(alpha, DUPLICATED_META, "aaa", false);
+        storeMetadata(beta, DUPLICATED_META, "zzz", true);
+        storeMetadata(alpha, HIDDEN_META, "internal", false);
     }
 
     @Test
@@ -91,12 +111,23 @@ class HiddenAttributeAgreementITest extends BaseSpringBootTest {
     }
 
     @Test
+    void theCatalogueOffersTheHiddenFieldNoValueCondition() {
+        SearchFieldDataDto hidden = field(discoveryService.getSearchableFieldInformationByGroup(), identifier(HIDDEN))
+                .orElseThrow();
+
+        Assertions
+                .assertEquals(List.of(FilterConditionOperator.EMPTY, FilterConditionOperator.NOT_EMPTY),
+                        hidden.getConditions());
+    }
+
+    @Test
     void theCatalogueStillOffersAVisibleFieldBesideIt() {
         SearchFieldDataDto visible = field(discoveryService.getSearchableFieldInformationByGroup(), identifier(VISIBLE))
                 .orElseThrow();
 
         Assertions.assertEquals(true, visible.getDisplayable());
         Assertions.assertEquals(true, visible.getSortable());
+        Assertions.assertTrue(visible.getConditions().contains(FilterConditionOperator.EQUALS));
     }
 
     @Test
@@ -139,6 +170,44 @@ class HiddenAttributeAgreementITest extends BaseSpringBootTest {
         Assertions.assertEquals(List.of(), names(request));
     }
 
+    @Test
+    void aHiddenMetadataFieldKeepsItsValueConditionsAndStaysFilterable() {
+        SearchFieldDataDto hiddenMeta = field(discoveryService.getSearchableFieldInformationByGroup(),
+                identifier(HIDDEN_META, AttributeContentType.STRING)).orElseThrow();
+        SearchRequestDto request = new SearchRequestDto();
+        request
+                .setFilters(List
+                        .of(aMetaAttributeFilter(HIDDEN_META, AttributeContentType.STRING,
+                                FilterConditionOperator.EQUALS, "internal")));
+
+        Assertions.assertTrue(hiddenMeta.getConditions().contains(FilterConditionOperator.EQUALS));
+        Assertions.assertEquals(List.of(alpha.getName()), names(request));
+    }
+
+    @Test
+    void anOrderingOnADuplicatedMetadataFieldReadsOnlyTheVisibleDefinition() {
+        String metadataField = identifier(DUPLICATED_META, AttributeContentType.STRING);
+        SearchRequestDto request = new SearchRequestDto();
+        request.setSort(new SearchSortRequestDto(FilterFieldSource.META, metadataField, SortDirection.ASC));
+        request.setColumns(List.of(new SearchColumnRequestDto(FilterFieldSource.META, metadataField)));
+
+        List<DiscoveryListDto> discoveries = list(request);
+
+        Assertions
+                .assertEquals(List.of(beta.getName(), alpha.getName()),
+                        discoveries.stream().map(DiscoveryListDto::getName).toList());
+        Assertions
+                .assertEquals("zzz",
+                        discoveries
+                                .getFirst()
+                                .getAttributeValues()
+                                .get(FilterFieldSource.META)
+                                .get(metadataField)
+                                .getFirst()
+                                .getData());
+        Assertions.assertNull(discoveries.getLast().getAttributeValues());
+    }
+
     private List<String> names(SearchRequestDto request) {
         return list(request).stream().map(DiscoveryListDto::getName).toList();
     }
@@ -149,7 +218,11 @@ class HiddenAttributeAgreementITest extends BaseSpringBootTest {
     }
 
     private static String identifier(String attributeName) {
-        return attributeName + "|" + AttributeContentType.TEXT.name();
+        return identifier(attributeName, AttributeContentType.TEXT);
+    }
+
+    private static String identifier(String attributeName, AttributeContentType contentType) {
+        return attributeName + "|" + contentType.name();
     }
 
     private UUID registerCustomAttribute(String name, boolean visible) throws Exception {
@@ -164,6 +237,27 @@ class HiddenAttributeAgreementITest extends BaseSpringBootTest {
         attribute.setProperties(properties);
         attributeEngine.updateCustomAttributeDefinition(attribute, List.of(Resource.DISCOVERY));
         return UUID.fromString(attribute.getUuid());
+    }
+
+    /** A fresh attribute uuid each call, which is what registers a second definition under the same name. */
+    private void storeMetadata(Discovery discovery, String name, String value, boolean visible) throws Exception {
+        MetadataAttributeV3 meta = new MetadataAttributeV3();
+        meta.setUuid(UUID.randomUUID().toString());
+        meta.setName(name);
+        meta.setType(AttributeType.META);
+        meta.setContentType(AttributeContentType.STRING);
+        MetadataAttributeProperties properties = new MetadataAttributeProperties();
+        properties.setLabel(name);
+        properties.setVisible(visible);
+        properties.setGlobal(false);
+        meta.setProperties(properties);
+        meta.setContent(List.of(new StringAttributeContentV3(value)));
+        attributeEngine
+                .updateMetadataAttribute(meta,
+                        ObjectAttributeContentInfo
+                                .builder(Resource.DISCOVERY, discovery.getUuid())
+                                .connector(connector.getUuid())
+                                .build());
     }
 
     private void storeContent(Discovery discovery, UUID definitionUuid, String name, String value) throws Exception {

--- a/src/test/java/com/otilm/core/integration/util/SearchHelperITest.java
+++ b/src/test/java/com/otilm/core/integration/util/SearchHelperITest.java
@@ -62,20 +62,20 @@ class SearchHelperITest extends BaseSpringBootTest {
         attributeV3.setContentType(AttributeContentType.DATE);
         attributeV3.setProperties(dataAttributeProperties);
         SearchFieldObject searchFieldObject = new SearchFieldObject(attributeV3.getName(), attributeV3.getContentType(),
-                AttributeType.DATA, "label", attributeV3);
+                AttributeType.DATA, "label", true, attributeV3);
         assertThat(searchFieldObject.getContentItems()).isEqualTo(List.of(now.toString()));
 
         dataAttributeProperties.setList(false);
         attributeV3.setProperties(dataAttributeProperties);
         searchFieldObject = new SearchFieldObject(attributeV3.getName(), attributeV3.getContentType(),
-                AttributeType.DATA, "label", attributeV3);
+                AttributeType.DATA, "label", true, attributeV3);
         assertThat(searchFieldObject.getContentItems()).isNull();
 
         dataAttributeProperties.setList(true);
         dataAttributeProperties.setProtectionLevel(ProtectionLevel.ENCRYPTED);
         attributeV3.setProperties(dataAttributeProperties);
         searchFieldObject = new SearchFieldObject(attributeV3.getName(), attributeV3.getContentType(),
-                AttributeType.DATA, "label", attributeV3);
+                AttributeType.DATA, "label", true, attributeV3);
         assertThat(searchFieldObject.getContentItems()).isNull();
 
         CustomAttributeV3 customAttributeV3 = new CustomAttributeV3();
@@ -86,19 +86,19 @@ class SearchHelperITest extends BaseSpringBootTest {
         customAttributeV3.setContentType(AttributeContentType.DATE);
         customAttributeV3.setProperties(customAttributeProperties);
         searchFieldObject = new SearchFieldObject(customAttributeV3.getName(), customAttributeV3.getContentType(),
-                AttributeType.CUSTOM, "label", customAttributeV3);
+                AttributeType.CUSTOM, "label", true, customAttributeV3);
         assertThat(searchFieldObject.getContentItems()).isEqualTo(List.of("string"));
 
         customAttributeProperties.setList(false);
         customAttributeV3.setProperties(customAttributeProperties);
         searchFieldObject = new SearchFieldObject(customAttributeV3.getName(), customAttributeV3.getContentType(),
-                AttributeType.CUSTOM, "label", customAttributeV3);
+                AttributeType.CUSTOM, "label", true, customAttributeV3);
         assertThat(searchFieldObject.getContentItems()).isNull();
         customAttributeProperties.setList(true);
         customAttributeProperties.setProtectionLevel(ProtectionLevel.ENCRYPTED);
         customAttributeV3.setProperties(customAttributeProperties);
         searchFieldObject = new SearchFieldObject(customAttributeV3.getName(), customAttributeV3.getContentType(),
-                AttributeType.CUSTOM, "label", customAttributeV3);
+                AttributeType.CUSTOM, "label", true, customAttributeV3);
         assertThat(searchFieldObject.getContentItems()).isNull();
 
     }

--- a/src/test/java/com/otilm/core/integration/util/SearchHelperITest.java
+++ b/src/test/java/com/otilm/core/integration/util/SearchHelperITest.java
@@ -222,6 +222,41 @@ class SearchHelperITest extends BaseSpringBootTest {
     }
 
     @Test
+    void testPrepareSearchForJSONMergedFieldIsVisibleWhenAnyDuplicateIsVisible() {
+        List<SearchFieldDataDto> fields = SearchHelper
+                .prepareSearchForJSON(List.of(visibilityFieldObject(false), visibilityFieldObject(true)),
+                        Resource.DISCOVERY);
+        List<SearchFieldDataDto> fieldsReversed = SearchHelper
+                .prepareSearchForJSON(List.of(visibilityFieldObject(true), visibilityFieldObject(false)),
+                        Resource.DISCOVERY);
+
+        assertThat(fields).hasSize(1);
+        assertThat(fields.getFirst().getDisplayable())
+                .as("projection and filtering keep the visible definition's content, so the field must be offered")
+                .isTrue();
+        assertThat(fieldsReversed.getFirst().getDisplayable())
+                .as("and not depend on the (unordered) query result order")
+                .isTrue();
+    }
+
+    @Test
+    void testPrepareSearchForJSONMergedFieldStaysHiddenWhenEveryDuplicateIsHidden() {
+        List<SearchFieldDataDto> fields = SearchHelper
+                .prepareSearchForJSON(List.of(visibilityFieldObject(false), visibilityFieldObject(false)),
+                        Resource.DISCOVERY);
+
+        assertThat(fields).hasSize(1);
+        assertThat(fields.getFirst().getDisplayable()).isFalse();
+    }
+
+    private static SearchFieldObject visibilityFieldObject(boolean visible) {
+        SearchFieldObject field = new SearchFieldObject("username", AttributeContentType.STRING, AttributeType.META);
+        field.setLabel("Username");
+        field.setVisible(visible);
+        return field;
+    }
+
+    @Test
     void testPrepareSearchForJSONMergeIsDeterministicRegardlessOfInputOrder() {
         SearchFieldObject labeledUser = new SearchFieldObject("username", AttributeContentType.STRING,
                 AttributeType.META);


### PR DESCRIPTION
`AttributeDefinition` mirrors `required`, `readOnly` and `enabled` as real columns but kept `visible` only inside the serialized definition document. Three read paths had to answer "may this attribute's values be shown to a user", and each reached it differently:

- `AttributeColumnProjector` read it off the deserialized definition, per row, after loading.
- `SearchHelper` derived it when building the catalogue.
- `FilterPredicatesBuilder.definitionIsVisible` extracted `properties -> visible` with `jsonb_extract_path_text` inside the query, and treated an absent value as visible.

The last one fails open. If the interfaces attribute model renames the property or nests it one level deeper, the extraction returns NULL for every definition, every predicate passes, and hidden content becomes filterable again — while the projector, reading the deserialized object, still hides it. Nothing fails to compile and no test catches the divergence.

## The change

`attribute_definition` carries `visible` alongside the other three, backfilled from the stored document by `V202609071200`. All three paths read that column.

`AttributeDefinition.setDefinition` re-derives the column from the definition it stores, which is what keeps the two in step: the entity is the only writer, and the value comes from `properties.isVisible()` — a typed accessor. A rename in the interfaces model is now a compile error rather than a silent authorization gap, which is the point of the issue.

The projection turns its per-row Java check into a query predicate, so `ProjectedAttributeContent` no longer carries the definition document it held solely for this flag, and the listing query stops loading a jsonb blob per content row.

## Scope held deliberately

The filter path applies visibility to `CUSTOM` definitions only, while the projection and the catalogue apply it to every type. That asymmetry predates this change and is preserved: on a data or metadata definition `visible` is a connector's display hint, so it governs what is rendered but not what is filterable, and enforcing it in filters would stop matching metadata callers filter on today. The comment above the early return now says so, so the new projection predicate is not read as evidence the split was meant to close.

## Verification

- `mvn -P test-integration-core` — 1133 tests, 0 failures.
- `HiddenAttributeAgreementITest` — one hidden custom attribute through the catalogue, a column, an ordering and a filter, with a visible control beside it.
- The migration was applied to a Postgres 16 instance and backfills correctly for every shape the document takes: explicit `false`, explicit `true`, `properties` without the key, and no `properties` at all. Core's tests build the schema from entities and never run Flyway, so this is the only coverage the migration has.

Closes #2220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hidden attributes are now consistently excluded from search results, projections, filtering, and sorting.
  * Visible attributes continue to support display, filtering, sorting, and ordering.
  * Attribute visibility is persisted and applied consistently across search and discovery operations.
* **Tests**
  * Added coverage verifying behavior for hidden and visible custom attributes across search paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->