### PR TITLE
Backport the ACME DNS-01 challenge fix to match every published TXT record

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@ A purely line-based local script will systematically over-report. Match the form
 
 When a test passes but JaCoCo (or the coverage report) shows the relevant lines as uncovered, the test is reaching a different code path than expected — usually a `catch (Exception)` upstream is swallowing the actual flow before the asserted code runs. Investigate the trace, don't trust the green. Common signal: the assertion checks the *type* of an exception or response without checking the *origin*; the test passes because *any* exception of that type is thrown, including ones from setup steps.
 
+A mock shaped like the implementation proves nothing either. When a test stubs a collaborator at whatever nesting level the production code happens to read — one `when(attr.get())` because the code calls `get()`, one enumeration entry because the loop reads one — the test passes for every input the code already handles and cannot fail for the input it mishandles. It encodes the bug as the expectation. Prefer a real instance of the collaborator's value type (`BasicAttributes`, a real DTO, a real record) built to look like what the external system actually returns, and mock only the boundary you cannot construct. If a mock's stubbing mirrors the production call sequence line for line, it is asserting that the code does what it does.
+
 For logic deep in private methods or complex Spring contexts, extract a static testable kernel — a pure function that takes inputs and returns outputs — and unit-test it independently. Keep the integration test for the integration concerns (DB, AOP, transactions). The kernel + integration split makes both halves much easier to reason about.
 
 ## Transactions and external calls

--- a/src/main/java/com/otilm/core/dao/entity/acme/AcmeChallenge.java
+++ b/src/main/java/com/otilm/core/dao/entity/acme/AcmeChallenge.java
@@ -7,15 +7,24 @@ import com.otilm.core.dao.entity.UniquelyIdentifiedAndAudited;
 import com.otilm.core.service.acme.AcmeConstants;
 import com.otilm.core.util.AcmeCommonHelper;
 import com.otilm.core.util.DtoMapper;
-import jakarta.persistence.*;
-import lombok.*;
-import org.hibernate.proxy.HibernateProxy;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Objects;
 import java.util.UUID;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.proxy.HibernateProxy;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @Getter
 @Setter
@@ -25,21 +34,21 @@ import java.util.UUID;
 @Table(name = "acme_challenge")
 public class AcmeChallenge extends UniquelyIdentifiedAndAudited implements Serializable, DtoMapper<Challenge> {
 
-    @Column(name="challenge_id")
+    @Column(name = "challenge_id")
     private String challengeId;
 
-    @Column(name="type")
+    @Column(name = "type")
     @Enumerated(EnumType.STRING)
     private ChallengeType type;
 
-    @Column(name="token")
+    @Column(name = "token")
     private String token;
 
-    @Column(name="status")
+    @Column(name = "status")
     @Enumerated(EnumType.STRING)
     private ChallengeStatus status;
 
-    @Column(name="validated")
+    @Column(name = "validated")
     private Date validated;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -51,7 +60,7 @@ public class AcmeChallenge extends UniquelyIdentifiedAndAudited implements Seria
     private UUID authorizationUuid;
 
     @Override
-    public Challenge mapToDto(){
+    public Challenge mapToDto() {
         Challenge challenge = new Challenge();
         challenge.setStatus(status);
         challenge.setToken(token);
@@ -68,7 +77,7 @@ public class AcmeChallenge extends UniquelyIdentifiedAndAudited implements Seria
 
     // Custom Getter for Challenge URL
     private String getBaseUrl() {
-        if(ServletUriComponentsBuilder.fromCurrentRequestUri().build().toUriString().contains("/raProfile/")){
+        if (ServletUriComponentsBuilder.fromCurrentRequestUri().build().toUriString().contains("/raProfile/")) {
             return ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString()
                     + AcmeConstants.ACME_URI_HEADER + "/raProfile/"
                     + authorization.getOrder().getAcmeAccount().getRaProfile().getName();
@@ -84,17 +93,29 @@ public class AcmeChallenge extends UniquelyIdentifiedAndAudited implements Seria
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null) return false;
-        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
-        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
-        if (thisEffectiveClass != oEffectiveClass) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+        Class<?> oEffectiveClass = o instanceof HibernateProxy
+                ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass()
+                : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy
+                ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass()
+                : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) {
+            return false;
+        }
         AcmeChallenge that = (AcmeChallenge) o;
         return getUuid() != null && Objects.equals(getUuid(), that.getUuid());
     }
 
     @Override
     public final int hashCode() {
-        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+        return this instanceof HibernateProxy
+                ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode()
+                : getClass().hashCode();
     }
 }

--- a/src/main/java/com/otilm/core/dao/entity/acme/AcmeChallenge.java
+++ b/src/main/java/com/otilm/core/dao/entity/acme/AcmeChallenge.java
@@ -3,6 +3,8 @@ package com.otilm.core.dao.entity.acme;
 import com.otilm.api.model.core.acme.Challenge;
 import com.otilm.api.model.core.acme.ChallengeStatus;
 import com.otilm.api.model.core.acme.ChallengeType;
+import com.otilm.api.model.core.acme.Problem;
+import com.otilm.api.model.core.acme.ProblemDocument;
 import com.otilm.core.dao.entity.UniquelyIdentifiedAndAudited;
 import com.otilm.core.service.acme.AcmeConstants;
 import com.otilm.core.util.AcmeCommonHelper;
@@ -16,7 +18,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.io.Serializable;
-import java.util.Date;
+import java.time.OffsetDateTime;
 import java.util.Objects;
 import java.util.UUID;
 import lombok.Getter;
@@ -49,7 +51,14 @@ public class AcmeChallenge extends UniquelyIdentifiedAndAudited implements Seria
     private ChallengeStatus status;
 
     @Column(name = "validated")
-    private Date validated;
+    private OffsetDateTime validated;
+
+    @Column(name = "error_problem")
+    @Enumerated(EnumType.STRING)
+    private Problem errorProblem;
+
+    @Column(name = "error_detail", length = Integer.MAX_VALUE)
+    private String errorDetail;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "authorization_uuid", nullable = false, insertable = false, updatable = false)
@@ -67,7 +76,24 @@ public class AcmeChallenge extends UniquelyIdentifiedAndAudited implements Seria
         challenge.setType(type);
         challenge.setUrl(getUrl());
         challenge.setValidated(AcmeCommonHelper.getStringFromDate(validated));
+        challenge.setError(mapErrorToDto());
         return challenge;
+    }
+
+    /**
+     * Reason of a failed validation, as the problem document the client reads back.
+     *
+     * <p>
+     * The {@link Problem} constants are shared and carry a mutable detail, so the recorded detail is set on the
+     * document rather than on the constant.
+     */
+    private ProblemDocument mapErrorToDto() {
+        if (errorProblem == null) {
+            return null;
+        }
+        ProblemDocument error = new ProblemDocument(errorProblem);
+        error.setDetail(errorDetail);
+        return error;
     }
 
     public void setAuthorization(AcmeAuthorization authorization) {

--- a/src/main/java/com/otilm/core/dao/repository/acme/AcmeAccountRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/acme/AcmeAccountRepository.java
@@ -2,6 +2,7 @@ package com.otilm.core.dao.repository.acme;
 
 import com.otilm.core.dao.entity.acme.AcmeAccount;
 import com.otilm.core.dao.repository.SecurityFilterRepository;
+import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.Modifying;
@@ -18,6 +19,30 @@ public interface AcmeAccountRepository extends SecurityFilterRepository<AcmeAcco
     AcmeAccount findByPublicKey(String publicKey);
 
     boolean existsByAcmeProfileUuidAndIsDefaultRaProfileTrue(UUID acmeProfileUuid);
+
+    /**
+     * Counts one more failed order against the account in the database itself, so that orders of one account failing
+     * concurrently cannot lose a count the way a read-modify-write of the entity would.
+     */
+    @Modifying(flushAutomatically = true)
+    @Query("UPDATE AcmeAccount a SET a.failedOrders = a.failedOrders + 1, a.updated = :now WHERE a.uuid = :uuid")
+    int incrementFailedOrders(@Param("uuid") UUID uuid, @Param("now") OffsetDateTime now);
+
+    /**
+     * Counts one more valid order against the account in the database itself, for the same reason as
+     * {@link #incrementFailedOrders(UUID, OffsetDateTime)}.
+     */
+    @Modifying(flushAutomatically = true)
+    @Query("UPDATE AcmeAccount a SET a.validOrders = a.validOrders + 1, a.updated = :now WHERE a.uuid = :uuid")
+    int incrementValidOrders(@Param("uuid") UUID uuid, @Param("now") OffsetDateTime now);
+
+    /**
+     * Counts several failed orders against the account in one statement, so a caller that settles a batch of orders
+     * writes the account once, after it holds every row lock it needs.
+     */
+    @Modifying(flushAutomatically = true)
+    @Query("UPDATE AcmeAccount a SET a.failedOrders = a.failedOrders + :count, a.updated = :now WHERE a.uuid = :uuid")
+    int incrementFailedOrdersBy(@Param("uuid") UUID uuid, @Param("count") int count, @Param("now") OffsetDateTime now);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE AcmeAccount a SET a.raProfileUuid = :newRaProfileUuid WHERE a.acmeProfileUuid = :acmeProfileUuid AND a.isDefaultRaProfile = true")

--- a/src/main/java/com/otilm/core/dao/repository/acme/AcmeAccountRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/acme/AcmeAccountRepository.java
@@ -2,22 +2,25 @@ package com.otilm.core.dao.repository.acme;
 
 import com.otilm.core.dao.entity.acme.AcmeAccount;
 import com.otilm.core.dao.repository.SecurityFilterRepository;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-import java.util.UUID;
-
 @Repository
 public interface AcmeAccountRepository extends SecurityFilterRepository<AcmeAccount, Long> {
     Optional<AcmeAccount> findByUuid(UUID uuid);
+
     Optional<AcmeAccount> findByAccountId(String accountId);
+
     AcmeAccount findByPublicKey(String publicKey);
+
     boolean existsByAcmeProfileUuidAndIsDefaultRaProfileTrue(UUID acmeProfileUuid);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE AcmeAccount a SET a.raProfileUuid = :newRaProfileUuid WHERE a.acmeProfileUuid = :acmeProfileUuid AND a.isDefaultRaProfile = true")
-    void updateRaProfileForDefaultAccounts(@Param("acmeProfileUuid") UUID acmeProfileUuid, @Param("newRaProfileUuid") UUID newRaProfileUuid);
+    void updateRaProfileForDefaultAccounts(@Param("acmeProfileUuid") UUID acmeProfileUuid,
+            @Param("newRaProfileUuid") UUID newRaProfileUuid);
 }

--- a/src/main/java/com/otilm/core/dao/repository/acme/AcmeChallengeRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/acme/AcmeChallengeRepository.java
@@ -14,4 +14,19 @@ public interface AcmeChallengeRepository extends SecurityFilterRepository<AcmeCh
 
     @EntityGraph(attributePaths = {"authorization"})
     Optional<AcmeChallenge> findByChallengeId(String challengeId);
+
+    /**
+     * Loads the challenge with its authorization, order, account and the account's profiles, which is everything the
+     * challenge endpoint reads and returns. The endpoint runs without a transaction so that the DNS and HTTP lookups do
+     * not hold one, and nothing may be loaded lazily once it has left the query.
+     */
+    @EntityGraph(attributePaths = {
+            "authorization",
+            "authorization.order",
+            "authorization.order.authorizations",
+            "authorization.order.authorizations.challenges",
+            "authorization.order.acmeAccount",
+            "authorization.order.acmeAccount.acmeProfile",
+            "authorization.order.acmeAccount.raProfile"})
+    Optional<AcmeChallenge> findWithContextByChallengeId(String challengeId);
 }

--- a/src/main/java/com/otilm/core/dao/repository/acme/AcmeChallengeRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/acme/AcmeChallengeRepository.java
@@ -2,11 +2,10 @@ package com.otilm.core.dao.repository.acme;
 
 import com.otilm.core.dao.entity.acme.AcmeChallenge;
 import com.otilm.core.dao.repository.SecurityFilterRepository;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AcmeChallengeRepository extends SecurityFilterRepository<AcmeChallenge, Long> {

--- a/src/main/java/com/otilm/core/dao/repository/acme/AcmeOrderRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/acme/AcmeOrderRepository.java
@@ -3,9 +3,11 @@ package com.otilm.core.dao.repository.acme;
 import com.otilm.core.dao.entity.acme.AcmeAccount;
 import com.otilm.core.dao.entity.acme.AcmeOrder;
 import com.otilm.core.dao.repository.SecurityFilterRepository;
+import jakarta.persistence.LockModeType;
 import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -18,6 +20,14 @@ public interface AcmeOrderRepository extends SecurityFilterRepository<AcmeOrder,
     Optional<AcmeOrder> findByOrderId(String orderId);
 
     Optional<AcmeOrder> findByCertificateId(String certificateId);
+
+    /**
+     * Locks the order row ({@code SELECT ... FOR UPDATE}) so that every status write to the order, its authorizations
+     * and their challenges is serialised on it. Must be called inside an active transaction, otherwise the lock is
+     * released as soon as the query completes.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<AcmeOrder> findWithLockByUuid(UUID uuid);
 
     @Modifying
     @Query(value = """

--- a/src/main/java/com/otilm/core/dao/repository/acme/AcmeOrderRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/acme/AcmeOrderRepository.java
@@ -3,13 +3,12 @@ package com.otilm.core.dao.repository.acme;
 import com.otilm.core.dao.entity.acme.AcmeAccount;
 import com.otilm.core.dao.entity.acme.AcmeOrder;
 import com.otilm.core.dao.repository.SecurityFilterRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
-
 import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AcmeOrderRepository extends SecurityFilterRepository<AcmeOrder, Long> {

--- a/src/main/java/com/otilm/core/service/acme/AcmeChallengeStateMachine.java
+++ b/src/main/java/com/otilm/core/service/acme/AcmeChallengeStateMachine.java
@@ -1,0 +1,165 @@
+package com.otilm.core.service.acme;
+
+import com.otilm.api.model.core.acme.AuthorizationStatus;
+import com.otilm.api.model.core.acme.ChallengeStatus;
+import com.otilm.api.model.core.acme.OrderStatus;
+import com.otilm.api.model.core.certificate.CertificateState;
+import com.otilm.core.dao.entity.acme.AcmeAuthorization;
+import com.otilm.core.dao.entity.acme.AcmeChallenge;
+import com.otilm.core.dao.entity.acme.AcmeOrder;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Status transitions a challenge validation attempt implies for the challenge, its authorization and its order (RFC
+ * 8555 section 7.1.6).
+ */
+public final class AcmeChallengeStateMachine {
+
+    private AcmeChallengeStateMachine() {
+    }
+
+    /**
+     * Records the outcome on the challenge and propagates it to the authorization and the order.
+     *
+     * <p>
+     * A failed attempt invalidates both. An authorization left pending behind a failed challenge can never settle, so a
+     * client waiting for it to reach a final status waits until its own request deadline expires instead of learning
+     * that validation failed.
+     *
+     * <p>
+     * Both final statuses are terminal, so this may only be applied to a pending challenge of a pending authorization.
+     * Applying it to an authorization that has already settled would move it back out of a final status, which the
+     * protocol does not allow.
+     *
+     * @param challenge the validated challenge, reached from its authorization and order
+     * @param result verdict to apply
+     */
+    public static void applyValidationResult(AcmeChallenge challenge, ChallengeValidationResult result) {
+        AcmeAuthorization authorization = challenge.getAuthorization();
+        AcmeOrder order = authorization.getOrder();
+
+        if (result.valid()) {
+            challenge.setValidated(OffsetDateTime.now(ZoneOffset.UTC));
+            challenge.setStatus(ChallengeStatus.VALID);
+            authorization.setStatus(AuthorizationStatus.VALID);
+            // An order carries an authorization per identifier and is ready to finalize only once all of them
+            // have been proven (RFC 8555 section 7.1.6).
+            if (order.getStatus() == OrderStatus.PENDING && order
+                    .getAuthorizations()
+                    .stream()
+                    .allMatch(candidate -> candidate.getStatus() == AuthorizationStatus.VALID)) {
+                order.setStatus(OrderStatus.READY);
+            }
+            return;
+        }
+
+        challenge.setStatus(ChallengeStatus.INVALID);
+        challenge.setErrorProblem(result.problem());
+        challenge.setErrorDetail(result.detail());
+        authorization.setStatus(AuthorizationStatus.INVALID);
+        invalidateOrder(order);
+    }
+
+    /**
+     * Whether the order holds a status an instance without failure propagation left behind: an authorization still
+     * pending behind a failed challenge, or the order still open behind a failed authorization.
+     */
+    public static boolean hasStaleStatus(AcmeOrder order) {
+        boolean authorizationBehindFailedChallenge = order
+                .getAuthorizations()
+                .stream()
+                .anyMatch(authorization -> authorization.getStatus() == AuthorizationStatus.PENDING && authorization
+                        .getChallenges()
+                        .stream()
+                        .anyMatch(challenge -> challenge.getStatus() == ChallengeStatus.INVALID));
+        boolean openBehindFailedAuthorization = isOpen(order)
+                && order.getAuthorizations().stream().anyMatch(AcmeChallengeStateMachine::hasFailed);
+        return authorizationBehindFailedChallenge || openBehindFailedAuthorization;
+    }
+
+    /**
+     * Settles the authorizations of an order that are left pending behind a failed challenge, then the order itself if
+     * any of its authorizations has failed.
+     *
+     * @return the authorizations that were settled; the order's own change shows in its status
+     */
+    public static List<AcmeAuthorization> settleOrder(AcmeOrder order) {
+        List<AcmeAuthorization> settled = new ArrayList<>();
+        for (AcmeAuthorization authorization : order.getAuthorizations()) {
+            if (settleAuthorizationBehindFailedChallenge(authorization)) {
+                settled.add(authorization);
+            }
+        }
+        if (order.getAuthorizations().stream().anyMatch(AcmeChallengeStateMachine::hasFailed)) {
+            invalidateOrder(order);
+        }
+        return settled;
+    }
+
+    private static boolean settleAuthorizationBehindFailedChallenge(AcmeAuthorization authorization) {
+        if (authorization.getStatus() != AuthorizationStatus.PENDING || authorization
+                .getChallenges()
+                .stream()
+                .noneMatch(challenge -> challenge.getStatus() == ChallengeStatus.INVALID)) {
+            return false;
+        }
+        authorization.setStatus(AuthorizationStatus.INVALID);
+        return true;
+    }
+
+    /**
+     * Deactivates an authorization at the client's request (RFC 8555 section 7.5.2). The order can no longer be
+     * completed, so an open order is invalidated with it.
+     */
+    public static void deactivate(AcmeAuthorization authorization) {
+        authorization.setStatus(AuthorizationStatus.DEACTIVATED);
+        invalidateOrder(authorization.getOrder());
+    }
+
+    /**
+     * An authorization that has failed or been deactivated can never become valid, so its order cannot complete.
+     */
+    private static boolean hasFailed(AcmeAuthorization authorization) {
+        return authorization.getStatus() == AuthorizationStatus.INVALID
+                || authorization.getStatus() == AuthorizationStatus.DEACTIVATED;
+    }
+
+    /**
+     * An order is invalidated only while it is still open. Once a certificate has been requested or issued for it, the
+     * certificate exists regardless of a later failure, so the order keeps the status that reflects it.
+     */
+    private static boolean invalidateOrder(AcmeOrder order) {
+        if (!isOpen(order)) {
+            return false;
+        }
+        order.setStatus(OrderStatus.INVALID);
+        return true;
+    }
+
+    /**
+     * The status an order takes from the certificate requested for it.
+     */
+    public static OrderStatus statusFromCertificate(CertificateState certificateState) {
+        if (certificateState == CertificateState.ISSUED) {
+            return OrderStatus.VALID;
+        }
+        if (certificateState == CertificateState.REQUESTED || certificateState == CertificateState.PENDING_APPROVAL
+                || certificateState == CertificateState.PENDING_ISSUE) {
+            return OrderStatus.PROCESSING;
+        }
+        return OrderStatus.INVALID;
+    }
+
+    /**
+     * An order is open while nothing has been issued for it. The stored status alone does not tell: an order finalized
+     * before failures were propagated can still read {@code READY} although its certificate exists.
+     */
+    private static boolean isOpen(AcmeOrder order) {
+        return order.getCertificateReferenceUuid() == null
+                && (order.getStatus() == OrderStatus.PENDING || order.getStatus() == OrderStatus.READY);
+    }
+
+}

--- a/src/main/java/com/otilm/core/service/acme/AcmeDnsChallengeValidator.java
+++ b/src/main/java/com/otilm/core/service/acme/AcmeDnsChallengeValidator.java
@@ -1,0 +1,141 @@
+package com.otilm.core.service.acme;
+
+import com.otilm.api.model.core.acme.Problem;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import javax.naming.Context;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resolves the TXT records proving control of an identifier and matches them against the key authorization expected for
+ * a DNS-01 challenge.
+ */
+public final class AcmeDnsChallengeValidator {
+
+    private static final Logger logger = LoggerFactory.getLogger(AcmeDnsChallengeValidator.class);
+
+    private static final String WILDCARD_PREFIX = "*.";
+
+    private AcmeDnsChallengeValidator() {
+    }
+
+    /**
+     * Queries the TXT records of {@code recordName} and reports whether one of them proves control.
+     *
+     * @param recordName name carrying the challenge response, from {@link #challengeRecordName(String)}
+     * @param expectedKeyAuthorization digest of the key authorization the challenge expects
+     * @param env resolver environment, from {@link #resolverEnv(String, String)}
+     * @return the verdict, reporting a DNS problem when the records cannot be queried
+     */
+    public static ChallengeValidationResult validate(String recordName, String expectedKeyAuthorization,
+            Properties env) {
+        List<String> txtValues;
+        try {
+            txtValues = extractTxtValues(lookupTxtRecords(recordName, env));
+        } catch (NamingException e) {
+            logger.error("DNS query for {} failed: {}", recordName, e.getMessage());
+            return ChallengeValidationResult.failure(Problem.DNS, "DNS query for " + recordName + " failed");
+        }
+
+        logger.debug("Resolved {} TXT record(s) for {}: {}", txtValues.size(), recordName, txtValues);
+        return evaluate(recordName, txtValues, expectedKeyAuthorization);
+    }
+
+    /**
+     * Name carrying the challenge response for an identifier. A wildcard identifier is proved at the challenge label of
+     * its base domain (RFC 8555 section 8.4).
+     */
+    public static String challengeRecordName(String identifierValue) {
+        String baseDomain = identifierValue.startsWith(WILDCARD_PREFIX)
+                ? identifierValue.substring(WILDCARD_PREFIX.length())
+                : identifierValue;
+        return AcmeConstants.DNS_ACME_PREFIX + baseDomain;
+    }
+
+    /**
+     * Resolver environment addressing the resolver declared by the ACME profile, or the system resolver when the
+     * profile declares none.
+     */
+    public static Properties resolverEnv(String dnsResolverIp, String dnsResolverPort) {
+        Properties env = new Properties();
+        env.setProperty(Context.INITIAL_CONTEXT_FACTORY, AcmeConstants.DNS_CONTENT_FACTORY);
+        if (dnsResolverIp == null || dnsResolverIp.isEmpty()) {
+            env.setProperty(Context.PROVIDER_URL, AcmeConstants.DNS_ENV_PREFIX);
+        } else {
+            env
+                    .setProperty(Context.PROVIDER_URL, AcmeConstants.DNS_ENV_PREFIX + dnsResolverIp + ":"
+                            + Optional.ofNullable(dnsResolverPort).orElse(AcmeConstants.DEFAULT_DNS_PORT));
+        }
+        return env;
+    }
+
+    /**
+     * Collects every TXT record returned for the queried name.
+     *
+     * <p>
+     * The DNS provider returns all TXT records of a name as separate values of one {@code TXT} attribute, so the values
+     * of each returned attribute have to be read. Reading the attributes alone yields a single record however many are
+     * published, and which one it is depends on the order the resolver answered in.
+     */
+    static List<String> extractTxtValues(Attributes attributes) throws NamingException {
+        List<String> txtValues = new ArrayList<>();
+        NamingEnumeration<? extends Attribute> records = attributes.getAll();
+        while (records.hasMore()) {
+            NamingEnumeration<?> values = records.next().getAll();
+            while (values.hasMore()) {
+                txtValues.add(values.next().toString());
+            }
+        }
+        return txtValues;
+    }
+
+    /**
+     * Reports whether any published record matches the expected key authorization.
+     *
+     * <p>
+     * Nothing published is a DNS problem, whereas records that are published but do not match are an incorrect
+     * response. The published values stay out of the detail: they may hold verification tokens owned by third parties,
+     * and the detail is returned to the client.
+     */
+    static ChallengeValidationResult evaluate(String recordName, List<String> txtValues,
+            String expectedKeyAuthorization) {
+        if (txtValues.isEmpty()) {
+            return ChallengeValidationResult.failure(Problem.DNS, "No TXT record found at " + recordName);
+        }
+        if (txtValues.stream().noneMatch(txtValue -> matches(txtValue, expectedKeyAuthorization))) {
+            return ChallengeValidationResult
+                    .failure(Problem.INCORRECT_RESPONSE,
+                            "No TXT record at " + recordName + " matches the expected key authorization");
+        }
+        return ChallengeValidationResult.success();
+    }
+
+    /**
+     * A TXT record may be published as several character-strings, and its value is their concatenation. The DNS
+     * provider renders such a record with the strings separated by a space, quoting only the strings that hold a
+     * meta-character, so a key authorization split across strings arrives space-separated. A key authorization is
+     * base64url and carries no space of its own, which is what makes removing them safe.
+     */
+    private static boolean matches(String txtValue, String expectedKeyAuthorization) {
+        return txtValue.equals(expectedKeyAuthorization) || txtValue.replace(" ", "").equals(expectedKeyAuthorization);
+    }
+
+    private static Attributes lookupTxtRecords(String recordName, Properties env) throws NamingException {
+        DirContext context = new InitialDirContext(env);
+        try {
+            return context.getAttributes(recordName, new String[]{AcmeConstants.DNS_RECORD_TYPE});
+        } finally {
+            context.close();
+        }
+    }
+
+}

--- a/src/main/java/com/otilm/core/service/acme/ChallengeValidationResult.java
+++ b/src/main/java/com/otilm/core/service/acme/ChallengeValidationResult.java
@@ -1,0 +1,28 @@
+package com.otilm.core.service.acme;
+
+import com.otilm.api.model.core.acme.Problem;
+
+/**
+ * Verdict of a single challenge validation attempt.
+ *
+ * <p>
+ * A failed attempt carries the reason to record on the challenge, which the client reads back as a problem document.
+ * The detail is therefore authored text, never a resolver response, a served response body or an exception message.
+ *
+ * @param valid whether the client proved control of the identifier
+ * @param problem ACME problem type of a failed attempt, {@code null} when valid
+ * @param detail reason of a failed attempt, {@code null} when valid
+ */
+public record ChallengeValidationResult(boolean valid, Problem problem, String detail) {
+
+    private static final ChallengeValidationResult SUCCESS = new ChallengeValidationResult(true, null, null);
+
+    public static ChallengeValidationResult success() {
+        return SUCCESS;
+    }
+
+    public static ChallengeValidationResult failure(Problem problem, String detail) {
+        return new ChallengeValidationResult(false, problem, detail);
+    }
+
+}

--- a/src/main/java/com/otilm/core/service/acme/impl/AcmeServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/acme/impl/AcmeServiceImpl.java
@@ -1,5 +1,8 @@
 package com.otilm.core.service.acme.impl;
 
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSObject;
+import com.nimbusds.jose.util.Base64URL;
 import com.otilm.api.exception.AcmeProblemDocumentException;
 import com.otilm.api.exception.AttributeException;
 import com.otilm.api.exception.CertificateRequestException;
@@ -7,7 +10,23 @@ import com.otilm.api.exception.ConnectorException;
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.common.attribute.v2.DataAttributeV2;
-import com.otilm.api.model.core.acme.*;
+import com.otilm.api.model.core.acme.Account;
+import com.otilm.api.model.core.acme.AccountStatus;
+import com.otilm.api.model.core.acme.Authorization;
+import com.otilm.api.model.core.acme.AuthorizationStatus;
+import com.otilm.api.model.core.acme.CertificateFinalizeRequest;
+import com.otilm.api.model.core.acme.CertificateRevocationRequest;
+import com.otilm.api.model.core.acme.Challenge;
+import com.otilm.api.model.core.acme.ChallengeStatus;
+import com.otilm.api.model.core.acme.ChallengeType;
+import com.otilm.api.model.core.acme.Directory;
+import com.otilm.api.model.core.acme.DirectoryMeta;
+import com.otilm.api.model.core.acme.Identifier;
+import com.otilm.api.model.core.acme.NewAccountRequest;
+import com.otilm.api.model.core.acme.Order;
+import com.otilm.api.model.core.acme.OrderStatus;
+import com.otilm.api.model.core.acme.Problem;
+import com.otilm.api.model.core.acme.ProblemDocument;
 import com.otilm.api.model.core.authority.CertificateRevocationReason;
 import com.otilm.api.model.core.certificate.CertificateChainResponseDto;
 import com.otilm.api.model.core.certificate.CertificateDetailDto;
@@ -15,8 +34,8 @@ import com.otilm.api.model.core.certificate.CertificateState;
 import com.otilm.api.model.core.enums.CertificateProtocol;
 import com.otilm.api.model.core.enums.CertificateRequestFormat;
 import com.otilm.api.model.core.v2.ClientCertificateDataResponseDto;
-import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
 import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.AttributeOperation;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
@@ -24,27 +43,75 @@ import com.otilm.core.certificate.request.ProtocolRequestAttributeValidator;
 import com.otilm.core.certificate.request.RequestAttributePolicyViolationException;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.RaProfile;
-import com.otilm.core.dao.entity.acme.*;
+import com.otilm.core.dao.entity.acme.AcmeAccount;
+import com.otilm.core.dao.entity.acme.AcmeAuthorization;
+import com.otilm.core.dao.entity.acme.AcmeChallenge;
+import com.otilm.core.dao.entity.acme.AcmeNonce;
+import com.otilm.core.dao.entity.acme.AcmeOrder;
+import com.otilm.core.dao.entity.acme.AcmeProfile;
 import com.otilm.core.dao.repository.AcmeProfileRepository;
 import com.otilm.core.dao.repository.RaProfileRepository;
-import com.otilm.core.dao.repository.acme.*;
+import com.otilm.core.dao.repository.acme.AcmeAccountRepository;
+import com.otilm.core.dao.repository.acme.AcmeAuthorizationRepository;
+import com.otilm.core.dao.repository.acme.AcmeChallengeRepository;
+import com.otilm.core.dao.repository.acme.AcmeNonceRepository;
+import com.otilm.core.dao.repository.acme.AcmeOrderRepository;
 import com.otilm.core.logging.LoggingHelper;
 import com.otilm.core.model.auth.CertificateProtocolInfo;
 import com.otilm.core.model.request.CertificateRequest;
 import com.otilm.core.model.request.Pkcs10CertificateRequest;
+import com.otilm.core.security.authz.ProtocolEndpoint;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.service.CertificateInternalService;
-import com.otilm.core.security.authz.ProtocolEndpoint;
 import com.otilm.core.service.acme.AcmeConstants;
 import com.otilm.core.service.acme.AcmeExternalService;
 import com.otilm.core.service.acme.message.AcmeJwsRequest;
 import com.otilm.core.service.v2.ClientOperationInternalService;
-import com.otilm.core.util.*;
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWSObject;
-import com.nimbusds.jose.util.Base64URL;
+import com.otilm.core.util.AcmeCommonHelper;
+import com.otilm.core.util.AcmeJsonProcessor;
+import com.otilm.core.util.AcmePublicKeyProcessor;
+import com.otilm.core.util.AcmeRandomGeneratorAndValidator;
+import com.otilm.core.util.AttributeDefinitionUtils;
+import com.otilm.core.util.CertificateRequestUtils;
+import com.otilm.core.util.CertificateUtil;
+import com.otilm.core.util.SerializationUtil;
+import com.otilm.core.util.X509ObjectToString;
 import jakarta.transaction.Transactional;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.naming.Context;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x500.style.IETFUtils;
@@ -67,31 +134,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
-
-import javax.naming.Context;
-import javax.naming.NamingEnumeration;
-import javax.naming.NamingException;
-import javax.naming.directory.Attribute;
-import javax.naming.directory.Attributes;
-import javax.naming.directory.DirContext;
-import javax.naming.directory.InitialDirContext;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.StringWriter;
-import java.net.HttpURLConnection;
-import java.net.URI;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.PublicKey;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.security.spec.InvalidKeySpecException;
-import java.text.ParseException;
-import java.util.*;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -117,7 +159,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
     }
 
     @Autowired
-    public void setProtocolRequestAttributeValidator(ProtocolRequestAttributeValidator protocolRequestAttributeValidator) {
+    public void setProtocolRequestAttributeValidator(
+            ProtocolRequestAttributeValidator protocolRequestAttributeValidator) {
         this.protocolRequestAttributeValidator = protocolRequestAttributeValidator;
     }
 
@@ -166,10 +209,10 @@ public class AcmeServiceImpl implements AcmeExternalService {
         this.certificateService = certificateService;
     }
 
-
     @Override
     @ProtocolEndpoint
-    public ResponseEntity<Directory> getDirectory(String acmeProfileName, URI requestUri, boolean isRaProfileBased) throws AcmeProblemDocumentException {
+    public ResponseEntity<Directory> getDirectory(String acmeProfileName, URI requestUri, boolean isRaProfileBased)
+            throws AcmeProblemDocumentException {
         logger.debug("Gathering Directory information for ACME: {}", acmeProfileName);
 
         Directory directory = new Directory();
@@ -189,11 +232,13 @@ public class AcmeServiceImpl implements AcmeExternalService {
         try {
             directory.setMeta(frameDirectoryMeta(acmeProfileName, isRaProfileBased));
         } catch (NotFoundException e) {
-            throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.SERVER_INTERNAL, "Given profile name is not found");
+            throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.SERVER_INTERNAL,
+                    "Given profile name is not found");
         }
         logger.debug("Directory information retrieved: {}", directory);
 
-        return ResponseEntity.ok()
+        return ResponseEntity
+                .ok()
                 .cacheControl(CacheControl.noStore())
                 .header(AcmeConstants.NONCE_HEADER_NAME, generateNonce())
                 .body(directory);
@@ -201,16 +246,15 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
     @Override
     @ProtocolEndpoint
-    public ResponseEntity<?> getNonce(String acmeProfileName, Boolean isHead, URI requestUri, boolean isRaProfileBased) {
+    public ResponseEntity<?> getNonce(String acmeProfileName, Boolean isHead, URI requestUri,
+            boolean isRaProfileBased) {
         String nonce = generateNonce();
         logger.debug("New Nonce: {}", nonce);
         ResponseEntity.HeadersBuilder<?> responseBuilder;
         if (isHead) {
-            responseBuilder = ResponseEntity.ok()
-                    .cacheControl(CacheControl.noStore());
+            responseBuilder = ResponseEntity.ok().cacheControl(CacheControl.noStore());
         } else {
-            responseBuilder = ResponseEntity.noContent()
-                    .cacheControl(CacheControl.noStore());
+            responseBuilder = ResponseEntity.noContent().cacheControl(CacheControl.noStore());
         }
 
         return responseBuilder
@@ -221,7 +265,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
     @Override
     @ProtocolEndpoint
-    public ResponseEntity<Account> newAccount(String acmeProfileName, String requestJson, URI requestUri, boolean isRaProfileBased) throws AcmeProblemDocumentException {
+    public ResponseEntity<Account> newAccount(String acmeProfileName, String requestJson, URI requestUri,
+            boolean isRaProfileBased) throws AcmeProblemDocumentException {
         if (requestJson.isEmpty()) {
             logger.error("New Account request is empty. JWS is malformed for profile: {}", acmeProfileName);
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED);
@@ -231,11 +276,13 @@ public class AcmeServiceImpl implements AcmeExternalService {
         AcmeJwsRequest jwsRequest = new AcmeJwsRequest(requestJson);
         validateRequest(jwsRequest, acmeProfileName, requestUri, isRaProfileBased);
 
-        NewAccountRequest accountRequest = AcmeJsonProcessor.getPayloadAsRequestObject(jwsRequest.getJwsObject(), NewAccountRequest.class);
+        NewAccountRequest accountRequest = AcmeJsonProcessor
+                .getPayloadAsRequestObject(jwsRequest.getJwsObject(), NewAccountRequest.class);
         logger.debug("New Account request: {}", accountRequest.toString());
 
         // Check if the Account already exists
-        AcmeAccount account = acmeAccountRepository.findByPublicKey(AcmePublicKeyProcessor.publicKeyPemStringFromObject(jwsRequest.getPublicKey()));
+        AcmeAccount account = acmeAccountRepository
+                .findByPublicKey(AcmePublicKeyProcessor.publicKeyPemStringFromObject(jwsRequest.getPublicKey()));
 
         if (accountRequest.isOnlyReturnExisting()) {
             logger.debug("Request to only return existing Account");
@@ -247,7 +294,9 @@ public class AcmeServiceImpl implements AcmeExternalService {
             // Create a new Account if it does not exist
             if (account == null) {
                 logger.debug("Request to create a new Account");
-                account = addNewAccount(acmeProfileName, AcmePublicKeyProcessor.publicKeyPemStringFromObject(jwsRequest.getPublicKey()), accountRequest, isRaProfileBased);
+                account = addNewAccount(acmeProfileName,
+                        AcmePublicKeyProcessor.publicKeyPemStringFromObject(jwsRequest.getPublicKey()), accountRequest,
+                        isRaProfileBased);
             }
         }
 
@@ -256,26 +305,38 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
         Account accountDto = account.mapToDto();
         String baseUri = getAcmeBaseUri();
-        LoggingHelper.putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, false, account.getUuid().toString(), account.getAccountId());
+        LoggingHelper
+                .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, false,
+                        account.getUuid().toString(), account.getAccountId());
 
         ResponseEntity.BodyBuilder responseBuilder;
         if (isRaProfileBased) {
-            accountDto.setOrders("%s/raProfile/%s/acct/%s/orders".formatted(baseUri, acmeProfileName, account.getAccountId()));
+            accountDto
+                    .setOrders("%s/raProfile/%s/acct/%s/orders"
+                            .formatted(baseUri, acmeProfileName, account.getAccountId()));
             if (accountRequest.isOnlyReturnExisting()) {
-                responseBuilder = ResponseEntity.ok()
-                        .location(URI.create("%s/raProfile/%s/acct/%s".formatted(baseUri, acmeProfileName, account.getAccountId())));
+                responseBuilder = ResponseEntity
+                        .ok()
+                        .location(URI
+                                .create("%s/raProfile/%s/acct/%s"
+                                        .formatted(baseUri, acmeProfileName, account.getAccountId())));
             } else {
                 responseBuilder = ResponseEntity
-                        .created(URI.create("%s/raProfile/%s/acct/%s".formatted(baseUri, acmeProfileName, account.getAccountId())));
+                        .created(URI
+                                .create("%s/raProfile/%s/acct/%s"
+                                        .formatted(baseUri, acmeProfileName, account.getAccountId())));
             }
         } else {
             accountDto.setOrders("%s/%s/acct/%s/orders".formatted(baseUri, acmeProfileName, account.getAccountId()));
             if (accountRequest.isOnlyReturnExisting()) {
-                responseBuilder = ResponseEntity.ok()
-                        .location(URI.create("%s/%s/acct/%s".formatted(baseUri, acmeProfileName, account.getAccountId())));
+                responseBuilder = ResponseEntity
+                        .ok()
+                        .location(URI
+                                .create("%s/%s/acct/%s".formatted(baseUri, acmeProfileName, account.getAccountId())));
             } else {
                 responseBuilder = ResponseEntity
-                        .created(URI.create("%s/%s/acct/%s".formatted(baseUri, acmeProfileName, account.getAccountId())));
+                        .created(URI
+                                .create("%s/%s/acct/%s".formatted(baseUri, acmeProfileName, account.getAccountId())));
             }
         }
 
@@ -288,7 +349,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
     @Override
     @ProtocolEndpoint
-    public ResponseEntity<Account> updateAccount(String acmeProfileName, String accountId, String requestJson, URI requestUri, boolean isRaProfileBased) throws AcmeProblemDocumentException {
+    public ResponseEntity<Account> updateAccount(String acmeProfileName, String accountId, String requestJson,
+            URI requestUri, boolean isRaProfileBased) throws AcmeProblemDocumentException {
         if (requestJson.isEmpty()) {
             logger.error("Update Account request is empty. JWS is malformed for profile: {}", acmeProfileName);
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED);
@@ -303,7 +365,9 @@ public class AcmeServiceImpl implements AcmeExternalService {
         AcmeAccount account;
         try {
             account = getAcmeAccountEntity(accountId);
-            LoggingHelper.putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, false, account.getUuid().toString(), account.getAccountId());
+            LoggingHelper
+                    .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, false,
+                            account.getUuid().toString(), account.getAccountId());
         } catch (NotFoundException e) {
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.ACCOUNT_DOES_NOT_EXIST);
         }
@@ -325,7 +389,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
             logger.debug("Updated Account: {}", account.mapToDto().toString());
         }
 
-        return ResponseEntity.ok()
+        return ResponseEntity
+                .ok()
                 .header(AcmeConstants.NONCE_HEADER_NAME, generateNonce())
                 .header(AcmeConstants.RETRY_HEADER_NAME, account.getAcmeProfile().getRetryInterval().toString())
                 .header(AcmeConstants.LINK_HEADER_NAME, generateLinkHeader(acmeProfileName, isRaProfileBased))
@@ -334,7 +399,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
     @Override
     @ProtocolEndpoint
-    public ResponseEntity<?> keyRollover(String acmeProfileName, String requestJson, URI requestUri, boolean isRaProfileBased) throws AcmeProblemDocumentException {
+    public ResponseEntity<?> keyRollover(String acmeProfileName, String requestJson, URI requestUri,
+            boolean isRaProfileBased) throws AcmeProblemDocumentException {
         if (requestJson.isEmpty()) {
             logger.error("Update Account request is empty. JWS is malformed for profile: {}", acmeProfileName);
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED);
@@ -359,14 +425,17 @@ public class AcmeServiceImpl implements AcmeExternalService {
                 oldKey = innerJws.getOldKeyJWK().toECKey().toPublicKey();
             } else {
                 logger.error("Unsupported Key Type: {}", keyType);
-                throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED, "Unsupported Key Type");
+                throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
+                        "Unsupported Key Type");
             }
         } catch (JOSEException e) {
             logger.error("Error while parsing JWS: {}", e.getMessage());
-            throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED, "JWS Malformed. Error while decoding the JWS Object");
+            throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
+                    "JWS Malformed. Error while decoding the JWS Object");
         } catch (ParseException e) {
             logger.error("Error while parsing JWS: {}", e.getMessage());
-            throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED, "Error while parsing the JWS Payload");
+            throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
+                    "Error while parsing the JWS Payload");
         }
 
         String account = innerJws.getJwsObject().getPayload().toJSONObject().get("account").toString();
@@ -375,7 +444,9 @@ public class AcmeServiceImpl implements AcmeExternalService {
         AcmeAccount acmeAccount;
         try {
             acmeAccount = getAcmeAccountEntity(accountId);
-            LoggingHelper.putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, false, acmeAccount.getUuid().toString(), acmeAccount.getAccountId());
+            LoggingHelper
+                    .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, false,
+                            acmeAccount.getUuid().toString(), acmeAccount.getAccountId());
         } catch (NotFoundException e) {
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.ACCOUNT_DOES_NOT_EXIST);
         }
@@ -384,13 +455,17 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
         if (!acmeAccount.getPublicKey().equals(AcmePublicKeyProcessor.publicKeyPemStringFromObject(oldKey))) {
             logger.error("Public key of the Account with ID: {} does not match with old key in request", accountId);
-            throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.UNAUTHORIZED, "Account key does not match with old key");
+            throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.UNAUTHORIZED,
+                    "Account key does not match with old key");
         }
-        AcmeAccount oldAccount = acmeAccountRepository.findByPublicKey(AcmePublicKeyProcessor.publicKeyPemStringFromObject(newKey));
+        AcmeAccount oldAccount = acmeAccountRepository
+                .findByPublicKey(AcmePublicKeyProcessor.publicKeyPemStringFromObject(newKey));
         if (oldAccount != null) {
-            return ResponseEntity.status(HttpStatus.CONFLICT)
+            return ResponseEntity
+                    .status(HttpStatus.CONFLICT)
                     .header(AcmeConstants.LOCATION_HEADER_NAME, oldAccount.getAccountId())
-                    .body(new ProblemDocument("keyExists", "New Key already exists", "New key already tagged to a different account"));
+                    .body(new ProblemDocument("keyExists", "New Key already exists",
+                            "New key already tagged to a different account"));
         }
 
         validateKey(jwsRequest.getJwsObject(), innerJws.getJwsObject());
@@ -398,14 +473,16 @@ public class AcmeServiceImpl implements AcmeExternalService {
         acmeAccount.setPublicKey(AcmePublicKeyProcessor.publicKeyPemStringFromObject(newKey));
         acmeAccountRepository.save(acmeAccount);
 
-        return ResponseEntity.ok()
+        return ResponseEntity
+                .ok()
                 .header(AcmeConstants.LINK_HEADER_NAME, generateLinkHeader(acmeProfileName, isRaProfileBased))
                 .build();
     }
 
     @Override
     @ProtocolEndpoint
-    public ResponseEntity<Order> newOrder(String acmeProfileName, String requestJson, URI requestUri, boolean isRaProfileBased) throws AcmeProblemDocumentException {
+    public ResponseEntity<Order> newOrder(String acmeProfileName, String requestJson, URI requestUri,
+            boolean isRaProfileBased) throws AcmeProblemDocumentException {
         if (requestJson.isEmpty()) {
             logger.error("Update Account request is empty. JWS is malformed for profile: {}", acmeProfileName);
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED);
@@ -421,7 +498,9 @@ public class AcmeServiceImpl implements AcmeExternalService {
         AcmeAccount acmeAccount;
         try {
             acmeAccount = getAcmeAccountEntity(acmeAccountId);
-            LoggingHelper.putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, true, acmeAccount.getUuid().toString(), acmeAccount.getAccountId());
+            LoggingHelper
+                    .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, true,
+                            acmeAccount.getUuid().toString(), acmeAccount.getAccountId());
             validateAccount(acmeAccount);
             logger.info("ACME Account set: {}", acmeAccount);
         } catch (NotFoundException e) {
@@ -431,22 +510,29 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
         AcmeOrder order = generateOrder(acmeAccount, jwsRequest);
         logger.debug("Order created: {}", order);
-        LoggingHelper.putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ORDER, false, order.getUuid().toString(), order.getOrderId());
+        LoggingHelper
+                .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ORDER, false,
+                        order.getUuid().toString(), order.getOrderId());
 
-        return ResponseEntity.created(URI.create(order.getUrl()))
+        return ResponseEntity
+                .created(URI.create(order.getUrl()))
                 .header(AcmeConstants.NONCE_HEADER_NAME, generateNonce())
-                .header(AcmeConstants.RETRY_HEADER_NAME, order.getAcmeAccount().getAcmeProfile().getRetryInterval().toString())
+                .header(AcmeConstants.RETRY_HEADER_NAME,
+                        order.getAcmeAccount().getAcmeProfile().getRetryInterval().toString())
                 .header(AcmeConstants.LINK_HEADER_NAME, generateLinkHeader(acmeProfileName, isRaProfileBased))
                 .body(order.mapToDto());
     }
 
     @Override
     @ProtocolEndpoint
-    public ResponseEntity<List<Order>> listOrders(String acmeProfileName, String accountId, URI requestUri, boolean isRaProfileBased) throws AcmeProblemDocumentException {
+    public ResponseEntity<List<Order>> listOrders(String acmeProfileName, String accountId, URI requestUri,
+            boolean isRaProfileBased) throws AcmeProblemDocumentException {
         AcmeAccount acmeAccount;
         try {
             acmeAccount = getAcmeAccountEntity(accountId);
-            LoggingHelper.putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, true, acmeAccount.getUuid().toString(), acmeAccount.getAccountId());
+            LoggingHelper
+                    .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, true,
+                            acmeAccount.getUuid().toString(), acmeAccount.getAccountId());
         } catch (NotFoundException e) {
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.ACCOUNT_DOES_NOT_EXIST);
         }
@@ -456,14 +542,11 @@ public class AcmeServiceImpl implements AcmeExternalService {
         acmeAccountRepository.save(acmeAccount);
 
         logger.debug("Request to list Orders for the Account with ID: {}", accountId);
-        List<Order> orders = acmeAccount
-                .getOrders()
-                .stream()
-                .map(AcmeOrder::mapToDto)
-                .collect(Collectors.toList());
+        List<Order> orders = acmeAccount.getOrders().stream().map(AcmeOrder::mapToDto).collect(Collectors.toList());
         logger.debug("Number of Orders: {}", orders.size());
 
-        return ResponseEntity.ok()
+        return ResponseEntity
+                .ok()
                 .header(AcmeConstants.NONCE_HEADER_NAME, generateNonce())
                 .header(AcmeConstants.LINK_HEADER_NAME, generateLinkHeader(acmeProfileName, isRaProfileBased))
                 .body(orders);
@@ -471,7 +554,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
     @Override
     @ProtocolEndpoint
-    public ResponseEntity<Authorization> getAuthorization(String acmeProfileName, String authorizationId, String requestJson, URI requestUri, boolean isRaProfileBased) throws AcmeProblemDocumentException {
+    public ResponseEntity<Authorization> getAuthorization(String acmeProfileName, String authorizationId,
+            String requestJson, URI requestUri, boolean isRaProfileBased) throws AcmeProblemDocumentException {
         if (requestJson.isEmpty()) {
             logger.error("Update Account request is empty. JWS is malformed for profile: {}", acmeProfileName);
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED);
@@ -481,14 +565,22 @@ public class AcmeServiceImpl implements AcmeExternalService {
         AcmeJwsRequest jwsRequest = new AcmeJwsRequest(requestJson);
         validateRequest(jwsRequest, acmeProfileName, requestUri, isRaProfileBased);
         AcmeAuthorization authorization = validateAuthorization(authorizationId);
-        LoggingHelper.putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_AUTHORIZATION, false, authorization.getUuid().toString(), authorization.getAuthorizationId());
+        LoggingHelper
+                .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_AUTHORIZATION, false,
+                        authorization.getUuid().toString(), authorization.getAuthorizationId());
         if (authorization.getOrder() != null) {
-            LoggingHelper.putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ORDER, true, authorization.getOrder().getUuid().toString(), authorization.getOrder().getOrderId());
+            LoggingHelper
+                    .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ORDER, true,
+                            authorization.getOrder().getUuid().toString(), authorization.getOrder().getOrderId());
         }
 
         boolean isDeactivateRequest = false;
         if (jwsRequest.getJwsObject().getPayload().toJSONObject() != null) {
-            isDeactivateRequest = jwsRequest.getJwsObject().getPayload().toJSONObject().getOrDefault("status", "") == "deactivated";
+            isDeactivateRequest = jwsRequest
+                    .getJwsObject()
+                    .getPayload()
+                    .toJSONObject()
+                    .getOrDefault("status", "") == "deactivated";
         }
 
         if (authorization.getExpires() != null && authorization.getExpires().before(new Date())) {
@@ -503,7 +595,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
         Authorization authorizationDto = authorization.mapToDto();
         logger.debug("Authorization: {}", authorizationDto.toString());
 
-        return ResponseEntity.ok()
+        return ResponseEntity
+                .ok()
                 .header(AcmeConstants.NONCE_HEADER_NAME, generateNonce())
                 .header(AcmeConstants.LINK_HEADER_NAME, generateLinkHeader(acmeProfileName, isRaProfileBased))
                 .body(authorizationDto);
@@ -511,7 +604,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
     @Override
     @ProtocolEndpoint
-    public ResponseEntity<Challenge> validateChallenge(String acmeProfileName, String challengeId, URI requestUri, boolean isRaProfileBased) throws AcmeProblemDocumentException {
+    public ResponseEntity<Challenge> validateChallenge(String acmeProfileName, String challengeId, URI requestUri,
+            boolean isRaProfileBased) throws AcmeProblemDocumentException {
         logger.debug("Validating Challenge with ID {}:", challengeId);
         AcmeChallenge challenge = validateChallenge(challengeId);
         validateAccount(challenge.getAuthorization().getOrder().getAcmeAccount());
@@ -520,7 +614,9 @@ public class AcmeServiceImpl implements AcmeExternalService {
         logger.debug("Authorization corresponding to the Order: {}", authorization.toString());
         AcmeOrder order = authorization.getOrder();
         logger.debug("Order corresponding to the Challenge: {}", order.toString());
-        LoggingHelper.putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ORDER, true, order.getUuid().toString(), order.getOrderId());
+        LoggingHelper
+                .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ORDER, true, order.getUuid().toString(),
+                        order.getOrderId());
 
         boolean isValid;
         if (challenge.getType().equals(ChallengeType.HTTP01)) {
@@ -544,7 +640,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
         logger.debug("Validation of the Challenge is completed: {}", challenge);
 
-        return ResponseEntity.ok()
+        return ResponseEntity
+                .ok()
                 .header(AcmeConstants.NONCE_HEADER_NAME, generateNonce())
                 .header(AcmeConstants.LINK_HEADER_NAME, generateLinkHeader(acmeProfileName, isRaProfileBased))
                 .header(AcmeConstants.LINK_HEADER_NAME, "<" + challenge.getAuthorization().getUrl() + ">;rel=\"up\"")
@@ -553,7 +650,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
     @Override
     @ProtocolEndpoint
-    public ResponseEntity<Order> finalizeOrder(String acmeProfileName, String orderId, String requestJson, URI requestUri, boolean isRaProfileBased) throws AcmeProblemDocumentException {
+    public ResponseEntity<Order> finalizeOrder(String acmeProfileName, String orderId, String requestJson,
+            URI requestUri, boolean isRaProfileBased) throws AcmeProblemDocumentException {
         if (requestJson.isEmpty()) {
             logger.error("Update Account request is empty. JWS is malformed for profile: {}", acmeProfileName);
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED);
@@ -565,15 +663,20 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
         logger.debug("Request to finalize the Order with ID: {}", orderId);
         AcmeOrder order = validateOrder(orderId);
-        LoggingHelper.putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ORDER, false, order.getUuid().toString(), order.getOrderId());
+        LoggingHelper
+                .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ORDER, false,
+                        order.getUuid().toString(), order.getOrderId());
         if (order.getAcmeAccount() != null) {
-            LoggingHelper.putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, true, order.getAcmeAccount().getUuid().toString(), order.getAcmeAccount().getAccountId());
+            LoggingHelper
+                    .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, true,
+                            order.getAcmeAccount().getUuid().toString(), order.getAcmeAccount().getAccountId());
         }
 
         validateAccount(order.getAcmeAccount());
         logger.debug("Order found : {}", order);
 
-        if (!order.getStatus().equals(OrderStatus.READY)) { // A request to finalize an order will result in error if the order is not in the "ready" state
+        if (!order.getStatus().equals(OrderStatus.READY)) { // A request to finalize an order will result in error if
+                                                            // the order is not in the "ready" state
             logger.error("Cannot finalize Order that is not ready.");
             throw new AcmeProblemDocumentException(HttpStatus.FORBIDDEN, Problem.ORDER_NOT_READY);
         }
@@ -581,19 +684,23 @@ public class AcmeServiceImpl implements AcmeExternalService {
         // Now finalize the order
         finalizeOrder(order, jwsRequest, isRaProfileBased);
 
-        return ResponseEntity.ok()
+        return ResponseEntity
+                .ok()
                 .location(URI.create(order.getUrl()))
                 .header(AcmeConstants.NONCE_HEADER_NAME, generateNonce())
-                .header(AcmeConstants.RETRY_HEADER_NAME, order.getAcmeAccount().getAcmeProfile().getRetryInterval().toString())
+                .header(AcmeConstants.RETRY_HEADER_NAME,
+                        order.getAcmeAccount().getAcmeProfile().getRetryInterval().toString())
                 .header(AcmeConstants.LINK_HEADER_NAME, generateLinkHeader(acmeProfileName, isRaProfileBased))
                 .body(order.mapToDto());
     }
 
     @Transactional
     @Async
-    public void finalizeOrder(AcmeOrder order, AcmeJwsRequest jwsRequest, boolean isRaProfileBased) throws AcmeProblemDocumentException {
+    public void finalizeOrder(AcmeOrder order, AcmeJwsRequest jwsRequest, boolean isRaProfileBased)
+            throws AcmeProblemDocumentException {
         logger.debug("Finalizing Order with ID: {}", order.getOrderId());
-        CertificateFinalizeRequest request = AcmeJsonProcessor.getPayloadAsRequestObject(jwsRequest.getJwsObject(), CertificateFinalizeRequest.class);
+        CertificateFinalizeRequest request = AcmeJsonProcessor
+                .getPayloadAsRequestObject(jwsRequest.getJwsObject(), CertificateFinalizeRequest.class);
         logger.debug("Finalize Order request: {}", request);
 
         JcaPKCS10CertificationRequest p10Object;
@@ -609,7 +716,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
         logger.debug("Initiating issue Certificate for Order with ID: {}", order.getOrderId());
         ClientCertificateIssueRequestDto certificateIssueRequestDto = new ClientCertificateIssueRequestDto();
-        certificateIssueRequestDto.setAttributes(getClientOperationAttributes(false, order.getAcmeAccount(), isRaProfileBased));
+        certificateIssueRequestDto
+                .setAttributes(getClientOperationAttributes(false, order.getAcmeAccount(), isRaProfileBased));
         certificateIssueRequestDto.setRequest(decodedCsr);
         certificateIssueRequestDto.setFormat(CertificateRequestFormat.PKCS10);
         order.setStatus(OrderStatus.PROCESSING);
@@ -619,11 +727,16 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
     @Override
     @ProtocolEndpoint
-    public ResponseEntity<Order> getOrder(String acmeProfileName, String orderId, URI requestUri, boolean isRaProfileBased) throws AcmeProblemDocumentException {
+    public ResponseEntity<Order> getOrder(String acmeProfileName, String orderId, URI requestUri,
+            boolean isRaProfileBased) throws AcmeProblemDocumentException {
         AcmeOrder order = validateOrder(orderId);
-        LoggingHelper.putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ORDER, false, order.getUuid().toString(), order.getOrderId());
+        LoggingHelper
+                .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ORDER, false,
+                        order.getUuid().toString(), order.getOrderId());
         if (order.getAcmeAccount() != null) {
-            LoggingHelper.putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, true, order.getAcmeAccount().getUuid().toString(), order.getAcmeAccount().getAccountId());
+            LoggingHelper
+                    .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ACCOUNT, true,
+                            order.getAcmeAccount().getUuid().toString(), order.getAcmeAccount().getAccountId());
         }
 
         if (order.getStatus().equals(OrderStatus.INVALID)) {
@@ -631,21 +744,25 @@ public class AcmeServiceImpl implements AcmeExternalService {
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.SERVER_INTERNAL);
         }
 
-        return ResponseEntity.ok()
+        return ResponseEntity
+                .ok()
                 .location(URI.create(order.getUrl()))
                 .header(AcmeConstants.NONCE_HEADER_NAME, generateNonce())
-                .header(AcmeConstants.RETRY_HEADER_NAME, order.getAcmeAccount().getAcmeProfile().getRetryInterval().toString())
+                .header(AcmeConstants.RETRY_HEADER_NAME,
+                        order.getAcmeAccount().getAcmeProfile().getRetryInterval().toString())
                 .header(AcmeConstants.LINK_HEADER_NAME, generateLinkHeader(acmeProfileName, isRaProfileBased))
                 .body(order.mapToDto());
     }
 
     @Override
     @ProtocolEndpoint
-    public ResponseEntity<Resource> downloadCertificate(String acmeProfileName, String certificateId, URI requestUri, boolean isRaProfileBased) throws NotFoundException, CertificateException {
+    public ResponseEntity<Resource> downloadCertificate(String acmeProfileName, String certificateId, URI requestUri,
+            boolean isRaProfileBased) throws NotFoundException, CertificateException {
         logger.debug("Downloading the Certificate with ID: {}", certificateId);
         ByteArrayResource byteArrayResource = getCertificateResource(certificateId);
 
-        return ResponseEntity.ok()
+        return ResponseEntity
+                .ok()
                 .header(AcmeConstants.NONCE_HEADER_NAME, generateNonce())
                 .header(AcmeConstants.LINK_HEADER_NAME, generateLinkHeader(acmeProfileName, isRaProfileBased))
                 .contentType(MediaType.valueOf("application/pem-certificate-chain"))
@@ -654,7 +771,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
     @Override
     @ProtocolEndpoint
-    public ResponseEntity<?> revokeCertificate(String acmeProfileName, String requestJson, URI requestUri, boolean isRaProfileBased) throws AcmeProblemDocumentException, ConnectorException, CertificateException {
+    public ResponseEntity<?> revokeCertificate(String acmeProfileName, String requestJson, URI requestUri,
+            boolean isRaProfileBased) throws AcmeProblemDocumentException, ConnectorException, CertificateException {
         if (requestJson.isEmpty()) {
             logger.error("Update Account request is empty. JWS is malformed for profile: {}", acmeProfileName);
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED);
@@ -664,7 +782,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
         AcmeJwsRequest jwsRequest = new AcmeJwsRequest(requestJson);
         validateRequest(jwsRequest, acmeProfileName, requestUri, isRaProfileBased);
 
-        CertificateRevocationRequest request = AcmeJsonProcessor.getPayloadAsRequestObject(jwsRequest.getJwsObject(), CertificateRevocationRequest.class);
+        CertificateRevocationRequest request = AcmeJsonProcessor
+                .getPayloadAsRequestObject(jwsRequest.getJwsObject(), CertificateRevocationRequest.class);
         logger.debug("Certificate revocation is triggered with the payload: {}", request.toString());
 
         String base64UrlCertificate = request.getCertificate();
@@ -674,10 +793,16 @@ public class AcmeServiceImpl implements AcmeExternalService {
         ClientCertificateRevocationDto revokeRequest = new ClientCertificateRevocationDto();
 
         Certificate cert = certificateService.getCertificateEntityByContent(base64Certificate);
-        LoggingHelper.putLogResourceInfo(com.otilm.api.model.core.auth.Resource.CERTIFICATE, false, cert.getUuid().toString(), cert.getSubjectDn());
-        if (cert.isArchived()) throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.ARCHIVED);
+        LoggingHelper
+                .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.CERTIFICATE, false,
+                        cert.getUuid().toString(), cert.getSubjectDn());
+        if (cert.isArchived()) {
+            throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.ARCHIVED);
+        }
         if (cert.getState().equals(CertificateState.REVOKED)) {
-            logger.error("Certificate is already revoked. Serial number: {}, Fingerprint: {}", cert.getSerialNumber(), cert.getFingerprint());
+            logger
+                    .error("Certificate is already revoked. Serial number: {}, Fingerprint: {}", cert.getSerialNumber(),
+                            cert.getFingerprint());
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.ALREADY_REVOKED);
         }
 
@@ -688,7 +813,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
             String pemPubKeyCert = AcmePublicKeyProcessor.publicKeyPemStringFromObject(certPublicKey);
             String pemPubKeyJws = AcmePublicKeyProcessor.publicKeyPemStringFromObject(jwsPublicKey);
-            if (!pemPubKeyCert.equals(pemPubKeyJws)) { // check that the public key of the certificate matches the public key of the JWS
+            if (!pemPubKeyCert.equals(pemPubKeyJws)) { // check that the public key of the certificate matches the
+                                                       // public key of the JWS
                 throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.BAD_PUBLIC_KEY);
             }
         }
@@ -698,25 +824,36 @@ public class AcmeServiceImpl implements AcmeExternalService {
             logger.debug("Validating revocation request signed with the account key pair");
             // check that the associated protocol is ACME
             if (cert.getProtocolAssociation() == null) {
-                throw new AcmeProblemDocumentException(HttpStatus.FORBIDDEN, Problem.UNAUTHORIZED, "Certificate is not associated with protocol");
+                throw new AcmeProblemDocumentException(HttpStatus.FORBIDDEN, Problem.UNAUTHORIZED,
+                        "Certificate is not associated with protocol");
             } else if (cert.getProtocolAssociation().getProtocol() != CertificateProtocol.ACME) {
-                throw new AcmeProblemDocumentException(HttpStatus.FORBIDDEN, Problem.UNAUTHORIZED, "Certificate is not associated with ACME protocol");
+                throw new AcmeProblemDocumentException(HttpStatus.FORBIDDEN, Problem.UNAUTHORIZED,
+                        "Certificate is not associated with ACME protocol");
             }
             // check that the ACME account ID of the certificate matches the account ID in the request
-            acmeAccount = acmeAccountRepository.findByUuid(cert.getProtocolAssociation().getAdditionalProtocolUuid())
-                    .orElseThrow(() -> new AcmeProblemDocumentException(HttpStatus.FORBIDDEN, Problem.UNAUTHORIZED, "Unable to find the ACME account that is associated with the certificate"));
+            acmeAccount = acmeAccountRepository
+                    .findByUuid(cert.getProtocolAssociation().getAdditionalProtocolUuid())
+                    .orElseThrow(() -> new AcmeProblemDocumentException(HttpStatus.FORBIDDEN, Problem.UNAUTHORIZED,
+                            "Unable to find the ACME account that is associated with the certificate"));
             String kid = jwsRequest.getKid();
             String requestAccountId = kid.split("/")[kid.split("/").length - 1];
             if (!acmeAccount.getAccountId().equals(requestAccountId)) {
-                throw new AcmeProblemDocumentException(HttpStatus.FORBIDDEN, Problem.UNAUTHORIZED, "Account does not match the certificate associated ACME Account");
+                throw new AcmeProblemDocumentException(HttpStatus.FORBIDDEN, Problem.UNAUTHORIZED,
+                        "Account does not match the certificate associated ACME Account");
             }
         }
 
         // if the revocation reason is null, set it to UNSPECIFIED, otherwise get the code from the request
-        final CertificateRevocationReason reason = request.getReason() == null ? CertificateRevocationReason.UNSPECIFIED : CertificateRevocationReason.fromReasonCode(request.getReason());
+        final CertificateRevocationReason reason = request.getReason() == null
+                ? CertificateRevocationReason.UNSPECIFIED
+                : CertificateRevocationReason.fromReasonCode(request.getReason());
         // when the reason is null, it means, that is not in the list
         if (reason == null) {
-            final String details = "Allowed revocation reason codes are: " + Arrays.toString(Arrays.stream(CertificateRevocationReason.values()).map(CertificateRevocationReason::getCode).toArray());
+            final String details = "Allowed revocation reason codes are: " + Arrays
+                    .toString(Arrays
+                            .stream(CertificateRevocationReason.values())
+                            .map(CertificateRevocationReason::getCode)
+                            .toArray());
             throw new AcmeProblemDocumentException(HttpStatus.FORBIDDEN, Problem.BAD_REVOCATION_REASON, details);
         }
 
@@ -724,7 +861,10 @@ public class AcmeServiceImpl implements AcmeExternalService {
         revokeRequest.setAttributes(getClientOperationAttributes(true, acmeAccount, isRaProfileBased));
 
         try {
-            clientOperationService.revokeCertificate(SecuredParentUUID.fromUUID(cert.getRaProfile().getAuthorityInstanceReferenceUuid()), cert.getRaProfile().getSecuredUuid(), cert.getUuid().toString(), revokeRequest);
+            clientOperationService
+                    .revokeCertificate(
+                            SecuredParentUUID.fromUUID(cert.getRaProfile().getAuthorityInstanceReferenceUuid()),
+                            cert.getRaProfile().getSecuredUuid(), cert.getUuid().toString(), revokeRequest);
             return ResponseEntity
                     .ok()
                     .header(AcmeConstants.NONCE_HEADER_NAME, generateNonce())
@@ -744,7 +884,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     private String getAcmeBaseUri() {
-        return ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString() + AcmeConstants.ACME_URI_HEADER;
+        return ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString()
+                + AcmeConstants.ACME_URI_HEADER;
     }
 
     private DirectoryMeta frameDirectoryMeta(String profileName, boolean isRaProfileBased) throws NotFoundException {
@@ -788,17 +929,21 @@ public class AcmeServiceImpl implements AcmeExternalService {
         return "<" + baseUri + AcmeConstants.ACME_URI_HEADER + "/" + profileName + "/directory>;rel=\"index\"";
     }
 
-    private AcmeAccount addNewAccount(String profileName, String publicKey, NewAccountRequest accountRequest, boolean isRaProfileBased) throws AcmeProblemDocumentException {
+    private AcmeAccount addNewAccount(String profileName, String publicKey, NewAccountRequest accountRequest,
+            boolean isRaProfileBased) throws AcmeProblemDocumentException {
         AcmeRaProfiles acmeRaProfiles = getProfiles(profileName, isRaProfileBased);
         AcmeProfile acmeProfile = acmeRaProfiles.acmeProfile;
         RaProfile raProfileToUse = acmeRaProfiles.raProfile;
 
         if (logger.isDebugEnabled()) {
-            logger.debug("RA Profile for new Account: {}, ACME Profile: {}", raProfileToUse.toString(), acmeProfile.toString());
+            logger
+                    .debug("RA Profile for new Account: {}, ACME Profile: {}", raProfileToUse.toString(),
+                            acmeProfile.toString());
         }
         String accountId = AcmeRandomGeneratorAndValidator.generateRandomId();
         AcmeAccount oldAccount = acmeAccountRepository.findByPublicKey(publicKey);
-        if (acmeProfile.isRequireContact() != null && acmeProfile.isRequireContact() && accountRequest.getContact().isEmpty()) {
+        if (acmeProfile.isRequireContact() != null && acmeProfile.isRequireContact()
+                && accountRequest.getContact().isEmpty()) {
             logger.error("Contact not found for Account: {}", accountRequest);
             {
                 throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.INVALID_CONTACT,
@@ -806,7 +951,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
             }
         }
 
-        if (acmeProfile.isRequireTermsOfService() != null && acmeProfile.isRequireTermsOfService() && accountRequest.isTermsOfServiceAgreed()) {
+        if (acmeProfile.isRequireTermsOfService() != null && acmeProfile.isRequireTermsOfService()
+                && accountRequest.isTermsOfServiceAgreed()) {
             logger.error("Terms of Service not agreed for the new Account: {}", accountRequest);
             {
                 throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.USER_ACTION_REQUIRED,
@@ -850,7 +996,9 @@ public class AcmeServiceImpl implements AcmeExternalService {
     }
 
     private AcmeAccount getAcmeAccountEntity(String accountId) throws NotFoundException {
-        return acmeAccountRepository.findByAccountId(accountId).orElseThrow(() -> new NotFoundException(AcmeAccount.class, accountId));
+        return acmeAccountRepository
+                .findByAccountId(accountId)
+                .orElseThrow(() -> new NotFoundException(AcmeAccount.class, accountId));
     }
 
     private void validateAccount(AcmeAccount acmeAccount) throws AcmeProblemDocumentException {
@@ -864,7 +1012,9 @@ public class AcmeServiceImpl implements AcmeExternalService {
         int failedOrdersCount = 0;
         for (AcmeOrder order : acmeAccount.getOrders()) {
             // Order might have already been invalid and accounted for, only update count for changed status
-            if (order.getStatus() != OrderStatus.INVALID) failedOrdersCount++;
+            if (order.getStatus() != OrderStatus.INVALID) {
+                failedOrdersCount++;
+            }
             order.setStatus(OrderStatus.INVALID);
             deactivateAuthorizations(order.getAuthorizations());
             acmeOrderRepository.save(order);
@@ -877,7 +1027,7 @@ public class AcmeServiceImpl implements AcmeExternalService {
             authorization.setStatus(AuthorizationStatus.DEACTIVATED);
             deactivateChallenges(authorization.getChallenges());
             acmeAuthorizationRepository.save(authorization);
-        }   
+        }
     }
 
     private void deactivateChallenges(Set<AcmeChallenge> challenges) {
@@ -887,22 +1037,21 @@ public class AcmeServiceImpl implements AcmeExternalService {
         }
     }
 
-
     private void validateKey(JWSObject jwsRequestObject, JWSObject jwsInnerObject) throws AcmeProblemDocumentException {
         if (!jwsInnerObject.getHeader().toJSONObject().containsKey("jwk")) {
-            throw new AcmeProblemDocumentException(
-                    HttpStatus.BAD_REQUEST, Problem.MALFORMED,
+            throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
                     "Inner JWS does not contain jwk");
         }
-        if (!jwsInnerObject.getHeader().toJSONObject().getOrDefault("url", "innerUrl")
+        if (!jwsInnerObject
+                .getHeader()
+                .toJSONObject()
+                .getOrDefault("url", "innerUrl")
                 .equals(jwsRequestObject.getHeader().toJSONObject().getOrDefault("url", "outerUrl"))) {
-            throw new AcmeProblemDocumentException(
-                    HttpStatus.BAD_REQUEST, Problem.MALFORMED,
+            throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
                     "URL in inner and outer JWS are different");
         }
         if (jwsInnerObject.getHeader().toJSONObject().containsKey("nonce")) {
-            throw new AcmeProblemDocumentException(
-                    HttpStatus.BAD_REQUEST, Problem.MALFORMED,
+            throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
                     "Inner JWS cannot contain nonce header");
         }
     }
@@ -946,7 +1095,9 @@ public class AcmeServiceImpl implements AcmeExternalService {
         authorization.setStatus(AuthorizationStatus.PENDING);
         authorization.setOrder(acmeOrder);
         if (acmeOrder.getAcmeAccount().getAcmeProfile().getValidity() != null) {
-            authorization.setExpires(AcmeCommonHelper.addSeconds(new Date(), acmeOrder.getAcmeAccount().getAcmeProfile().getValidity()));
+            authorization
+                    .setExpires(AcmeCommonHelper
+                            .addSeconds(new Date(), acmeOrder.getAcmeAccount().getAcmeProfile().getValidity()));
         } else {
             authorization.setExpires(AcmeCommonHelper.getDefaultExpires());
         }
@@ -977,22 +1128,21 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
     private boolean validateHttpChallenge(AcmeChallenge challenge) throws AcmeProblemDocumentException {
         logger.debug("Initiating HTTP-01 Challenge validation: {}", challenge.toString());
-        String response = getHttpChallengeResponse(
-                SerializationUtil.deserializeIdentifier(
-                                challenge
-                                        .getAuthorization()
-                                        .getIdentifier()
-                        )
-                        .getValue().replace("*.", ""),
-                challenge.getToken());
+        String response = getHttpChallengeResponse(SerializationUtil
+                .deserializeIdentifier(challenge.getAuthorization().getIdentifier())
+                .getValue()
+                .replace("*.", ""), challenge.getToken());
         PublicKey pubKey;
         try {
-            pubKey = AcmePublicKeyProcessor.publicKeyObjectFromString(challenge.getAuthorization().getOrder().getAcmeAccount().getPublicKey());
+            pubKey = AcmePublicKeyProcessor
+                    .publicKeyObjectFromString(challenge.getAuthorization().getOrder().getAcmeAccount().getPublicKey());
         } catch (Exception e) {
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.SERVER_INTERNAL);
         }
         String expectedResponse = AcmeCommonHelper.createKeyAuthorization(challenge.getToken(), pubKey);
-        logger.debug("HTTP01 validation response from the server: {}, expected response: {}", response, expectedResponse);
+        logger
+                .debug("HTTP01 validation response from the server: {}, expected response: {}", response,
+                        expectedResponse);
         return response.equals(expectedResponse);
     }
 
@@ -1000,14 +1150,15 @@ public class AcmeServiceImpl implements AcmeExternalService {
         logger.info("Initiating DNS-01 validation for challenge: {}", challenge.toString());
         Properties env = getEnv(challenge);
         List<String> txtRecords = new ArrayList<>();
-        String expectedKeyAuthorization = generateDnsValidationToken(challenge.getAuthorization().getOrder().getAcmeAccount().getPublicKey(), challenge.getToken());
+        String expectedKeyAuthorization = generateDnsValidationToken(
+                challenge.getAuthorization().getOrder().getAcmeAccount().getPublicKey(), challenge.getToken());
         DirContext context;
         try {
             context = new InitialDirContext(env);
-            Attributes list = context.getAttributes(AcmeConstants.DNS_ACME_PREFIX
-                            + SerializationUtil.deserializeIdentifier(
-                            challenge.getAuthorization().getIdentifier()).getValue(),
-                    new String[]{AcmeConstants.DNS_RECORD_TYPE});
+            Attributes list = context
+                    .getAttributes(AcmeConstants.DNS_ACME_PREFIX + SerializationUtil
+                            .deserializeIdentifier(challenge.getAuthorization().getIdentifier())
+                            .getValue(), new String[]{AcmeConstants.DNS_RECORD_TYPE});
             NamingEnumeration<? extends Attribute> records = list.getAll();
 
             while (records.hasMore()) {
@@ -1035,8 +1186,12 @@ public class AcmeServiceImpl implements AcmeExternalService {
         if (acmeProfile.getDnsResolverIp() == null || acmeProfile.getDnsResolverIp().isEmpty()) {
             env.setProperty(Context.PROVIDER_URL, AcmeConstants.DNS_ENV_PREFIX);
         } else {
-            env.setProperty(Context.PROVIDER_URL, AcmeConstants.DNS_ENV_PREFIX + acmeProfile.getDnsResolverIp() + ":" + Optional.ofNullable(acmeProfile.getDnsResolverPort())
-                    .orElse(AcmeConstants.DEFAULT_DNS_PORT));
+            env
+                    .setProperty(Context.PROVIDER_URL,
+                            AcmeConstants.DNS_ENV_PREFIX + acmeProfile.getDnsResolverIp() + ":"
+                                    + Optional
+                                            .ofNullable(acmeProfile.getDnsResolverPort())
+                                            .orElse(AcmeConstants.DEFAULT_DNS_PORT));
         }
         return env;
     }
@@ -1055,7 +1210,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
                 redirectFollowCount += 1;
                 URL urlObject = new URL(finalUrl);
                 if (!(urlObject.getPort() == 80 || urlObject.getPort() == 443 || urlObject.getPort() == -1)) {
-                    throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.TLS, "Only 80 and 443 ports can be followed");
+                    throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.TLS,
+                            "Only 80 and 443 ports can be followed");
                 }
                 connection = (HttpURLConnection) new URL(finalUrl).openConnection();
                 connection.setInstanceFollowRedirects(false);
@@ -1064,7 +1220,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
                 connection.connect();
                 int responseCode = connection.getResponseCode();
                 if (100 <= connection.getResponseCode() && connection.getResponseCode() <= 399) {
-                    BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+                    BufferedReader bufferedReader = new BufferedReader(
+                            new InputStreamReader(connection.getInputStream()));
                     acmeChallengeOutput = bufferedReader.lines().collect(Collectors.joining());
                 }
                 if (responseCode >= 300 && responseCode < 400) {
@@ -1073,9 +1230,11 @@ public class AcmeServiceImpl implements AcmeExternalService {
                         break;
                     }
                     finalUrl = redirectedUrl;
-                } else
+                } else {
                     break;
-            } while (connection.getResponseCode() != HttpURLConnection.HTTP_OK && redirectFollowCount < AcmeConstants.MAX_REDIRECT_COUNT);
+                }
+            } while (connection.getResponseCode() != HttpURLConnection.HTTP_OK
+                    && redirectFollowCount < AcmeConstants.MAX_REDIRECT_COUNT);
             connection.disconnect();
         } catch (AcmeProblemDocumentException e) {
             throw e;
@@ -1090,7 +1249,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
         try {
             PublicKey pubKey = AcmePublicKeyProcessor.publicKeyObjectFromString(publicKey);
             digest = MessageDigest.getInstance(AcmeConstants.MESSAGE_DIGEST_ALGORITHM);
-            final byte[] encodedHashOfExpectedKeyAuthorization = digest.digest(AcmeCommonHelper.createKeyAuthorization(token, pubKey).getBytes(StandardCharsets.UTF_8));
+            final byte[] encodedHashOfExpectedKeyAuthorization = digest
+                    .digest(AcmeCommonHelper.createKeyAuthorization(token, pubKey).getBytes(StandardCharsets.UTF_8));
             return Base64URL.encode(encodedHashOfExpectedKeyAuthorization).toString();
         } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
             logger.error(e.getMessage());
@@ -1129,7 +1289,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
             }
         }
 
-        List<String> identifiers = SerializationUtil.deserializeIdentifiers(order.getIdentifiers())
+        List<String> identifiers = SerializationUtil
+                .deserializeIdentifiers(order.getIdentifiers())
                 .stream()
                 .map(Identifier::getValue)
                 .toList();
@@ -1172,7 +1333,8 @@ public class AcmeServiceImpl implements AcmeExternalService {
         return decodedCsr.toString();
     }
 
-    private List<RequestAttribute> getClientOperationAttributes(boolean isRevoke, AcmeAccount acmeAccount, boolean isRaProfileBased) {
+    private List<RequestAttribute> getClientOperationAttributes(boolean isRevoke, AcmeAccount acmeAccount,
+            boolean isRaProfileBased) {
         if (acmeAccount == null) {
             return List.of();
         }
@@ -1184,40 +1346,73 @@ public class AcmeServiceImpl implements AcmeExternalService {
             } else {
                 attributes = acmeAccount.getRaProfile().getProtocolAttribute().getAcmeIssueCertificateAttributes();
             }
-            return AttributeDefinitionUtils.getClientAttributes(AttributeDefinitionUtils.deserialize(attributes, DataAttributeV2.class));
+            return AttributeDefinitionUtils
+                    .getClientAttributes(AttributeDefinitionUtils.deserialize(attributes, DataAttributeV2.class));
         } else {
             if (isRevoke) {
-                return attributeEngine.getRequestObjectDataAttributesContent(ObjectAttributeContentInfo.builder(com.otilm.api.model.core.auth.Resource.ACME_PROFILE, acmeAccount.getAcmeProfile().getUuid()).connector(acmeAccount.getAcmeProfile().getRaProfile().getAuthorityInstanceReference().getConnectorUuid()).operation(AttributeOperation.CERTIFICATE_REVOKE).build());
+                return attributeEngine
+                        .getRequestObjectDataAttributesContent(ObjectAttributeContentInfo
+                                .builder(com.otilm.api.model.core.auth.Resource.ACME_PROFILE,
+                                        acmeAccount.getAcmeProfile().getUuid())
+                                .connector(acmeAccount
+                                        .getAcmeProfile()
+                                        .getRaProfile()
+                                        .getAuthorityInstanceReference()
+                                        .getConnectorUuid())
+                                .operation(AttributeOperation.CERTIFICATE_REVOKE)
+                                .build());
             } else {
-                return attributeEngine.getRequestObjectDataAttributesContent(ObjectAttributeContentInfo.builder(com.otilm.api.model.core.auth.Resource.ACME_PROFILE, acmeAccount.getAcmeProfile().getUuid()).connector(acmeAccount.getAcmeProfile().getRaProfile().getAuthorityInstanceReference().getConnectorUuid()).operation(AttributeOperation.CERTIFICATE_ISSUE).build());
+                return attributeEngine
+                        .getRequestObjectDataAttributesContent(ObjectAttributeContentInfo
+                                .builder(com.otilm.api.model.core.auth.Resource.ACME_PROFILE,
+                                        acmeAccount.getAcmeProfile().getUuid())
+                                .connector(acmeAccount
+                                        .getAcmeProfile()
+                                        .getRaProfile()
+                                        .getAuthorityInstanceReference()
+                                        .getConnectorUuid())
+                                .operation(AttributeOperation.CERTIFICATE_ISSUE)
+                                .build());
             }
         }
 
     }
 
     private void createCert(AcmeOrder order, ClientCertificateIssueRequestDto certificateIssueRequestDto) {
-        // check if certificate is not already requested (prevent calling finalize multiple times issuing more certificates)
+        // check if certificate is not already requested (prevent calling finalize multiple times issuing more
+        // certificates)
         // not sure if it is necessary
         if (order.getCertificateReference() == null) {
             try {
                 // keep state as PROCESSING since issuing is async process
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Requesting Certificate for the Order: {} and issue request: {}", order, certificateIssueRequestDto);
+                    logger
+                            .debug("Requesting Certificate for the Order: {} and issue request: {}", order,
+                                    certificateIssueRequestDto);
                 }
-                ClientCertificateDataResponseDto certificateOutput = clientOperationService.issueCertificate(SecuredParentUUID.fromUUID(order.getAcmeAccount().getRaProfile().getAuthorityInstanceReferenceUuid()), order.getAcmeAccount().getRaProfile().getSecuredUuid(), certificateIssueRequestDto,
-                        CertificateProtocolInfo.Acme(order.getAcmeAccount().getAcmeProfileUuid(), order.getAcmeAccountUuid()));
+                ClientCertificateDataResponseDto certificateOutput = clientOperationService
+                        .issueCertificate(SecuredParentUUID
+                                .fromUUID(order.getAcmeAccount().getRaProfile().getAuthorityInstanceReferenceUuid()),
+                                order.getAcmeAccount().getRaProfile().getSecuredUuid(), certificateIssueRequestDto,
+                                CertificateProtocolInfo
+                                        .Acme(order.getAcmeAccount().getAcmeProfileUuid(), order.getAcmeAccountUuid()));
                 order.setCertificateId(AcmeRandomGeneratorAndValidator.generateRandomId());
-                order.setCertificateReference(certificateService.getCertificateEntity(SecuredUUID.fromString(certificateOutput.getUuid())));
+                order
+                        .setCertificateReference(certificateService
+                                .getCertificateEntity(SecuredUUID.fromString(certificateOutput.getUuid())));
             } catch (Exception e) {
                 logger.error("Issue Certificate failed. Exception: {}", e.getMessage());
                 order.setStatus(OrderStatus.INVALID);
-                // Order with previously invalid status would not have reached issuing of certificate, therefore count needs to be incremented always
+                // Order with previously invalid status would not have reached issuing of certificate, therefore count
+                // needs to be incremented always
                 incrementFailedOrdersCount(order);
             }
             acmeOrderRepository.save(order);
         } else {
             OrderStatus newStatus = checkOrderStatusByCertificate(order.getCertificateReference());
-            logger.debug("Calling finalize of Order but certificate is already requested. Current status: {}", newStatus);
+            logger
+                    .debug("Calling finalize of Order but certificate is already requested. Current status: {}",
+                            newStatus);
             if (!newStatus.equals(order.getStatus())) {
                 order.setStatus(newStatus);
                 incrementOrderCounts(newStatus, order);
@@ -1227,21 +1422,34 @@ public class AcmeServiceImpl implements AcmeExternalService {
     }
 
     private OrderStatus checkOrderStatusByCertificate(Certificate certificate) {
-        if (certificate.getState().equals(CertificateState.ISSUED)) return OrderStatus.VALID;
+        if (certificate.getState().equals(CertificateState.ISSUED)) {
+            return OrderStatus.VALID;
+        }
         if (certificate.getState().equals(CertificateState.REQUESTED)
                 || certificate.getState().equals(CertificateState.PENDING_APPROVAL)
-                || certificate.getState().equals(CertificateState.PENDING_ISSUE)) return OrderStatus.PROCESSING;
+                || certificate.getState().equals(CertificateState.PENDING_ISSUE)) {
+            return OrderStatus.PROCESSING;
+        }
 
         return OrderStatus.INVALID;
     }
 
-    protected ByteArrayResource getCertificateResource(String certificateId) throws NotFoundException, CertificateException {
-        AcmeOrder order = acmeOrderRepository.findByCertificateId(certificateId).orElseThrow(() -> new NotFoundException(Order.class, certificateId));
-        LoggingHelper.putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ORDER, true, order.getUuid().toString(), order.getOrderId());
+    protected ByteArrayResource getCertificateResource(String certificateId)
+            throws NotFoundException, CertificateException {
+        AcmeOrder order = acmeOrderRepository
+                .findByCertificateId(certificateId)
+                .orElseThrow(() -> new NotFoundException(Order.class, certificateId));
+        LoggingHelper
+                .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ORDER, true, order.getUuid().toString(),
+                        order.getOrderId());
 
-        CertificateChainResponseDto certificateChainResponse = certificateService.getCertificateChain(SecuredUUID.fromUUID(order.getCertificateReferenceUuid()), true);
+        CertificateChainResponseDto certificateChainResponse = certificateService
+                .getCertificateChain(SecuredUUID.fromUUID(order.getCertificateReferenceUuid()), true);
         if (!certificateChainResponse.getCertificates().isEmpty()) {
-            LoggingHelper.putLogResourceInfo(com.otilm.api.model.core.auth.Resource.CERTIFICATE, false, certificateChainResponse.getCertificates().getFirst().getUuid(), certificateChainResponse.getCertificates().getFirst().getSubjectDn());
+            LoggingHelper
+                    .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.CERTIFICATE, false,
+                            certificateChainResponse.getCertificates().getFirst().getUuid(),
+                            certificateChainResponse.getCertificates().getFirst().getSubjectDn());
         }
         String chainString = frameCertChainString(certificateChainResponse.getCertificates());
         return new ByteArrayResource(chainString.getBytes(StandardCharsets.UTF_8));
@@ -1259,16 +1467,19 @@ public class AcmeServiceImpl implements AcmeExternalService {
         return CertificateUtil.getX509Certificate(CertificateUtil.normalizeCertificateContent(certificate));
     }
 
-    private void checkAccountConfiguration(AcmeAccount account, String profileName, boolean isRaProfileBased) throws AcmeProblemDocumentException {
+    private void checkAccountConfiguration(AcmeAccount account, String profileName, boolean isRaProfileBased)
+            throws AcmeProblemDocumentException {
         AcmeRaProfiles acmeRaProfiles = getProfiles(profileName, isRaProfileBased);
 
-        if (!account.getAcmeProfileUuid().equals(acmeRaProfiles.acmeProfile.getUuid()) ||
-                !account.getRaProfileUuid().equals(acmeRaProfiles.raProfile.getUuid())) {
-            throw new AcmeProblemDocumentException(HttpStatus.UNAUTHORIZED, Problem.UNAUTHORIZED, "Account does not belong to this profile");
+        if (!account.getAcmeProfileUuid().equals(acmeRaProfiles.acmeProfile.getUuid())
+                || !account.getRaProfileUuid().equals(acmeRaProfiles.raProfile.getUuid())) {
+            throw new AcmeProblemDocumentException(HttpStatus.UNAUTHORIZED, Problem.UNAUTHORIZED,
+                    "Account does not belong to this profile");
         }
     }
 
-    private AcmeRaProfiles getProfiles(String profileName, boolean isRaProfileBased) throws AcmeProblemDocumentException {
+    private AcmeRaProfiles getProfiles(String profileName, boolean isRaProfileBased)
+            throws AcmeProblemDocumentException {
         AcmeProfile acmeProfile;
         RaProfile raProfileToUse;
 
@@ -1276,14 +1487,16 @@ public class AcmeServiceImpl implements AcmeExternalService {
             try {
                 raProfileToUse = getRaProfileEntity(profileName);
             } catch (NotFoundException e) {
-                throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED, "RA Profile is not found");
+                throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
+                        "RA Profile is not found");
             }
             acmeProfile = raProfileToUse.getAcmeProfile();
         } else {
             try {
                 acmeProfile = getAcmeProfileEntityByName(profileName);
             } catch (NotFoundException e) {
-                throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED, "ACME Profile is not found");
+                throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
+                        "ACME Profile is not found");
             }
             raProfileToUse = acmeProfile.getRaProfile();
         }
@@ -1291,20 +1504,23 @@ public class AcmeServiceImpl implements AcmeExternalService {
         return new AcmeRaProfiles(acmeProfile, raProfileToUse);
     }
 
-    private record AcmeRaProfiles(AcmeProfile acmeProfile, RaProfile raProfile) {}
+    private record AcmeRaProfiles(AcmeProfile acmeProfile, RaProfile raProfile) {
+    }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Validation of ACME requests
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    private void validateRequest(AcmeJwsRequest acmeJwsRequest, String acmeProfileName, URI requestUri, boolean isRaProfileBased) throws AcmeProblemDocumentException {
+    private void validateRequest(AcmeJwsRequest acmeJwsRequest, String acmeProfileName, URI requestUri,
+            boolean isRaProfileBased) throws AcmeProblemDocumentException {
         validateRequestNoNonce(acmeJwsRequest, acmeProfileName, requestUri, isRaProfileBased);
 
-        //Validate JWS Header for Nonce if it has the correct value
+        // Validate JWS Header for Nonce if it has the correct value
         validateNonce(acmeJwsRequest.getJwsHeader().getCustomParam("nonce"));
     }
 
-    private void validateRequestNoNonce(AcmeJwsRequest acmeJwsRequest, String acmeProfileName, URI requestUri, boolean isRaProfileBased) throws AcmeProblemDocumentException {
+    private void validateRequestNoNonce(AcmeJwsRequest acmeJwsRequest, String acmeProfileName, URI requestUri,
+            boolean isRaProfileBased) throws AcmeProblemDocumentException {
         if (acmeJwsRequest.getJwsHeader() == null) {
             logger.error("JWS header is missing or malformed");
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED);
@@ -1327,8 +1543,9 @@ public class AcmeServiceImpl implements AcmeExternalService {
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.BAD_NONCE);
         }
 
-        AcmeNonce acmeNonce = acmeNonceRepository.findByNonce(nonce.toString()).orElseThrow(
-                () -> new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.BAD_NONCE));
+        AcmeNonce acmeNonce = acmeNonceRepository
+                .findByNonce(nonce.toString())
+                .orElseThrow(() -> new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.BAD_NONCE));
         if (acmeNonce.getExpires().after(AcmeCommonHelper.addSeconds(new Date(), AcmeConstants.NONCE_VALIDITY))) {
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.BAD_NONCE);
         }
@@ -1339,10 +1556,10 @@ public class AcmeServiceImpl implements AcmeExternalService {
             acmeJwsRequest.checkSignature(acmeJwsRequest.getPublicKey());
         } else {
             String kid = acmeJwsRequest.getKid();
-            AcmeAccount account = acmeAccountRepository.findByAccountId(
-                            kid.split("/")[kid.split("/").length - 1])
-                    .orElseThrow(
-                            () -> new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.ACCOUNT_DOES_NOT_EXIST));
+            AcmeAccount account = acmeAccountRepository
+                    .findByAccountId(kid.split("/")[kid.split("/").length - 1])
+                    .orElseThrow(() -> new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST,
+                            Problem.ACCOUNT_DOES_NOT_EXIST));
             PublicKey publicKey;
             try {
                 publicKey = AcmePublicKeyProcessor.publicKeyObjectFromString(account.getPublicKey());
@@ -1357,8 +1574,9 @@ public class AcmeServiceImpl implements AcmeExternalService {
     }
 
     public void validateRaBasedAcme(String raProfileName) throws AcmeProblemDocumentException {
-        RaProfile raProfile = raProfileRepository.findByName(raProfileName).orElseThrow(() ->
-                new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
+        RaProfile raProfile = raProfileRepository
+                .findByName(raProfileName)
+                .orElseThrow(() -> new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
                         "Given RA Profile in the request URL is not found"));
         if (raProfile.getAcmeProfile() == null) {
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
@@ -1399,15 +1617,17 @@ public class AcmeServiceImpl implements AcmeExternalService {
             problemDocument.setInstance(acmeProfile.getTermsOfServiceUrl());
             problemDocument.setDetail("Terms of service have changed");
             Map<String, String> additionalHeaders = new HashMap<>();
-            additionalHeaders.put("Link", "<" + acmeProfile.getTermsOfServiceChangeUrl() + ">;rel=\"terms-of-service\"");
+            additionalHeaders
+                    .put("Link", "<" + acmeProfile.getTermsOfServiceChangeUrl() + ">;rel=\"terms-of-service\"");
             throw new AcmeProblemDocumentException(HttpStatus.FORBIDDEN, problemDocument, additionalHeaders);
         }
     }
 
     private AcmeOrder validateOrder(String orderId) throws AcmeProblemDocumentException {
-        AcmeOrder order = acmeOrderRepository.findByOrderId(orderId).orElseThrow(() -> new
-                AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.SERVER_INTERNAL,
-                "Requested order is not found"));
+        AcmeOrder order = acmeOrderRepository
+                .findByOrderId(orderId)
+                .orElseThrow(() -> new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.SERVER_INTERNAL,
+                        "Requested order is not found"));
 
         if (order.getExpires() != null) {
             if (order.getExpires().before(new Date())) {
@@ -1448,9 +1668,10 @@ public class AcmeServiceImpl implements AcmeExternalService {
     }
 
     private AcmeAuthorization validateAuthorization(String authorizationId) throws AcmeProblemDocumentException {
-        AcmeAuthorization authorization = acmeAuthorizationRepository.findByAuthorizationId(authorizationId)
-                .orElseThrow(() -> new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST,
-                        Problem.SERVER_INTERNAL, "Requested authorization is not found"));
+        AcmeAuthorization authorization = acmeAuthorizationRepository
+                .findByAuthorizationId(authorizationId)
+                .orElseThrow(() -> new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.SERVER_INTERNAL,
+                        "Requested authorization is not found"));
         if (authorization.getExpires() != null) {
             if (authorization.getExpires().before(new Date())) {
                 throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
@@ -1461,22 +1682,24 @@ public class AcmeServiceImpl implements AcmeExternalService {
     }
 
     private AcmeChallenge validateChallenge(String challengeId) throws AcmeProblemDocumentException {
-        AcmeChallenge challenge = acmeChallengeRepository.findByChallengeId(challengeId)
-                .orElseThrow(() -> new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST,
-                        Problem.SERVER_INTERNAL, "Requested challenge is not found"));
+        AcmeChallenge challenge = acmeChallengeRepository
+                .findByChallengeId(challengeId)
+                .orElseThrow(() -> new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.SERVER_INTERNAL,
+                        "Requested challenge is not found"));
         if (challenge.getAuthorization().getExpires() != null) {
             if (challenge.getAuthorization().getExpires().before(new Date())) {
-                throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST,
-                        Problem.MALFORMED, "Challenge is expired");
+                throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
+                        "Challenge is expired");
             }
         }
         return challenge;
     }
 
     private void validateAccount(String accountId) throws AcmeProblemDocumentException {
-        AcmeAccount acmeAccount = acmeAccountRepository.findByAccountId(accountId)
-                .orElseThrow(() ->
-                        new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.ACCOUNT_DOES_NOT_EXIST));
+        AcmeAccount acmeAccount = acmeAccountRepository
+                .findByAccountId(accountId)
+                .orElseThrow(
+                        () -> new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.ACCOUNT_DOES_NOT_EXIST));
         validateAccount(acmeAccount);
     }
 

--- a/src/main/java/com/otilm/core/service/acme/impl/AcmeServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/acme/impl/AcmeServiceImpl.java
@@ -64,10 +64,14 @@ import com.otilm.core.security.authz.ProtocolEndpoint;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.service.CertificateInternalService;
+import com.otilm.core.service.acme.AcmeChallengeStateMachine;
 import com.otilm.core.service.acme.AcmeConstants;
+import com.otilm.core.service.acme.AcmeDnsChallengeValidator;
 import com.otilm.core.service.acme.AcmeExternalService;
+import com.otilm.core.service.acme.ChallengeValidationResult;
 import com.otilm.core.service.acme.message.AcmeJwsRequest;
 import com.otilm.core.service.v2.ClientOperationInternalService;
+import com.otilm.core.service.writer.AcmeChallengeWriter;
 import com.otilm.core.util.AcmeCommonHelper;
 import com.otilm.core.util.AcmeJsonProcessor;
 import com.otilm.core.util.AcmePublicKeyProcessor;
@@ -77,6 +81,8 @@ import com.otilm.core.util.CertificateRequestUtils;
 import com.otilm.core.util.CertificateUtil;
 import com.otilm.core.util.SerializationUtil;
 import com.otilm.core.util.X509ObjectToString;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -96,22 +102,14 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.naming.Context;
-import javax.naming.NamingEnumeration;
-import javax.naming.NamingException;
-import javax.naming.directory.Attribute;
-import javax.naming.directory.Attributes;
-import javax.naming.directory.DirContext;
-import javax.naming.directory.InitialDirContext;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x500.style.IETFUtils;
@@ -133,6 +131,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @Service
@@ -150,8 +149,18 @@ public class AcmeServiceImpl implements AcmeExternalService {
     private AcmeChallengeRepository acmeChallengeRepository;
     private ClientOperationInternalService clientOperationService;
     private CertificateInternalService certificateService;
+    private AcmeChallengeWriter acmeChallengeWriter;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
     private AttributeEngine attributeEngine;
     private ProtocolRequestAttributeValidator protocolRequestAttributeValidator;
+
+    @Autowired
+    public void setAcmeChallengeWriter(AcmeChallengeWriter acmeChallengeWriter) {
+        this.acmeChallengeWriter = acmeChallengeWriter;
+    }
 
     @Autowired
     public void setAttributeEngine(AttributeEngine attributeEngine) {
@@ -376,12 +385,17 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
         Account request = AcmeJsonProcessor.getPayloadAsRequestObject(jwsRequest.getJwsObject(), Account.class);
         logger.debug("Account Update request: {}", request.toString());
+        boolean deactivate = request.getStatus() != null && request.getStatus().equals(AccountStatus.DEACTIVATED);
+        // The orders are locked and settled before the account row is touched, so the account row is written only
+        // after every order lock is held, in the order the other writers take them.
+        if (deactivate) {
+            logger.info("Deactivating Account with ID: {}", accountId);
+            deactivateOrders(account);
+        }
         if (request.getContact() != null) {
             account.setContact(SerializationUtil.serialize(request.getContact()));
         }
-        if (request.getStatus() != null && request.getStatus().equals(AccountStatus.DEACTIVATED)) {
-            logger.info("Deactivating Account with ID: {}", accountId);
-            deactivateOrders(account);
+        if (deactivate) {
             account.setStatus(AccountStatus.DEACTIVATED);
         }
         acmeAccountRepository.save(account);
@@ -564,32 +578,26 @@ public class AcmeServiceImpl implements AcmeExternalService {
         // Parse and check the JWS request
         AcmeJwsRequest jwsRequest = new AcmeJwsRequest(requestJson);
         validateRequest(jwsRequest, acmeProfileName, requestUri, isRaProfileBased);
-        AcmeAuthorization authorization = validateAuthorization(authorizationId);
+        AcmeAuthorization authorization = loadAuthorization(authorizationId);
+        requireOwnership(jwsRequest, authorization.getOrder().getAcmeAccount());
         LoggingHelper
                 .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_AUTHORIZATION, false,
                         authorization.getUuid().toString(), authorization.getAuthorizationId());
-        if (authorization.getOrder() != null) {
-            LoggingHelper
-                    .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ORDER, true,
-                            authorization.getOrder().getUuid().toString(), authorization.getOrder().getOrderId());
-        }
+        LoggingHelper
+                .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ORDER, true,
+                        authorization.getOrder().getUuid().toString(), authorization.getOrder().getOrderId());
+        settleStaleStatuses(authorization.getOrder());
+        rejectExpiredAuthorization(authorization);
 
         boolean isDeactivateRequest = false;
         if (jwsRequest.getJwsObject().getPayload().toJSONObject() != null) {
-            isDeactivateRequest = jwsRequest
-                    .getJwsObject()
-                    .getPayload()
-                    .toJSONObject()
-                    .getOrDefault("status", "") == "deactivated";
+            isDeactivateRequest = "deactivated"
+                    .equals(jwsRequest.getJwsObject().getPayload().toJSONObject().get("status"));
         }
 
-        if (authorization.getExpires() != null && authorization.getExpires().before(new Date())) {
-            authorization.setStatus(AuthorizationStatus.INVALID);
-            acmeAuthorizationRepository.save(authorization);
-        }
         if (isDeactivateRequest) {
-            authorization.setStatus(AuthorizationStatus.DEACTIVATED);
-            acmeAuthorizationRepository.save(authorization);
+            authorization = acmeChallengeWriter
+                    .deactivateAuthorization(authorization.getOrder().getUuid(), authorizationId);
         }
 
         Authorization authorizationDto = authorization.mapToDto();
@@ -604,42 +612,59 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
     @Override
     @ProtocolEndpoint
+    // Spring's annotation rather than the class's jakarta one: the transaction-boundary rules read Spring's, and the
+    // rollback attribute is what those rules require of a method declaring a checked exception.
+    @org.springframework.transaction.annotation.Transactional(propagation = Propagation.NOT_SUPPORTED,
+            noRollbackFor = AcmeProblemDocumentException.class)
     public ResponseEntity<Challenge> validateChallenge(String acmeProfileName, String challengeId, URI requestUri,
             boolean isRaProfileBased) throws AcmeProblemDocumentException {
         logger.debug("Validating Challenge with ID {}:", challengeId);
-        AcmeChallenge challenge = validateChallenge(challengeId);
-        validateAccount(challenge.getAuthorization().getOrder().getAcmeAccount());
-
-        AcmeAuthorization authorization = challenge.getAuthorization();
-        logger.debug("Authorization corresponding to the Order: {}", authorization.toString());
-        AcmeOrder order = authorization.getOrder();
+        AcmeChallenge challenge = loadChallenge(challengeId);
+        AcmeOrder order = challenge.getAuthorization().getOrder();
+        validateAccount(order.getAcmeAccount());
+        logger.debug("Authorization corresponding to the Order: {}", challenge.getAuthorization().toString());
         logger.debug("Order corresponding to the Challenge: {}", order.toString());
         LoggingHelper
                 .putLogResourceInfo(com.otilm.api.model.core.auth.Resource.ACME_ORDER, true, order.getUuid().toString(),
                         order.getOrderId());
 
-        boolean isValid;
-        if (challenge.getType().equals(ChallengeType.HTTP01)) {
-            isValid = validateHttpChallenge(challenge);
-        } else {
-            isValid = validateDnsChallenge(challenge);
+        if (AcmeChallengeStateMachine.hasStaleStatus(order)) {
+            acmeChallengeWriter.settleOrder(order.getUuid());
+            challenge = loadChallenge(challengeId);
+        }
+        AcmeAuthorization authorization = challenge.getAuthorization();
+        rejectExpiredAuthorization(authorization, "Challenge is expired");
+
+        if (challenge.getStatus() != ChallengeStatus.PENDING
+                || authorization.getStatus() != AuthorizationStatus.PENDING) {
+            logger
+                    .debug("Challenge {} is {} on a {} authorization, returning its current state without validating",
+                            challengeId, challenge.getStatus(), authorization.getStatus());
+            return challengeResponse(acmeProfileName, challenge, isRaProfileBased);
         }
 
-        if (isValid) {
-            challenge.setValidated(new Date());
-            challenge.setStatus(ChallengeStatus.VALID);
-            authorization.setStatus(AuthorizationStatus.VALID);
-            order.setStatus(OrderStatus.READY);
-        } else {
-            challenge.setStatus(ChallengeStatus.INVALID);
+        ChallengeValidationResult result = challenge.getType().equals(ChallengeType.HTTP01)
+                ? validateHttpChallenge(challenge)
+                : validateDnsChallenge(challenge);
+        AcmeChallenge settledChallenge = acmeChallengeWriter
+                .applyValidationResult(order.getUuid(), challengeId, result);
+        logger.debug("Validation of the Challenge is completed: {}", settledChallenge);
+
+        return challengeResponse(acmeProfileName, settledChallenge, isRaProfileBased);
+    }
+
+    /**
+     * Settles the rows of an order that an instance not yet propagating challenge failures left stale, before the order
+     * or one of its authorizations is judged or answered.
+     */
+    private void settleStaleStatuses(AcmeOrder order) {
+        if (AcmeChallengeStateMachine.hasStaleStatus(order)) {
+            acmeChallengeWriter.settleOrder(order.getUuid());
         }
+    }
 
-        acmeOrderRepository.save(order);
-        acmeChallengeRepository.save(challenge);
-        acmeAuthorizationRepository.save(authorization);
-
-        logger.debug("Validation of the Challenge is completed: {}", challenge);
-
+    private ResponseEntity<Challenge> challengeResponse(String acmeProfileName, AcmeChallenge challenge,
+            boolean isRaProfileBased) {
         return ResponseEntity
                 .ok()
                 .header(AcmeConstants.NONCE_HEADER_NAME, generateNonce())
@@ -673,6 +698,7 @@ public class AcmeServiceImpl implements AcmeExternalService {
         }
 
         validateAccount(order.getAcmeAccount());
+        requireOwnership(jwsRequest, order.getAcmeAccount());
         logger.debug("Order found : {}", order);
 
         if (!order.getStatus().equals(OrderStatus.READY)) { // A request to finalize an order will result in error if
@@ -739,9 +765,11 @@ public class AcmeServiceImpl implements AcmeExternalService {
                             order.getAcmeAccount().getUuid().toString(), order.getAcmeAccount().getAccountId());
         }
 
+        // An invalid order is a state the protocol defines, not a server fault: it is returned with that status
+        // (RFC 8555 section 7.1.3). Why validation failed is reported per identifier, on the challenges of the
+        // order's authorizations.
         if (order.getStatus().equals(OrderStatus.INVALID)) {
-            logger.error("Order status is invalid: {}", order);
-            throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.SERVER_INTERNAL);
+            logger.debug("Order {} is invalid", order.getOrderId());
         }
 
         return ResponseEntity
@@ -1009,32 +1037,25 @@ public class AcmeServiceImpl implements AcmeExternalService {
     }
 
     private void deactivateOrders(AcmeAccount acmeAccount) {
-        int failedOrdersCount = 0;
-        for (AcmeOrder order : acmeAccount.getOrders()) {
-            // Order might have already been invalid and accounted for, only update count for changed status
-            if (order.getStatus() != OrderStatus.INVALID) {
-                failedOrdersCount++;
+        int closed = 0;
+        // The orders are taken in a fixed order. Each lock is held until this request commits, so two
+        // deactivations of one account walking them in different orders would each hold the order the other
+        // waits for.
+        List<AcmeOrder> orders = acmeAccount
+                .getOrders()
+                .stream()
+                .sorted(Comparator.comparing(AcmeOrder::getUuid))
+                .toList();
+        for (AcmeOrder order : orders) {
+            if (acmeChallengeWriter.deactivateOrder(order.getUuid())) {
+                closed++;
             }
-            order.setStatus(OrderStatus.INVALID);
-            deactivateAuthorizations(order.getAuthorizations());
-            acmeOrderRepository.save(order);
         }
-        acmeAccount.setFailedOrders(acmeAccount.getFailedOrders() + failedOrdersCount);
-    }
-
-    private void deactivateAuthorizations(Set<AcmeAuthorization> authorizations) {
-        for (AcmeAuthorization authorization : authorizations) {
-            authorization.setStatus(AuthorizationStatus.DEACTIVATED);
-            deactivateChallenges(authorization.getChallenges());
-            acmeAuthorizationRepository.save(authorization);
-        }
-    }
-
-    private void deactivateChallenges(Set<AcmeChallenge> challenges) {
-        for (AcmeChallenge challenge : challenges) {
-            challenge.setStatus(ChallengeStatus.INVALID);
-            acmeChallengeRepository.save(challenge);
-        }
+        // The account is written once, after every order has been locked: writing it earlier would make a
+        // validation holding a later order wait for the account while this request waits for that order. It is
+        // then re-read so that writing it back afterwards carries this count rather than the one loaded before.
+        acmeChallengeWriter.countFailedOrders(acmeAccount.getUuid(), closed);
+        entityManager.refresh(acmeAccount);
     }
 
     private void validateKey(JWSObject jwsRequestObject, JWSObject jwsInnerObject) throws AcmeProblemDocumentException {
@@ -1126,12 +1147,11 @@ public class AcmeServiceImpl implements AcmeExternalService {
         return challenge;
     }
 
-    private boolean validateHttpChallenge(AcmeChallenge challenge) throws AcmeProblemDocumentException {
+    private ChallengeValidationResult validateHttpChallenge(AcmeChallenge challenge)
+            throws AcmeProblemDocumentException {
         logger.debug("Initiating HTTP-01 Challenge validation: {}", challenge.toString());
-        String response = getHttpChallengeResponse(SerializationUtil
-                .deserializeIdentifier(challenge.getAuthorization().getIdentifier())
-                .getValue()
-                .replace("*.", ""), challenge.getToken());
+        String identifierValue = identifierValue(challenge);
+        String response = getHttpChallengeResponse(identifierValue.replace("*.", ""), challenge.getToken());
         PublicKey pubKey;
         try {
             pubKey = AcmePublicKeyProcessor
@@ -1143,57 +1163,33 @@ public class AcmeServiceImpl implements AcmeExternalService {
         logger
                 .debug("HTTP01 validation response from the server: {}, expected response: {}", response,
                         expectedResponse);
-        return response.equals(expectedResponse);
+        if (!response.equals(expectedResponse)) {
+            return ChallengeValidationResult
+                    .failure(Problem.INCORRECT_RESPONSE, "The response served for the HTTP-01 challenge of "
+                            + identifierValue + " does not match the expected key authorization");
+        }
+        return ChallengeValidationResult.success();
     }
 
-    private boolean validateDnsChallenge(AcmeChallenge challenge) throws AcmeProblemDocumentException {
+    private ChallengeValidationResult validateDnsChallenge(AcmeChallenge challenge)
+            throws AcmeProblemDocumentException {
         logger.info("Initiating DNS-01 validation for challenge: {}", challenge.toString());
-        Properties env = getEnv(challenge);
-        List<String> txtRecords = new ArrayList<>();
+        AcmeProfile acmeProfile = challenge.getAuthorization().getOrder().getAcmeAccount().getAcmeProfile();
         String expectedKeyAuthorization = generateDnsValidationToken(
                 challenge.getAuthorization().getOrder().getAcmeAccount().getPublicKey(), challenge.getToken());
-        DirContext context;
-        try {
-            context = new InitialDirContext(env);
-            Attributes list = context
-                    .getAttributes(AcmeConstants.DNS_ACME_PREFIX + SerializationUtil
-                            .deserializeIdentifier(challenge.getAuthorization().getIdentifier())
-                            .getValue(), new String[]{AcmeConstants.DNS_RECORD_TYPE});
-            NamingEnumeration<? extends Attribute> records = list.getAll();
-
-            while (records.hasMore()) {
-                javax.naming.directory.Attribute record = records.next();
-                txtRecords.add(record.get().toString());
-            }
-        } catch (NamingException e) {
-            logger.error(e.getMessage());
-        }
-        if (txtRecords.isEmpty()) {
-            logger.error("TXT record is empty for Challenge: {}", challenge);
-            return false;
-        }
-        if (!txtRecords.contains(expectedKeyAuthorization)) {
-            logger.error("TXT record not found for Challenge: {}", challenge);
-            return false;
-        }
-        return true;
+        return AcmeDnsChallengeValidator
+                .validate(AcmeDnsChallengeValidator.challengeRecordName(identifierValue(challenge)),
+                        expectedKeyAuthorization, AcmeDnsChallengeValidator
+                                .resolverEnv(acmeProfile.getDnsResolverIp(), acmeProfile.getDnsResolverPort()));
     }
 
-    private static Properties getEnv(AcmeChallenge challenge) {
-        Properties env = new Properties();
-        env.setProperty(Context.INITIAL_CONTEXT_FACTORY, AcmeConstants.DNS_CONTENT_FACTORY);
-        AcmeProfile acmeProfile = challenge.getAuthorization().getOrder().getAcmeAccount().getAcmeProfile();
-        if (acmeProfile.getDnsResolverIp() == null || acmeProfile.getDnsResolverIp().isEmpty()) {
-            env.setProperty(Context.PROVIDER_URL, AcmeConstants.DNS_ENV_PREFIX);
-        } else {
-            env
-                    .setProperty(Context.PROVIDER_URL,
-                            AcmeConstants.DNS_ENV_PREFIX + acmeProfile.getDnsResolverIp() + ":"
-                                    + Optional
-                                            .ofNullable(acmeProfile.getDnsResolverPort())
-                                            .orElse(AcmeConstants.DEFAULT_DNS_PORT));
+    private static String identifierValue(AcmeChallenge challenge) throws AcmeProblemDocumentException {
+        Identifier identifier = SerializationUtil.deserializeIdentifier(challenge.getAuthorization().getIdentifier());
+        if (identifier == null) {
+            throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.SERVER_INTERNAL,
+                    "Authorization has no identifier");
         }
-        return env;
+        return identifier.getValue();
     }
 
     private String getHttpChallengeResponse(String domain, String token) throws AcmeProblemDocumentException {
@@ -1422,16 +1418,7 @@ public class AcmeServiceImpl implements AcmeExternalService {
     }
 
     private OrderStatus checkOrderStatusByCertificate(Certificate certificate) {
-        if (certificate.getState().equals(CertificateState.ISSUED)) {
-            return OrderStatus.VALID;
-        }
-        if (certificate.getState().equals(CertificateState.REQUESTED)
-                || certificate.getState().equals(CertificateState.PENDING_APPROVAL)
-                || certificate.getState().equals(CertificateState.PENDING_ISSUE)) {
-            return OrderStatus.PROCESSING;
-        }
-
-        return OrderStatus.INVALID;
+        return AcmeChallengeStateMachine.statusFromCertificate(certificate.getState());
     }
 
     protected ByteArrayResource getCertificateResource(String certificateId)
@@ -1629,22 +1616,14 @@ public class AcmeServiceImpl implements AcmeExternalService {
                 .orElseThrow(() -> new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.SERVER_INTERNAL,
                         "Requested order is not found"));
 
-        if (order.getExpires() != null) {
-            if (order.getExpires().before(new Date())) {
-                throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
-                        "Expiry of the order is reached");
-            }
-        }
+        // An order that has requested or received a certificate takes its status from the certificate, decided
+        // under the order lock, before a status left open behind it could be settled as a failure.
+        order = acmeChallengeWriter.reconcileCertificateStatus(order.getUuid());
+        settleStaleStatuses(order);
 
-        // check for status if certificate reference is set
-        if (order.getCertificateReference() != null) {
-            OrderStatus newStatus = checkOrderStatusByCertificate(order.getCertificateReference());
-            if (!newStatus.equals(order.getStatus())) {
-                logger.info("ACME Order status changed from {} to {}.", order.getStatus(), newStatus);
-                order.setStatus(newStatus);
-                incrementOrderCounts(newStatus, order);
-                acmeOrderRepository.save(order);
-            }
+        if (order.getExpires() != null && order.getExpires().before(new Date())) {
+            throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
+                    "Expiry of the order is reached");
         }
 
         return order;
@@ -1657,42 +1636,55 @@ public class AcmeServiceImpl implements AcmeExternalService {
             incrementFailedOrdersCount(order);
         }
         if (newStatus == OrderStatus.VALID) {
-            order.getAcmeAccount().setValidOrders(order.getAcmeAccount().getValidOrders() + 1);
-            acmeAccountRepository.save(order.getAcmeAccount());
+            acmeChallengeWriter.countValidOrder(order.getAcmeAccountUuid());
         }
     }
 
     private void incrementFailedOrdersCount(AcmeOrder order) {
-        order.getAcmeAccount().setFailedOrders(order.getAcmeAccount().getFailedOrders() + 1);
-        acmeAccountRepository.save(order.getAcmeAccount());
+        acmeChallengeWriter.countFailedOrder(order.getAcmeAccountUuid());
     }
 
-    private AcmeAuthorization validateAuthorization(String authorizationId) throws AcmeProblemDocumentException {
-        AcmeAuthorization authorization = acmeAuthorizationRepository
+    /**
+     * The account that signed the request must be the one the object belongs to. A request about an existing object has
+     * to name its account with {@code kid} (RFC 8555 section 6.2); a key supplied inline proves only possession of that
+     * key, not an account.
+     */
+    private void requireOwnership(AcmeJwsRequest jwsRequest, AcmeAccount owner) throws AcmeProblemDocumentException {
+        if (jwsRequest.isJwkPresent()) {
+            throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
+                    "The request must be signed with the account key and name the account");
+        }
+        String kid = jwsRequest.getKid();
+        String requestAccountId = kid.substring(kid.lastIndexOf('/') + 1);
+        if (!owner.getAccountId().equals(requestAccountId)) {
+            throw new AcmeProblemDocumentException(HttpStatus.FORBIDDEN, Problem.UNAUTHORIZED,
+                    "The requested object belongs to a different account");
+        }
+    }
+
+    private AcmeAuthorization loadAuthorization(String authorizationId) throws AcmeProblemDocumentException {
+        return acmeAuthorizationRepository
                 .findByAuthorizationId(authorizationId)
                 .orElseThrow(() -> new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.SERVER_INTERNAL,
                         "Requested authorization is not found"));
-        if (authorization.getExpires() != null) {
-            if (authorization.getExpires().before(new Date())) {
-                throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
-                        "Expiry of the authorization is reached");
-            }
-        }
-        return authorization;
     }
 
-    private AcmeChallenge validateChallenge(String challengeId) throws AcmeProblemDocumentException {
-        AcmeChallenge challenge = acmeChallengeRepository
-                .findByChallengeId(challengeId)
+    private void rejectExpiredAuthorization(AcmeAuthorization authorization) throws AcmeProblemDocumentException {
+        rejectExpiredAuthorization(authorization, "Expiry of the authorization is reached");
+    }
+
+    private void rejectExpiredAuthorization(AcmeAuthorization authorization, String detail)
+            throws AcmeProblemDocumentException {
+        if (authorization.getExpires() != null && authorization.getExpires().before(new Date())) {
+            throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED, detail);
+        }
+    }
+
+    private AcmeChallenge loadChallenge(String challengeId) throws AcmeProblemDocumentException {
+        return acmeChallengeRepository
+                .findWithContextByChallengeId(challengeId)
                 .orElseThrow(() -> new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.SERVER_INTERNAL,
                         "Requested challenge is not found"));
-        if (challenge.getAuthorization().getExpires() != null) {
-            if (challenge.getAuthorization().getExpires().before(new Date())) {
-                throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, Problem.MALFORMED,
-                        "Challenge is expired");
-            }
-        }
-        return challenge;
     }
 
     private void validateAccount(String accountId) throws AcmeProblemDocumentException {

--- a/src/main/java/com/otilm/core/service/writer/AcmeChallengeWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/AcmeChallengeWriter.java
@@ -1,0 +1,262 @@
+package com.otilm.core.service.writer;
+
+import com.otilm.api.model.core.acme.AuthorizationStatus;
+import com.otilm.api.model.core.acme.ChallengeStatus;
+import com.otilm.api.model.core.acme.OrderStatus;
+import com.otilm.core.dao.entity.acme.AcmeAuthorization;
+import com.otilm.core.dao.entity.acme.AcmeChallenge;
+import com.otilm.core.dao.entity.acme.AcmeOrder;
+import com.otilm.core.dao.repository.acme.AcmeAccountRepository;
+import com.otilm.core.dao.repository.acme.AcmeAuthorizationRepository;
+import com.otilm.core.dao.repository.acme.AcmeChallengeRepository;
+import com.otilm.core.dao.repository.acme.AcmeOrderRepository;
+import com.otilm.core.service.acme.AcmeChallengeStateMachine;
+import com.otilm.core.service.acme.ChallengeValidationResult;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Writer bean for the status transitions of ACME challenges, authorizations and orders.
+ *
+ * <p>
+ * Every method locks the order row first ({@code SELECT ... FOR UPDATE}) and re-reads the rows under that lock before
+ * deciding anything, so all writes to one order — the same challenge accepted twice, sibling challenges of one
+ * authorization, sibling authorizations of one order — are serialised. Methods use the default propagation
+ * ({@code REQUIRED}): they join an ambient transaction if one is active and open one otherwise, which lets the
+ * challenge endpoint keep its DNS and HTTP lookups outside any transaction.
+ */
+@Service
+public class AcmeChallengeWriter {
+
+    private static final Logger logger = LoggerFactory.getLogger(AcmeChallengeWriter.class);
+
+    private final AcmeOrderRepository acmeOrderRepository;
+    private final AcmeAuthorizationRepository acmeAuthorizationRepository;
+    private final AcmeChallengeRepository acmeChallengeRepository;
+    private final AcmeAccountRepository acmeAccountRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    public AcmeChallengeWriter(AcmeOrderRepository acmeOrderRepository,
+            AcmeAuthorizationRepository acmeAuthorizationRepository, AcmeChallengeRepository acmeChallengeRepository,
+            AcmeAccountRepository acmeAccountRepository) {
+        this.acmeOrderRepository = acmeOrderRepository;
+        this.acmeAuthorizationRepository = acmeAuthorizationRepository;
+        this.acmeChallengeRepository = acmeChallengeRepository;
+        this.acmeAccountRepository = acmeAccountRepository;
+    }
+
+    /**
+     * Records the verdict of a validation attempt on the challenge, its authorization and its order. A challenge or
+     * authorization that settled while the attempt was running is left as it is, and that recorded state is returned.
+     *
+     * @param orderUuid the order the challenge belongs to, locked for the duration of the write
+     * @param challengeId the challenge the verdict is for
+     * @param result the verdict
+     * @return the challenge as it stands after this call
+     */
+    @Transactional
+    public AcmeChallenge applyValidationResult(UUID orderUuid, String challengeId, ChallengeValidationResult result) {
+        AcmeOrder order = lockOrder(orderUuid);
+        AcmeChallenge challenge = challengeUnderLock(challengeId);
+        AcmeAuthorization authorization = challenge.getAuthorization();
+        if (challenge.getStatus() != ChallengeStatus.PENDING
+                || authorization.getStatus() != AuthorizationStatus.PENDING) {
+            logger
+                    .debug("Challenge {} settled as {} on a {} authorization while it was being validated", challengeId,
+                            challenge.getStatus(), authorization.getStatus());
+            return challenge;
+        }
+
+        OrderStatus orderStatusBefore = order.getStatus();
+        AcmeChallengeStateMachine.applyValidationResult(challenge, result);
+        acmeChallengeRepository.save(challenge);
+        acmeAuthorizationRepository.save(authorization);
+        recordOrderTransition(order, orderStatusBefore);
+        return challenge;
+    }
+
+    /**
+     * Settles the authorizations of an order left pending behind a failed challenge, and the order itself if any of its
+     * authorizations has failed. Such rows are written by an instance that does not yet propagate failures; an order
+     * whose rows are consistent is left untouched.
+     */
+    @Transactional
+    public void settleOrder(UUID orderUuid) {
+        AcmeOrder order = lockOrder(orderUuid);
+        OrderStatus orderStatusBefore = order.getStatus();
+        List<AcmeAuthorization> settled = AcmeChallengeStateMachine.settleOrder(order);
+        acmeAuthorizationRepository.saveAll(settled);
+        if (!settled.isEmpty() || order.getStatus() != orderStatusBefore) {
+            logger.info("Settled order {} left open behind a failed challenge", order.getOrderId());
+        }
+        recordOrderTransition(order, orderStatusBefore);
+    }
+
+    /**
+     * Deactivates an authorization at the client's request (RFC 8555 section 7.5.2), under the same lock as every other
+     * status write to its order, so a validation running at the same time cannot write over it.
+     *
+     * @return the authorization as it stands after this call
+     */
+    @Transactional
+    public AcmeAuthorization deactivateAuthorization(UUID orderUuid, String authorizationId) {
+        AcmeOrder order = lockOrder(orderUuid);
+        AcmeAuthorization authorization = order
+                .getAuthorizations()
+                .stream()
+                .filter(candidate -> authorizationId.equals(candidate.getAuthorizationId()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "ACME authorization " + authorizationId + " no longer belongs to order " + orderUuid));
+        OrderStatus orderStatusBefore = order.getStatus();
+        AcmeChallengeStateMachine.deactivate(authorization);
+        acmeAuthorizationRepository.save(authorization);
+        recordOrderTransition(order, orderStatusBefore);
+        return authorization;
+    }
+
+    /**
+     * Invalidates an order whose account is being deactivated: the order becomes {@code INVALID}, its authorizations
+     * {@code DEACTIVATED} and their challenges {@code INVALID}, under the same lock as every other status write to the
+     * order.
+     *
+     * <p>
+     * The account is deliberately not written here. A caller deactivating an account walks its orders one by one and
+     * holds every lock until it commits, so writing the account between two of them would let a challenge failing
+     * concurrently hold the next order while waiting for the account this call had already written, deadlocking both.
+     * The caller counts the orders it closed once it has locked all of them.
+     *
+     * @return whether the order was still open, for the caller to count against the account
+     */
+    @Transactional
+    public boolean deactivateOrder(UUID orderUuid) {
+        AcmeOrder order = lockOrder(orderUuid);
+        OrderStatus statusBefore = order.getStatus();
+        order.setStatus(OrderStatus.INVALID);
+        for (AcmeAuthorization authorization : order.getAuthorizations()) {
+            authorization.setStatus(AuthorizationStatus.DEACTIVATED);
+            authorization.getChallenges().forEach(challenge -> challenge.setStatus(ChallengeStatus.INVALID));
+            acmeChallengeRepository.saveAll(authorization.getChallenges());
+        }
+        acmeAuthorizationRepository.saveAll(order.getAuthorizations());
+        acmeOrderRepository.save(order);
+        return statusBefore != OrderStatus.INVALID;
+    }
+
+    /**
+     * Brings the order's status in line with the certificate requested for it and counts the transition against its
+     * account. Both happen under the order lock, so two requests polling the same order record one transition between
+     * them rather than each counting the one it observed.
+     *
+     * @param orderUuid the order to reconcile
+     * @return the order as it stands after this call
+     */
+    @Transactional
+    public AcmeOrder reconcileCertificateStatus(UUID orderUuid) {
+        AcmeOrder order = lockOrder(orderUuid);
+        if (order.getCertificateReferenceUuid() == null) {
+            return order;
+        }
+        OrderStatus statusBefore = order.getStatus();
+        OrderStatus statusFromCertificate = AcmeChallengeStateMachine
+                .statusFromCertificate(order.getCertificateReference().getState());
+        if (statusFromCertificate == statusBefore) {
+            return order;
+        }
+        logger
+                .info("ACME order {} status changed from {} to {}", order.getOrderId(), statusBefore,
+                        statusFromCertificate);
+        order.setStatus(statusFromCertificate);
+        acmeOrderRepository.save(order);
+        countOrderOutcome(order, statusBefore);
+        return order;
+    }
+
+    /**
+     * Counts a failed order against its account.
+     */
+    @Transactional
+    public void countFailedOrder(UUID accountUuid) {
+        acmeAccountRepository.incrementFailedOrders(accountUuid, OffsetDateTime.now(ZoneOffset.UTC));
+    }
+
+    /**
+     * Counts a batch of failed orders against an account in one statement.
+     */
+    @Transactional
+    public void countFailedOrders(UUID accountUuid, int count) {
+        if (count > 0) {
+            acmeAccountRepository.incrementFailedOrdersBy(accountUuid, count, OffsetDateTime.now(ZoneOffset.UTC));
+        }
+    }
+
+    /**
+     * Counts a valid order against its account.
+     */
+    @Transactional
+    public void countValidOrder(UUID accountUuid) {
+        acmeAccountRepository.incrementValidOrders(accountUuid, OffsetDateTime.now(ZoneOffset.UTC));
+    }
+
+    /**
+     * Locks the order row and re-reads the order, all of its authorizations and all of their challenges. The
+     * persistence context may already hold any of these rows from reads made before the lock was taken, and every
+     * decision below depends on their current state, not on what a sibling looked like before another request
+     * committed.
+     */
+    private AcmeOrder lockOrder(UUID orderUuid) {
+        AcmeOrder order = acmeOrderRepository
+                .findWithLockByUuid(orderUuid)
+                .orElseThrow(() -> new IllegalStateException("ACME order " + orderUuid + " no longer exists"));
+        // Changes made earlier in the same transaction are written before the rows are re-read: refresh discards
+        // what is still pending, and a query on the order table alone need not have flushed them.
+        entityManager.flush();
+        entityManager.refresh(order);
+        for (AcmeAuthorization authorization : order.getAuthorizations()) {
+            entityManager.refresh(authorization);
+            authorization.getChallenges().forEach(entityManager::refresh);
+        }
+        return order;
+    }
+
+    private AcmeChallenge challengeUnderLock(String challengeId) {
+        return acmeChallengeRepository
+                .findWithContextByChallengeId(challengeId)
+                .orElseThrow(() -> new IllegalStateException("ACME challenge " + challengeId + " no longer exists"));
+    }
+
+    private void recordOrderTransition(AcmeOrder order, OrderStatus statusBefore) {
+        if (order.getStatus() == statusBefore) {
+            return;
+        }
+        acmeOrderRepository.save(order);
+        countOrderOutcome(order, statusBefore);
+    }
+
+    /**
+     * Counts a settled order against its account, in the database, when this call is the one that settled it.
+     */
+    private void countOrderOutcome(AcmeOrder order, OrderStatus statusBefore) {
+        if (order.getStatus() == statusBefore) {
+            return;
+        }
+        if (order.getStatus() == OrderStatus.INVALID) {
+            acmeAccountRepository.incrementFailedOrders(order.getAcmeAccountUuid(), OffsetDateTime.now(ZoneOffset.UTC));
+        } else if (order.getStatus() == OrderStatus.VALID) {
+            acmeAccountRepository.incrementValidOrders(order.getAcmeAccountUuid(), OffsetDateTime.now(ZoneOffset.UTC));
+        }
+    }
+
+}

--- a/src/main/java/com/otilm/core/util/AcmeCommonHelper.java
+++ b/src/main/java/com/otilm/core/util/AcmeCommonHelper.java
@@ -4,7 +4,6 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
-
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -14,7 +13,11 @@ import java.security.interfaces.RSAPublicKey;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.Base64;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Class contains the common operations and helper functions to process the acme request

--- a/src/main/java/com/otilm/core/util/AcmeCommonHelper.java
+++ b/src/main/java/com/otilm/core/util/AcmeCommonHelper.java
@@ -11,6 +11,7 @@ import java.security.PublicKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
@@ -25,6 +26,11 @@ import java.util.Map;
 public class AcmeCommonHelper {
 
     private static final Integer COMMON_EXPIRES_IN_SECONDS = 10 * 60 * 60;
+
+    /** The timestamp format the ACME wire objects carry, in UTC. */
+    private static final DateTimeFormatter WIRE_TIMESTAMP_FORMAT = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SS'Z'")
+            .withZone(ZoneId.of("UTC"));
 
     public static Date getDefaultExpires() {
         return new Date(new Date().getTime() + COMMON_EXPIRES_IN_SECONDS);
@@ -58,20 +64,25 @@ public class AcmeCommonHelper {
         if (date == null) {
             return null;
         }
-        DateTimeFormatter formatter = DateTimeFormatter
-                .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SS'Z'")
-                .withZone(ZoneId.of("UTC"));
-        return formatter.format(date.toInstant());
+        return WIRE_TIMESTAMP_FORMAT.format(date.toInstant());
+    }
+
+    /**
+     * The same wire format as {@link #getStringFromDate(Date)}, for a value already held as a {@code java.time}
+     * instant.
+     */
+    public static String getStringFromDate(OffsetDateTime dateTime) {
+        if (dateTime == null) {
+            return null;
+        }
+        return WIRE_TIMESTAMP_FORMAT.format(dateTime.toInstant());
     }
 
     public static Date getDateFromString(String date) {
         if (date == null || date.isEmpty()) {
             return null;
         }
-        DateTimeFormatter formatter = DateTimeFormatter
-                .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SS'Z'")
-                .withZone(ZoneId.of("UTC"));
-        return new Date(Instant.from(formatter.parse(date)).getEpochSecond());
+        return new Date(Instant.from(WIRE_TIMESTAMP_FORMAT.parse(date)).getEpochSecond());
     }
 
     public static Date addSeconds(Date date, int seconds) {

--- a/src/main/resources/db/migration/V202609021000__acme_challenge_validation_error.sql
+++ b/src/main/resources/db/migration/V202609021000__acme_challenge_validation_error.sql
@@ -1,0 +1,5 @@
+-- A failed challenge has to report why it failed (RFC 8555 section 8). Validation runs while the client is
+-- accepting the challenge, but the client reads the reason back on a later request, so the reason is recorded
+-- on the challenge row rather than held for the duration of the accepting request.
+ALTER TABLE acme_challenge ADD COLUMN error_problem VARCHAR NULL DEFAULT NULL;
+ALTER TABLE acme_challenge ADD COLUMN error_detail VARCHAR NULL DEFAULT NULL;

--- a/src/main/resources/db/migration/V202609021100__settle_authorizations_behind_failed_challenges.sql
+++ b/src/main/resources/db/migration/V202609021100__settle_authorizations_behind_failed_challenges.sql
@@ -1,0 +1,34 @@
+-- The repair of rows the previous behaviour left behind is a separate migration from the columns it follows,
+-- so that each runs in its own transaction. Merged into one, the transaction would still hold the exclusive
+-- lock the column additions take on acme_challenge while waiting for the row locks below, and an instance of
+-- the previous version that holds one of those rows and then reads a challenge would deadlock the start-up.
+-- Until a failed challenge invalidated its authorization and order, a failure left both pending behind the
+-- challenge that recorded it. Such an authorization can never settle: the challenge is final and is not
+-- validated again, and once the authorization expires it is refused rather than reported as invalid. These
+-- rows are settled the way a failure is recorded now. An order that has requested or received a certificate
+-- keeps its status, because the certificate exists regardless of how the order reached that state.
+-- Share row exclusive keeps concurrent writers out while the repair runs without blocking readers. A request
+-- that read one of these rows before the repair and writes it back afterwards still wins that write; an
+-- exclusive lock would prevent it, but a request holding its read locks across a challenge validation
+-- could then deadlock against the migration and fail the start-up.
+LOCK TABLE acme_authorization, acme_order, acme_account IN SHARE ROW EXCLUSIVE MODE;
+
+UPDATE acme_authorization a
+SET status = 'INVALID', i_upd = CURRENT_TIMESTAMP
+WHERE a.status = 'PENDING'
+  AND EXISTS (SELECT 1 FROM acme_challenge c WHERE c.authorization_uuid = a.uuid AND c.status = 'INVALID');
+
+-- The failed-order count of an account is kept as orders fail, and orders already invalid are never counted
+-- again, so the orders settled here are counted now.
+WITH settled AS (
+    UPDATE acme_order o
+    SET status = 'INVALID', i_upd = CURRENT_TIMESTAMP
+    WHERE o.status IN ('PENDING', 'READY')
+      AND o.certificate_ref IS NULL
+      AND EXISTS (SELECT 1 FROM acme_authorization a WHERE a.order_uuid = o.uuid AND a.status = 'INVALID')
+    RETURNING o.account_uuid
+)
+UPDATE acme_account acc
+SET failed_orders = acc.failed_orders + counted.orders, i_upd = CURRENT_TIMESTAMP
+FROM (SELECT account_uuid, COUNT(*) AS orders FROM settled GROUP BY account_uuid) counted
+WHERE acc.uuid = counted.account_uuid;

--- a/src/test/java/com/otilm/core/dao/entity/acme/AcmeChallengeTest.java
+++ b/src/test/java/com/otilm/core/dao/entity/acme/AcmeChallengeTest.java
@@ -1,0 +1,91 @@
+package com.otilm.core.dao.entity.acme;
+
+import com.otilm.api.model.core.acme.Challenge;
+import com.otilm.api.model.core.acme.ChallengeStatus;
+import com.otilm.api.model.core.acme.ChallengeType;
+import com.otilm.api.model.core.acme.Problem;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+class AcmeChallengeTest {
+
+    private static final String FAILURE_DETAIL = "No TXT record found at _acme-challenge.example.org";
+
+    @BeforeEach
+    void bindRequest() {
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(new MockHttpServletRequest()));
+    }
+
+    @AfterEach
+    void unbindRequest() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    /**
+     * A failed challenge carries the reason as a problem document so the client can report why validation failed (RFC
+     * 8555 section 8).
+     */
+    @Test
+    void reportsTheRecordedFailureAsAProblemDocument() {
+        AcmeChallenge challenge = challenge();
+        challenge.setStatus(ChallengeStatus.INVALID);
+        challenge.setErrorProblem(Problem.DNS);
+        challenge.setErrorDetail(FAILURE_DETAIL);
+
+        Challenge dto = challenge.mapToDto();
+
+        Assertions.assertNotNull(dto.getError());
+        Assertions.assertEquals(Problem.DNS.getType(), dto.getError().getType());
+        Assertions.assertEquals(Problem.DNS.getTitle(), dto.getError().getTitle());
+        Assertions.assertEquals(FAILURE_DETAIL, dto.getError().getDetail());
+    }
+
+    @Test
+    void reportsNoErrorWhenNoFailureWasRecorded() {
+        Assertions.assertNull(challenge().mapToDto().getError());
+    }
+
+    /**
+     * The shared {@link Problem} constants must keep their own detail, so recording a challenge failure may not write
+     * through to them.
+     */
+    @Test
+    void leavesTheSharedProblemConstantUntouched() {
+        String detailBefore = Problem.DNS.getDetail();
+        AcmeChallenge challenge = challenge();
+        challenge.setErrorProblem(Problem.DNS);
+        challenge.setErrorDetail(FAILURE_DETAIL);
+
+        challenge.mapToDto();
+
+        Assertions.assertEquals(detailBefore, Problem.DNS.getDetail());
+    }
+
+    private static AcmeChallenge challenge() {
+        AcmeProfile acmeProfile = new AcmeProfile();
+        acmeProfile.setName("test-profile");
+
+        AcmeAccount acmeAccount = new AcmeAccount();
+        acmeAccount.setAcmeProfile(acmeProfile);
+
+        AcmeOrder order = new AcmeOrder();
+        order.setAcmeAccount(acmeAccount);
+
+        AcmeAuthorization authorization = new AcmeAuthorization();
+        authorization.setOrder(order);
+
+        AcmeChallenge challenge = new AcmeChallenge();
+        challenge.setChallengeId("challenge-1");
+        challenge.setType(ChallengeType.DNS01);
+        challenge.setStatus(ChallengeStatus.PENDING);
+        challenge.setToken("token");
+        challenge.setAuthorization(authorization);
+        return challenge;
+    }
+
+}

--- a/src/test/java/com/otilm/core/integration/service/AcmeServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/AcmeServiceITest.java
@@ -1,28 +1,62 @@
 package com.otilm.core.integration.service;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.argThat;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockConstruction;
-import static org.mockito.Mockito.when;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSObjectJSON;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.Payload;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jose.util.Base64URL;
 import com.otilm.api.exception.AcmeProblemDocumentException;
 import com.otilm.api.exception.AlreadyExistException;
 import com.otilm.api.exception.ConnectorException;
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.model.client.connector.v2.ConnectorVersion;
-import com.otilm.api.model.core.acme.*;
+import com.otilm.api.model.core.acme.Account;
+import com.otilm.api.model.core.acme.AccountStatus;
+import com.otilm.api.model.core.acme.Authorization;
+import com.otilm.api.model.core.acme.AuthorizationStatus;
+import com.otilm.api.model.core.acme.Challenge;
+import com.otilm.api.model.core.acme.ChallengeStatus;
+import com.otilm.api.model.core.acme.ChallengeType;
+import com.otilm.api.model.core.acme.Directory;
+import com.otilm.api.model.core.acme.Order;
+import com.otilm.api.model.core.acme.OrderStatus;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.certificate.CertificateState;
 import com.otilm.api.model.core.certificate.CertificateValidationStatus;
 import com.otilm.api.model.core.connector.ConnectorStatus;
 import com.otilm.api.model.core.enums.CertificateProtocol;
-import com.otilm.core.dao.entity.*;
-import com.otilm.core.dao.entity.acme.*;
-import com.otilm.core.dao.repository.*;
-import com.otilm.core.dao.repository.acme.*;
+import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.CertificateContent;
+import com.otilm.core.dao.entity.CertificateProtocolAssociation;
+import com.otilm.core.dao.entity.Connector;
+import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.dao.entity.acme.AcmeAccount;
+import com.otilm.core.dao.entity.acme.AcmeAuthorization;
+import com.otilm.core.dao.entity.acme.AcmeChallenge;
+import com.otilm.core.dao.entity.acme.AcmeNonce;
+import com.otilm.core.dao.entity.acme.AcmeOrder;
+import com.otilm.core.dao.entity.acme.AcmeProfile;
+import com.otilm.core.dao.repository.AcmeProfileRepository;
+import com.otilm.core.dao.repository.AuthorityInstanceReferenceRepository;
+import com.otilm.core.dao.repository.CertificateContentRepository;
+import com.otilm.core.dao.repository.CertificateProtocolAssociationRepository;
+import com.otilm.core.dao.repository.CertificateRepository;
+import com.otilm.core.dao.repository.ConnectorRepository;
+import com.otilm.core.dao.repository.RaProfileRepository;
+import com.otilm.core.dao.repository.acme.AcmeAccountRepository;
+import com.otilm.core.dao.repository.acme.AcmeAuthorizationRepository;
+import com.otilm.core.dao.repository.acme.AcmeChallengeRepository;
+import com.otilm.core.dao.repository.acme.AcmeNonceRepository;
+import com.otilm.core.dao.repository.acme.AcmeOrderRepository;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authz.opa.dto.OpaRequestedResource;
 import com.otilm.core.security.authz.opa.dto.OpaResourceAccessResult;
@@ -31,16 +65,31 @@ import com.otilm.core.service.acme.AcmeExternalService;
 import com.otilm.core.util.AcmeCommonHelper;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.CertificateTestUtil;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.nimbusds.jose.*;
-import com.nimbusds.jose.crypto.RSASSASigner;
-import com.nimbusds.jose.jwk.RSAKey;
-import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SignatureException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.InitialDirContext;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.jupiter.api.AfterEach;
-import com.nimbusds.jose.util.Base64URL;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,21 +97,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import javax.naming.NamingEnumeration;
-import javax.naming.NamingException;
-import javax.naming.directory.Attribute;
-import javax.naming.directory.Attributes;
-import javax.naming.directory.InitialDirContext;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.security.*;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.security.spec.InvalidKeySpecException;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
 
 class AcmeServiceITest extends BaseSpringBootTest {
 
@@ -127,7 +168,8 @@ class AcmeServiceITest extends BaseSpringBootTest {
     WireMockServer mockServer;
 
     @BeforeEach
-    void setUp() throws JOSEException, NoSuchAlgorithmException, CertificateException, SignatureException, InvalidKeyException, NoSuchProviderException, OperatorCreationException {
+    void setUp() throws JOSEException, NoSuchAlgorithmException, CertificateException, SignatureException,
+            InvalidKeyException, NoSuchProviderException, OperatorCreationException {
         // prepare mock server
         mockServer = new WireMockServer(0);
         mockServer.start();
@@ -136,21 +178,25 @@ class AcmeServiceITest extends BaseSpringBootTest {
 
         WireMock.configureFor("localhost", mockServer.port());
 
-        mockServer.stubFor(WireMock
-                .post(WireMock.urlPathMatching("/v2/authorityProvider/authorities/[^/]+/certificates/revoke/attributes/validate"))
-                .willReturn(WireMock.okJson("true")));
+        mockServer
+                .stubFor(WireMock
+                        .post(WireMock
+                                .urlPathMatching(
+                                        "/v2/authorityProvider/authorities/[^/]+/certificates/revoke/attributes/validate"))
+                        .willReturn(WireMock.okJson("true")));
 
-        mockServer.stubFor(WireMock
-                .get(WireMock.urlPathMatching("/v2/authorityProvider/authorities/[^/]+/certificates/revoke/attributes"))
-                .willReturn(WireMock.okJson("[]")));
+        mockServer
+                .stubFor(WireMock
+                        .get(WireMock
+                                .urlPathMatching(
+                                        "/v2/authorityProvider/authorities/[^/]+/certificates/revoke/attributes"))
+                        .willReturn(WireMock.okJson("[]")));
 
-        RSAKey rsa2048JWK = new RSAKeyGenerator(2048)
-                .generate();
+        RSAKey rsa2048JWK = new RSAKeyGenerator(2048).generate();
         rsa2048PublicJWK = rsa2048JWK.toPublicJWK();
         rsa2048Signer = new RSASSASigner(rsa2048JWK);
 
-        RSAKey newRsa2048JWK = new RSAKeyGenerator(2048)
-                .generate();
+        RSAKey newRsa2048JWK = new RSAKeyGenerator(2048).generate();
         newRsa2048PublicJWK = newRsa2048JWK.toPublicJWK();
         newRsa2048Signer = new RSASSASigner(newRsa2048JWK);
 
@@ -306,198 +352,124 @@ class AcmeServiceITest extends BaseSpringBootTest {
     }
 
     private void mockAcmeRolePermissions() {
-        OpaResourceAccessResult resourceAccessAllowed = new OpaResourceAccessResult(true, List.of("AllResourcesAllowed"));
+        OpaResourceAccessResult resourceAccessAllowed = new OpaResourceAccessResult(true,
+                List.of("AllResourcesAllowed"));
         OpaResourceAccessResult resourceAccessNotAllowed = new OpaResourceAccessResult(false, List.of());
 
-
         // By default, reject all
-        when(
-                opaClient.checkResourceAccess(any(), any(), any(), any())
-        ).thenReturn(resourceAccessNotAllowed);
+        when(opaClient.checkResourceAccess(any(), any(), any(), any())).thenReturn(resourceAccessNotAllowed);
 
         // allow all ACME account actions
-        when(
-                opaClient.checkResourceAccess(any(), argThat(req ->
-                        req != null && req.getProperties().containsKey(Resource.ACME_ACCOUNT.getCode())
-                ), any(), any())
-        ).thenReturn(resourceAccessAllowed);
+        when(opaClient
+                .checkResourceAccess(any(),
+                        argThat(req -> req != null && req.getProperties().containsKey(Resource.ACME_ACCOUNT.getCode())),
+                        any(), any()))
+                .thenReturn(resourceAccessAllowed);
 
         // allow all ACME Profile detail and list
-        when(
-                opaClient.checkResourceAccess(
-                        any(),
-                        argThat(req ->
-                                isRequestForResourceAction(req, Resource.ACME_PROFILE, ResourceAction.LIST)
-                        ),
-                        any(),
-                        any()
-                )
-        ).thenReturn(resourceAccessAllowed);
+        when(opaClient
+                .checkResourceAccess(any(),
+                        argThat(req -> isRequestForResourceAction(req, Resource.ACME_PROFILE, ResourceAction.LIST)),
+                        any(), any()))
+                .thenReturn(resourceAccessAllowed);
 
-        when(
-                opaClient.checkResourceAccess(
-                        any(),
-                        argThat(req ->
-                                isRequestForResourceAction(req, Resource.ACME_PROFILE, ResourceAction.DETAIL)
-                        ),
-                        any(),
-                        any()
-                )
-        ).thenReturn(resourceAccessAllowed);
+        when(opaClient
+                .checkResourceAccess(any(),
+                        argThat(req -> isRequestForResourceAction(req, Resource.ACME_PROFILE, ResourceAction.DETAIL)),
+                        any(), any()))
+                .thenReturn(resourceAccessAllowed);
 
         // Allow attribute members
-        when(
-                opaClient.checkResourceAccess(
-                        any(),
-                        argThat(req ->
-                                isRequestForResourceAction(req, Resource.ATTRIBUTE, ResourceAction.MEMBERS)
-                        ),
-                        any(),
-                        any()
-                )
-        ).thenReturn(resourceAccessAllowed);
+        when(opaClient
+                .checkResourceAccess(any(),
+                        argThat(req -> isRequestForResourceAction(req, Resource.ATTRIBUTE, ResourceAction.MEMBERS)),
+                        any(), any()))
+                .thenReturn(resourceAccessAllowed);
 
         // Allow authorities detail, list and members
-        when(
-                opaClient.checkResourceAccess(
-                        any(),
-                        argThat(req ->
-                                isRequestForResourceAction(req, Resource.AUTHORITY, ResourceAction.LIST)
-                        ),
-                        any(),
-                        any()
-                )
-        ).thenReturn(resourceAccessAllowed);
+        when(opaClient
+                .checkResourceAccess(any(),
+                        argThat(req -> isRequestForResourceAction(req, Resource.AUTHORITY, ResourceAction.LIST)), any(),
+                        any()))
+                .thenReturn(resourceAccessAllowed);
 
-        when(
-                opaClient.checkResourceAccess(
-                        any(),
-                        argThat(req ->
-                                isRequestForResourceAction(req, Resource.AUTHORITY, ResourceAction.DETAIL)
-                        ),
-                        any(),
-                        any()
-                )
-        ).thenReturn(resourceAccessAllowed);
+        when(opaClient
+                .checkResourceAccess(any(),
+                        argThat(req -> isRequestForResourceAction(req, Resource.AUTHORITY, ResourceAction.DETAIL)),
+                        any(), any()))
+                .thenReturn(resourceAccessAllowed);
 
-        when(
-                opaClient.checkResourceAccess(
-                        any(),
-                        argThat(req ->
-                                isRequestForResourceAction(req, Resource.AUTHORITY, ResourceAction.MEMBERS)
-                        ),
-                        any(),
-                        any()
-                )
-        ).thenReturn(resourceAccessAllowed);
+        when(opaClient
+                .checkResourceAccess(any(),
+                        argThat(req -> isRequestForResourceAction(req, Resource.AUTHORITY, ResourceAction.MEMBERS)),
+                        any(), any()))
+                .thenReturn(resourceAccessAllowed);
 
         // Allow certificates create, detail, issue, list, renew, revoke, update
-        when(
-                opaClient.checkResourceAccess(
-                        any(),
-                        argThat(req ->
-                                isRequestForResourceAction(req, Resource.CERTIFICATE, ResourceAction.LIST)
-                        ),
-                        any(),
-                        any()
-                )
-        ).thenReturn(resourceAccessAllowed);
+        when(opaClient
+                .checkResourceAccess(any(),
+                        argThat(req -> isRequestForResourceAction(req, Resource.CERTIFICATE, ResourceAction.LIST)),
+                        any(), any()))
+                .thenReturn(resourceAccessAllowed);
 
-        when(
-                opaClient.checkResourceAccess(
-                        any(),
-                        argThat(req ->
-                                isRequestForResourceAction(req, Resource.CERTIFICATE, ResourceAction.CREATE)
-                        ),
-                        any(),
-                        any()
-                )
-        ).thenReturn(resourceAccessAllowed);
+        when(opaClient
+                .checkResourceAccess(any(),
+                        argThat(req -> isRequestForResourceAction(req, Resource.CERTIFICATE, ResourceAction.CREATE)),
+                        any(), any()))
+                .thenReturn(resourceAccessAllowed);
 
-        when(
-                opaClient.checkResourceAccess(
-                        any(),
-                        argThat(req ->
-                                isRequestForResourceAction(req, Resource.CERTIFICATE, ResourceAction.DETAIL)
-                        ),
-                        any(),
-                        any()
-                )
-        ).thenReturn(resourceAccessAllowed);
+        when(opaClient
+                .checkResourceAccess(any(),
+                        argThat(req -> isRequestForResourceAction(req, Resource.CERTIFICATE, ResourceAction.DETAIL)),
+                        any(), any()))
+                .thenReturn(resourceAccessAllowed);
 
-        when(
-                opaClient.checkResourceAccess(
-                        any(),
-                        argThat(req ->
-                                isRequestForResourceAction(req, Resource.CERTIFICATE, ResourceAction.RENEW)
-                        ),
-                        any(),
-                        any()
-                )
-        ).thenReturn(resourceAccessAllowed);
+        when(opaClient
+                .checkResourceAccess(any(),
+                        argThat(req -> isRequestForResourceAction(req, Resource.CERTIFICATE, ResourceAction.RENEW)),
+                        any(), any()))
+                .thenReturn(resourceAccessAllowed);
 
-        when(
-                opaClient.checkResourceAccess(
-                        any(),
-                        argThat(req ->
-                                isRequestForResourceAction(req, Resource.CERTIFICATE, ResourceAction.REVOKE)
-                        ),
-                        any(),
-                        any()
-                )
-        ).thenReturn(resourceAccessAllowed);
+        when(opaClient
+                .checkResourceAccess(any(),
+                        argThat(req -> isRequestForResourceAction(req, Resource.CERTIFICATE, ResourceAction.REVOKE)),
+                        any(), any()))
+                .thenReturn(resourceAccessAllowed);
 
-        when(
-                opaClient.checkResourceAccess(
-                        any(),
-                        argThat(req ->
-                                isRequestForResourceAction(req, Resource.CERTIFICATE, ResourceAction.UPDATE)
-                        ),
-                        any(),
-                        any()
-                )
-        ).thenReturn(resourceAccessAllowed);
+        when(opaClient
+                .checkResourceAccess(any(),
+                        argThat(req -> isRequestForResourceAction(req, Resource.CERTIFICATE, ResourceAction.UPDATE)),
+                        any(), any()))
+                .thenReturn(resourceAccessAllowed);
 
         // Allow RA Profiles detail, list and members
-        when(
-                opaClient.checkResourceAccess(
-                        any(),
-                        argThat(req ->
-                                isRequestForResourceAction(req, Resource.RA_PROFILE, ResourceAction.LIST)
-                        ),
-                        any(),
-                        any()
-                )
-        ).thenReturn(resourceAccessAllowed);
+        when(opaClient
+                .checkResourceAccess(any(),
+                        argThat(req -> isRequestForResourceAction(req, Resource.RA_PROFILE, ResourceAction.LIST)),
+                        any(), any()))
+                .thenReturn(resourceAccessAllowed);
 
-        when(
-                opaClient.checkResourceAccess(
-                        any(),
-                        argThat(req ->
-                                isRequestForResourceAction(req, Resource.RA_PROFILE, ResourceAction.DETAIL)
-                        ),
-                        any(),
-                        any()
-                )
-        ).thenReturn(resourceAccessAllowed);
+        when(opaClient
+                .checkResourceAccess(any(),
+                        argThat(req -> isRequestForResourceAction(req, Resource.RA_PROFILE, ResourceAction.DETAIL)),
+                        any(), any()))
+                .thenReturn(resourceAccessAllowed);
 
-        when(
-                opaClient.checkResourceAccess(
-                        any(),
-                        argThat(req ->
-                                isRequestForResourceAction(req, Resource.RA_PROFILE, ResourceAction.MEMBERS)
-                        ),
-                        any(),
-                        any()
-                )
-        ).thenReturn(resourceAccessAllowed);
+        when(opaClient
+                .checkResourceAccess(any(),
+                        argThat(req -> isRequestForResourceAction(req, Resource.RA_PROFILE, ResourceAction.MEMBERS)),
+                        any(), any()))
+                .thenReturn(resourceAccessAllowed);
 
     }
 
-    private static boolean isRequestForResourceAction(OpaRequestedResource requestedResource, Resource resource, ResourceAction resourceAction) {
-        return requestedResource != null && requestedResource.getProperties() != null &&
-                (requestedResource.getProperties().containsKey("name") && requestedResource.getProperties().get("name").equals(resource.getCode())) &&
-                (requestedResource.getProperties().containsKey("action") && requestedResource.getProperties().get("action").equals(resourceAction.getCode()));
+    private static boolean isRequestForResourceAction(OpaRequestedResource requestedResource, Resource resource,
+            ResourceAction resourceAction) {
+        return requestedResource != null && requestedResource.getProperties() != null
+                && (requestedResource.getProperties().containsKey("name")
+                        && requestedResource.getProperties().get("name").equals(resource.getCode()))
+                && (requestedResource.getProperties().containsKey("action")
+                        && requestedResource.getProperties().get("action").equals(resourceAction.getCode()));
     }
 
     @AfterEach
@@ -553,56 +525,63 @@ class AcmeServiceITest extends BaseSpringBootTest {
     }
 
     @Test
-    void testNewAccount_acmeProfileBased_withExistingKey() throws AcmeProblemDocumentException, NotFoundException, URISyntaxException, JOSEException {
+    void testNewAccount_acmeProfileBased_withExistingKey()
+            throws AcmeProblemDocumentException, NotFoundException, URISyntaxException, JOSEException {
         URI requestUri = new URI(BASE_URI + ACME_PROFILE_NAME + "/new-account");
-        ResponseEntity<Account> account = acmeService.newAccount(ACME_PROFILE_NAME, buildNewAccountRequestJSON_withExistingKey(requestUri), requestUri, false);
+        ResponseEntity<Account> account = acmeService
+                .newAccount(ACME_PROFILE_NAME, buildNewAccountRequestJSON_withExistingKey(requestUri), requestUri,
+                        false);
         assertNewAccount(account);
     }
 
     @Test
-    void testNewAccount_raProfileBased_withExistingKey() throws AcmeProblemDocumentException, NotFoundException, URISyntaxException, JOSEException {
+    void testNewAccount_raProfileBased_withExistingKey()
+            throws AcmeProblemDocumentException, NotFoundException, URISyntaxException, JOSEException {
         URI requestUri = new URI(RA_BASE_URI + RA_PROFILE_NAME + "/new-account");
-        ResponseEntity<Account> account = acmeService.newAccount(RA_PROFILE_NAME, buildNewAccountRequestJSON_withExistingKey(requestUri), requestUri, true);
+        ResponseEntity<Account> account = acmeService
+                .newAccount(RA_PROFILE_NAME, buildNewAccountRequestJSON_withExistingKey(requestUri), requestUri, true);
         assertNewAccount(account);
     }
 
     @Test
-    void testNewAccount_acmeProfileBased_withNewKey() throws AcmeProblemDocumentException, NotFoundException, URISyntaxException, JOSEException {
+    void testNewAccount_acmeProfileBased_withNewKey()
+            throws AcmeProblemDocumentException, NotFoundException, URISyntaxException, JOSEException {
         URI requestUri = new URI(BASE_URI + ACME_PROFILE_NAME + "/new-account");
-        ResponseEntity<Account> account = acmeService.newAccount(ACME_PROFILE_NAME, buildNewAccountRequestJSON_withNewKey(requestUri), requestUri, false);
+        ResponseEntity<Account> account = acmeService
+                .newAccount(ACME_PROFILE_NAME, buildNewAccountRequestJSON_withNewKey(requestUri), requestUri, false);
         assertNewAccount(account);
     }
 
     @Test
-    void testNewAccount_raProfileBased_withNewKey() throws AcmeProblemDocumentException, NotFoundException, URISyntaxException, JOSEException {
+    void testNewAccount_raProfileBased_withNewKey()
+            throws AcmeProblemDocumentException, NotFoundException, URISyntaxException, JOSEException {
         URI requestUri = new URI(RA_BASE_URI + RA_PROFILE_NAME + "/new-account");
-        ResponseEntity<Account> account = acmeService.newAccount(RA_PROFILE_NAME, buildNewAccountRequestJSON_withNewKey(requestUri), requestUri, true);
+        ResponseEntity<Account> account = acmeService
+                .newAccount(RA_PROFILE_NAME, buildNewAccountRequestJSON_withNewKey(requestUri), requestUri, true);
         assertNewAccount(account);
     }
 
     private String buildNewAccountRequestJSON_withExistingKey(URI requestUri) throws JOSEException {
-        JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload("{\"contact\":[\"mailto:test.test@test\"],\"termsOfServiceAgreed\":true, \"status\": \"deactivated\"}"));
-        jwsObjectJSON.sign(
-                new JWSHeader.Builder(JWSAlgorithm.RS256)
+        JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload(
+                "{\"contact\":[\"mailto:test.test@test\"],\"termsOfServiceAgreed\":true, \"status\": \"deactivated\"}"));
+        jwsObjectJSON
+                .sign(new JWSHeader.Builder(JWSAlgorithm.RS256)
                         .jwk(rsa2048PublicJWK)
                         .customParam(NONCE_HEADER_CUSTOM_PARAM, acmeValidNonce.getNonce())
                         .customParam(URL_HEADER_CUSTOM_PARAM, requestUri.toString())
-                        .build(),
-                rsa2048Signer
-        );
+                        .build(), rsa2048Signer);
         return jwsObjectJSON.serializeFlattened();
     }
 
     private String buildNewAccountRequestJSON_withNewKey(URI requestUri) throws JOSEException {
-        JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload("{\"contact\":[\"mailto:test.test@test\"],\"termsOfServiceAgreed\":true, \"status\": \"deactivated\"}"));
-        jwsObjectJSON.sign(
-                new JWSHeader.Builder(JWSAlgorithm.RS256)
+        JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload(
+                "{\"contact\":[\"mailto:test.test@test\"],\"termsOfServiceAgreed\":true, \"status\": \"deactivated\"}"));
+        jwsObjectJSON
+                .sign(new JWSHeader.Builder(JWSAlgorithm.RS256)
                         .jwk(newRsa2048PublicJWK)
                         .customParam(NONCE_HEADER_CUSTOM_PARAM, acmeValidNonce.getNonce())
                         .customParam(URL_HEADER_CUSTOM_PARAM, requestUri.toString())
-                        .build(),
-                newRsa2048Signer
-        );
+                        .build(), newRsa2048Signer);
         return jwsObjectJSON.serializeFlattened();
     }
 
@@ -618,32 +597,31 @@ class AcmeServiceITest extends BaseSpringBootTest {
     @Test
     void testNewAccount_fail() throws URISyntaxException {
         URI requestUri = new URI(BASE_URI + ACME_PROFILE_NAME + "/new-account");
-        Assertions.assertThrows(AcmeProblemDocumentException.class,
-                () -> acmeService.newAccount(ACME_PROFILE_NAME, buildNewAccountRequestJSON_fail(), requestUri, false));
+        Assertions
+                .assertThrows(AcmeProblemDocumentException.class, () -> acmeService
+                        .newAccount(ACME_PROFILE_NAME, buildNewAccountRequestJSON_fail(), requestUri, false));
     }
 
     @Test
     void testNewAccount_fail_raProfileBased() throws URISyntaxException {
         URI requestUri = new URI(RA_BASE_URI + RA_PROFILE_NAME + "/new-account");
-        Assertions.assertThrows(AcmeProblemDocumentException.class,
-                () -> acmeService.newAccount(RA_PROFILE_NAME, buildNewAccountRequestJSON_fail(), requestUri, true));
+        Assertions
+                .assertThrows(AcmeProblemDocumentException.class, () -> acmeService
+                        .newAccount(RA_PROFILE_NAME, buildNewAccountRequestJSON_fail(), requestUri, true));
     }
 
     private String buildNewAccountRequestJSON_fail() throws JOSEException {
         JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload("dfgdrtyufghgjghktyfghdtu"));
-        jwsObjectJSON.sign(
-                new JWSHeader.Builder(JWSAlgorithm.RS256)
-                        .jwk(rsa2048PublicJWK)
-                        .build(),
-                rsa2048Signer
-        );
+        jwsObjectJSON.sign(new JWSHeader.Builder(JWSAlgorithm.RS256).jwk(rsa2048PublicJWK).build(), rsa2048Signer);
         return jwsObjectJSON.serializeFlattened();
     }
 
     @Test
-    void testOnlyReturnExistingAccount() throws URISyntaxException, JOSEException, AcmeProblemDocumentException, NotFoundException {
+    void testOnlyReturnExistingAccount()
+            throws URISyntaxException, JOSEException, AcmeProblemDocumentException, NotFoundException {
         URI requestUri = new URI(RA_BASE_URI + RA_PROFILE_NAME + "/new-account");
-        ResponseEntity<Account> account = acmeService.newAccount(RA_PROFILE_NAME, buildOnlyReturnExistingAccountJSON(requestUri), requestUri, true);
+        ResponseEntity<Account> account = acmeService
+                .newAccount(RA_PROFILE_NAME, buildOnlyReturnExistingAccountJSON(requestUri), requestUri, true);
         Assertions.assertEquals(HttpStatus.OK, account.getStatusCode());
         Assertions.assertNotNull(account);
         Assertions.assertEquals(AccountStatus.VALID, Objects.requireNonNull(account.getBody()).getStatus());
@@ -651,79 +629,84 @@ class AcmeServiceITest extends BaseSpringBootTest {
 
     private String buildOnlyReturnExistingAccountJSON(URI requestUri) throws JOSEException {
         JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload("{\"onlyReturnExisting\":true}"));
-        jwsObjectJSON.sign(
-                new JWSHeader.Builder(JWSAlgorithm.RS256)
+        jwsObjectJSON
+                .sign(new JWSHeader.Builder(JWSAlgorithm.RS256)
                         .jwk(rsa2048PublicJWK)
                         .customParam(NONCE_HEADER_CUSTOM_PARAM, acmeValidNonce.getNonce())
                         .customParam(URL_HEADER_CUSTOM_PARAM, requestUri.toString())
-                        .build(),
-                rsa2048Signer
-        );
+                        .build(), rsa2048Signer);
         return jwsObjectJSON.serializeFlattened();
     }
 
     @Test
     void testOnlyReturnExistingAccount_fail() throws URISyntaxException {
         URI requestUri = new URI(RA_BASE_URI + RA_PROFILE_NAME + "/new-account");
-        Assertions.assertThrows(AcmeProblemDocumentException.class,
-                () -> acmeService.newAccount(RA_PROFILE_NAME, buildOnlyReturnExistingAccountJSON_fail(requestUri), requestUri, true));
+        Assertions
+                .assertThrows(AcmeProblemDocumentException.class,
+                        () -> acmeService
+                                .newAccount(RA_PROFILE_NAME, buildOnlyReturnExistingAccountJSON_fail(requestUri),
+                                        requestUri, true));
     }
 
     private String buildOnlyReturnExistingAccountJSON_fail(URI requestUri) throws JOSEException {
         JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload("{\"onlyReturnExisting\":true}"));
-        jwsObjectJSON.sign(
-                new JWSHeader.Builder(JWSAlgorithm.RS256)
+        jwsObjectJSON
+                .sign(new JWSHeader.Builder(JWSAlgorithm.RS256)
                         .jwk(newRsa2048PublicJWK)
                         .customParam(NONCE_HEADER_CUSTOM_PARAM, acmeValidNonce.getNonce())
                         .customParam(URL_HEADER_CUSTOM_PARAM, requestUri.toString())
-                        .build(),
-                newRsa2048Signer
-        );
+                        .build(), newRsa2048Signer);
         return jwsObjectJSON.serializeFlattened();
     }
 
     @Test
     void testNewAccountOnExisting_wrongConfiguration() throws URISyntaxException {
         URI requestUri = new URI(BASE_URI + ACME_PROFILE_NAME_2 + "/new-account");
-        Assertions.assertThrows(AcmeProblemDocumentException.class,
-                () -> acmeService.newAccount(ACME_PROFILE_NAME_2, buildNewAccountRequestJSON_withExistingKey(requestUri), requestUri, false));
+        Assertions
+                .assertThrows(AcmeProblemDocumentException.class,
+                        () -> acmeService
+                                .newAccount(ACME_PROFILE_NAME_2, buildNewAccountRequestJSON_withExistingKey(requestUri),
+                                        requestUri, false));
     }
 
     @Test
     void testNewAccountOnExisting_wrongConfiguration_raProfileBased() throws URISyntaxException {
         URI requestUri = new URI(RA_BASE_URI + RA_PROFILE_NAME_2 + "/new-account");
-        Assertions.assertThrows(AcmeProblemDocumentException.class,
-                () -> acmeService.newAccount(RA_PROFILE_NAME_2, buildNewAccountRequestJSON_withExistingKey(requestUri), requestUri, true));
+        Assertions
+                .assertThrows(AcmeProblemDocumentException.class,
+                        () -> acmeService
+                                .newAccount(RA_PROFILE_NAME_2, buildNewAccountRequestJSON_withExistingKey(requestUri),
+                                        requestUri, true));
     }
 
     @Test
     void testNewOrder() throws JOSEException, URISyntaxException, AcmeProblemDocumentException, NotFoundException {
         URI requestUri = new URI(BASE_URI + ACME_PROFILE_NAME + "/new-order");
-        ResponseEntity<Order> order = acmeService.newOrder(
-                ACME_PROFILE_NAME,
-                buildNewOrderRequestJSON(requestUri, BASE_URI + ACME_PROFILE_NAME), requestUri, false);
+        ResponseEntity<Order> order = acmeService
+                .newOrder(ACME_PROFILE_NAME, buildNewOrderRequestJSON(requestUri, BASE_URI + ACME_PROFILE_NAME),
+                        requestUri, false);
         assertNewOrder(order);
     }
 
     @Test
-    void testNewOrder_raProfileBased() throws JOSEException, URISyntaxException, AcmeProblemDocumentException, NotFoundException {
+    void testNewOrder_raProfileBased()
+            throws JOSEException, URISyntaxException, AcmeProblemDocumentException, NotFoundException {
         URI requestUri = new URI(RA_BASE_URI + RA_PROFILE_NAME + "/new-order");
-        ResponseEntity<Order> order = acmeService.newOrder(
-                RA_PROFILE_NAME,
-                buildNewOrderRequestJSON(requestUri, RA_BASE_URI + RA_PROFILE_NAME), requestUri, true);
+        ResponseEntity<Order> order = acmeService
+                .newOrder(RA_PROFILE_NAME, buildNewOrderRequestJSON(requestUri, RA_BASE_URI + RA_PROFILE_NAME),
+                        requestUri, true);
         assertNewOrder(order);
     }
 
     private String buildNewOrderRequestJSON(URI requestUri, String baseUri) throws JOSEException {
-        JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload("{\"identifiers\":[{\"type\":\"dns\",\"value\":\"debian10.acme.local\"}]}"));
-        jwsObjectJSON.sign(
-                new JWSHeader.Builder(JWSAlgorithm.RS256)
+        JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(
+                new Payload("{\"identifiers\":[{\"type\":\"dns\",\"value\":\"debian10.acme.local\"}]}"));
+        jwsObjectJSON
+                .sign(new JWSHeader.Builder(JWSAlgorithm.RS256)
                         .keyID(baseUri + "/acct/" + ACME_ACCOUNT_ID_VALID)
                         .customParam(NONCE_HEADER_CUSTOM_PARAM, acmeValidNonce.getNonce())
                         .customParam(URL_HEADER_CUSTOM_PARAM, requestUri.toString())
-                        .build(),
-                rsa2048Signer
-        );
+                        .build(), rsa2048Signer);
         return jwsObjectJSON.serializeFlattened();
     }
 
@@ -739,57 +722,55 @@ class AcmeServiceITest extends BaseSpringBootTest {
     @Test
     void testNewOrder_Fail() throws URISyntaxException {
         URI requestUri = new URI(BASE_URI + ACME_PROFILE_NAME + "/new-order");
-        Assertions.assertThrows(AcmeProblemDocumentException.class,
-                () -> acmeService.newOrder(ACME_PROFILE_NAME, buildNewOrderRequestJSON_fail(), requestUri, false));
+        Assertions
+                .assertThrows(AcmeProblemDocumentException.class, () -> acmeService
+                        .newOrder(ACME_PROFILE_NAME, buildNewOrderRequestJSON_fail(), requestUri, false));
     }
 
     @Test
     void testNewOrder_fail_raProfileBased() throws URISyntaxException {
         URI requestUri = new URI(RA_BASE_URI + RA_PROFILE_NAME + "/new-order");
-        Assertions.assertThrows(AcmeProblemDocumentException.class,
-                () -> acmeService.newOrder(RA_PROFILE_NAME, buildNewOrderRequestJSON_fail(), requestUri, true));
+        Assertions
+                .assertThrows(AcmeProblemDocumentException.class,
+                        () -> acmeService.newOrder(RA_PROFILE_NAME, buildNewOrderRequestJSON_fail(), requestUri, true));
     }
 
     private String buildNewOrderRequestJSON_fail() throws JOSEException {
         JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload("dfgdrtyufghgjghktyfghdtu"));
-        jwsObjectJSON.sign(
-                new JWSHeader.Builder(JWSAlgorithm.RS256)
-                        .build(),
-                rsa2048Signer
-        );
+        jwsObjectJSON.sign(new JWSHeader.Builder(JWSAlgorithm.RS256).build(), rsa2048Signer);
         return jwsObjectJSON.serializeFlattened();
     }
 
     @Test
-    void testGetAuthorization() throws AcmeProblemDocumentException, NotFoundException, URISyntaxException, JOSEException {
+    void testGetAuthorization()
+            throws AcmeProblemDocumentException, NotFoundException, URISyntaxException, JOSEException {
         String baseUri = BASE_URI + ACME_PROFILE_NAME;
         URI requestUri = new URI(baseUri + "/authz/" + AUTHORIZATION_ID_PENDING);
-        ResponseEntity<Authorization> authorization = acmeService.getAuthorization(
-                ACME_PROFILE_NAME, AUTHORIZATION_ID_PENDING,
-                buildGetAuthorizationRequestJSON(requestUri, baseUri), requestUri, false);
+        ResponseEntity<Authorization> authorization = acmeService
+                .getAuthorization(ACME_PROFILE_NAME, AUTHORIZATION_ID_PENDING,
+                        buildGetAuthorizationRequestJSON(requestUri, baseUri), requestUri, false);
         assertGetAuthorization(authorization);
     }
 
     @Test
-    void testGetAuthorization_raProfileBased() throws AcmeProblemDocumentException, NotFoundException, URISyntaxException, JOSEException {
+    void testGetAuthorization_raProfileBased()
+            throws AcmeProblemDocumentException, NotFoundException, URISyntaxException, JOSEException {
         String baseUri = RA_BASE_URI + RA_PROFILE_NAME;
         URI requestUri = new URI(baseUri + "/authz/" + AUTHORIZATION_ID_PENDING);
-        ResponseEntity<Authorization> authorization = acmeService.getAuthorization(
-                RA_PROFILE_NAME, AUTHORIZATION_ID_PENDING,
-                buildGetAuthorizationRequestJSON(requestUri, baseUri), requestUri, true);
+        ResponseEntity<Authorization> authorization = acmeService
+                .getAuthorization(RA_PROFILE_NAME, AUTHORIZATION_ID_PENDING,
+                        buildGetAuthorizationRequestJSON(requestUri, baseUri), requestUri, true);
         assertGetAuthorization(authorization);
     }
 
     private String buildGetAuthorizationRequestJSON(URI requestUri, String baseUri) throws JOSEException {
         JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload(""));
-        jwsObjectJSON.sign(
-                new JWSHeader.Builder(JWSAlgorithm.RS256)
+        jwsObjectJSON
+                .sign(new JWSHeader.Builder(JWSAlgorithm.RS256)
                         .keyID(baseUri + "/acct/" + ACME_ACCOUNT_ID_VALID)
                         .customParam(NONCE_HEADER_CUSTOM_PARAM, acmeValidNonce.getNonce())
                         .customParam(URL_HEADER_CUSTOM_PARAM, requestUri.toString())
-                        .build(),
-                rsa2048Signer
-        );
+                        .build(), rsa2048Signer);
         return jwsObjectJSON.serializeFlattened();
     }
 
@@ -804,52 +785,62 @@ class AcmeServiceITest extends BaseSpringBootTest {
     }
 
     @Test
-    void testFinalize() throws URISyntaxException, ConnectorException, CertificateException, AlreadyExistException, JOSEException, AcmeProblemDocumentException, JsonProcessingException {
+    void testFinalize() throws URISyntaxException, ConnectorException, CertificateException, AlreadyExistException,
+            JOSEException, AcmeProblemDocumentException, JsonProcessingException {
         String baseUri = BASE_URI + ACME_PROFILE_NAME;
         URI requestUri = new URI(baseUri + "/order/" + ORDER_ID_VALID + "/finalize");
         certificate.setState(CertificateState.FAILED);
         certificateRepository.save(certificate);
         order1.setStatus(OrderStatus.PENDING);
         acmeOrderRepository.save(order1);
-        Assertions.assertThrows(AcmeProblemDocumentException.class, () -> acmeService.finalizeOrder(
-                ACME_PROFILE_NAME, ORDER_ID_VALID,
-                buildFinalizeRequestJSON(requestUri, baseUri), requestUri, false));
+        Assertions
+                .assertThrows(AcmeProblemDocumentException.class,
+                        () -> acmeService
+                                .finalizeOrder(ACME_PROFILE_NAME, ORDER_ID_VALID,
+                                        buildFinalizeRequestJSON(requestUri, baseUri), requestUri, false));
         AcmeAccount acmeAccount = acmeAccountRepository.findByUuid(order1.getAcmeAccountUuid()).orElseThrow();
         Assertions.assertEquals(1, acmeAccount.getFailedOrders());
         certificate.setState(CertificateState.ISSUED);
         certificateRepository.save(certificate);
         order1.setStatus(OrderStatus.PENDING);
         acmeOrderRepository.save(order1);
-        Assertions.assertThrows(AcmeProblemDocumentException.class, () -> acmeService.finalizeOrder(
-                ACME_PROFILE_NAME, ORDER_ID_VALID,
-                buildFinalizeRequestJSON(requestUri, baseUri), requestUri, false));
+        Assertions
+                .assertThrows(AcmeProblemDocumentException.class,
+                        () -> acmeService
+                                .finalizeOrder(ACME_PROFILE_NAME, ORDER_ID_VALID,
+                                        buildFinalizeRequestJSON(requestUri, baseUri), requestUri, false));
         acmeAccount = acmeAccountRepository.findByUuid(order1.getAcmeAccountUuid()).orElseThrow();
         Assertions.assertEquals(1, acmeAccount.getValidOrders());
 
-
         order1.setCertificateReference(null);
         order1.setCertificateReferenceUuid(null);
         order1.setStatus(OrderStatus.READY);
         acmeOrderRepository.save(order1);
-        acmeService.finalizeOrder(
-                ACME_PROFILE_NAME, ORDER_ID_VALID,
-                buildFinalizeRequestJSON(requestUri, baseUri), requestUri, false);
+        acmeService
+                .finalizeOrder(ACME_PROFILE_NAME, ORDER_ID_VALID, buildFinalizeRequestJSON(requestUri, baseUri),
+                        requestUri, false);
         acmeAccount = acmeAccountRepository.findByUuid(order1.getAcmeAccountUuid()).orElseThrow();
         Assertions.assertEquals(2, acmeAccount.getFailedOrders());
 
-        mockServer.stubFor(WireMock
-                .post(WireMock.urlPathMatching("/v2/authorityProvider/authorities/[^/]+/certificates/issue/attributes/validate"))
-                .willReturn(WireMock.okJson("true")));
-        mockServer.stubFor(WireMock
-                .get(WireMock.urlPathMatching("/v2/authorityProvider/authorities/[^/]+/certificates/issue/attributes"))
-                .willReturn(WireMock.okJson("[]")));
+        mockServer
+                .stubFor(WireMock
+                        .post(WireMock
+                                .urlPathMatching(
+                                        "/v2/authorityProvider/authorities/[^/]+/certificates/issue/attributes/validate"))
+                        .willReturn(WireMock.okJson("true")));
+        mockServer
+                .stubFor(WireMock
+                        .get(WireMock
+                                .urlPathMatching(
+                                        "/v2/authorityProvider/authorities/[^/]+/certificates/issue/attributes"))
+                        .willReturn(WireMock.okJson("[]")));
         order1.setCertificateReference(null);
         order1.setCertificateReferenceUuid(null);
         order1.setStatus(OrderStatus.READY);
         acmeOrderRepository.save(order1);
-        acmeService.finalizeOrder(
-                ACME_PROFILE_NAME, ORDER_ID_VALID,
-                buildFinalizeRequestJSON(requestUri, baseUri), requestUri, false);
+        acmeService
+                .finalizeOrder(ACME_PROFILE_NAME, ORDER_ID_VALID, buildFinalizeRequestJSON(requestUri, baseUri),
+                        requestUri, false);
         acmeAccount = acmeAccountRepository.findByUuid(order1.getAcmeAccountUuid()).orElseThrow();
         Assertions.assertEquals(2, acmeAccount.getFailedOrders());
     }
@@ -858,21 +849,22 @@ class AcmeServiceITest extends BaseSpringBootTest {
     void testFinalize_raProfileBased() throws URISyntaxException {
         String baseUri = RA_BASE_URI + RA_PROFILE_NAME;
         URI requestUri = new URI(baseUri + "/order/" + ORDER_ID_VALID + "/finalize");
-        Assertions.assertThrows(AcmeProblemDocumentException.class, () -> acmeService.finalizeOrder(
-                RA_PROFILE_NAME, ORDER_ID_VALID,
-                buildFinalizeRequestJSON(requestUri, baseUri), requestUri, true));
+        Assertions
+                .assertThrows(AcmeProblemDocumentException.class,
+                        () -> acmeService
+                                .finalizeOrder(RA_PROFILE_NAME, ORDER_ID_VALID,
+                                        buildFinalizeRequestJSON(requestUri, baseUri), requestUri, true));
     }
 
     private String buildFinalizeRequestJSON(URI requestUri, String baseUri) throws JOSEException {
-        JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload("{\"csr\":\"MIICdjCCAV4CAQIwADCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALeJvx7JWbwzobWL74KyHz0FjPqt0R5iOaOxiYqpfMY-ZVhMBkS0FqnCBQzMn5BkHukdx7HsIMkJ-sM01HVHJaRpgpf1zeTyRQjY7ESDikRL_1Ekxi6Sgf5unzB35aP2EBxiAaomG610HjpqSfGtOzEf12hy4jkcC446TT8nE9dm6CBf7XAoq9vXxXRjnAgdkr62yIzanXedDwdcNyk5EiiRWQXwW-L5Pex5808ip2gmE5Al5SPUiv8eDCq02QVDJ8Ln4UPYkxL1b6RMlfEgKLsGEZX0e-FC0w_fiBN48zrvHxqM2fdU7Ae8pRDwUOClYOxDkrvDv60RGikLlQZ45FcCAwEAAaAxMC8GCSqGSIb3DQEJDjEiMCAwHgYDVR0RBBcwFYITZGViaWFuMTAuYWNtZS5sb2NhbDANBgkqhkiG9w0BAQsFAAOCAQEAHlO0ZuPuYEtplU0gEUj88Yi1MWkrElx0JoTk7qonRsufu_Y2P_u-RrkWOzM3VJ08lNz90L_mnc8NOONMl_WlYWBywbUMsGar4Y_1x0ySOEdp5fg87rxY1b2jbSL7tPe4OV7yAebdCEzzXXBi3Ay9NoJAhwNONjyRp92vqT5-MWMXQyZvdcUMM38l6aNc9jof3EluNbgO7nWSle6MQJJvlEYwXx7ZPvvgxMfrRa-Yc_aWS7w25MSAODKKwvIivGn5q_owfd5AozYp0pymiLLbvAWhYVWL_-bGvJ13xpyfNPnGJIdwcY8zgikYPyBfbRmPyKJLPI4QnWz8GsWGiaUgjA\"}"));
-        jwsObjectJSON.sign(
-                new JWSHeader.Builder(JWSAlgorithm.RS256)
+        JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload(
+                "{\"csr\":\"MIICdjCCAV4CAQIwADCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALeJvx7JWbwzobWL74KyHz0FjPqt0R5iOaOxiYqpfMY-ZVhMBkS0FqnCBQzMn5BkHukdx7HsIMkJ-sM01HVHJaRpgpf1zeTyRQjY7ESDikRL_1Ekxi6Sgf5unzB35aP2EBxiAaomG610HjpqSfGtOzEf12hy4jkcC446TT8nE9dm6CBf7XAoq9vXxXRjnAgdkr62yIzanXedDwdcNyk5EiiRWQXwW-L5Pex5808ip2gmE5Al5SPUiv8eDCq02QVDJ8Ln4UPYkxL1b6RMlfEgKLsGEZX0e-FC0w_fiBN48zrvHxqM2fdU7Ae8pRDwUOClYOxDkrvDv60RGikLlQZ45FcCAwEAAaAxMC8GCSqGSIb3DQEJDjEiMCAwHgYDVR0RBBcwFYITZGViaWFuMTAuYWNtZS5sb2NhbDANBgkqhkiG9w0BAQsFAAOCAQEAHlO0ZuPuYEtplU0gEUj88Yi1MWkrElx0JoTk7qonRsufu_Y2P_u-RrkWOzM3VJ08lNz90L_mnc8NOONMl_WlYWBywbUMsGar4Y_1x0ySOEdp5fg87rxY1b2jbSL7tPe4OV7yAebdCEzzXXBi3Ay9NoJAhwNONjyRp92vqT5-MWMXQyZvdcUMM38l6aNc9jof3EluNbgO7nWSle6MQJJvlEYwXx7ZPvvgxMfrRa-Yc_aWS7w25MSAODKKwvIivGn5q_owfd5AozYp0pymiLLbvAWhYVWL_-bGvJ13xpyfNPnGJIdwcY8zgikYPyBfbRmPyKJLPI4QnWz8GsWGiaUgjA\"}"));
+        jwsObjectJSON
+                .sign(new JWSHeader.Builder(JWSAlgorithm.RS256)
                         .keyID(baseUri + "/acct/" + ACME_ACCOUNT_ID_VALID)
                         .customParam(NONCE_HEADER_CUSTOM_PARAM, acmeValidNonce.getNonce())
                         .customParam(URL_HEADER_CUSTOM_PARAM, requestUri.toString())
-                        .build(),
-                rsa2048Signer
-        );
+                        .build(), rsa2048Signer);
         return jwsObjectJSON.serializeFlattened();
     }
 
@@ -881,9 +873,9 @@ class AcmeServiceITest extends BaseSpringBootTest {
         String baseUri = BASE_URI + ACME_PROFILE_NAME;
         URI requestUri = new URI(baseUri + "/revoke-cert");
         var requestJson = buildRevokeCertRequestJSON_fail(requestUri, baseUri);
-        Assertions.assertThrows(NullPointerException.class,
-                () -> acmeService.revokeCertificate(
-                        ACME_PROFILE_NAME, requestJson, requestUri, false));
+        Assertions
+                .assertThrows(NullPointerException.class,
+                        () -> acmeService.revokeCertificate(ACME_PROFILE_NAME, requestJson, requestUri, false));
 
     }
 
@@ -892,9 +884,9 @@ class AcmeServiceITest extends BaseSpringBootTest {
         String baseUri = RA_BASE_URI + RA_PROFILE_NAME;
         URI requestUri = new URI(baseUri + "/revoke-cert");
         var requestJson = buildRevokeCertRequestJSON_fail(requestUri, baseUri);
-        Assertions.assertThrows(NullPointerException.class,
-                () -> acmeService.revokeCertificate(
-                        RA_PROFILE_NAME, requestJson, requestUri, true));
+        Assertions
+                .assertThrows(NullPointerException.class,
+                        () -> acmeService.revokeCertificate(RA_PROFILE_NAME, requestJson, requestUri, true));
 
     }
 
@@ -904,41 +896,46 @@ class AcmeServiceITest extends BaseSpringBootTest {
         URI requestUri = new URI(baseUri + "/revoke-cert");
         certificate.setArchived(true);
         certificateRepository.save(certificate);
-        Assertions.assertThrows(AcmeProblemDocumentException.class, () -> acmeService.revokeCertificate(
-                ACME_PROFILE_NAME,
-                buildRevokeCertRequestJSON_withAccountKey(requestUri, baseUri, b64UrlCertificate), requestUri, false));
+        Assertions
+                .assertThrows(AcmeProblemDocumentException.class, () -> acmeService
+                        .revokeCertificate(ACME_PROFILE_NAME,
+                                buildRevokeCertRequestJSON_withAccountKey(requestUri, baseUri, b64UrlCertificate),
+                                requestUri, false));
     }
 
     private String buildRevokeCertRequestJSON_fail(URI requestUri, String baseUri) throws JOSEException {
-        JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload("{\"certificate\":\"MIIFOzCCAyOgAwIBAgITGAAAA4HCMidgplmlrQAAAAADgTANBgkqhkiG9w0BAQ0FADA3MRcwFQYDVQQDDA5EZW1vIE1TIFN1YiBDQTEcMBoGA1UECgwTM0tleSBDb21wYW55IHMuci5vLjAeFw0yNDAzMTIxMTI3MDBaFw0yNjAzMTIxMTI3MDBaMBgxFjAUBgNVBAMTDXRmdC4za2V5LnRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDgoHj1WO_sXoqfcr7pm5KUjsAnmdjgzBbFwHCAvlDwsF8Z6B6i77AB-xLIUdcVLPu417mApEbH9Nu9jvcO_b2QEh_tDAczbug6SVMwgl7va3H5qGwg_0qepRHNWAMt1TWgY-rFZbUn1WLSO97armFjVPKK-AeuBVz4EQIqS1vxLLg0MxajR19euvkLBjbjYtjp7pwgHT2jMsccJ06bGN3Ik7wTZMnObfwxhhmwApEjyeDevVywopULc9zarvOSgFTnejlfOmwUBnnHlp8Xpq7P_izt1AhJkij9eElzSXnZUHAFQoQh3fQ6yelXFBxDOEAao8o3FR-R6Ss3kZ3mxkbjAgMBAAGjggFdMIIBWTAnBgNVHREEIDAegg10ZnQuM2tleS50ZXN0gg13d3cuM2tleS50ZXN0MB0GA1UdDgQWBBSA81KtARou26mp921nppmTGjC6BTAfBgNVHSMEGDAWgBSSwrzfVcXBk4VJB_esyR0LaAEHUTBNBgNVHR8ERjBEMEKgQKA-hjxodHRwOi8vbGFiMDIuM2tleS5jb21wYW55L2NybHMvZGVtby9EZW1vJTIwTVMlMjBTdWIlMjBDQS5jcmwwVwYIKwYBBQUHAQEESzBJMEcGCCsGAQUFBzABhjtodHRwOi8vbGFiMDIuM2tleS5jb21wYW55L2Nhcy9kZW1vL0RlbW8lMjBNUyUyMFN1YiUyMENBLmNydDAhBgkrBgEEAYI3FAIEFB4SAFcAZQBiAFMAZQByAHYAZQByMA4GA1UdDwEB_wQEAwIFoDATBgNVHSUEDDAKBggrBgEFBQcDATANBgkqhkiG9w0BAQ0FAAOCAgEAb_N3sf9Kda5t_jsL_VQYW0OPiHD0V1QcwqiyplvclD7NahnV7QiUwS7V-QmHHD1V2_xkYNhlgkinu1SWbpJ8gAcLDbADfnMkaOZNr6dvKiDGw0Xppmfbha1Bbb3JA_DOHFrXBm3795mQDgaRuvPke0qyyL1DP9xAdxubQaYQDZA9WAYNztgVe3V4zngwzI6P6BiDQ7CgZLNv_e8e5ME4_MCeO0cUFxt7mzKIhH54wL4yY8DJ3LHVWXsMPntRMdvYWjYf-1Ivb5x2WvuU_SPcnCSyEj0qdcLlm9BWxbfM-5h4gXWvsCjG2anGLtsl5Ut3Sz1vvoM49N981pZEZDlNFlsBgYCF-MDKZwBOiX8uTgQkv5bqA7_tPvIgQI_JTbSYeqRtb4J6SH1_uRrhyU7w88PlSmZwkf5S5ZxX9eqjSEFENB7ARh4KaiHyYqTfYxAP6-EFs9dxBTQ5eQu2jFXy4xJG4g-r1KZujv6wgPoDZsbbqTfBg27_sQsTyzZqI1vL5UrCqxDSo-Pw9JPITYi8AdOffT0hkgQ7RmLHb6HYV7JqABmhZ3G9QQfuk2W7_o6l6jnpZM7pHEkZ30s54cIHgYG3JifXd2m6uxU6iX48mJy_VUZcVikxSbCg5eLlvq_HWnxk2DE_9PWjA_YxZs2Jtqpi2FtLCli2cykGGumhhJ0\",\"reason\":8}"));
-        jwsObjectJSON.sign(
-                new JWSHeader.Builder(JWSAlgorithm.RS256)
+        JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload(
+                "{\"certificate\":\"MIIFOzCCAyOgAwIBAgITGAAAA4HCMidgplmlrQAAAAADgTANBgkqhkiG9w0BAQ0FADA3MRcwFQYDVQQDDA5EZW1vIE1TIFN1YiBDQTEcMBoGA1UECgwTM0tleSBDb21wYW55IHMuci5vLjAeFw0yNDAzMTIxMTI3MDBaFw0yNjAzMTIxMTI3MDBaMBgxFjAUBgNVBAMTDXRmdC4za2V5LnRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDgoHj1WO_sXoqfcr7pm5KUjsAnmdjgzBbFwHCAvlDwsF8Z6B6i77AB-xLIUdcVLPu417mApEbH9Nu9jvcO_b2QEh_tDAczbug6SVMwgl7va3H5qGwg_0qepRHNWAMt1TWgY-rFZbUn1WLSO97armFjVPKK-AeuBVz4EQIqS1vxLLg0MxajR19euvkLBjbjYtjp7pwgHT2jMsccJ06bGN3Ik7wTZMnObfwxhhmwApEjyeDevVywopULc9zarvOSgFTnejlfOmwUBnnHlp8Xpq7P_izt1AhJkij9eElzSXnZUHAFQoQh3fQ6yelXFBxDOEAao8o3FR-R6Ss3kZ3mxkbjAgMBAAGjggFdMIIBWTAnBgNVHREEIDAegg10ZnQuM2tleS50ZXN0gg13d3cuM2tleS50ZXN0MB0GA1UdDgQWBBSA81KtARou26mp921nppmTGjC6BTAfBgNVHSMEGDAWgBSSwrzfVcXBk4VJB_esyR0LaAEHUTBNBgNVHR8ERjBEMEKgQKA-hjxodHRwOi8vbGFiMDIuM2tleS5jb21wYW55L2NybHMvZGVtby9EZW1vJTIwTVMlMjBTdWIlMjBDQS5jcmwwVwYIKwYBBQUHAQEESzBJMEcGCCsGAQUFBzABhjtodHRwOi8vbGFiMDIuM2tleS5jb21wYW55L2Nhcy9kZW1vL0RlbW8lMjBNUyUyMFN1YiUyMENBLmNydDAhBgkrBgEEAYI3FAIEFB4SAFcAZQBiAFMAZQByAHYAZQByMA4GA1UdDwEB_wQEAwIFoDATBgNVHSUEDDAKBggrBgEFBQcDATANBgkqhkiG9w0BAQ0FAAOCAgEAb_N3sf9Kda5t_jsL_VQYW0OPiHD0V1QcwqiyplvclD7NahnV7QiUwS7V-QmHHD1V2_xkYNhlgkinu1SWbpJ8gAcLDbADfnMkaOZNr6dvKiDGw0Xppmfbha1Bbb3JA_DOHFrXBm3795mQDgaRuvPke0qyyL1DP9xAdxubQaYQDZA9WAYNztgVe3V4zngwzI6P6BiDQ7CgZLNv_e8e5ME4_MCeO0cUFxt7mzKIhH54wL4yY8DJ3LHVWXsMPntRMdvYWjYf-1Ivb5x2WvuU_SPcnCSyEj0qdcLlm9BWxbfM-5h4gXWvsCjG2anGLtsl5Ut3Sz1vvoM49N981pZEZDlNFlsBgYCF-MDKZwBOiX8uTgQkv5bqA7_tPvIgQI_JTbSYeqRtb4J6SH1_uRrhyU7w88PlSmZwkf5S5ZxX9eqjSEFENB7ARh4KaiHyYqTfYxAP6-EFs9dxBTQ5eQu2jFXy4xJG4g-r1KZujv6wgPoDZsbbqTfBg27_sQsTyzZqI1vL5UrCqxDSo-Pw9JPITYi8AdOffT0hkgQ7RmLHb6HYV7JqABmhZ3G9QQfuk2W7_o6l6jnpZM7pHEkZ30s54cIHgYG3JifXd2m6uxU6iX48mJy_VUZcVikxSbCg5eLlvq_HWnxk2DE_9PWjA_YxZs2Jtqpi2FtLCli2cykGGumhhJ0\",\"reason\":8}"));
+        jwsObjectJSON
+                .sign(new JWSHeader.Builder(JWSAlgorithm.RS256)
                         .keyID(baseUri + "/acct/" + ACME_ACCOUNT_ID_VALID)
                         .customParam(NONCE_HEADER_CUSTOM_PARAM, acmeValidNonce.getNonce())
                         .customParam(URL_HEADER_CUSTOM_PARAM, requestUri.toString())
-                        .build(),
-                rsa2048Signer
-        );
+                        .build(), rsa2048Signer);
         return jwsObjectJSON.serializeFlattened();
     }
 
     @Test
-    void testRevokeCert_withAccountKey() throws URISyntaxException, JOSEException, AcmeProblemDocumentException, ConnectorException, CertificateException {
+    void testRevokeCert_withAccountKey() throws URISyntaxException, JOSEException, AcmeProblemDocumentException,
+            ConnectorException, CertificateException {
         String baseUri = BASE_URI + ACME_PROFILE_NAME;
         URI requestUri = new URI(baseUri + "/revoke-cert");
-        ResponseEntity<?> response = acmeService.revokeCertificate(
-                ACME_PROFILE_NAME,
-                buildRevokeCertRequestJSON_withAccountKey(requestUri, baseUri, b64UrlCertificate), requestUri, false);
+        ResponseEntity<?> response = acmeService
+                .revokeCertificate(ACME_PROFILE_NAME,
+                        buildRevokeCertRequestJSON_withAccountKey(requestUri, baseUri, b64UrlCertificate), requestUri,
+                        false);
         assertRevokeCert_withAccountKey(response);
     }
 
     @Test
-    void testRevokeCert_withAccountKey_raProfileBased() throws URISyntaxException, JOSEException, AcmeProblemDocumentException, ConnectorException, CertificateException {
+    void testRevokeCert_withAccountKey_raProfileBased() throws URISyntaxException, JOSEException,
+            AcmeProblemDocumentException, ConnectorException, CertificateException {
         String baseUri = RA_BASE_URI + RA_PROFILE_NAME;
         URI requestUri = new URI(baseUri + "/revoke-cert");
-        ResponseEntity<?> response = acmeService.revokeCertificate(
-                RA_PROFILE_NAME,
-                buildRevokeCertRequestJSON_withAccountKey(requestUri, baseUri, b64UrlCertificate), requestUri, true);
+        ResponseEntity<?> response = acmeService
+                .revokeCertificate(RA_PROFILE_NAME,
+                        buildRevokeCertRequestJSON_withAccountKey(requestUri, baseUri, b64UrlCertificate), requestUri,
+                        true);
         assertRevokeCert_withAccountKey(response);
     }
 
@@ -946,10 +943,11 @@ class AcmeServiceITest extends BaseSpringBootTest {
     void testRevokeCert_withAccountKey_nonAcmeCertificate() throws URISyntaxException {
         String baseUri = BASE_URI + ACME_PROFILE_NAME;
         URI requestUri = new URI(baseUri + "/revoke-cert");
-        AcmeProblemDocumentException thrown = Assertions.assertThrows(AcmeProblemDocumentException.class,
-                () -> acmeService.revokeCertificate(
-                        ACME_PROFILE_NAME,
-                        buildRevokeCertRequestJSON_withAccountKey(requestUri, baseUri, nonAcmeB64UrlCertificate), requestUri, false));
+        AcmeProblemDocumentException thrown = Assertions
+                .assertThrows(AcmeProblemDocumentException.class,
+                        () -> acmeService
+                                .revokeCertificate(ACME_PROFILE_NAME, buildRevokeCertRequestJSON_withAccountKey(
+                                        requestUri, baseUri, nonAcmeB64UrlCertificate), requestUri, false));
         Assertions.assertEquals(thrown.getHttpStatusCode(), HttpStatus.FORBIDDEN.value());
     }
 
@@ -957,10 +955,11 @@ class AcmeServiceITest extends BaseSpringBootTest {
     void testRevokeCert_withAccountKey_nonAcmeCertificate_raProfileBased() throws URISyntaxException {
         String baseUri = RA_BASE_URI + RA_PROFILE_NAME;
         URI requestUri = new URI(baseUri + "/revoke-cert");
-        AcmeProblemDocumentException thrown = Assertions.assertThrows(AcmeProblemDocumentException.class,
-                () -> acmeService.revokeCertificate(
-                        RA_PROFILE_NAME,
-                        buildRevokeCertRequestJSON_withAccountKey(requestUri, baseUri, nonAcmeB64UrlCertificate), requestUri, true));
+        AcmeProblemDocumentException thrown = Assertions
+                .assertThrows(AcmeProblemDocumentException.class,
+                        () -> acmeService
+                                .revokeCertificate(RA_PROFILE_NAME, buildRevokeCertRequestJSON_withAccountKey(
+                                        requestUri, baseUri, nonAcmeB64UrlCertificate), requestUri, true));
         Assertions.assertEquals(thrown.getHttpStatusCode(), HttpStatus.FORBIDDEN.value());
     }
 
@@ -968,21 +967,23 @@ class AcmeServiceITest extends BaseSpringBootTest {
     void testUpdateAccount() throws URISyntaxException, JOSEException, AcmeProblemDocumentException, NotFoundException {
         String baseUri = BASE_URI + ACME_PROFILE_NAME;
         URI requestUri = new URI(baseUri + "/update");
-        acmeService.updateAccount(ACME_PROFILE_NAME, ACME_ACCOUNT_ID_VALID, buildNewAccountRequestJSON_withExistingKey(requestUri), requestUri, false);
+        acmeService
+                .updateAccount(ACME_PROFILE_NAME, ACME_ACCOUNT_ID_VALID,
+                        buildNewAccountRequestJSON_withExistingKey(requestUri), requestUri, false);
         AcmeAccount acmeAccount = acmeAccountRepository.findByAccountId(ACME_ACCOUNT_ID_VALID).orElseThrow();
         Assertions.assertEquals(1, acmeAccount.getFailedOrders());
     }
 
-    private String buildRevokeCertRequestJSON_withAccountKey(URI requestUri, String baseUri, String certificate) throws JOSEException {
-        JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload("{\"certificate\":\"" + certificate + "\",\"reason\":0}"));
-        jwsObjectJSON.sign(
-                new JWSHeader.Builder(JWSAlgorithm.RS256)
+    private String buildRevokeCertRequestJSON_withAccountKey(URI requestUri, String baseUri, String certificate)
+            throws JOSEException {
+        JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(
+                new Payload("{\"certificate\":\"" + certificate + "\",\"reason\":0}"));
+        jwsObjectJSON
+                .sign(new JWSHeader.Builder(JWSAlgorithm.RS256)
                         .keyID(baseUri + "/acct/" + ACME_ACCOUNT_ID_VALID)
                         .customParam(NONCE_HEADER_CUSTOM_PARAM, acmeValidNonce.getNonce())
                         .customParam(URL_HEADER_CUSTOM_PARAM, requestUri.toString())
-                        .build(),
-                rsa2048Signer
-        );
+                        .build(), rsa2048Signer);
         return jwsObjectJSON.serializeFlattened();
     }
 
@@ -992,33 +993,34 @@ class AcmeServiceITest extends BaseSpringBootTest {
     }
 
     @Test
-    public void testRevokeCert_withPrivateKey() throws URISyntaxException, JOSEException, AcmeProblemDocumentException, ConnectorException, CertificateException {
+    public void testRevokeCert_withPrivateKey() throws URISyntaxException, JOSEException, AcmeProblemDocumentException,
+            ConnectorException, CertificateException {
         URI requestUri = new URI(BASE_URI + ACME_PROFILE_NAME + "/revoke-cert");
-        ResponseEntity<?> response = acmeService.revokeCertificate(
-                ACME_PROFILE_NAME,
-                buildRevokeCertRequestJSON_withPrivateKey(requestUri), requestUri, false);
+        ResponseEntity<?> response = acmeService
+                .revokeCertificate(ACME_PROFILE_NAME, buildRevokeCertRequestJSON_withPrivateKey(requestUri), requestUri,
+                        false);
         assertRevokeCert_withPrivateKey(response);
     }
 
     @Test
-    void testRevokeCert_withPrivateKey_raProfileBased() throws URISyntaxException, JOSEException, AcmeProblemDocumentException, ConnectorException, CertificateException {
+    void testRevokeCert_withPrivateKey_raProfileBased() throws URISyntaxException, JOSEException,
+            AcmeProblemDocumentException, ConnectorException, CertificateException {
         URI requestUri = new URI(RA_BASE_URI + RA_PROFILE_NAME + "/revoke-cert");
-        ResponseEntity<?> response = acmeService.revokeCertificate(
-                RA_PROFILE_NAME,
-                buildRevokeCertRequestJSON_withPrivateKey(requestUri), requestUri, true);
+        ResponseEntity<?> response = acmeService
+                .revokeCertificate(RA_PROFILE_NAME, buildRevokeCertRequestJSON_withPrivateKey(requestUri), requestUri,
+                        true);
         assertRevokeCert_withPrivateKey(response);
     }
 
     private String buildRevokeCertRequestJSON_withPrivateKey(URI requestUri) throws JOSEException {
-        JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload("{\"certificate\":\"" + b64UrlCertificate + "\",\"reason\":0}"));
-        jwsObjectJSON.sign(
-                new JWSHeader.Builder(JWSAlgorithm.RS256)
+        JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(
+                new Payload("{\"certificate\":\"" + b64UrlCertificate + "\",\"reason\":0}"));
+        jwsObjectJSON
+                .sign(new JWSHeader.Builder(JWSAlgorithm.RS256)
                         .jwk(rsa2048PublicJWK)
                         .customParam(NONCE_HEADER_CUSTOM_PARAM, acmeValidNonce.getNonce())
                         .customParam(URL_HEADER_CUSTOM_PARAM, requestUri.toString())
-                        .build(),
-                rsa2048Signer
-        );
+                        .build(), rsa2048Signer);
         return jwsObjectJSON.serializeFlattened();
     }
 
@@ -1030,7 +1032,8 @@ class AcmeServiceITest extends BaseSpringBootTest {
     @Test
     void testGetOrderList() throws AcmeProblemDocumentException, NotFoundException {
         URI requestUri = URI.create(BASE_URI + ACME_PROFILE_NAME + "/orders/" + ACME_ACCOUNT_ID_VALID);
-        ResponseEntity<List<Order>> orders = acmeService.listOrders(ACME_PROFILE_NAME, ACME_ACCOUNT_ID_VALID, requestUri, false);
+        ResponseEntity<List<Order>> orders = acmeService
+                .listOrders(ACME_PROFILE_NAME, ACME_ACCOUNT_ID_VALID, requestUri, false);
         assertGetOrderList(orders);
         order1.setStatus(OrderStatus.READY);
         order1.setExpires(Date.from(Instant.now().minus(1, ChronoUnit.DAYS)));
@@ -1043,7 +1046,8 @@ class AcmeServiceITest extends BaseSpringBootTest {
     @Test
     void testGetOrderList_raProfileBased() throws AcmeProblemDocumentException, NotFoundException {
         URI requestUri = URI.create(RA_BASE_URI + RA_PROFILE_NAME + "/orders/" + ACME_ACCOUNT_ID_VALID);
-        ResponseEntity<List<Order>> orders = acmeService.listOrders(RA_PROFILE_NAME, ACME_ACCOUNT_ID_VALID, requestUri, true);
+        ResponseEntity<List<Order>> orders = acmeService
+                .listOrders(RA_PROFILE_NAME, ACME_ACCOUNT_ID_VALID, requestUri, true);
         assertGetOrderList(orders);
     }
 
@@ -1056,15 +1060,17 @@ class AcmeServiceITest extends BaseSpringBootTest {
     @Test
     void testGetOrderListFail() {
         URI requestUri = URI.create(BASE_URI + ACME_PROFILE_NAME + "/orders/" + ACME_ACCOUNT_ID_INVALID);
-        Assertions.assertThrows(AcmeProblemDocumentException.class,
-                () -> acmeService.listOrders(ACME_PROFILE_NAME, ACME_ACCOUNT_ID_INVALID, requestUri, false));
+        Assertions
+                .assertThrows(AcmeProblemDocumentException.class,
+                        () -> acmeService.listOrders(ACME_PROFILE_NAME, ACME_ACCOUNT_ID_INVALID, requestUri, false));
     }
 
     @Test
     void testGetOrderList_fail_isRaProfileBased() {
         URI requestUri = URI.create(RA_BASE_URI + RA_PROFILE_NAME + "/orders/" + ACME_ACCOUNT_ID_INVALID);
-        Assertions.assertThrows(AcmeProblemDocumentException.class,
-                () -> acmeService.listOrders(RA_PROFILE_NAME, ACME_ACCOUNT_ID_INVALID, requestUri, true));
+        Assertions
+                .assertThrows(AcmeProblemDocumentException.class,
+                        () -> acmeService.listOrders(RA_PROFILE_NAME, ACME_ACCOUNT_ID_INVALID, requestUri, true));
     }
 
     @Test
@@ -1092,18 +1098,18 @@ class AcmeServiceITest extends BaseSpringBootTest {
     @Test
     void testKeyRollover() throws JOSEException, AcmeProblemDocumentException, NotFoundException {
         URI requestUri = URI.create(BASE_URI + ACME_PROFILE_NAME + "/key-change");
-        ResponseEntity<?> response = acmeService.keyRollover(
-                ACME_PROFILE_NAME,
-                buildKeyRolloverRequestJSON(requestUri, BASE_URI + ACME_PROFILE_NAME), requestUri, false);
+        ResponseEntity<?> response = acmeService
+                .keyRollover(ACME_PROFILE_NAME, buildKeyRolloverRequestJSON(requestUri, BASE_URI + ACME_PROFILE_NAME),
+                        requestUri, false);
         assertKeyRollover(response);
     }
 
     @Test
     void testKeyRollover_raProfileBased() throws JOSEException, AcmeProblemDocumentException, NotFoundException {
         URI requestUri = URI.create(RA_BASE_URI + RA_PROFILE_NAME + "/key-change");
-        ResponseEntity<?> response = acmeService.keyRollover(
-                RA_PROFILE_NAME,
-                buildKeyRolloverRequestJSON(requestUri, RA_BASE_URI + RA_PROFILE_NAME), requestUri, true);
+        ResponseEntity<?> response = acmeService
+                .keyRollover(RA_PROFILE_NAME, buildKeyRolloverRequestJSON(requestUri, RA_BASE_URI + RA_PROFILE_NAME),
+                        requestUri, true);
         assertKeyRollover(response);
     }
 
@@ -1111,24 +1117,21 @@ class AcmeServiceITest extends BaseSpringBootTest {
         String account = baseUri + "/acct/" + ACME_ACCOUNT_ID_VALID;
         String oldKey = rsa2048PublicJWK.toString();
 
-        JWSObjectJSON innerJwsObjectJSON = new JWSObjectJSON(new Payload("{\"account\":\"" + account + "\",\"oldKey\":" + oldKey + "}"));
-        innerJwsObjectJSON.sign(
-                new JWSHeader.Builder(JWSAlgorithm.RS256)
+        JWSObjectJSON innerJwsObjectJSON = new JWSObjectJSON(
+                new Payload("{\"account\":\"" + account + "\",\"oldKey\":" + oldKey + "}"));
+        innerJwsObjectJSON
+                .sign(new JWSHeader.Builder(JWSAlgorithm.RS256)
                         .jwk(newRsa2048PublicJWK)
                         .customParam(URL_HEADER_CUSTOM_PARAM, requestUri.toString())
-                        .build(),
-                newRsa2048Signer
-        );
+                        .build(), newRsa2048Signer);
 
         JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload(innerJwsObjectJSON.serializeFlattened()));
-        jwsObjectJSON.sign(
-                new JWSHeader.Builder(JWSAlgorithm.RS256)
+        jwsObjectJSON
+                .sign(new JWSHeader.Builder(JWSAlgorithm.RS256)
                         .keyID(baseUri + "/acct/" + ACME_ACCOUNT_ID_VALID)
                         .customParam(NONCE_HEADER_CUSTOM_PARAM, acmeValidNonce.getNonce())
                         .customParam(URL_HEADER_CUSTOM_PARAM, requestUri.toString())
-                        .build(),
-                rsa2048Signer
-        );
+                        .build(), rsa2048Signer);
         return jwsObjectJSON.serializeFlattened();
     }
 
@@ -1140,7 +1143,8 @@ class AcmeServiceITest extends BaseSpringBootTest {
     }
 
     @Test
-    void testValidateChallenge_Dns01() throws AcmeProblemDocumentException, JOSEException, NotFoundException, NoSuchAlgorithmException, InvalidKeySpecException, NamingException {
+    void testValidateChallenge_Dns01() throws AcmeProblemDocumentException, JOSEException, NotFoundException,
+            NoSuchAlgorithmException, InvalidKeySpecException, NamingException {
         AcmeAuthorization authorization = new AcmeAuthorization();
         authorization.setAuthorizationId("authDns01");
         authorization.setStatus(AuthorizationStatus.PENDING);
@@ -1158,9 +1162,11 @@ class AcmeServiceITest extends BaseSpringBootTest {
         challenge.setAuthorization(authorization);
         acmeChallengeRepository.save(challenge);
 
-        String keyAuthorization = AcmeCommonHelper.createKeyAuthorization(challenge.getToken(), rsa2048PublicJWK.toPublicKey());
+        String keyAuthorization = AcmeCommonHelper
+                .createKeyAuthorization(challenge.getToken(), rsa2048PublicJWK.toPublicKey());
         MessageDigest digest = MessageDigest.getInstance("SHA-256");
-        final byte[] encodedHashOfExpectedKeyAuthorization = digest.digest(keyAuthorization.getBytes(StandardCharsets.UTF_8));
+        final byte[] encodedHashOfExpectedKeyAuthorization = digest
+                .digest(keyAuthorization.getBytes(StandardCharsets.UTF_8));
         String expectedDnsValidationToken = Base64URL.encode(encodedHashOfExpectedKeyAuthorization).toString();
 
         try (var mockedContext = mockConstruction(InitialDirContext.class, (mock, context) -> {
@@ -1176,12 +1182,15 @@ class AcmeServiceITest extends BaseSpringBootTest {
             when(attr.get()).thenReturn(expectedDnsValidationToken);
         })) {
             URI requestUri = URI.create(BASE_URI + ACME_PROFILE_NAME + "/chall/" + challenge.getChallengeId());
-            ResponseEntity<Challenge> response = acmeService.validateChallenge(ACME_PROFILE_NAME, challenge.getChallengeId(), requestUri, false);
+            ResponseEntity<Challenge> response = acmeService
+                    .validateChallenge(ACME_PROFILE_NAME, challenge.getChallengeId(), requestUri, false);
 
             Assertions.assertEquals(HttpStatus.OK, response.getStatusCode());
             Assertions.assertEquals(ChallengeStatus.VALID, Objects.requireNonNull(response.getBody()).getStatus());
 
-            AcmeChallenge updatedChallenge = acmeChallengeRepository.findByChallengeId(challenge.getChallengeId()).orElseThrow();
+            AcmeChallenge updatedChallenge = acmeChallengeRepository
+                    .findByChallengeId(challenge.getChallengeId())
+                    .orElseThrow();
             Assertions.assertEquals(ChallengeStatus.VALID, updatedChallenge.getStatus());
             Assertions.assertNotNull(updatedChallenge.getValidated());
         }

--- a/src/test/java/com/otilm/core/integration/service/AcmeServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/AcmeServiceITest.java
@@ -28,6 +28,7 @@ import com.otilm.api.model.core.acme.ChallengeType;
 import com.otilm.api.model.core.acme.Directory;
 import com.otilm.api.model.core.acme.Order;
 import com.otilm.api.model.core.acme.OrderStatus;
+import com.otilm.api.model.core.acme.Problem;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.certificate.CertificateState;
 import com.otilm.api.model.core.certificate.CertificateValidationStatus;
@@ -62,6 +63,8 @@ import com.otilm.core.security.authz.opa.dto.OpaRequestedResource;
 import com.otilm.core.security.authz.opa.dto.OpaResourceAccessResult;
 import com.otilm.core.service.acme.AcmeConstants;
 import com.otilm.core.service.acme.AcmeExternalService;
+import com.otilm.core.service.acme.ChallengeValidationResult;
+import com.otilm.core.service.writer.AcmeChallengeWriter;
 import com.otilm.core.util.AcmeCommonHelper;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.CertificateTestUtil;
@@ -83,16 +86,17 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
-import javax.naming.NamingEnumeration;
-import javax.naming.NamingException;
-import javax.naming.directory.Attribute;
+import java.util.UUID;
 import javax.naming.directory.Attributes;
+import javax.naming.directory.BasicAttribute;
+import javax.naming.directory.BasicAttributes;
 import javax.naming.directory.InitialDirContext;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -100,7 +104,6 @@ import org.springframework.http.ResponseEntity;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.argThat;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
@@ -113,10 +116,12 @@ class AcmeServiceITest extends BaseSpringBootTest {
     private static final String RA_PROFILE_NAME = "testRaProfile1";
     private static final String ACME_PROFILE_NAME_2 = "testAcmeProfile2";
     private static final String RA_PROFILE_NAME_2 = "testRaProfile2";
+    private static final String STALE_DNS_VALIDATION_TOKEN = "f5R9M-KeH3NR4Yqq8J2EUN2ZjkjLWAUxC9gnZgR9B_4";
     private static final String NONCE_HEADER_CUSTOM_PARAM = "nonce";
     private static final String URL_HEADER_CUSTOM_PARAM = "url";
     private static final String ACME_ACCOUNT_ID_VALID = "RMAl70zrRrs";
     private static final String ACME_ACCOUNT_ID_INVALID = "invalidAccountId";
+    private static final String OTHER_ACCOUNT_ID = "otherAccount";
     private static final String AUTHORIZATION_ID_PENDING = "auth123";
     private static final String ORDER_ID_VALID = "order123";
 
@@ -140,6 +145,9 @@ class AcmeServiceITest extends BaseSpringBootTest {
 
     @Autowired
     private AcmeAuthorizationRepository acmeAuthorizationRepository;
+
+    @Autowired
+    private AcmeChallengeWriter acmeChallengeWriter;
 
     @Autowired
     private AcmeChallengeRepository acmeChallengeRepository;
@@ -1142,57 +1150,758 @@ class AcmeServiceITest extends BaseSpringBootTest {
         Assertions.assertNotNull(response.getHeaders().get("Link"));
     }
 
+    /**
+     * The expected record is accepted when the name also carries records left behind by earlier attempts, which a name
+     * under continuous renewal regularly does.
+     */
     @Test
     void testValidateChallenge_Dns01() throws AcmeProblemDocumentException, JOSEException, NotFoundException,
-            NoSuchAlgorithmException, InvalidKeySpecException, NamingException {
-        AcmeAuthorization authorization = new AcmeAuthorization();
-        authorization.setAuthorizationId("authDns01");
-        authorization.setStatus(AuthorizationStatus.PENDING);
-        authorization.setIdentifier("{\"type\":\"dns\",\"value\":\"example.com\"}");
-        authorization.setOrderUuid(order1.getUuid());
-        authorization.setOrder(order1);
-        acmeAuthorizationRepository.save(authorization);
+            NoSuchAlgorithmException, InvalidKeySpecException {
+        AcmeChallenge challenge = pendingDnsChallenge(pendingOrder("orderDns01"), "authDns01", "challengeDns01",
+                "tokenDns01");
 
-        AcmeChallenge challenge = new AcmeChallenge();
-        challenge.setChallengeId("challengeDns01");
-        challenge.setStatus(ChallengeStatus.PENDING);
-        challenge.setType(ChallengeType.DNS01);
-        challenge.setToken("tokenDns01");
-        challenge.setAuthorizationUuid(authorization.getUuid());
-        challenge.setAuthorization(authorization);
-        acmeChallengeRepository.save(challenge);
-
-        String keyAuthorization = AcmeCommonHelper
-                .createKeyAuthorization(challenge.getToken(), rsa2048PublicJWK.toPublicKey());
-        MessageDigest digest = MessageDigest.getInstance("SHA-256");
-        final byte[] encodedHashOfExpectedKeyAuthorization = digest
-                .digest(keyAuthorization.getBytes(StandardCharsets.UTF_8));
-        String expectedDnsValidationToken = Base64URL.encode(encodedHashOfExpectedKeyAuthorization).toString();
-
-        try (var mockedContext = mockConstruction(InitialDirContext.class, (mock, context) -> {
-            Attributes attrs = mock(Attributes.class);
-            Attribute attr = mock(Attribute.class);
-            @SuppressWarnings("unchecked")
-            NamingEnumeration<Attribute> enumeration = (NamingEnumeration<Attribute>) mock(NamingEnumeration.class);
-
-            when(mock.getAttributes(anyString(), any(String[].class))).thenReturn(attrs);
-            doReturn(enumeration).when(attrs).getAll();
-            when(enumeration.hasMore()).thenReturn(true, false);
-            when(enumeration.next()).thenReturn(attr);
-            when(attr.get()).thenReturn(expectedDnsValidationToken);
-        })) {
-            URI requestUri = URI.create(BASE_URI + ACME_PROFILE_NAME + "/chall/" + challenge.getChallengeId());
-            ResponseEntity<Challenge> response = acmeService
-                    .validateChallenge(ACME_PROFILE_NAME, challenge.getChallengeId(), requestUri, false);
+        try (var mockedContext = mockTxtRecords(STALE_DNS_VALIDATION_TOKEN,
+                expectedDnsValidationToken(challenge.getToken()))) {
+            ResponseEntity<Challenge> response = validateChallenge(challenge);
 
             Assertions.assertEquals(HttpStatus.OK, response.getStatusCode());
             Assertions.assertEquals(ChallengeStatus.VALID, Objects.requireNonNull(response.getBody()).getStatus());
+            Assertions.assertNull(response.getBody().getError());
 
-            AcmeChallenge updatedChallenge = acmeChallengeRepository
-                    .findByChallengeId(challenge.getChallengeId())
-                    .orElseThrow();
+            AcmeChallenge updatedChallenge = reload(challenge);
             Assertions.assertEquals(ChallengeStatus.VALID, updatedChallenge.getStatus());
             Assertions.assertNotNull(updatedChallenge.getValidated());
+            Assertions.assertEquals(AuthorizationStatus.VALID, updatedChallenge.getAuthorization().getStatus());
+            Assertions
+                    .assertEquals(OrderStatus.READY,
+                            acmeOrderRepository.findByOrderId("orderDns01").orElseThrow().getStatus());
+            Assertions.assertEquals(1, mockedContext.constructed().size());
         }
+    }
+
+    /**
+     * A challenge whose records do not match invalidates its authorization and order, so a client waiting for the
+     * authorization to settle learns that validation failed instead of polling a permanently pending one.
+     */
+    @Test
+    void testValidateChallenge_Dns01_noMatchingRecord()
+            throws AcmeProblemDocumentException, NotFoundException, NoSuchAlgorithmException, InvalidKeySpecException {
+        AcmeChallenge challenge = pendingDnsChallenge(pendingOrder("orderDns01Invalid"), "authDns01Invalid",
+                "challengeDns01Invalid", "tokenDns01Invalid");
+
+        try (var mockedContext = mockTxtRecords(STALE_DNS_VALIDATION_TOKEN)) {
+            ResponseEntity<Challenge> response = validateChallenge(challenge);
+
+            Assertions.assertEquals(ChallengeStatus.INVALID, Objects.requireNonNull(response.getBody()).getStatus());
+            Assertions.assertEquals(Problem.INCORRECT_RESPONSE.getType(), response.getBody().getError().getType());
+            Assertions
+                    .assertTrue(response
+                            .getBody()
+                            .getError()
+                            .getDetail()
+                            .contains(AcmeConstants.DNS_ACME_PREFIX + "example.com"));
+            Assertions.assertFalse(response.getBody().getError().getDetail().contains(STALE_DNS_VALIDATION_TOKEN));
+
+            AcmeChallenge updatedChallenge = reload(challenge);
+            Assertions.assertEquals(ChallengeStatus.INVALID, updatedChallenge.getStatus());
+            Assertions.assertNull(updatedChallenge.getValidated());
+            Assertions.assertEquals(Problem.INCORRECT_RESPONSE, updatedChallenge.getErrorProblem());
+            Assertions.assertEquals(AuthorizationStatus.INVALID, updatedChallenge.getAuthorization().getStatus());
+            Assertions
+                    .assertEquals(OrderStatus.INVALID,
+                            acmeOrderRepository.findByOrderId("orderDns01Invalid").orElseThrow().getStatus());
+        }
+    }
+
+    /**
+     * A client may accept the same challenge more than once. A challenge that has already settled reports its recorded
+     * state and is not validated again, so a repeated request cannot revive a failed authorization.
+     */
+    @Test
+    void testValidateChallenge_Dns01_settledChallengeIsNotValidatedAgain() throws AcmeProblemDocumentException,
+            JOSEException, NotFoundException, NoSuchAlgorithmException, InvalidKeySpecException {
+        AcmeChallenge challenge = pendingDnsChallenge(pendingOrder("orderDns01Settled"), "authDns01Settled",
+                "challengeDns01Settled", "tokenDns01Settled");
+        challenge.setStatus(ChallengeStatus.INVALID);
+        challenge.setErrorProblem(Problem.DNS);
+        challenge.setErrorDetail("No TXT record found at " + AcmeConstants.DNS_ACME_PREFIX + "example.com");
+        acmeChallengeRepository.save(challenge);
+
+        try (var mockedContext = mockTxtRecords(expectedDnsValidationToken(challenge.getToken()))) {
+            ResponseEntity<Challenge> response = validateChallenge(challenge);
+
+            Assertions.assertEquals(HttpStatus.OK, response.getStatusCode());
+            Assertions.assertEquals(ChallengeStatus.INVALID, Objects.requireNonNull(response.getBody()).getStatus());
+            Assertions.assertEquals(Problem.DNS.getType(), response.getBody().getError().getType());
+            Assertions.assertEquals(ChallengeStatus.INVALID, reload(challenge).getStatus());
+            Assertions.assertTrue(mockedContext.constructed().isEmpty());
+        }
+    }
+
+    /**
+     * An authorization that has already failed is terminal (RFC 8555 section 7.1.6), so the challenge still pending
+     * beside the failed one cannot revive it even once the record it expects is published.
+     */
+    @Test
+    void testValidateChallenge_Dns01_failedAuthorizationIsNotRevived() throws AcmeProblemDocumentException,
+            JOSEException, NotFoundException, NoSuchAlgorithmException, InvalidKeySpecException {
+        AcmeChallenge challenge = pendingDnsChallenge(pendingOrder("orderDns01Failed"), "authDns01Failed",
+                "challengeDns01Failed", "tokenDns01Failed");
+        AcmeAuthorization authorization = challenge.getAuthorization();
+        authorization.setStatus(AuthorizationStatus.INVALID);
+        acmeAuthorizationRepository.save(authorization);
+
+        try (var mockedContext = mockTxtRecords(expectedDnsValidationToken(challenge.getToken()))) {
+            ResponseEntity<Challenge> response = validateChallenge(challenge);
+
+            Assertions.assertEquals(ChallengeStatus.PENDING, Objects.requireNonNull(response.getBody()).getStatus());
+            Assertions.assertEquals(ChallengeStatus.PENDING, reload(challenge).getStatus());
+            Assertions
+                    .assertEquals(AuthorizationStatus.INVALID,
+                            acmeAuthorizationRepository
+                                    .findByAuthorizationId("authDns01Failed")
+                                    .orElseThrow()
+                                    .getStatus());
+            Assertions.assertTrue(mockedContext.constructed().isEmpty());
+        }
+    }
+
+    /**
+     * The recorded reason names the challenge record, so it grows with the identifier and can exceed the width a
+     * generated schema gives a plain string column. It has to persist in full.
+     */
+    @Test
+    void testValidateChallenge_recordedReasonPersistsInFull() {
+        AcmeChallenge challenge = pendingDnsChallenge(pendingOrder("orderDns01Detail"), "authDns01Detail",
+                "challengeDns01Detail", "tokenDns01Detail");
+        String recordName = AcmeConstants.DNS_ACME_PREFIX + "a".repeat(250) + ".example.com";
+        String detail = "No TXT record at " + recordName + " matches the expected key authorization";
+        challenge.setErrorProblem(Problem.DNS);
+        challenge.setErrorDetail(detail);
+
+        acmeChallengeRepository.saveAndFlush(challenge);
+
+        Assertions.assertTrue(detail.length() > 255);
+        Assertions.assertEquals(detail, reload(challenge).getErrorDetail());
+    }
+
+    /**
+     * An instance that does not yet propagate a failure leaves the authorization pending behind the failed challenge. A
+     * client asking for that authorization is answered with the settled state instead of waiting for it to change.
+     */
+    @Test
+    void testGetAuthorization_settlesAuthorizationLeftPendingBehindFailedChallenge() throws Exception {
+        AcmeChallenge challenge = failedChallengeLeftUnpropagated("orderStale", "authStale", "challengeStale");
+        int failedOrdersBefore = failedOrders(challenge);
+        String baseUri = BASE_URI + ACME_PROFILE_NAME;
+        URI requestUri = new URI(baseUri + "/authz/authStale");
+
+        ResponseEntity<Authorization> response = acmeService
+                .getAuthorization(ACME_PROFILE_NAME, "authStale", buildGetAuthorizationRequestJSON(requestUri, baseUri),
+                        requestUri, false);
+
+        Assertions.assertEquals(AuthorizationStatus.INVALID, Objects.requireNonNull(response.getBody()).getStatus());
+        Assertions
+                .assertEquals(AuthorizationStatus.INVALID,
+                        acmeAuthorizationRepository.findByAuthorizationId("authStale").orElseThrow().getStatus());
+        Assertions
+                .assertEquals(OrderStatus.INVALID,
+                        acmeOrderRepository.findByOrderId("orderStale").orElseThrow().getStatus());
+        Assertions.assertEquals(failedOrdersBefore + 1, failedOrders(challenge));
+    }
+
+    @Test
+    void testValidateChallenge_settlesAuthorizationLeftPendingBehindFailedChallenge() throws Exception {
+        AcmeChallenge challenge = failedChallengeLeftUnpropagated("orderStaleChall", "authStaleChall",
+                "challengeStaleChall");
+
+        try (var mockedContext = mockTxtRecords(STALE_DNS_VALIDATION_TOKEN)) {
+            ResponseEntity<Challenge> response = validateChallenge(challenge);
+
+            Assertions.assertEquals(ChallengeStatus.INVALID, Objects.requireNonNull(response.getBody()).getStatus());
+            Assertions
+                    .assertEquals(AuthorizationStatus.INVALID,
+                            acmeAuthorizationRepository
+                                    .findByAuthorizationId("authStaleChall")
+                                    .orElseThrow()
+                                    .getStatus());
+            Assertions
+                    .assertEquals(OrderStatus.INVALID,
+                            acmeOrderRepository.findByOrderId("orderStaleChall").orElseThrow().getStatus());
+            Assertions.assertTrue(mockedContext.constructed().isEmpty());
+        }
+    }
+
+    /**
+     * An order left open behind a failed authorization is settled before it is answered, so it is reported the way an
+     * invalid order is reported.
+     */
+    @Test
+    void testGetOrder_settlesOrderLeftPendingBehindFailedAuthorization() throws Exception {
+        AcmeOrder order = orderLeftOpenBehindFailedAuthorization("orderStaleGet", "authStaleGet", OrderStatus.PENDING);
+        int failedOrdersBefore = failedOrders(order);
+        URI requestUri = new URI(BASE_URI + ACME_PROFILE_NAME + "/order/orderStaleGet");
+
+        ResponseEntity<Order> response = acmeService.getOrder(ACME_PROFILE_NAME, "orderStaleGet", requestUri, false);
+
+        Assertions.assertEquals(OrderStatus.INVALID, Objects.requireNonNull(response.getBody()).getStatus());
+        Assertions
+                .assertEquals(OrderStatus.INVALID,
+                        acmeOrderRepository.findByOrderId("orderStaleGet").orElseThrow().getStatus());
+        Assertions.assertEquals(failedOrdersBefore + 1, failedOrders(order));
+    }
+
+    /**
+     * An order cannot be finalized while one of its authorizations has failed, however it came to be ready.
+     */
+    @Test
+    void testFinalizeOrder_refusesOrderLeftReadyBehindFailedAuthorization() throws Exception {
+        orderLeftOpenBehindFailedAuthorization("orderStaleFin", "authStaleFin", OrderStatus.READY);
+        String baseUri = BASE_URI + ACME_PROFILE_NAME;
+        URI requestUri = new URI(baseUri + "/order/orderStaleFin/finalize");
+
+        AcmeProblemDocumentException refused = Assertions
+                .assertThrows(AcmeProblemDocumentException.class,
+                        () -> acmeService
+                                .finalizeOrder(ACME_PROFILE_NAME, "orderStaleFin",
+                                        buildFinalizeRequestJSON(requestUri, baseUri), requestUri, false));
+
+        Assertions.assertEquals(Problem.ORDER_NOT_READY.getType(), refused.getProblemDocument().getType());
+        Assertions
+                .assertEquals(OrderStatus.INVALID,
+                        acmeOrderRepository.findByOrderId("orderStaleFin").orElseThrow().getStatus());
+    }
+
+    /**
+     * The order is asked for before its authorization ever was: the failed challenge under the still-pending
+     * authorization is what settles it.
+     */
+    @Test
+    void testGetOrder_settlesOrderWhoseAuthorizationIsStillPendingBehindFailedChallenge() throws Exception {
+        failedChallengeLeftUnpropagated("orderStaleChall2", "authStaleChall2", "challengeStaleChall2");
+        URI requestUri = new URI(BASE_URI + ACME_PROFILE_NAME + "/order/orderStaleChall2");
+
+        ResponseEntity<Order> response = acmeService.getOrder(ACME_PROFILE_NAME, "orderStaleChall2", requestUri, false);
+
+        Assertions.assertEquals(OrderStatus.INVALID, Objects.requireNonNull(response.getBody()).getStatus());
+        Assertions
+                .assertEquals(AuthorizationStatus.INVALID,
+                        acmeAuthorizationRepository.findByAuthorizationId("authStaleChall2").orElseThrow().getStatus());
+        Assertions
+                .assertEquals(OrderStatus.INVALID,
+                        acmeOrderRepository.findByOrderId("orderStaleChall2").orElseThrow().getStatus());
+    }
+
+    @Test
+    void testFinalizeOrder_refusesOrderWhoseAuthorizationIsStillPendingBehindFailedChallenge() throws Exception {
+        AcmeChallenge challenge = failedChallengeLeftUnpropagated("orderStaleFin2", "authStaleFin2",
+                "challengeStaleFin2");
+        AcmeOrder order = challenge.getAuthorization().getOrder();
+        order.setStatus(OrderStatus.READY);
+        acmeOrderRepository.save(order);
+        String baseUri = BASE_URI + ACME_PROFILE_NAME;
+        URI requestUri = new URI(baseUri + "/order/orderStaleFin2/finalize");
+
+        AcmeProblemDocumentException refused = Assertions
+                .assertThrows(AcmeProblemDocumentException.class,
+                        () -> acmeService
+                                .finalizeOrder(ACME_PROFILE_NAME, "orderStaleFin2",
+                                        buildFinalizeRequestJSON(requestUri, baseUri), requestUri, false));
+
+        Assertions.assertEquals(Problem.ORDER_NOT_READY.getType(), refused.getProblemDocument().getType());
+        Assertions
+                .assertEquals(AuthorizationStatus.INVALID,
+                        acmeAuthorizationRepository.findByAuthorizationId("authStaleFin2").orElseThrow().getStatus());
+        Assertions
+                .assertEquals(OrderStatus.INVALID,
+                        acmeOrderRepository.findByOrderId("orderStaleFin2").orElseThrow().getStatus());
+    }
+
+    /**
+     * A certificate has already been issued for the order, so a challenge validated afterwards leaves the order and the
+     * account's counts as they are.
+     */
+    @Test
+    void testValidateChallenge_leavesAnOrderWithAnIssuedCertificateAlone() throws Exception {
+        AcmeChallenge challenge = pendingDnsChallenge(order1, "authIssued", "challengeIssued", "tokenIssued");
+        int failedOrdersBefore = failedOrders(challenge);
+
+        try (var mockedContext = mockTxtRecords(expectedDnsValidationToken(challenge.getToken()))) {
+            ResponseEntity<Challenge> response = validateChallenge(challenge);
+
+            Assertions.assertEquals(ChallengeStatus.VALID, Objects.requireNonNull(response.getBody()).getStatus());
+            Assertions
+                    .assertEquals(OrderStatus.VALID,
+                            acmeOrderRepository.findByOrderId(ORDER_ID_VALID).orElseThrow().getStatus());
+            Assertions.assertEquals(failedOrdersBefore, failedOrders(challenge));
+            Assertions.assertEquals(1, mockedContext.constructed().size());
+        }
+    }
+
+    /**
+     * A multi-identifier order has an authorization per identifier and becomes ready only once every one of them has
+     * been proven.
+     */
+    @Test
+    void testValidateChallenge_multiIdentifierOrderBecomesReadyOnlyWhenEveryAuthorizationIsValid() throws Exception {
+        AcmeOrder order = pendingOrder("orderMulti");
+        AcmeChallenge first = pendingDnsChallenge(order, "authMulti1", "challengeMulti1", "tokenMulti1");
+        AcmeChallenge second = pendingDnsChallenge(order, "authMulti2", "challengeMulti2", "tokenMulti2");
+
+        try (var mockedContext = mockTxtRecords(expectedDnsValidationToken(first.getToken()))) {
+            validateChallenge(first);
+        }
+        Assertions
+                .assertEquals(OrderStatus.PENDING,
+                        acmeOrderRepository.findByOrderId("orderMulti").orElseThrow().getStatus());
+
+        try (var mockedContext = mockTxtRecords(expectedDnsValidationToken(second.getToken()))) {
+            validateChallenge(second);
+        }
+        Assertions
+                .assertEquals(OrderStatus.READY,
+                        acmeOrderRepository.findByOrderId("orderMulti").orElseThrow().getStatus());
+    }
+
+    /**
+     * Two accepts of one challenge can overlap: the second finds the challenge settled under the order lock and leaves
+     * the recorded outcome alone instead of applying its own.
+     */
+    @Test
+    void testWriter_leavesAChallengeSettledMeanwhileAlone() {
+        AcmeChallenge challenge = failedChallengeLeftUnpropagated("orderRaced", "authRaced", "challengeRaced");
+        AcmeAuthorization authorization = challenge.getAuthorization();
+        authorization.setStatus(AuthorizationStatus.INVALID);
+        acmeAuthorizationRepository.save(authorization);
+
+        AcmeChallenge outcome = acmeChallengeWriter
+                .applyValidationResult(authorization.getOrder().getUuid(), "challengeRaced",
+                        ChallengeValidationResult.success());
+
+        Assertions.assertEquals(ChallengeStatus.INVALID, outcome.getStatus());
+        Assertions.assertEquals(AuthorizationStatus.INVALID, reload(challenge).getAuthorization().getStatus());
+    }
+
+    /**
+     * The failed-order count is incremented in the database, so counting twice yields two whatever the entity held.
+     */
+    @Test
+    void testWriter_countsFailedOrdersInTheDatabase() {
+        UUID accountUuid = order1.getAcmeAccountUuid();
+        int before = acmeAccountRepository.findByUuid(accountUuid).orElseThrow().getFailedOrders();
+
+        acmeChallengeWriter.countFailedOrder(accountUuid);
+        acmeChallengeWriter.countFailedOrder(accountUuid);
+
+        Assertions
+                .assertEquals(before + 2,
+                        acmeAccountRepository.findByUuid(accountUuid).orElseThrow().getFailedOrders());
+    }
+
+    /**
+     * An authorization left pending behind a failed challenge is settled before its expiry is enforced, so the request
+     * is still refused but the rows no longer stay pending.
+     */
+    @Test
+    void testGetAuthorization_settlesAnExpiredStaleAuthorizationBeforeRefusingIt() throws Exception {
+        AcmeChallenge challenge = failedChallengeLeftUnpropagated("orderStaleExp", "authStaleExp", "challengeStaleExp");
+        AcmeAuthorization authorization = challenge.getAuthorization();
+        authorization.setExpires(new Date(System.currentTimeMillis() - 60_000));
+        acmeAuthorizationRepository.save(authorization);
+        String baseUri = BASE_URI + ACME_PROFILE_NAME;
+        URI requestUri = new URI(baseUri + "/authz/authStaleExp");
+
+        Assertions
+                .assertThrows(AcmeProblemDocumentException.class,
+                        () -> acmeService
+                                .getAuthorization(ACME_PROFILE_NAME, "authStaleExp",
+                                        buildGetAuthorizationRequestJSON(requestUri, baseUri), requestUri, false));
+
+        Assertions
+                .assertEquals(AuthorizationStatus.INVALID,
+                        acmeAuthorizationRepository.findByAuthorizationId("authStaleExp").orElseThrow().getStatus());
+        Assertions
+                .assertEquals(OrderStatus.INVALID,
+                        acmeOrderRepository.findByOrderId("orderStaleExp").orElseThrow().getStatus());
+    }
+
+    /**
+     * An order left open behind a failed authorization is settled before its expiry is enforced, so the request is
+     * still refused but the row no longer stays open.
+     */
+    @Test
+    void testGetOrder_settlesAnExpiredStaleOrderBeforeRefusingIt() throws Exception {
+        AcmeOrder order = orderLeftOpenBehindFailedAuthorization("orderStaleExpired", "authStaleExpired",
+                OrderStatus.READY);
+        order.setExpires(new Date(System.currentTimeMillis() - 60_000));
+        acmeOrderRepository.save(order);
+        URI requestUri = new URI(BASE_URI + ACME_PROFILE_NAME + "/order/orderStaleExpired");
+
+        AcmeProblemDocumentException refused = Assertions
+                .assertThrows(AcmeProblemDocumentException.class,
+                        () -> acmeService.getOrder(ACME_PROFILE_NAME, "orderStaleExpired", requestUri, false));
+
+        Assertions.assertEquals(Problem.MALFORMED.getType(), refused.getProblemDocument().getType());
+        Assertions
+                .assertEquals(OrderStatus.INVALID,
+                        acmeOrderRepository.findByOrderId("orderStaleExpired").orElseThrow().getStatus());
+    }
+
+    /**
+     * A client deactivates an authorization by posting its status (RFC 8555 section 7.5.2).
+     */
+    @Test
+    void testGetAuthorization_deactivatesTheAuthorizationOnRequest() throws Exception {
+        pendingDnsChallenge(pendingOrder("orderDeact"), "authDeact", "challengeDeact", "tokenDeact");
+        String baseUri = BASE_URI + ACME_PROFILE_NAME;
+        URI requestUri = new URI(baseUri + "/authz/authDeact");
+
+        ResponseEntity<Authorization> response = acmeService
+                .getAuthorization(ACME_PROFILE_NAME, "authDeact", buildDeactivateRequestJSON(requestUri, baseUri),
+                        requestUri, false);
+
+        Assertions
+                .assertEquals(AuthorizationStatus.DEACTIVATED, Objects.requireNonNull(response.getBody()).getStatus());
+        Assertions
+                .assertEquals(AuthorizationStatus.DEACTIVATED,
+                        acmeAuthorizationRepository.findByAuthorizationId("authDeact").orElseThrow().getStatus());
+        Assertions
+                .assertEquals(OrderStatus.INVALID,
+                        acmeOrderRepository.findByOrderId("orderDeact").orElseThrow().getStatus());
+    }
+
+    /**
+     * A request that both settles a stale sibling and deactivates the asked-for authorization runs in one transaction;
+     * the settlement of the sibling must survive the second lock on the order.
+     */
+    @Test
+    void testGetAuthorization_deactivationKeepsTheSettlementOfAStaleSibling() throws Exception {
+        AcmeOrder order = pendingOrder("orderDeactSibling");
+        AcmeChallenge stale = pendingDnsChallenge(order, "authDeactStale", "challengeDeactStale", "tokenDeactStale");
+        stale.setStatus(ChallengeStatus.INVALID);
+        acmeChallengeRepository.save(stale);
+        pendingDnsChallenge(order, "authDeactTarget", "challengeDeactTarget", "tokenDeactTarget");
+        String baseUri = BASE_URI + ACME_PROFILE_NAME;
+        URI requestUri = new URI(baseUri + "/authz/authDeactTarget");
+
+        acmeService
+                .getAuthorization(ACME_PROFILE_NAME, "authDeactTarget", buildDeactivateRequestJSON(requestUri, baseUri),
+                        requestUri, false);
+
+        Assertions
+                .assertEquals(AuthorizationStatus.INVALID,
+                        acmeAuthorizationRepository.findByAuthorizationId("authDeactStale").orElseThrow().getStatus());
+        Assertions
+                .assertEquals(AuthorizationStatus.DEACTIVATED,
+                        acmeAuthorizationRepository.findByAuthorizationId("authDeactTarget").orElseThrow().getStatus());
+        Assertions
+                .assertEquals(OrderStatus.INVALID,
+                        acmeOrderRepository.findByOrderId("orderDeactSibling").orElseThrow().getStatus());
+    }
+
+    /**
+     * An authorization can be read or deactivated only by the account that placed its order.
+     */
+    @Test
+    void testGetAuthorization_refusesAnotherAccount() throws Exception {
+        pendingDnsChallenge(pendingOrder("orderForeign"), "authForeign", "challengeForeign", "tokenForeign");
+        otherAccount();
+        String baseUri = BASE_URI + ACME_PROFILE_NAME;
+        URI requestUri = new URI(baseUri + "/authz/authForeign");
+
+        AcmeProblemDocumentException refused = Assertions
+                .assertThrows(AcmeProblemDocumentException.class,
+                        () -> acmeService
+                                .getAuthorization(ACME_PROFILE_NAME, "authForeign",
+                                        signedByOtherAccount("{\"status\":\"deactivated\"}", requestUri, baseUri),
+                                        requestUri, false));
+
+        Assertions.assertEquals(Problem.UNAUTHORIZED.getType(), refused.getProblemDocument().getType());
+        Assertions
+                .assertEquals(AuthorizationStatus.PENDING,
+                        acmeAuthorizationRepository.findByAuthorizationId("authForeign").orElseThrow().getStatus());
+    }
+
+    @Test
+    void testGetAuthorization_refusesAKeySuppliedInline() throws Exception {
+        pendingDnsChallenge(pendingOrder("orderInlineKey"), "authInlineKey", "challengeInlineKey", "tokenInlineKey");
+        String baseUri = BASE_URI + ACME_PROFILE_NAME;
+        URI requestUri = new URI(baseUri + "/authz/authInlineKey");
+        JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload(""));
+        jwsObjectJSON
+                .sign(new JWSHeader.Builder(JWSAlgorithm.RS256)
+                        .jwk(rsa2048PublicJWK)
+                        .customParam(NONCE_HEADER_CUSTOM_PARAM, acmeValidNonce.getNonce())
+                        .customParam(URL_HEADER_CUSTOM_PARAM, requestUri.toString())
+                        .build(), rsa2048Signer);
+
+        AcmeProblemDocumentException refused = Assertions
+                .assertThrows(AcmeProblemDocumentException.class,
+                        () -> acmeService
+                                .getAuthorization(ACME_PROFILE_NAME, "authInlineKey",
+                                        jwsObjectJSON.serializeFlattened(), requestUri, false));
+
+        Assertions.assertEquals(Problem.MALFORMED.getType(), refused.getProblemDocument().getType());
+    }
+
+    /**
+     * An order can be finalized only by the account that placed it.
+     */
+    @Test
+    void testFinalizeOrder_refusesAnotherAccount() throws Exception {
+        AcmeOrder order = pendingOrder("orderForeignFin");
+        order.setStatus(OrderStatus.READY);
+        acmeOrderRepository.save(order);
+        otherAccount();
+        String baseUri = BASE_URI + ACME_PROFILE_NAME;
+        URI requestUri = new URI(baseUri + "/order/orderForeignFin/finalize");
+
+        AcmeProblemDocumentException refused = Assertions
+                .assertThrows(AcmeProblemDocumentException.class, () -> acmeService
+                        .finalizeOrder(ACME_PROFILE_NAME, "orderForeignFin",
+                                signedByOtherAccount("{\"csr\":\"\"}", requestUri, baseUri), requestUri, false));
+
+        Assertions.assertEquals(Problem.UNAUTHORIZED.getType(), refused.getProblemDocument().getType());
+        Assertions
+                .assertEquals(OrderStatus.READY,
+                        acmeOrderRepository.findByOrderId("orderForeignFin").orElseThrow().getStatus());
+    }
+
+    private AcmeAccount otherAccount() throws JOSEException {
+        AcmeAccount other = new AcmeAccount();
+        other.setStatus(AccountStatus.VALID);
+        other.setEnabled(true);
+        other.setAccountId(OTHER_ACCOUNT_ID);
+        other.setTermsOfServiceAgreed(true);
+        other.setAcmeProfile(order1.getAcmeAccount().getAcmeProfile());
+        other.setRaProfile(order1.getAcmeAccount().getRaProfile());
+        other.setPublicKey(Base64.getEncoder().encodeToString(newRsa2048PublicJWK.toPublicKey().getEncoded()));
+        return acmeAccountRepository.save(other);
+    }
+
+    private String signedByOtherAccount(String payload, URI requestUri, String baseUri) throws JOSEException {
+        JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload(payload));
+        jwsObjectJSON
+                .sign(new JWSHeader.Builder(JWSAlgorithm.RS256)
+                        .keyID(baseUri + "/acct/" + OTHER_ACCOUNT_ID)
+                        .customParam(NONCE_HEADER_CUSTOM_PARAM, acmeValidNonce.getNonce())
+                        .customParam(URL_HEADER_CUSTOM_PARAM, requestUri.toString())
+                        .build(), newRsa2048Signer);
+        return jwsObjectJSON.serializeFlattened();
+    }
+
+    /**
+     * A request that deactivates whatever it is addressed to: the payload is the same for an account and for an
+     * authorization (RFC 8555 sections 7.3.6 and 7.5.2).
+     */
+    private String buildDeactivateRequestJSON(URI requestUri, String baseUri) throws JOSEException {
+        JWSObjectJSON jwsObjectJSON = new JWSObjectJSON(new Payload("{\"status\":\"deactivated\"}"));
+        jwsObjectJSON
+                .sign(new JWSHeader.Builder(JWSAlgorithm.RS256)
+                        .keyID(baseUri + "/acct/" + ACME_ACCOUNT_ID_VALID)
+                        .customParam(NONCE_HEADER_CUSTOM_PARAM, acmeValidNonce.getNonce())
+                        .customParam(URL_HEADER_CUSTOM_PARAM, requestUri.toString())
+                        .build(), rsa2048Signer);
+        return jwsObjectJSON.serializeFlattened();
+    }
+
+    @Test
+    void testValidateChallenge_refusesAnAuthorizationWithoutAnIdentifier() {
+        AcmeChallenge challenge = pendingDnsChallenge(pendingOrder("orderNoId"), "authNoId", "challengeNoId",
+                "tokenNoId");
+        AcmeAuthorization authorization = challenge.getAuthorization();
+        authorization.setIdentifier(null);
+        acmeAuthorizationRepository.save(authorization);
+
+        AcmeProblemDocumentException refused = Assertions
+                .assertThrows(AcmeProblemDocumentException.class, () -> validateChallenge(challenge));
+
+        Assertions.assertEquals(Problem.SERVER_INTERNAL.getType(), refused.getProblemDocument().getType());
+        Assertions.assertEquals(ChallengeStatus.PENDING, reload(challenge).getStatus());
+    }
+
+    /**
+     * An order the previous behaviour let finalize despite a failed authorization already has its certificate. Polling
+     * that authorization settles it, but the order keeps its status and is not counted as failed.
+     */
+    @Test
+    void testGetAuthorization_doesNotFailAnOrderWhoseCertificateWasIssued() throws Exception {
+        AcmeChallenge challenge = failedChallengeLeftUnpropagated("orderIssuedStale", "authIssuedStale",
+                "challengeIssuedStale");
+        AcmeOrder order = challenge.getAuthorization().getOrder();
+        order.setStatus(OrderStatus.READY);
+        order.setCertificateReference(order1.getCertificateReference());
+        order.setCertificateReferenceUuid(order1.getCertificateReferenceUuid());
+        acmeOrderRepository.save(order);
+        int failedOrdersBefore = failedOrders(order);
+        String baseUri = BASE_URI + ACME_PROFILE_NAME;
+        URI requestUri = new URI(baseUri + "/authz/authIssuedStale");
+
+        ResponseEntity<Authorization> response = acmeService
+                .getAuthorization(ACME_PROFILE_NAME, "authIssuedStale",
+                        buildGetAuthorizationRequestJSON(requestUri, baseUri), requestUri, false);
+
+        Assertions.assertEquals(AuthorizationStatus.INVALID, Objects.requireNonNull(response.getBody()).getStatus());
+        Assertions
+                .assertEquals(OrderStatus.READY,
+                        acmeOrderRepository.findByOrderId("orderIssuedStale").orElseThrow().getStatus());
+        Assertions.assertEquals(failedOrdersBefore, failedOrders(order));
+    }
+
+    /**
+     * An invalid order is a protocol state, so it is reported with that status rather than as a server fault.
+     */
+    @Test
+    void testGetOrder_reportsAnInvalidOrderWithItsStatus() throws Exception {
+        AcmeOrder order = pendingOrder("orderInvalidReport");
+        order.setStatus(OrderStatus.INVALID);
+        acmeOrderRepository.save(order);
+        URI requestUri = new URI(BASE_URI + ACME_PROFILE_NAME + "/order/orderInvalidReport");
+
+        ResponseEntity<Order> response = acmeService
+                .getOrder(ACME_PROFILE_NAME, "orderInvalidReport", requestUri, false);
+
+        Assertions.assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assertions.assertEquals(OrderStatus.INVALID, Objects.requireNonNull(response.getBody()).getStatus());
+    }
+
+    /**
+     * The status an order takes from its certificate is decided under the order lock and counted once, so two requests
+     * polling the same order between them record one transition rather than one each.
+     */
+    @Test
+    void testWriter_countsACertificateDerivedTransitionOnce() {
+        UUID accountUuid = order1.getAcmeAccountUuid();
+        order1.setStatus(OrderStatus.PROCESSING);
+        acmeOrderRepository.save(order1);
+        int validBefore = acmeAccountRepository.findByUuid(accountUuid).orElseThrow().getValidOrders();
+
+        AcmeOrder first = acmeChallengeWriter.reconcileCertificateStatus(order1.getUuid());
+        AcmeOrder second = acmeChallengeWriter.reconcileCertificateStatus(order1.getUuid());
+
+        Assertions.assertEquals(OrderStatus.VALID, first.getStatus());
+        Assertions.assertEquals(OrderStatus.VALID, second.getStatus());
+        Assertions
+                .assertEquals(validBefore + 1,
+                        acmeAccountRepository.findByUuid(accountUuid).orElseThrow().getValidOrders());
+    }
+
+    /**
+     * Deactivating an account counts each order it closes in the database, so a count recorded while the orders were
+     * being locked survives the account being written back.
+     */
+    @Test
+    void testUpdateAccount_deactivationKeepsACountRecordedWhileItRan() throws Exception {
+        AcmeOrder open = pendingOrder("orderDeactCount");
+        UUID accountUuid = open.getAcmeAccountUuid();
+        int failedBefore = acmeAccountRepository.findByUuid(accountUuid).orElseThrow().getFailedOrders();
+        // stands in for a challenge that failed while the deactivation was acquiring its order locks
+        acmeChallengeWriter.countFailedOrder(accountUuid);
+        String baseUri = BASE_URI + ACME_PROFILE_NAME;
+        URI requestUri = new URI(baseUri + "/acct/" + ACME_ACCOUNT_ID_VALID);
+
+        acmeService
+                .updateAccount(ACME_PROFILE_NAME, ACME_ACCOUNT_ID_VALID,
+                        buildDeactivateRequestJSON(requestUri, baseUri), requestUri, false);
+
+        AcmeAccount reloaded = acmeAccountRepository.findByUuid(accountUuid).orElseThrow();
+        Assertions.assertEquals(AccountStatus.DEACTIVATED, reloaded.getStatus());
+        Assertions
+                .assertEquals(OrderStatus.INVALID,
+                        acmeOrderRepository.findByOrderId("orderDeactCount").orElseThrow().getStatus());
+        // the concurrent count, plus every order this deactivation closed
+        Assertions.assertTrue(reloaded.getFailedOrders() >= failedBefore + 2);
+    }
+
+    /**
+     * The state an instance without failure propagation leaves behind: the challenge is invalid, nothing else is.
+     */
+    private AcmeChallenge failedChallengeLeftUnpropagated(String orderId, String authorizationId, String challengeId) {
+        AcmeChallenge challenge = pendingDnsChallenge(pendingOrder(orderId), authorizationId, challengeId,
+                "token-" + challengeId);
+        challenge.setStatus(ChallengeStatus.INVALID);
+        acmeChallengeRepository.save(challenge);
+        return challenge;
+    }
+
+    private AcmeOrder orderLeftOpenBehindFailedAuthorization(String orderId, String authorizationId,
+            OrderStatus orderStatus) {
+        AcmeOrder order = pendingOrder(orderId);
+        order.setStatus(orderStatus);
+        acmeOrderRepository.save(order);
+        AcmeAuthorization authorization = pendingDnsChallenge(order, authorizationId, "challenge-" + authorizationId,
+                "token-" + authorizationId).getAuthorization();
+        authorization.setStatus(AuthorizationStatus.INVALID);
+        acmeAuthorizationRepository.save(authorization);
+        return order;
+    }
+
+    private int failedOrders(AcmeChallenge challenge) {
+        return failedOrders(challenge.getAuthorization().getOrder());
+    }
+
+    private int failedOrders(AcmeOrder order) {
+        return acmeAccountRepository.findByUuid(order.getAcmeAccountUuid()).orElseThrow().getFailedOrders();
+    }
+
+    private AcmeOrder pendingOrder(String orderId) {
+        AcmeOrder order = new AcmeOrder();
+        order.setOrderId(orderId);
+        order.setStatus(OrderStatus.PENDING);
+        order.setAcmeAccount(order1.getAcmeAccount());
+        acmeOrderRepository.save(order);
+        return order;
+    }
+
+    private AcmeChallenge pendingDnsChallenge(AcmeOrder order, String authorizationId, String challengeId,
+            String token) {
+        AcmeAuthorization authorization = new AcmeAuthorization();
+        authorization.setAuthorizationId(authorizationId);
+        authorization.setStatus(AuthorizationStatus.PENDING);
+        authorization.setIdentifier("{\"type\":\"dns\",\"value\":\"example.com\"}");
+        authorization.setOrderUuid(order.getUuid());
+        authorization.setOrder(order);
+        acmeAuthorizationRepository.save(authorization);
+
+        AcmeChallenge challenge = new AcmeChallenge();
+        challenge.setChallengeId(challengeId);
+        challenge.setStatus(ChallengeStatus.PENDING);
+        challenge.setType(ChallengeType.DNS01);
+        challenge.setToken(token);
+        challenge.setAuthorizationUuid(authorization.getUuid());
+        challenge.setAuthorization(authorization);
+        acmeChallengeRepository.save(challenge);
+        return challenge;
+    }
+
+    private ResponseEntity<Challenge> validateChallenge(AcmeChallenge challenge)
+            throws NotFoundException, NoSuchAlgorithmException, InvalidKeySpecException, AcmeProblemDocumentException {
+        URI requestUri = URI.create(BASE_URI + ACME_PROFILE_NAME + "/chall/" + challenge.getChallengeId());
+        return acmeService.validateChallenge(ACME_PROFILE_NAME, challenge.getChallengeId(), requestUri, false);
+    }
+
+    private AcmeChallenge reload(AcmeChallenge challenge) {
+        return acmeChallengeRepository.findByChallengeId(challenge.getChallengeId()).orElseThrow();
+    }
+
+    private String expectedDnsValidationToken(String token) throws JOSEException, NoSuchAlgorithmException {
+        String keyAuthorization = AcmeCommonHelper.createKeyAuthorization(token, rsa2048PublicJWK.toPublicKey());
+        byte[] digest = MessageDigest.getInstance("SHA-256").digest(keyAuthorization.getBytes(StandardCharsets.UTF_8));
+        return Base64URL.encode(digest).toString();
+    }
+
+    /**
+     * Stands in for the DNS provider, which returns every TXT record of a name as a separate value of one {@code TXT}
+     * attribute.
+     */
+    private static MockedConstruction<InitialDirContext> mockTxtRecords(String... txtValues) {
+        BasicAttribute records = new BasicAttribute(AcmeConstants.DNS_RECORD_TYPE);
+        for (String txtValue : txtValues) {
+            records.add(txtValue);
+        }
+        Attributes attributes = new BasicAttributes(true);
+        attributes.put(records);
+        return mockConstruction(InitialDirContext.class,
+                (mock, context) -> when(mock.getAttributes(anyString(), any(String[].class))).thenReturn(attributes));
     }
 }

--- a/src/test/java/com/otilm/core/integration/service/AcmeServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/AcmeServiceITest.java
@@ -82,11 +82,17 @@ import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.BasicAttribute;
 import javax.naming.directory.BasicAttributes;
@@ -100,6 +106,8 @@ import org.mockito.MockedConstruction;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
@@ -1480,6 +1488,71 @@ class AcmeServiceITest extends BaseSpringBootTest {
 
         Assertions.assertEquals(ChallengeStatus.INVALID, outcome.getStatus());
         Assertions.assertEquals(AuthorizationStatus.INVALID, reload(challenge).getAuthorization().getStatus());
+    }
+
+    /**
+     * The same test as above, but with the two accepts actually running at once rather than one after the other. Both
+     * threads are held at a start line and released together, so they contend for the order lock for real. Whichever
+     * takes it first decides the outcome; the other must re-read the settled rows under the same lock and report that
+     * outcome rather than apply its own. The order and its authorization have to agree with the challenge afterwards,
+     * and the account's failed-order count has to move by one at most -- a count of two would mean both accepts wrote.
+     */
+    @Test
+    void testWriter_concurrentAcceptsOfOneChallengeSettleItOnce() throws Exception {
+        AcmeChallenge challenge = pendingDnsChallenge(pendingOrder("orderConcurrent"), "authConcurrent",
+                "challengeConcurrent", "token-challengeConcurrent");
+        UUID orderUuid = challenge.getAuthorization().getOrder().getUuid();
+        UUID accountUuid = challenge.getAuthorization().getOrder().getAcmeAccountUuid();
+        int failedBefore = acmeAccountRepository.findByUuid(accountUuid).orElseThrow().getFailedOrders();
+
+        // The writer opens a transaction per call, so each thread needs the caller's authentication: the security
+        // context is thread-local and the audit path reads it.
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        // Deliberately conflicting verdicts, so a lost lock shows up as a status that disagrees with what was reported.
+        List<ChallengeValidationResult> verdicts = List.of(ChallengeValidationResult.success(),
+                ChallengeValidationResult.failure(Problem.INCORRECT_RESPONSE, "the raced accept"));
+
+        CountDownLatch atStartLine = new CountDownLatch(verdicts.size());
+        CountDownLatch go = new CountDownLatch(1);
+        ExecutorService accepts = Executors.newFixedThreadPool(verdicts.size());
+        try {
+            List<Future<ChallengeStatus>> reported = new ArrayList<>();
+            for (ChallengeValidationResult verdict : verdicts) {
+                reported.add(accepts.submit(() -> {
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                    atStartLine.countDown();
+                    Assertions.assertTrue(go.await(30, TimeUnit.SECONDS), "the start line was never released");
+                    return acmeChallengeWriter
+                            .applyValidationResult(orderUuid, "challengeConcurrent", verdict)
+                            .getStatus();
+                }));
+            }
+            Assertions.assertTrue(atStartLine.await(30, TimeUnit.SECONDS), "the accepts never reached the start line");
+            go.countDown();
+
+            List<ChallengeStatus> outcomes = new ArrayList<>();
+            for (Future<ChallengeStatus> accept : reported) {
+                outcomes.add(accept.get(60, TimeUnit.SECONDS));
+            }
+
+            ChallengeStatus settled = reload(challenge).getStatus();
+            Assertions.assertNotEquals(ChallengeStatus.PENDING, settled, "neither accept settled the challenge");
+            Assertions.assertEquals(List.of(settled, settled), outcomes, "an accept reported a status it did not win");
+
+            AcmeOrder order = acmeOrderRepository.findByUuid(orderUuid).orElseThrow();
+            AcmeAuthorization authorization = reload(challenge).getAuthorization();
+            if (settled == ChallengeStatus.INVALID) {
+                Assertions.assertEquals(AuthorizationStatus.INVALID, authorization.getStatus());
+                Assertions.assertEquals(OrderStatus.INVALID, order.getStatus());
+                Assertions.assertEquals(failedBefore + 1, failedOrders(order), "the failed order was counted twice");
+            } else {
+                Assertions.assertEquals(AuthorizationStatus.VALID, authorization.getStatus());
+                Assertions.assertEquals(OrderStatus.READY, order.getStatus());
+                Assertions.assertEquals(failedBefore, failedOrders(order));
+            }
+        } finally {
+            accepts.shutdownNow();
+        }
     }
 
     /**

--- a/src/test/java/com/otilm/core/integration/service/acme/AcmeProtocolFlowITest.java
+++ b/src/test/java/com/otilm/core/integration/service/acme/AcmeProtocolFlowITest.java
@@ -49,8 +49,9 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Base64;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -445,7 +446,7 @@ public class AcmeProtocolFlowITest extends BaseSpringBootTest {
         AcmeOrder acmeOrder = acmeOrderRepository.findByUuid(acmeAuthorization.getOrderUuid()).orElseThrow();
 
         acmeChallenge.setStatus(ChallengeStatus.VALID);
-        acmeChallenge.setValidated(new Date());
+        acmeChallenge.setValidated(OffsetDateTime.now(ZoneOffset.UTC));
         acmeAuthorization.setStatus(AuthorizationStatus.VALID);
         acmeOrder.setStatus(OrderStatus.READY);
 

--- a/src/test/java/com/otilm/core/integration/service/acme/AcmeProtocolFlowITest.java
+++ b/src/test/java/com/otilm/core/integration/service/acme/AcmeProtocolFlowITest.java
@@ -1,5 +1,8 @@
 package com.otilm.core.integration.service.acme;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.otilm.api.model.client.acme.AcmeProfileRequestDto;
 import com.otilm.api.model.client.raprofile.ActivateAcmeForRaProfileRequestDto;
 import com.otilm.api.model.client.raprofile.AddRaProfileRequestDto;
@@ -17,20 +20,20 @@ import com.otilm.core.dao.entity.acme.AcmeAuthorization;
 import com.otilm.core.dao.entity.acme.AcmeChallenge;
 import com.otilm.core.dao.entity.acme.AcmeOrder;
 import com.otilm.core.dao.entity.acme.AcmeProfile;
+import com.otilm.core.dao.repository.AcmeProfileRepository;
 import com.otilm.core.dao.repository.AuthorityInstanceReferenceRepository;
 import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.dao.repository.Connector2FunctionGroupRepository;
 import com.otilm.core.dao.repository.ConnectorInterfaceRepository;
 import com.otilm.core.dao.repository.ConnectorRepository;
 import com.otilm.core.dao.repository.FunctionGroupRepository;
-import com.otilm.core.dao.repository.AcmeProfileRepository;
 import com.otilm.core.dao.repository.RaProfileRepository;
 import com.otilm.core.dao.repository.acme.AcmeAuthorizationRepository;
 import com.otilm.core.dao.repository.acme.AcmeChallengeRepository;
 import com.otilm.core.dao.repository.acme.AcmeNonceRepository;
 import com.otilm.core.dao.repository.acme.AcmeOrderRepository;
-import com.otilm.core.messaging.model.ActionMessage;
 import com.otilm.core.messaging.jms.producers.ActionProducer;
+import com.otilm.core.messaging.model.ActionMessage;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
@@ -41,21 +44,6 @@ import com.otilm.core.service.acme.AcmeTestUtil;
 import com.otilm.core.service.v2.ClientOperationInternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.builders.AuthorityFixtures;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.WireMock;
-import org.bouncycastle.pkcs.PKCS10CertificationRequest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-
-import org.awaitility.Awaitility;
-
 import java.net.URI;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -69,30 +57,45 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+import org.awaitility.Awaitility;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 
 /**
  * End-to-end integration test for the ACME (RFC 8555) protocol implementation.
  *
- * <p>Exercises the full certificate lifecycle through the service layer:
+ * <p>
+ * Exercises the full certificate lifecycle through the service layer:
  * <ol>
- *   <li>Infrastructure setup – connector, authority instance, RA profile, ACME profile</li>
- *   <li>Account creation ({@code POST /new-account})</li>
- *   <li>Order creation ({@code POST /new-order})</li>
- *   <li>HTTP-01 challenge authorization ({@code GET /authz/{id}}) – validated via direct DB state update</li>
- *   <li>Order finalization ({@code POST /order/{id}/finalize}) with PKCS#10 CSR</li>
- *   <li>Order status verification ({@code GET /order/{id}})</li>
- *   <li>Certificate download ({@code GET /cert/{id}})</li>
+ * <li>Infrastructure setup – connector, authority instance, RA profile, ACME profile</li>
+ * <li>Account creation ({@code POST /new-account})</li>
+ * <li>Order creation ({@code POST /new-order})</li>
+ * <li>HTTP-01 challenge authorization ({@code GET /authz/{id}}) – validated via direct DB state update</li>
+ * <li>Order finalization ({@code POST /order/{id}/finalize}) with PKCS#10 CSR</li>
+ * <li>Order status verification ({@code GET /order/{id}})</li>
+ * <li>Certificate download ({@code GET /cert/{id}})</li>
  * </ol>
  *
- * <p>The external Authority Provider connector is stubbed with WireMock.
- * Challenge HTTP validation is simulated by directly setting the entity state in the database,
- * which is appropriate for a service-layer integration test.
+ * <p>
+ * The external Authority Provider connector is stubbed with WireMock. Challenge HTTP validation is simulated by
+ * directly setting the entity state in the database, which is appropriate for a service-layer integration test.
  * Certificate issuance via the connector is driven through the real
- * {@link com.otilm.core.service.v2.ClientOperationInternalService} code path: the
- * {@link ActionProducer} is spied on so that each {@code ActionMessage} is dispatched
- * synchronously to {@code issueCertificateAction} instead of being sent over RabbitMQ.
+ * {@link com.otilm.core.service.v2.ClientOperationInternalService} code path: the {@link ActionProducer} is spied on so
+ * that each {@code ActionMessage} is dispatched synchronously to {@code issueCertificateAction} instead of being sent
+ * over RabbitMQ.
  */
 public class AcmeProtocolFlowITest extends BaseSpringBootTest {
 
@@ -159,20 +162,28 @@ public class AcmeProtocolFlowITest extends BaseSpringBootTest {
 
         // Stubs for raProfileService.addRaProfile (mergeAndValidateAttributes calls v1 RA-profile attribute
         // endpoints to validate and list attributes before saving the RA profile).
-        wireMockServer.stubFor(get(urlMatching("/v1/authorityProvider/authorities/[^/]+/raProfile/attributes"))
-                .willReturn(okJson("[]")));
-        wireMockServer.stubFor(post(urlMatching("/v1/authorityProvider/authorities/[^/]+/raProfile/attributes/validate"))
-                .willReturn(okJson("true")));
+        wireMockServer
+                .stubFor(get(urlMatching("/v1/authorityProvider/authorities/[^/]+/raProfile/attributes"))
+                        .willReturn(okJson("[]")));
+        wireMockServer
+                .stubFor(post(urlMatching("/v1/authorityProvider/authorities/[^/]+/raProfile/attributes/validate"))
+                        .willReturn(okJson("true")));
         // Stubs for raProfileService.activateAcmeForRaProfile (mergeAndValidateIssueAttributes /
         // mergeAndValidateRevokeAttributes call the connector to validate and list certificate attributes).
-        wireMockServer.stubFor(get(urlMatching("/v2/authorityProvider/authorities/[^/]+/certificates/issue/attributes"))
-                .willReturn(okJson("[]")));
-        wireMockServer.stubFor(get(urlMatching("/v2/authorityProvider/authorities/[^/]+/certificates/revoke/attributes"))
-                .willReturn(okJson("[]")));
-        wireMockServer.stubFor(post(urlMatching("/v2/authorityProvider/authorities/[^/]+/certificates/issue/attributes/validate"))
-                .willReturn(okJson("true")));
-        wireMockServer.stubFor(post(urlMatching("/v2/authorityProvider/authorities/[^/]+/certificates/revoke/attributes/validate"))
-                .willReturn(okJson("true")));
+        wireMockServer
+                .stubFor(get(urlMatching("/v2/authorityProvider/authorities/[^/]+/certificates/issue/attributes"))
+                        .willReturn(okJson("[]")));
+        wireMockServer
+                .stubFor(get(urlMatching("/v2/authorityProvider/authorities/[^/]+/certificates/revoke/attributes"))
+                        .willReturn(okJson("[]")));
+        wireMockServer
+                .stubFor(post(
+                        urlMatching("/v2/authorityProvider/authorities/[^/]+/certificates/issue/attributes/validate"))
+                        .willReturn(okJson("true")));
+        wireMockServer
+                .stubFor(post(
+                        urlMatching("/v2/authorityProvider/authorities/[^/]+/certificates/revoke/attributes/validate"))
+                        .willReturn(okJson("true")));
 
         keyPairGenerator = KeyPairGenerator.getInstance("RSA");
         keyPairGenerator.initialize(2048);
@@ -225,24 +236,23 @@ public class AcmeProtocolFlowITest extends BaseSpringBootTest {
         awaitOrderStatus(order.orderId, OrderStatus.VALID);
 
         // Verify the issue call was routed to the exact authority instance (not just any authority).
-        wireMockServer.verify(postRequestedFor(urlMatching(
-                "/v2/authorityProvider/authorities/"
-                        + Pattern.quote(fixture.authority().getAuthorityInstanceUuid())
-                        + "/certificates/issue")));
+        wireMockServer
+                .verify(postRequestedFor(urlMatching("/v2/authorityProvider/authorities/"
+                        + Pattern.quote(fixture.authority().getAuthorityInstanceUuid()) + "/certificates/issue")));
 
         // ── Step 7: Verify order status ───────────────────────────────────────
-        ResponseEntity<com.otilm.api.model.core.acme.Order> orderResponse = acmeService.getOrder(
-                ACME_PROFILE_NAME, order.orderId,
-                new URI("/acme/" + ACME_PROFILE_NAME + "/order/" + order.orderId), false);
+        ResponseEntity<com.otilm.api.model.core.acme.Order> orderResponse = acmeService
+                .getOrder(ACME_PROFILE_NAME, order.orderId,
+                        new URI("/acme/" + ACME_PROFILE_NAME + "/order/" + order.orderId), false);
         Assertions.assertNotNull(orderResponse.getBody());
         Assertions.assertEquals(OrderStatus.VALID, orderResponse.getBody().getStatus());
 
         // ── Step 8: Certificate download ──────────────────────────────────────
         String certUrl = orderResponse.getBody().getCertificate();
         String certificateId = certUrl.substring(certUrl.lastIndexOf('/') + 1);
-        ResponseEntity<org.springframework.core.io.Resource> downloadResponse = acmeService.downloadCertificate(
-                ACME_PROFILE_NAME, certificateId,
-                new URI("/acme/" + ACME_PROFILE_NAME + "/cert/" + certificateId), false);
+        ResponseEntity<org.springframework.core.io.Resource> downloadResponse = acmeService
+                .downloadCertificate(ACME_PROFILE_NAME, certificateId,
+                        new URI("/acme/" + ACME_PROFILE_NAME + "/cert/" + certificateId), false);
         Assertions.assertEquals(200, downloadResponse.getStatusCode().value());
         Assertions.assertNotNull(downloadResponse.getBody());
     }
@@ -250,14 +260,15 @@ public class AcmeProtocolFlowITest extends BaseSpringBootTest {
     /**
      * Ensure a change to the default RA Profile is reflected in existing ACME accounts.
      *
-     * <p>When an ACME account is created through the ACME-Profile-based flow it is marked with
-     * {@code isDefaultRaProfile = true}. If the ACME Profile is later updated to a different RA Profile
-     * via {@link AcmeProfileExternalService#updateRaProfile}, all such accounts must have their RA profiles updated
-     * so that subsequent certificate operations are issued under the new RA Profile.
+     * <p>
+     * When an ACME account is created through the ACME-Profile-based flow it is marked with
+     * {@code isDefaultRaProfile = true}. If the ACME Profile is later updated to a different RA Profile via
+     * {@link AcmeProfileExternalService#updateRaProfile}, all such accounts must have their RA profiles updated so that
+     * subsequent certificate operations are issued under the new RA Profile.
      *
-     * <p>This test verifies that after switching the ACME Profile from
-     * a second RA profile ({@value #RA_PROFILE_NAME_2}), a new order finalized on the
-     * existing account results in a certificate associated with that updated RA profile.
+     * <p>
+     * This test verifies that after switching the ACME Profile from a second RA profile ({@value #RA_PROFILE_NAME_2}),
+     * a new order finalized on the existing account results in a certificate associated with that updated RA profile.
      */
     @Test
     public void acmeRaProfileChangeReflectedInExistingAccount() throws Exception {
@@ -280,14 +291,15 @@ public class AcmeProtocolFlowITest extends BaseSpringBootTest {
 
         // ── Step 5: Create raProfile2 and update the ACME Profile to use it ──
         RaProfileDto raProfile2 = createSecondRaProfile(fixture);
-        acmeProfileService.updateRaProfile(
-                SecuredUUID.fromString(acmeProfile.getUuid()),
-                raProfile2.getUuid());
+        acmeProfileService.updateRaProfile(SecuredUUID.fromString(acmeProfile.getUuid()), raProfile2.getUuid());
 
         // ── Step 6: Assert that the ACME Profile's RA Profile was persisted correctly ──
-        AcmeProfile reloadedAcmeProfile = acmeProfileRepository.findByUuid(UUID.fromString(acmeProfile.getUuid())).orElseThrow();
-        Assertions.assertEquals(UUID.fromString(raProfile2.getUuid()), reloadedAcmeProfile.getRaProfileUuid(),
-                "ACME Profile ra_profile_uuid must be persisted to the database after updateRaProfile");
+        AcmeProfile reloadedAcmeProfile = acmeProfileRepository
+                .findByUuid(UUID.fromString(acmeProfile.getUuid()))
+                .orElseThrow();
+        Assertions
+                .assertEquals(UUID.fromString(raProfile2.getUuid()), reloadedAcmeProfile.getRaProfileUuid(),
+                        "ACME Profile ra_profile_uuid must be persisted to the database after updateRaProfile");
 
         // ── Step 7: Place a new order on the same ACME account ─────────────────
         OrderAndId order2 = createAcmeOrder(acmeAccountId);
@@ -301,27 +313,28 @@ public class AcmeProtocolFlowITest extends BaseSpringBootTest {
         AcmeOrder acmeOrder = acmeOrderRepository.findByOrderId(order2.orderId).orElseThrow();
         Assertions.assertNotNull(acmeOrder.getCertificateReferenceUuid(), "Issued certificate must not be null");
         Certificate certificate = certificateRepository
-                .findByUuid(acmeOrder.getCertificateReferenceUuid()).orElseThrow();
-        Assertions.assertEquals(
-                UUID.fromString(raProfile2.getUuid()),
-                certificate.getRaProfileUuid(),
-                "Certificate should be issued under the updated RA Profile (" + RA_PROFILE_NAME_2 + ")");
+                .findByUuid(acmeOrder.getCertificateReferenceUuid())
+                .orElseThrow();
+        Assertions
+                .assertEquals(UUID.fromString(raProfile2.getUuid()), certificate.getRaProfileUuid(),
+                        "Certificate should be issued under the updated RA Profile (" + RA_PROFILE_NAME_2 + ")");
     }
 
     // ── Infrastructure setup helpers ──────────────────────────────────────────
 
     /**
-     * Creates the authority fixture (connector + authority reference + RA profile) via
-     * {@link AuthorityFixtures}, bypassing the service layer for faster, stub-free setup.
+     * Creates the authority fixture (connector + authority reference + RA profile) via {@link AuthorityFixtures},
+     * bypassing the service layer for faster, stub-free setup.
      */
     private AuthorityFixtures.Fixture createAuthorityFixture() {
-        AuthorityFixtures.Repos repos = new AuthorityFixtures.Repos(
-                connectorRepository, functionGroupRepository, connector2FunctionGroupRepository,
-                authorityInstanceReferenceRepository, raProfileRepository, connectorInterfaceRepository);
+        AuthorityFixtures.Repos repos = new AuthorityFixtures.Repos(connectorRepository, functionGroupRepository,
+                connector2FunctionGroupRepository, authorityInstanceReferenceRepository, raProfileRepository,
+                connectorInterfaceRepository);
         return AuthorityFixtures.v2Authority(repos, wireMockServer, KIND_NAME);
     }
 
-    private AcmeProfileDto createAcmeProfile(RaProfileDto raProfile, AuthorityFixtures.Fixture fixture) throws Exception {
+    private AcmeProfileDto createAcmeProfile(RaProfileDto raProfile, AuthorityFixtures.Fixture fixture)
+            throws Exception {
         AcmeProfileRequestDto request = new AcmeProfileRequestDto();
         request.setName(ACME_PROFILE_NAME);
         request.setRaProfileUuid(raProfile.getUuid());
@@ -334,11 +347,10 @@ public class AcmeProtocolFlowITest extends BaseSpringBootTest {
         ActivateAcmeForRaProfileRequestDto activateRequest = new ActivateAcmeForRaProfileRequestDto();
         activateRequest.setIssueCertificateAttributes(List.of());
         activateRequest.setRevokeCertificateAttributes(List.of());
-        raProfileService.activateAcmeForRaProfile(
-                SecuredParentUUID.fromUUID(fixture.authority().getUuid()),
-                SecuredUUID.fromString(raProfile.getUuid()),
-                SecuredUUID.fromString(acmeProfileDto.getUuid()),
-                activateRequest);
+        raProfileService
+                .activateAcmeForRaProfile(SecuredParentUUID.fromUUID(fixture.authority().getUuid()),
+                        SecuredUUID.fromString(raProfile.getUuid()), SecuredUUID.fromString(acmeProfileDto.getUuid()),
+                        activateRequest);
 
         return acmeProfileDto;
     }
@@ -347,19 +359,17 @@ public class AcmeProtocolFlowITest extends BaseSpringBootTest {
         AddRaProfileRequestDto request = new AddRaProfileRequestDto();
         request.setName(RA_PROFILE_NAME_2);
         request.setAttributes(List.of());
-        RaProfileDto raProfile = raProfileService.addRaProfile(
-                SecuredParentUUID.fromUUID(fixture.authority().getUuid()), request);
-        raProfileService.enableRaProfile(
-                SecuredParentUUID.fromUUID(fixture.authority().getUuid()),
-                SecuredUUID.fromString(raProfile.getUuid()));
+        RaProfileDto raProfile = raProfileService
+                .addRaProfile(SecuredParentUUID.fromUUID(fixture.authority().getUuid()), request);
+        raProfileService
+                .enableRaProfile(SecuredParentUUID.fromUUID(fixture.authority().getUuid()),
+                        SecuredUUID.fromString(raProfile.getUuid()));
         return raProfile;
     }
 
     // ── ACME flow helpers ─────────────────────────────────────────────────────
 
-    private record OrderAndId(
-            com.otilm.api.model.core.acme.Order order,
-            String orderId) {
+    private record OrderAndId(com.otilm.api.model.core.acme.Order order, String orderId) {
     }
 
     /**
@@ -371,9 +381,8 @@ public class AcmeProtocolFlowITest extends BaseSpringBootTest {
         payload.put("contact", List.of("mailto:admin@example.com"));
 
         String jws = createJws(payload, "/acme/" + ACME_PROFILE_NAME + "/new-account", null);
-        ResponseEntity<Account> response = acmeService.newAccount(
-                ACME_PROFILE_NAME, jws,
-                new URI("/acme/" + ACME_PROFILE_NAME + "/new-account"), false);
+        ResponseEntity<Account> response = acmeService
+                .newAccount(ACME_PROFILE_NAME, jws, new URI("/acme/" + ACME_PROFILE_NAME + "/new-account"), false);
         Assertions.assertEquals(201, response.getStatusCode().value());
         Assertions.assertNotNull(response.getHeaders().getLocation());
 
@@ -392,9 +401,8 @@ public class AcmeProtocolFlowITest extends BaseSpringBootTest {
         payload.put("identifiers", List.of(identifier));
 
         String jws = createJws(payload, "/acme/" + ACME_PROFILE_NAME + "/new-order", accountId);
-        ResponseEntity<com.otilm.api.model.core.acme.Order> response = acmeService.newOrder(
-                ACME_PROFILE_NAME, jws,
-                new URI("/acme/" + ACME_PROFILE_NAME + "/new-order"), false);
+        ResponseEntity<com.otilm.api.model.core.acme.Order> response = acmeService
+                .newOrder(ACME_PROFILE_NAME, jws, new URI("/acme/" + ACME_PROFILE_NAME + "/new-order"), false);
         Assertions.assertEquals(201, response.getStatusCode().value());
 
         com.otilm.api.model.core.acme.Order order = response.getBody();
@@ -406,8 +414,8 @@ public class AcmeProtocolFlowITest extends BaseSpringBootTest {
     }
 
     /**
-     * Retrieves the authorization, finds the HTTP-01 challenge, and simulates validation
-     * by directly updating entity state in the database.
+     * Retrieves the authorization, finds the HTTP-01 challenge, and simulates validation by directly updating entity
+     * state in the database.
      */
     private void validateChallenge(OrderAndId order, String accountId) throws Exception {
         Assertions.assertNotNull(order.order.getAuthorizations());
@@ -415,13 +423,15 @@ public class AcmeProtocolFlowITest extends BaseSpringBootTest {
         String authzId = authzUrl.substring(authzUrl.lastIndexOf('/') + 1);
 
         String jws = createJws(null, "/acme/" + ACME_PROFILE_NAME + "/authz/" + authzId, accountId);
-        ResponseEntity<Authorization> authzResponse = acmeService.getAuthorization(
-                ACME_PROFILE_NAME, authzId, jws,
-                new URI("/acme/" + ACME_PROFILE_NAME + "/authz/" + authzId), false);
+        ResponseEntity<Authorization> authzResponse = acmeService
+                .getAuthorization(ACME_PROFILE_NAME, authzId, jws,
+                        new URI("/acme/" + ACME_PROFILE_NAME + "/authz/" + authzId), false);
         Authorization authz = authzResponse.getBody();
         Assertions.assertNotNull(authz);
 
-        Challenge httpChallenge = authz.getChallenges().stream()
+        Challenge httpChallenge = authz
+                .getChallenges()
+                .stream()
                 .filter(c -> c.getType().equals(ChallengeType.HTTP01))
                 .findFirst()
                 .orElseThrow();
@@ -430,7 +440,8 @@ public class AcmeProtocolFlowITest extends BaseSpringBootTest {
         // Simulate successful HTTP-01 validation by directly setting the entity state.
         AcmeChallenge acmeChallenge = acmeChallengeRepository.findByChallengeId(challengeId).orElseThrow();
         AcmeAuthorization acmeAuthorization = acmeAuthorizationRepository
-                .findByAuthorizationId(acmeChallenge.getAuthorization().getAuthorizationId()).orElseThrow();
+                .findByAuthorizationId(acmeChallenge.getAuthorization().getAuthorizationId())
+                .orElseThrow();
         AcmeOrder acmeOrder = acmeOrderRepository.findByUuid(acmeAuthorization.getOrderUuid()).orElseThrow();
 
         acmeChallenge.setStatus(ChallengeStatus.VALID);
@@ -442,9 +453,9 @@ public class AcmeProtocolFlowITest extends BaseSpringBootTest {
         acmeAuthorizationRepository.save(acmeAuthorization);
         acmeOrderRepository.save(acmeOrder);
 
-        ResponseEntity<com.otilm.api.model.core.acme.Order> updatedOrder = acmeService.getOrder(
-                ACME_PROFILE_NAME, order.orderId,
-                new URI("/acme/" + ACME_PROFILE_NAME + "/order/" + order.orderId), false);
+        ResponseEntity<com.otilm.api.model.core.acme.Order> updatedOrder = acmeService
+                .getOrder(ACME_PROFILE_NAME, order.orderId,
+                        new URI("/acme/" + ACME_PROFILE_NAME + "/order/" + order.orderId), false);
         Assertions.assertNotNull(updatedOrder.getBody());
         Assertions.assertEquals(OrderStatus.READY, updatedOrder.getBody().getStatus());
     }
@@ -457,8 +468,9 @@ public class AcmeProtocolFlowITest extends BaseSpringBootTest {
         X509Certificate testCert = AcmeTestUtil.createTestCertificate(csrKeyPair, DOMAIN_NAME);
         String certData = Base64.getEncoder().encodeToString(testCert.getEncoded());
         // Mock the actual certificate issuance.
-        wireMockServer.stubFor(post(urlMatching("/v2/authorityProvider/authorities/[^/]+/certificates/issue"))
-                .willReturn(okJson("{ \"certificateData\": \"" + certData + "\" }")));
+        wireMockServer
+                .stubFor(post(urlMatching("/v2/authorityProvider/authorities/[^/]+/certificates/issue"))
+                        .willReturn(okJson("{ \"certificateData\": \"" + certData + "\" }")));
 
         PKCS10CertificationRequest csr = AcmeTestUtil.createCsr(csrKeyPair, DOMAIN_NAME);
         String base64Csr = Base64.getUrlEncoder().withoutPadding().encodeToString(csr.getEncoded());
@@ -467,33 +479,32 @@ public class AcmeProtocolFlowITest extends BaseSpringBootTest {
         payload.put("csr", base64Csr);
 
         String jws = createJws(payload, "/acme/" + ACME_PROFILE_NAME + "/order/" + orderId + "/finalize", accountId);
-        ResponseEntity<com.otilm.api.model.core.acme.Order> response = acmeService.finalizeOrder(
-                ACME_PROFILE_NAME, orderId, jws,
-                new URI("/acme/" + ACME_PROFILE_NAME + "/order/" + orderId + "/finalize"), false);
+        ResponseEntity<com.otilm.api.model.core.acme.Order> response = acmeService
+                .finalizeOrder(ACME_PROFILE_NAME, orderId, jws,
+                        new URI("/acme/" + ACME_PROFILE_NAME + "/order/" + orderId + "/finalize"), false);
         Assertions.assertEquals(200, response.getStatusCode().value());
     }
 
     /**
-     * Polls via {@link AcmeExternalService#getOrder} (which recomputes order status from the
-     * certificate state on each call) until the expected status is reached or a
-     * terminal failure state is detected, failing the test if the timeout (10 s)
-     * is exceeded.
+     * Polls via {@link AcmeExternalService#getOrder} (which recomputes order status from the certificate state on each
+     * call) until the expected status is reached or a terminal failure state is detected, failing the test if the
+     * timeout (10 s) is exceeded.
      */
     private void awaitOrderStatus(String orderId, OrderStatus expected) throws Exception {
         URI orderUri = new URI("/acme/" + ACME_PROFILE_NAME + "/order/" + orderId);
-        Awaitility.await("Order " + orderId + " reaches " + expected)
+        Awaitility
+                .await("Order " + orderId + " reaches " + expected)
                 .atMost(10, TimeUnit.SECONDS)
                 .pollInterval(200, TimeUnit.MILLISECONDS)
                 .pollInSameThread()
-                .failFast("Order reached INVALID status",
-                        () -> {
-                            ResponseEntity<com.otilm.api.model.core.acme.Order> r =
-                                    acmeService.getOrder(ACME_PROFILE_NAME, orderId, orderUri, false);
-                            return r.getBody() != null && r.getBody().getStatus() == OrderStatus.INVALID;
-                        })
+                .failFast("Order reached INVALID status", () -> {
+                    ResponseEntity<com.otilm.api.model.core.acme.Order> r = acmeService
+                            .getOrder(ACME_PROFILE_NAME, orderId, orderUri, false);
+                    return r.getBody() != null && r.getBody().getStatus() == OrderStatus.INVALID;
+                })
                 .until(() -> {
-                    ResponseEntity<com.otilm.api.model.core.acme.Order> r =
-                            acmeService.getOrder(ACME_PROFILE_NAME, orderId, orderUri, false);
+                    ResponseEntity<com.otilm.api.model.core.acme.Order> r = acmeService
+                            .getOrder(ACME_PROFILE_NAME, orderId, orderUri, false);
                     return r.getBody() != null && r.getBody().getStatus() == expected;
                 });
     }
@@ -504,8 +515,8 @@ public class AcmeProtocolFlowITest extends BaseSpringBootTest {
      * Delegates to {@link AcmeTestUtil#createJwsRequest} with the shared key pair and nonce repository.
      */
     private String createJws(Object payload, String url, String accountId) throws Exception {
-        return AcmeTestUtil.createJwsRequest(
-                objectMapper, acmeKeyPair, acmeNonceRepository,
-                payload, url, accountId, ACME_PROFILE_NAME);
+        return AcmeTestUtil
+                .createJwsRequest(objectMapper, acmeKeyPair, acmeNonceRepository, payload, url, accountId,
+                        ACME_PROFILE_NAME);
     }
 }

--- a/src/test/java/com/otilm/core/service/acme/AcmeChallengeStateMachineTest.java
+++ b/src/test/java/com/otilm/core/service/acme/AcmeChallengeStateMachineTest.java
@@ -1,0 +1,349 @@
+package com.otilm.core.service.acme;
+
+import com.otilm.api.model.core.acme.AuthorizationStatus;
+import com.otilm.api.model.core.acme.ChallengeStatus;
+import com.otilm.api.model.core.acme.ChallengeType;
+import com.otilm.api.model.core.acme.OrderStatus;
+import com.otilm.api.model.core.acme.Problem;
+import com.otilm.core.dao.entity.acme.AcmeAuthorization;
+import com.otilm.core.dao.entity.acme.AcmeChallenge;
+import com.otilm.core.dao.entity.acme.AcmeOrder;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class AcmeChallengeStateMachineTest {
+
+    private static final String FAILURE_DETAIL = "No TXT record found at _acme-challenge.example.org";
+
+    @Test
+    void successfulValidationMarksTheChallengeAuthorizationAndOrder() {
+        AcmeChallenge challenge = pendingChallenge();
+
+        AcmeChallengeStateMachine.applyValidationResult(challenge, ChallengeValidationResult.success());
+
+        Assertions.assertEquals(ChallengeStatus.VALID, challenge.getStatus());
+        Assertions.assertNotNull(challenge.getValidated());
+        Assertions.assertEquals(AuthorizationStatus.VALID, challenge.getAuthorization().getStatus());
+        Assertions.assertEquals(OrderStatus.READY, challenge.getAuthorization().getOrder().getStatus());
+    }
+
+    @Test
+    void successfulValidationRecordsNoError() {
+        AcmeChallenge challenge = pendingChallenge();
+
+        AcmeChallengeStateMachine.applyValidationResult(challenge, ChallengeValidationResult.success());
+
+        Assertions.assertNull(challenge.getErrorProblem());
+        Assertions.assertNull(challenge.getErrorDetail());
+    }
+
+    /**
+     * A failed challenge invalidates its authorization and order (RFC 8555 section 7.1.6). Without this the client
+     * polls a permanently pending authorization until its own request deadline expires.
+     */
+    @Test
+    void failedValidationInvalidatesTheAuthorizationAndOrder() {
+        AcmeChallenge challenge = pendingChallenge();
+
+        AcmeChallengeStateMachine.applyValidationResult(challenge, dnsFailure());
+
+        Assertions.assertEquals(ChallengeStatus.INVALID, challenge.getStatus());
+        Assertions.assertNull(challenge.getValidated());
+        Assertions.assertEquals(AuthorizationStatus.INVALID, challenge.getAuthorization().getStatus());
+        Assertions.assertEquals(OrderStatus.INVALID, challenge.getAuthorization().getOrder().getStatus());
+    }
+
+    @Test
+    void failedValidationRecordsTheReasonOnTheChallenge() {
+        AcmeChallenge challenge = pendingChallenge();
+
+        AcmeChallengeStateMachine.applyValidationResult(challenge, dnsFailure());
+
+        Assertions.assertEquals(Problem.DNS, challenge.getErrorProblem());
+        Assertions.assertEquals(FAILURE_DETAIL, challenge.getErrorDetail());
+    }
+
+    /**
+     * An order invalidated through one of its authorizations is final. A multi-identifier order has an authorization
+     * per identifier, and one of them validating later may not move the order back to ready.
+     */
+    @Test
+    void successfulValidationDoesNotReviveAnInvalidatedOrder() {
+        AcmeChallenge challenge = pendingChallenge();
+        challenge.getAuthorization().getOrder().setStatus(OrderStatus.INVALID);
+
+        AcmeChallengeStateMachine.applyValidationResult(challenge, ChallengeValidationResult.success());
+
+        Assertions.assertEquals(ChallengeStatus.VALID, challenge.getStatus());
+        Assertions.assertEquals(AuthorizationStatus.VALID, challenge.getAuthorization().getStatus());
+        Assertions.assertEquals(OrderStatus.INVALID, challenge.getAuthorization().getOrder().getStatus());
+    }
+
+    /**
+     * A certificate that has already been requested or issued exists regardless of a later challenge failure on the
+     * order, so the order keeps its status.
+     */
+    @Test
+    void failedValidationLeavesAnOrderWithARequestedCertificateAlone() {
+        AcmeChallenge challenge = pendingChallenge();
+        challenge.getAuthorization().getOrder().setStatus(OrderStatus.PROCESSING);
+
+        AcmeChallengeStateMachine.applyValidationResult(challenge, dnsFailure());
+
+        Assertions.assertEquals(AuthorizationStatus.INVALID, challenge.getAuthorization().getStatus());
+        Assertions.assertEquals(OrderStatus.PROCESSING, challenge.getAuthorization().getOrder().getStatus());
+    }
+
+    /**
+     * An authorization left pending behind a failed challenge, by an instance that did not yet propagate the failure,
+     * is settled the way the failure would have been recorded.
+     */
+    @Test
+    void settlesAPendingAuthorizationBehindAFailedChallenge() {
+        AcmeChallenge failed = pendingChallenge();
+        failed.setStatus(ChallengeStatus.INVALID);
+        AcmeAuthorization authorization = failed.getAuthorization();
+        authorization.setChallenges(Set.of(failed, siblingChallenge(authorization)));
+        authorization.getOrder().setStatus(OrderStatus.READY);
+
+        Assertions
+                .assertEquals(List.of(authorization), AcmeChallengeStateMachine.settleOrder(authorization.getOrder()));
+
+        Assertions.assertEquals(AuthorizationStatus.INVALID, authorization.getStatus());
+        Assertions.assertEquals(OrderStatus.INVALID, authorization.getOrder().getStatus());
+    }
+
+    @Test
+    void leavesAPendingAuthorizationWithOnlyPendingChallengesAlone() {
+        AcmeChallenge pending = pendingChallenge();
+        AcmeAuthorization authorization = pending.getAuthorization();
+        authorization.setChallenges(Set.of(pending));
+
+        Assertions.assertTrue(AcmeChallengeStateMachine.settleOrder(authorization.getOrder()).isEmpty());
+
+        Assertions.assertEquals(AuthorizationStatus.PENDING, authorization.getStatus());
+        Assertions.assertEquals(OrderStatus.PENDING, authorization.getOrder().getStatus());
+    }
+
+    /**
+     * An authorization that became valid through its other challenge type after one failed has settled, and stays
+     * valid.
+     */
+    @Test
+    void leavesASettledAuthorizationAlone() {
+        AcmeChallenge failed = pendingChallenge();
+        failed.setStatus(ChallengeStatus.INVALID);
+        AcmeAuthorization authorization = failed.getAuthorization();
+        authorization.setStatus(AuthorizationStatus.VALID);
+        authorization.setChallenges(Set.of(failed));
+        authorization.getOrder().setStatus(OrderStatus.VALID);
+
+        Assertions.assertTrue(AcmeChallengeStateMachine.settleOrder(authorization.getOrder()).isEmpty());
+
+        Assertions.assertEquals(AuthorizationStatus.VALID, authorization.getStatus());
+        Assertions.assertEquals(OrderStatus.VALID, authorization.getOrder().getStatus());
+    }
+
+    @Test
+    void settlesAnOrderLeftReadyBehindAFailedAuthorization() {
+        AcmeOrder order = orderWithAuthorizations(OrderStatus.READY, AuthorizationStatus.INVALID,
+                AuthorizationStatus.VALID);
+
+        Assertions.assertTrue(AcmeChallengeStateMachine.settleOrder(order).isEmpty());
+
+        Assertions.assertEquals(OrderStatus.INVALID, order.getStatus());
+    }
+
+    /**
+     * The shape an instance without failure propagation leaves behind is a failed challenge under an authorization that
+     * is still pending. Settling the order settles that authorization first, so an order asked for directly is not
+     * reported open, nor finalized, behind a failed challenge.
+     */
+    @Test
+    void settlesAnOrderWhoseAuthorizationIsStillPendingBehindAFailedChallenge() {
+        AcmeChallenge failed = pendingChallenge();
+        failed.setStatus(ChallengeStatus.INVALID);
+        AcmeAuthorization authorization = failed.getAuthorization();
+        authorization.setChallenges(Set.of(failed));
+        AcmeOrder order = authorization.getOrder();
+        order.setStatus(OrderStatus.READY);
+        order.setAuthorizations(Set.of(authorization));
+
+        Assertions.assertEquals(List.of(authorization), AcmeChallengeStateMachine.settleOrder(order));
+
+        Assertions.assertEquals(AuthorizationStatus.INVALID, authorization.getStatus());
+        Assertions.assertEquals(OrderStatus.INVALID, order.getStatus());
+    }
+
+    @Test
+    void leavesAnOrderWithoutAFailedAuthorizationAlone() {
+        AcmeOrder order = orderWithAuthorizations(OrderStatus.PENDING, AuthorizationStatus.PENDING,
+                AuthorizationStatus.VALID);
+
+        Assertions.assertTrue(AcmeChallengeStateMachine.settleOrder(order).isEmpty());
+
+        Assertions.assertEquals(OrderStatus.PENDING, order.getStatus());
+    }
+
+    @Test
+    void leavesAnOrderWithARequestedCertificateAlone() {
+        AcmeOrder order = orderWithAuthorizations(OrderStatus.PROCESSING, AuthorizationStatus.INVALID);
+
+        Assertions.assertTrue(AcmeChallengeStateMachine.settleOrder(order).isEmpty());
+
+        Assertions.assertEquals(OrderStatus.PROCESSING, order.getStatus());
+    }
+
+    private static AcmeChallenge siblingChallenge(AcmeAuthorization authorization) {
+        AcmeChallenge sibling = new AcmeChallenge();
+        sibling.setType(ChallengeType.HTTP01);
+        sibling.setStatus(ChallengeStatus.PENDING);
+        sibling.setAuthorization(authorization);
+        return sibling;
+    }
+
+    private static AcmeOrder orderWithAuthorizations(OrderStatus orderStatus, AuthorizationStatus... statuses) {
+        AcmeOrder order = new AcmeOrder();
+        order.setStatus(orderStatus);
+        Set<AcmeAuthorization> authorizations = new HashSet<>();
+        for (AuthorizationStatus status : statuses) {
+            AcmeAuthorization authorization = new AcmeAuthorization();
+            authorization.setStatus(status);
+            authorization.setOrder(order);
+            authorizations.add(authorization);
+        }
+        order.setAuthorizations(authorizations);
+        return order;
+    }
+
+    /**
+     * A multi-identifier order has an authorization per identifier and may be finalized only once all of them are
+     * proven, so validating one of them leaves the order pending while another is still open.
+     */
+    @Test
+    void successfulValidationLeavesTheOrderPendingWhileASiblingAuthorizationIsStillOpen() {
+        AcmeChallenge challenge = pendingChallenge();
+        AcmeOrder order = challenge.getAuthorization().getOrder();
+        order.getAuthorizations().add(siblingAuthorization(order, AuthorizationStatus.PENDING));
+
+        AcmeChallengeStateMachine.applyValidationResult(challenge, ChallengeValidationResult.success());
+
+        Assertions.assertEquals(AuthorizationStatus.VALID, challenge.getAuthorization().getStatus());
+        Assertions.assertEquals(OrderStatus.PENDING, order.getStatus());
+    }
+
+    @Test
+    void successfulValidationOfTheLastOpenAuthorizationMakesTheOrderReady() {
+        AcmeChallenge challenge = pendingChallenge();
+        AcmeOrder order = challenge.getAuthorization().getOrder();
+        order.getAuthorizations().add(siblingAuthorization(order, AuthorizationStatus.VALID));
+
+        AcmeChallengeStateMachine.applyValidationResult(challenge, ChallengeValidationResult.success());
+
+        Assertions.assertEquals(OrderStatus.READY, order.getStatus());
+    }
+
+    @Test
+    void reportsAStaleStatusOnlyForTheShapesAnOldInstanceLeavesBehind() {
+        AcmeChallenge failed = pendingChallenge();
+        failed.setStatus(ChallengeStatus.INVALID);
+        failed.getAuthorization().setChallenges(Set.of(failed));
+        Assertions.assertTrue(AcmeChallengeStateMachine.hasStaleStatus(failed.getAuthorization().getOrder()));
+
+        AcmeOrder openBehindFailure = orderWithAuthorizations(OrderStatus.READY, AuthorizationStatus.INVALID);
+        Assertions.assertTrue(AcmeChallengeStateMachine.hasStaleStatus(openBehindFailure));
+
+        AcmeOrder consistent = orderWithAuthorizations(OrderStatus.PENDING, AuthorizationStatus.PENDING);
+        Assertions.assertFalse(AcmeChallengeStateMachine.hasStaleStatus(consistent));
+
+        AcmeOrder issued = orderWithAuthorizations(OrderStatus.VALID, AuthorizationStatus.INVALID);
+        Assertions.assertFalse(AcmeChallengeStateMachine.hasStaleStatus(issued));
+    }
+
+    /**
+     * A deactivated authorization can never become valid, so the order behind it cannot complete either.
+     */
+    @Test
+    void deactivatingAnAuthorizationInvalidatesAnOpenOrder() {
+        AcmeChallenge challenge = pendingChallenge();
+        AcmeOrder order = challenge.getAuthorization().getOrder();
+        order.setStatus(OrderStatus.READY);
+
+        AcmeChallengeStateMachine.deactivate(challenge.getAuthorization());
+
+        Assertions.assertEquals(AuthorizationStatus.DEACTIVATED, challenge.getAuthorization().getStatus());
+        Assertions.assertEquals(OrderStatus.INVALID, order.getStatus());
+    }
+
+    @Test
+    void deactivatingAnAuthorizationLeavesAnOrderWithARequestedCertificateAlone() {
+        AcmeChallenge challenge = pendingChallenge();
+        challenge.getAuthorization().getOrder().setStatus(OrderStatus.PROCESSING);
+
+        AcmeChallengeStateMachine.deactivate(challenge.getAuthorization());
+
+        Assertions.assertEquals(OrderStatus.PROCESSING, challenge.getAuthorization().getOrder().getStatus());
+    }
+
+    @Test
+    void settlesAnOrderLeftOpenBehindADeactivatedAuthorization() {
+        AcmeOrder order = orderWithAuthorizations(OrderStatus.PENDING, AuthorizationStatus.DEACTIVATED);
+
+        Assertions.assertTrue(AcmeChallengeStateMachine.hasStaleStatus(order));
+        AcmeChallengeStateMachine.settleOrder(order);
+
+        Assertions.assertEquals(OrderStatus.INVALID, order.getStatus());
+    }
+
+    /**
+     * An order finalized before failures were propagated can still read ready although its certificate exists; neither
+     * settlement nor a late failure may invalidate it.
+     */
+    @Test
+    void leavesAnOrderWithAnIssuedCertificateAloneWhateverItsStoredStatusSays() {
+        AcmeOrder settled = orderWithAuthorizations(OrderStatus.READY, AuthorizationStatus.INVALID);
+        settled.setCertificateReferenceUuid(UUID.randomUUID());
+
+        Assertions.assertFalse(AcmeChallengeStateMachine.hasStaleStatus(settled));
+        AcmeChallengeStateMachine.settleOrder(settled);
+        Assertions.assertEquals(OrderStatus.READY, settled.getStatus());
+
+        AcmeChallenge challenge = pendingChallenge();
+        challenge.getAuthorization().getOrder().setStatus(OrderStatus.READY);
+        challenge.getAuthorization().getOrder().setCertificateReferenceUuid(UUID.randomUUID());
+        AcmeChallengeStateMachine.applyValidationResult(challenge, dnsFailure());
+        Assertions.assertEquals(OrderStatus.READY, challenge.getAuthorization().getOrder().getStatus());
+    }
+
+    private static AcmeAuthorization siblingAuthorization(AcmeOrder order, AuthorizationStatus status) {
+        AcmeAuthorization sibling = new AcmeAuthorization();
+        sibling.setStatus(status);
+        sibling.setOrder(order);
+        return sibling;
+    }
+
+    private static ChallengeValidationResult dnsFailure() {
+        return ChallengeValidationResult.failure(Problem.DNS, FAILURE_DETAIL);
+    }
+
+    private static AcmeChallenge pendingChallenge() {
+        AcmeOrder order = new AcmeOrder();
+        order.setStatus(OrderStatus.PENDING);
+
+        AcmeAuthorization authorization = new AcmeAuthorization();
+        authorization.setStatus(AuthorizationStatus.PENDING);
+        authorization.setOrder(order);
+        order.setAuthorizations(new HashSet<>(Set.of(authorization)));
+
+        AcmeChallenge challenge = new AcmeChallenge();
+        challenge.setType(ChallengeType.DNS01);
+        challenge.setStatus(ChallengeStatus.PENDING);
+        challenge.setAuthorization(authorization);
+        return challenge;
+    }
+
+}

--- a/src/test/java/com/otilm/core/service/acme/AcmeDnsChallengeValidatorTest.java
+++ b/src/test/java/com/otilm/core/service/acme/AcmeDnsChallengeValidatorTest.java
@@ -1,0 +1,174 @@
+package com.otilm.core.service.acme;
+
+import com.otilm.api.model.core.acme.Problem;
+import java.util.List;
+import java.util.Properties;
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.BasicAttribute;
+import javax.naming.directory.BasicAttributes;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class AcmeDnsChallengeValidatorTest {
+
+    private static final String IDENTIFIER = "nrf01.thp.nrf.5gc.mnc001.mcc230.example.org";
+    private static final String RECORD_NAME = AcmeConstants.DNS_ACME_PREFIX + IDENTIFIER;
+    private static final String EXPECTED_KEY_AUTHORIZATION = "pB0hVv6ackTHYaUi0Cap0dd9ORg47zEKsOtAEXcgmQQ";
+    private static final String STALE_KEY_AUTHORIZATION = "f5R9M-KeH3NR4Yqq8J2EUN2ZjkjLWAUxC9gnZgR9B_4";
+
+    /**
+     * The DNS provider returns every TXT record of a name as separate values of one {@code TXT} attribute, so a name
+     * carrying several records must still yield every value.
+     */
+    @Test
+    void extractsEveryValueOfAMultiValuedTxtAttribute() throws NamingException {
+        List<String> values = AcmeDnsChallengeValidator
+                .extractTxtValues(txtAttributes(STALE_KEY_AUTHORIZATION, EXPECTED_KEY_AUTHORIZATION));
+
+        Assertions.assertEquals(List.of(STALE_KEY_AUTHORIZATION, EXPECTED_KEY_AUTHORIZATION), values);
+    }
+
+    @Test
+    void extractsNoValuesWhenTheNameHasNoTxtRecord() throws NamingException {
+        Assertions.assertEquals(List.of(), AcmeDnsChallengeValidator.extractTxtValues(new BasicAttributes(true)));
+    }
+
+    @Test
+    void acceptsTheExpectedRecordPublishedAlongsideStaleRecords() throws NamingException {
+        List<String> values = AcmeDnsChallengeValidator
+                .extractTxtValues(txtAttributes(STALE_KEY_AUTHORIZATION, EXPECTED_KEY_AUTHORIZATION));
+
+        ChallengeValidationResult result = AcmeDnsChallengeValidator
+                .evaluate(RECORD_NAME, values, EXPECTED_KEY_AUTHORIZATION);
+
+        Assertions.assertTrue(result.valid());
+        Assertions.assertNull(result.problem());
+        Assertions.assertNull(result.detail());
+    }
+
+    /**
+     * A record published as several character-strings arrives with the strings separated by a space, and its value is
+     * their concatenation.
+     */
+    @Test
+    void acceptsAKeyAuthorizationPublishedAsSeveralCharacterStrings() {
+        String splitAcrossStrings = EXPECTED_KEY_AUTHORIZATION.substring(0, 20) + " "
+                + EXPECTED_KEY_AUTHORIZATION.substring(20);
+
+        ChallengeValidationResult result = AcmeDnsChallengeValidator
+                .evaluate(RECORD_NAME, List.of(splitAcrossStrings), EXPECTED_KEY_AUTHORIZATION);
+
+        Assertions.assertTrue(result.valid());
+    }
+
+    @Test
+    void rejectsAnUnrelatedRecordThatContainsSpaces() {
+        ChallengeValidationResult result = AcmeDnsChallengeValidator
+                .evaluate(RECORD_NAME, List.of("v=spf1 include:_spf.example.com ~all"), EXPECTED_KEY_AUTHORIZATION);
+
+        Assertions.assertFalse(result.valid());
+        Assertions.assertEquals(Problem.INCORRECT_RESPONSE, result.problem());
+    }
+
+    @Test
+    void reportsDnsProblemWhenNoRecordIsPublished() {
+        ChallengeValidationResult result = AcmeDnsChallengeValidator
+                .evaluate(RECORD_NAME, List.of(), EXPECTED_KEY_AUTHORIZATION);
+
+        Assertions.assertFalse(result.valid());
+        Assertions.assertEquals(Problem.DNS, result.problem());
+        Assertions.assertTrue(result.detail().contains(RECORD_NAME));
+    }
+
+    @Test
+    void reportsIncorrectResponseWhenPublishedRecordsDoNotMatch() {
+        ChallengeValidationResult result = AcmeDnsChallengeValidator
+                .evaluate(RECORD_NAME, List.of(STALE_KEY_AUTHORIZATION), EXPECTED_KEY_AUTHORIZATION);
+
+        Assertions.assertFalse(result.valid());
+        Assertions.assertEquals(Problem.INCORRECT_RESPONSE, result.problem());
+        Assertions.assertTrue(result.detail().contains(RECORD_NAME));
+    }
+
+    /**
+     * The published records may hold verification tokens owned by third parties, so they must never reach the client
+     * through the challenge error.
+     */
+    @Test
+    void keepsPublishedRecordValuesOutOfTheReportedDetail() {
+        ChallengeValidationResult result = AcmeDnsChallengeValidator
+                .evaluate(RECORD_NAME, List.of(STALE_KEY_AUTHORIZATION), EXPECTED_KEY_AUTHORIZATION);
+
+        Assertions.assertFalse(result.detail().contains(STALE_KEY_AUTHORIZATION));
+        Assertions.assertFalse(result.detail().contains(EXPECTED_KEY_AUTHORIZATION));
+    }
+
+    @Test
+    void prefixesTheIdentifierWithTheChallengeLabel() {
+        Assertions.assertEquals(RECORD_NAME, AcmeDnsChallengeValidator.challengeRecordName(IDENTIFIER));
+    }
+
+    /**
+     * A wildcard identifier is validated at the challenge label of its base domain (RFC 8555 section 8.4).
+     */
+    @Test
+    void resolvesAWildcardIdentifierAgainstItsBaseDomain() {
+        Assertions
+                .assertEquals(AcmeConstants.DNS_ACME_PREFIX + "example.org",
+                        AcmeDnsChallengeValidator.challengeRecordName("*.example.org"));
+    }
+
+    @Test
+    void usesTheSystemResolverWhenTheProfileDeclaresNone() {
+        Assertions
+                .assertEquals(AcmeConstants.DNS_ENV_PREFIX,
+                        AcmeDnsChallengeValidator.resolverEnv(null, null).getProperty(Context.PROVIDER_URL));
+        Assertions
+                .assertEquals(AcmeConstants.DNS_ENV_PREFIX,
+                        AcmeDnsChallengeValidator.resolverEnv("", "5353").getProperty(Context.PROVIDER_URL));
+    }
+
+    @Test
+    void usesTheResolverDeclaredByTheProfile() {
+        Assertions
+                .assertEquals("dns://10.0.0.53:5353",
+                        AcmeDnsChallengeValidator.resolverEnv("10.0.0.53", "5353").getProperty(Context.PROVIDER_URL));
+    }
+
+    @Test
+    void fallsBackToTheDefaultPortWhenTheProfileDeclaresNone() {
+        Assertions
+                .assertEquals("dns://10.0.0.53:" + AcmeConstants.DEFAULT_DNS_PORT,
+                        AcmeDnsChallengeValidator.resolverEnv("10.0.0.53", null).getProperty(Context.PROVIDER_URL));
+    }
+
+    @Test
+    void reportsDnsProblemWhenTheResolverCannotBeReached() {
+        ChallengeValidationResult result = AcmeDnsChallengeValidator
+                .validate(RECORD_NAME, EXPECTED_KEY_AUTHORIZATION, unreachableResolverEnv());
+
+        Assertions.assertFalse(result.valid());
+        Assertions.assertEquals(Problem.DNS, result.problem());
+        Assertions.assertTrue(result.detail().contains(RECORD_NAME));
+    }
+
+    private static Attributes txtAttributes(String... values) {
+        BasicAttribute txtRecords = new BasicAttribute(AcmeConstants.DNS_RECORD_TYPE);
+        for (String value : values) {
+            txtRecords.add(value);
+        }
+        Attributes attributes = new BasicAttributes(true);
+        attributes.put(txtRecords);
+        return attributes;
+    }
+
+    private static Properties unreachableResolverEnv() {
+        Properties env = AcmeDnsChallengeValidator.resolverEnv("127.0.0.1", "1");
+        env.setProperty("com.sun.jndi.dns.timeout.initial", "1");
+        env.setProperty("com.sun.jndi.dns.timeout.retries", "0");
+        return env;
+    }
+
+}


### PR DESCRIPTION
## TLDR

Backport of #2201 to the 2.19 line. Both migrations come along, byte-identical to main, so Flyway
records the same checksum and skips them on a later upgrade to 2.20.0. The fix itself cherry-picks
with no conflicts once the ACME sources carry main's formatting, which the first commit does on its
own. 156 tests green locally: 37 new unit tests, 69 ACME integration tests, 50 architecture tests.

## Why this is two commits

The 2.19 line predates the repository-wide Spotless and Checkstyle pass, and that pass is the *only*
commit that touched these ACME sources between `2.19.1` and #2201's merge base — there is no
behavioural drift in the ACME area at all. The first commit therefore takes main's formatting of
exactly the eight files the fix touches, and nothing else. The second is #2201 cherry-picked, and its
diff is byte-identical to the one that merged on main. Reviewing the second commit alone is reviewing
the change.

## Both migrations are included, unchanged

`V202609021000__acme_challenge_validation_error.sql` is not optional. `AcmeChallenge` maps
`error_problem` and `error_detail`, so the columns have to exist for a failed challenge to report why
it failed — which is half of what the bug was about.

`V202609021100__settle_authorizations_behind_failed_challenges.sql` repairs the rows this bug already
left behind, and a 2.19 deployment is exactly the population that has them. The service also settles
such rows lazily when a client asks, so the migration is the eager half of behaviour the code carries
anyway; without it, a stale authorization is only settled if someone happens to poll it and the
account's failed-order count stays wrong until then.

Neither file is renamed or edited for this branch — same version, same filename, same bytes. That is
what keeps the Flyway checksum identical across the release lines:

| Upgrade path | What Flyway does |
| --- | --- |
| `2.19.1` → `2.19.2` | Applies both migrations once. |
| `2.19.2` → `2.20.0` | Same version and checksum already recorded, so both are skipped. |
| `2.19.0`/`2.19.1` → `2.20.0` | Applies both once, having never seen the hotfix. |

The 2.19 line already sets `flyway.out-of-order: true`, which it needs here: these migrations carry a
September version, so a `2.19.2` database later moving to `2.20.0` receives `2.20.0`'s August-dated
migrations out of order.

Should either migration ever need a correction after this ships, the correction has to be a new
migration rather than an edit to an applied one.

## How the migrations were verified

The test suite never runs them — the test profile sets `flyway.enabled: false` and builds the schema
from the entities with `ddl-auto: create-drop`. A full Flyway run from an empty database is not
reproducible locally either, because `V202209211100__Access_Control` calls the auth service over
HTTP.

So both migrations were run against the ACME schema as `2.19.1` actually leaves it, composed from the
three migrations that shape those tables (`V202201311030__acme.sql`, the uuid-PK conversion in
`V202208161211__unique_identifiers.sql`, and `V202509091426__acme_orders.sql`), on PostgreSQL 17.
Every column the migrations touch is present in `2.19.1`, and no ACME schema migration landed between
`2.19.1` and this change. Seeded with the cases that matter:

| Row | Before | After | Correct |
| --- | --- | --- | --- |
| authorization `PENDING` behind an `INVALID` challenge | `PENDING` | `INVALID` | yes |
| authorization `PENDING` behind a `VALID` challenge | `PENDING` | `PENDING` | yes |
| authorization already `INVALID` | `INVALID` | untouched, `i_upd` not bumped | yes |
| authorization `VALID` | `VALID` | `VALID` | yes |
| order `PENDING` behind a settled authorization | `PENDING` | `INVALID`, counted | yes |
| order `READY` behind a settled authorization | `READY` | `INVALID`, counted | yes |
| order `PENDING` **with a certificate** | `PENDING` | `PENDING`, not counted | yes |
| order `VALID` behind an `INVALID` authorization | `VALID` | `VALID`, not counted | yes |
| order already `INVALID` | `INVALID` | not counted a second time | yes |
| order with one `VALID` and one failed authorization | `PENDING` | `INVALID`, counted | yes |
| `failed_orders` | 0 and 5 | 3 and 6 | yes |

The `AND o.certificate_ref IS NULL` guard from the review of #2201 is in the file, so a
certificate-backed order keeps its status.

## What is deliberately not here

The pom still reads `2.19.1`. The version bump belongs to the release commit on `hotfix/2.19.2`, the
way `2.19.1` was cut.

`interfaces` stays at `2.19.0`. It already carries `Challenge.error`, `ProblemDocument(Problem)` and
`setDetail`, and the module compiles and tests green against it, so there is nothing to backport
there.
