### PR TITLE
Update embedded Tomcat to 10.1.59 to fix reported CVEs in 10.1.55

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,10 +24,10 @@
         <testcontainers.version>1.21.4</testcontainers.version>
         <git-commit-id-maven.version>9.0.2</git-commit-id-maven.version>
         <java.version>21</java.version>
-        <!-- Temporary override for CVE-2026-41293 and CVE-2026-43512.
-          Remove after the parent com.otilm:dependencies upgrades to a Spring Boot release that ships Tomcat 10.1.55+
-          (expected with Spring Boot 3.5.15). Then delete this override. -->
-        <tomcat.version>10.1.55</tomcat.version>
+        <!-- CVE-2026-65182, CVE-2026-65905, CVE-2026-68525 (auth/constraint bypasses in embedded Tomcat).
+          The announced fix version 10.1.58 was never published; 10.1.59 is its released successor.
+          Remove when the parent BOM manages at least this version. -->
+        <tomcat.version>10.1.59</tomcat.version>
 
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>ilm</sonar.organization>


### PR DESCRIPTION
## TLDR

`test / Build amd64` and `arm64` fail on the 2.19 line because Trivy finds three critical CVEs in
embedded Tomcat 10.1.55. They are the only findings in the image and they sit on the base itself, not
on anything the ACME backport added. Main already fixed this by moving the override to 10.1.59; this
brings the same change across. Verified locally: the override resolves, and the tests that start a
real servlet container pass.

## What fails

Trivy's verdict on the image is `Total: 3 (HIGH: 0, CRITICAL: 3)`, every one of them in
`org.apache.tomcat.embed:tomcat-embed-core (app.jar)` at 10.1.55:

| CVE | Severity | What it is |
| --- | --- | --- |
| CVE-2026-65182 | CRITICAL | Security constraint bypass |
| CVE-2026-65905 | CRITICAL | Authentication bypass via limited requests |
| CVE-2026-68525 | CRITICAL | Unauthorized access |

Nothing else is reported — no other Java dependency, no OS package, no secret. The gate uses the
org-default Trivy policy from `OmniTrustILM/.github`, which this repo is not permitted to override,
so the only way to clear it is to stop shipping the vulnerable Tomcat.

This is a pre-existing condition of the base, not a regression. `2.19.1` was cut on 2026-08-20 with an
override at 10.1.55 for an earlier pair of CVEs; these three were disclosed afterwards. The container
workflow calls the reusable `OmniTrustILM/.github/.github/workflows/containers-test.yml@main`, so the
August pom is graded by today's policy and the base fails on its own.

## Why 10.1.59 and not the version Trivy names

Trivy reports the fixed version as `11.0.25, 10.1.58, 9.0.121`. **10.1.58 was never published** —
`repo.maven.apache.org` returns 404 for it, and the published 10.1.x sequence runs 10.1.55, 10.1.56,
10.1.57, 10.1.59. 10.1.59 is its released successor and is what main carries, so the override moves
there and the comment is aligned with main's.

## Verified

- The override takes effect: `tomcat-embed-core`, `-el` and `-websocket` all resolve to 10.1.59, on
  Spring Boot 3.5.16.
- Nothing in `src/main` or `src/test` references an `org.apache.tomcat`, `catalina` or `coyote` API,
  so this is a patch-level move inside 10.1.x with no source surface.
- Main and test sources compile, and the two tests that boot a real servlet container rather than a
  mock one — `ContextSignatureTest` and `OAuth2LoginControllerITest` — pass, 19 tests in total.

The remaining CI is the authority on the rest of the suite and on the container gate itself.

## Scope

The Tomcat override is the only security-motivated difference in the version properties between this
line and main. The one other delta is `querydsl.version` 5.1.0, which the 2.19 pom pins and main has
dropped to the parent BOM; that is not a vulnerability and is left alone.

Once this merges, #2237 needs `hotfix/2.19.2` merged into it to pick the bump up and clear its own
container gate.
