### PR TITLE
Offer as columns only the fields a listing carries

### DIFF
--- a/src/main/java/com/otilm/core/service/impl/ListViewServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/ListViewServiceImpl.java
@@ -208,16 +208,22 @@ public class ListViewServiceImpl implements ListViewExternalService, ListViewInt
                 .setColumns(view
                         .getColumns()
                         .stream()
-                        .filter(column -> catalogue.offers(CatalogueField.of(column)))
+                        .filter(column -> catalogue.canDisplay(CatalogueField.of(column)))
                         .toList());
         dto.setFilters(view.getFilters());
-        dto.setSort(view.getSort());
+        // Returning an ordering the listing would now refuse hands the client a view whose every application answers
+        // an error; dropping it opens the view in the listing's own order instead.
+        dto
+                .setSort(view.getSort() != null && catalogue.canSortBy(CatalogueField.of(view.getSort()))
+                        ? view.getSort()
+                        : null);
         return dto;
     }
 
     /**
      * Rejects anything the resource's catalogue cannot apply, so a view is stored only in a shape the listing can
-     * actually use. A field that disappears afterwards is a different case, and is skipped on read instead.
+     * actually use. A field that afterwards disappears, or stops being one the listing can show or order by, is a
+     * different case and is dropped on read instead.
      */
     private void validateRequest(Resource resource, ListViewUpdateRequestDto request) {
         Catalogue catalogue = catalogueOf(resource);
@@ -250,6 +256,17 @@ public class ListViewServiceImpl implements ListViewExternalService, ListViewInt
                         .filter(column -> !catalogue.offers(CatalogueField.of(column)))
                         .map(ListViewColumnDto::getFieldIdentifier)
                         .toList());
+
+        List<String> unshowable = columns
+                .stream()
+                .filter(column -> !catalogue.canDisplay(CatalogueField.of(column)))
+                .map(ListViewColumnDto::getFieldIdentifier)
+                .toList();
+        if (!unshowable.isEmpty()) {
+            throw new ValidationException(ValidationError
+                    .create("Resource %s does not offer these fields as columns: %s."
+                            .formatted(resource.getCode(), String.join(", ", unshowable))));
+        }
     }
 
     /**
@@ -282,8 +299,16 @@ public class ListViewServiceImpl implements ListViewExternalService, ListViewInt
     }
 
     private static void validateSort(Resource resource, SearchSortRequestDto sort, Catalogue catalogue) {
-        if (sort != null && !catalogue.offers(CatalogueField.of(sort))) {
+        if (sort == null) {
+            return;
+        }
+        if (!catalogue.offers(CatalogueField.of(sort))) {
             rejectUnknown(resource, List.of(sort.getFieldIdentifier()));
+        }
+        if (!catalogue.canSortBy(CatalogueField.of(sort))) {
+            throw new ValidationException(ValidationError
+                    .create("Resource %s cannot be ordered by %s."
+                            .formatted(resource.getCode(), sort.getFieldIdentifier())));
         }
     }
 
@@ -295,27 +320,42 @@ public class ListViewServiceImpl implements ListViewExternalService, ListViewInt
     }
 
     /**
-     * Every field the resource's listing can address, with the conditions each of them accepts. Properties come from
-     * the filter-field enum, everything else from the attribute definitions currently registered for the resource.
+     * Every field the resource's listing can address, with what each of them may be used for. Properties come from the
+     * filter-field enum, everything else from the attribute definitions currently registered for the resource.
+     *
+     * <p>
+     * Read from the published catalogue rather than from a copy of its rules, so the flags the client picked a view out
+     * of and the answer it gets back when it saves one cannot disagree.
      */
     private Catalogue catalogueOf(Resource resource) {
-        Map<CatalogueField, List<FilterConditionOperator>> fields = new HashMap<>();
+        Map<CatalogueField, Capabilities> fields = new HashMap<>();
         FilterField
                 .getEnumsForResource(resource)
                 .forEach(field -> fields
                         .put(new CatalogueField(FilterFieldSource.PROPERTY, field.name()),
-                                SearchHelper.availableConditions(field)));
+                                new Capabilities(SearchHelper.availableConditions(field),
+                                        SearchHelper.isDisplayable(field), SearchHelper.isSortableField(field))));
         attributeEngine
                 .getResourceSearchableFields(resource, false)
                 .forEach(group -> group
                         .getSearchFieldData()
                         .forEach(field -> fields
                                 .put(new CatalogueField(group.getFilterFieldSource(), field.getFieldIdentifier()),
-                                        field.getConditions())));
+                                        new Capabilities(field.getConditions(),
+                                                Boolean.TRUE.equals(field.getDisplayable()),
+                                                Boolean.TRUE.equals(field.getSortable())))));
         return new Catalogue(fields);
     }
 
-    private record Catalogue(Map<CatalogueField, List<FilterConditionOperator>> fields) {
+    /**
+     * What one field of a catalogue may be used for. The three are separate capabilities rather than one membership: a
+     * listing filters on values it does not select - a certificate is found by its protocol without the listing
+     * carrying one - and orders only by the values it shows.
+     */
+    private record Capabilities(List<FilterConditionOperator> conditions, boolean displayable, boolean sortable) {
+    }
+
+    private record Catalogue(Map<CatalogueField, Capabilities> fields) {
 
         boolean isEmpty() {
             return fields.isEmpty();
@@ -325,9 +365,20 @@ public class ListViewServiceImpl implements ListViewExternalService, ListViewInt
             return fields.containsKey(field);
         }
 
+        boolean canDisplay(CatalogueField field) {
+            Capabilities capabilities = fields.get(field);
+            return capabilities != null && capabilities.displayable();
+        }
+
+        boolean canSortBy(CatalogueField field) {
+            Capabilities capabilities = fields.get(field);
+            return capabilities != null && capabilities.sortable();
+        }
+
         boolean accepts(CatalogueField field, FilterConditionOperator condition) {
-            List<FilterConditionOperator> conditions = fields.get(field);
-            return conditions != null && conditions.contains(condition);
+            Capabilities capabilities = fields.get(field);
+            return capabilities != null && capabilities.conditions() != null
+                    && capabilities.conditions().contains(condition);
         }
     }
 

--- a/src/main/java/com/otilm/core/service/impl/ListViewServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/ListViewServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -89,7 +90,7 @@ public class ListViewServiceImpl implements ListViewExternalService, ListViewInt
     public ListViewDto createView(ListViewRequestDto request) throws AlreadyExistException {
         UUID userUuid = loggedUserUuid();
         Resource resource = request.getResource();
-        validateRequest(resource, request);
+        validateRequest(resource, request, Set.of());
 
         serializeWritesFor(userUuid, resource);
         if (listViewRepository.existsByUserUuidAndResourceAndName(userUuid, resource, request.getName())) {
@@ -111,7 +112,7 @@ public class ListViewServiceImpl implements ListViewExternalService, ListViewInt
             throws NotFoundException, AlreadyExistException {
         UUID userUuid = loggedUserUuid();
         ListView view = ownView(uuid, userUuid);
-        validateRequest(view.getResource(), request);
+        validateRequest(view.getResource(), request, columnsOf(view));
 
         serializeWritesFor(userUuid, view.getResource());
         if (listViewRepository
@@ -204,11 +205,15 @@ public class ListViewServiceImpl implements ListViewExternalService, ListViewInt
         dto.setName(view.getName());
         dto.setResource(view.getResource());
         dto.setDefaultView(view.isDefaultView());
+        // A column the listing can no longer show is still returned: the client has the same catalogue this is read
+        // from, so it can mark the column unavailable and offer to remove it, and a view whose every column was
+        // withdrawn still reads back in a shape it can be saved in. Only a field that has left the catalogue outright
+        // is dropped, having nothing left to label it with.
         dto
                 .setColumns(view
                         .getColumns()
                         .stream()
-                        .filter(column -> catalogue.canDisplay(CatalogueField.of(column)))
+                        .filter(column -> catalogue.offers(CatalogueField.of(column)))
                         .toList());
         dto.setFilters(view.getFilters());
         // Returning an ordering the listing would now refuse hands the client a view whose every application answers
@@ -222,10 +227,22 @@ public class ListViewServiceImpl implements ListViewExternalService, ListViewInt
 
     /**
      * Rejects anything the resource's catalogue cannot apply, so a view is stored only in a shape the listing can
-     * actually use. A field that afterwards disappears, or stops being one the listing can show or order by, is a
-     * different case and is dropped on read instead.
+     * actually use.
+     *
+     * <p>
+     * {@code carriedAlready} are the columns the stored view holds, which are exempt from the column gate. A field can
+     * stop being one the listing shows after a view stored it, and rejecting it would leave that view unsaveable: the
+     * client reads it back, renames it, and the rename is refused over a column it did not touch. So a withdrawn column
+     * can be kept or removed but not introduced, and a creation - which carries nothing already - is held to the
+     * current catalogue in full.
+     *
+     * <p>
+     * An ordering has no such exemption. It is applied by re-issuing the listing request, which refuses a field that is
+     * not sortable, so keeping one would answer an error on every application rather than show a blank column. Such an
+     * ordering is dropped on read instead.
      */
-    private void validateRequest(Resource resource, ListViewUpdateRequestDto request) {
+    private void validateRequest(Resource resource, ListViewUpdateRequestDto request,
+            Set<CatalogueField> carriedAlready) {
         Catalogue catalogue = catalogueOf(resource);
         if (catalogue.isEmpty()) {
             throw new ValidationException(ValidationError
@@ -233,12 +250,17 @@ public class ListViewServiceImpl implements ListViewExternalService, ListViewInt
                             .formatted(resource.getCode())));
         }
 
-        validateColumns(resource, request.getColumns(), catalogue);
+        validateColumns(resource, request.getColumns(), catalogue, carriedAlready);
         validateFilters(resource, request.getFilters(), catalogue);
         validateSort(resource, request.getSort(), catalogue);
     }
 
-    private static void validateColumns(Resource resource, List<ListViewColumnDto> columns, Catalogue catalogue) {
+    private static Set<CatalogueField> columnsOf(ListView view) {
+        return view.getColumns().stream().map(CatalogueField::of).collect(Collectors.toUnmodifiableSet());
+    }
+
+    private static void validateColumns(Resource resource, List<ListViewColumnDto> columns, Catalogue catalogue,
+            Set<CatalogueField> carriedAlready) {
         Set<CatalogueField> seen = new LinkedHashSet<>();
         List<String> duplicated = columns
                 .stream()
@@ -259,6 +281,7 @@ public class ListViewServiceImpl implements ListViewExternalService, ListViewInt
 
         List<String> unshowable = columns
                 .stream()
+                .filter(column -> !carriedAlready.contains(CatalogueField.of(column)))
                 .filter(column -> !catalogue.canDisplay(CatalogueField.of(column)))
                 .map(ListViewColumnDto::getFieldIdentifier)
                 .toList();

--- a/src/main/java/com/otilm/core/util/SearchHelper.java
+++ b/src/main/java/com/otilm/core/util/SearchHelper.java
@@ -19,6 +19,7 @@ import jakarta.persistence.metamodel.Attribute;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -32,21 +33,63 @@ public class SearchHelper {
     private static final String SEARCH_LABEL_TEMPLATE = "%s (%s)";
 
     /**
-     * Fields that share one attribute with another field of the same resource, and so display something drawn out of it
-     * rather than the attribute itself. Derived rather than listed, so a field added later is classified without an
-     * edit here: the certificate validation-check fields are the case that exists today, each reading one serialized
-     * validation result.
+     * The {@link FilterField} sets the flags are decided against.
      *
      * <p>
-     * Held in a nested class so it is computed on first use rather than when {@link SearchHelper} loads. Reading it
+     * Held in a nested class so they are computed on first use rather than when {@link SearchHelper} loads. Reading one
      * initializes {@link FilterField}, whose entries reference the JPA static metamodel, so a caller without a
      * persistence context would otherwise fail on this class rather than on the field it asked about.
      */
-    private static final class SharedAttributeFields {
+    private static final class FilterFieldSets {
 
-        private static final Set<FilterField> VALUES = fieldsSharingAnAttribute();
+        /**
+         * Fields that share one attribute with another field of the same resource, and so display something drawn out
+         * of it rather than the attribute itself. Derived rather than listed, so a field added later is classified
+         * without an edit here: the certificate validation-check fields are the case that exists today, each reading
+         * one serialized validation result.
+         */
+        private static final Set<FilterField> SHARING_AN_ATTRIBUTE = fieldsSharingAnAttribute();
 
-        private SharedAttributeFields() {
+        /**
+         * Fields of a configurable-column listing whose value that listing does not carry. Offering one as a column
+         * publishes a heading whose every cell is empty, whatever the request asks for.
+         *
+         * <p>
+         * Listed rather than derived. Neither of the two rules that look like they would decide this holds: every field
+         * of these listings has a non-null attribute, so having one excludes nothing, and reaching a value through a
+         * join predicts nothing either - {@code CERTIFICATE_PROTOCOL} is joined and absent from the listing while
+         * {@code RA_PROFILE_NAME} and {@code GROUP_NAME} are joined and present. What decides it is whether the query
+         * the listing runs selects the value, which only reading that query answers.
+         *
+         * <p>
+         * A field is listed here when the listing DTO has no property for it, or has one the list mapper leaves unset.
+         * A field the DTO does carry stays displayable even where no frontend renderer draws it yet: that is a column
+         * waiting for its cell, not a column that can never have one.
+         */
+        private static final Set<FilterField> ABSENT_FROM_LISTING = EnumSet
+                .of(
+                        // Certificates. The listing builds each CertificateDto from the constructor projection in
+                        // CertificateRepository.findCertificateDtosByUuidsIn, filling groups from a second query;
+                        // CertificateDetailDtoMapper.toListDto serves the protocol-specific listings instead. Neither
+                        // the projection nor the DTO carries any of these.
+                        FilterField.CERT_LOCATION_NAME, FilterField.KEY_USAGE, FilterField.SUBJECT_TYPE,
+                        FilterField.SUBJECT_ALTERNATIVE_NAMES, FilterField.OCSP_VALIDATION, FilterField.CRL_VALIDATION,
+                        FilterField.SIGNATURE_VALIDATION, FilterField.CERTIFICATE_PROTOCOL, FilterField.ACME_PROFILE,
+                        FilterField.SCEP_PROFILE, FilterField.CMP_PROFILE, FilterField.ACME_ACCOUNT,
+                        FilterField.SUCCEEDING_CERTIFICATES, FilterField.PRECEDING_CERTIFICATES,
+
+                        // Connectors. The v2 ConnectorDto the listing returns carries no authentication type; only
+                        // the v1 detail DTO does.
+                        FilterField.CONNECTOR_AUTH_TYPE,
+
+                        // Secrets. Secret.setCommonFields sets the source vault profile and not the sync ones.
+                        FilterField.SECRET_SYNC_VAULT_PROFILE,
+
+                        // Signing records. SigningRecordMapper.toListDto sets the retrieval timestamp on the detail
+                        // DTO only; SigningRecordListDto has no property for it.
+                        FilterField.SIGNING_RECORD_SIGNED_DOCUMENT_RETRIEVED_AT);
+
+        private FilterFieldSets() {
         }
     }
 
@@ -85,8 +128,8 @@ public class SearchHelper {
             values = withoutNull;
         }
         fieldDataDto.setValue(values);
-        fieldDataDto.setDisplayable(true);
-        fieldDataDto.setSortable(isSortable(filterField));
+        fieldDataDto.setDisplayable(isDisplayable(filterField));
+        fieldDataDto.setSortable(isSortableField(filterField));
 
         if (filterField.getEnumClass() != null) {
             fieldDataDto.setPlatformEnum(PlatformEnum.findByClass(filterField.getEnumClass()));
@@ -174,20 +217,21 @@ public class SearchHelper {
     }
 
     /**
-     * The resources whose listing passes the sort a request carries to the repository.
+     * The resources whose listing is wired to the configurable-column pipeline: it returns an {@code
+     * AttributeProjectable} DTO and passes the sort a request carries to the repository.
      *
      * <p>
-     * The flag is published per field while the ordering is wired per listing, and only the listings named here are
-     * wired. A field of any other resource is reported not sortable however orderable its path is, because a catalogue
-     * reporting {@code true} there would advertise an ordering that listing discards: the client sorts, receives the
-     * default order, and is told nothing.
+     * Both flags are published per field while the pipeline is wired per listing, and only the listings named here are
+     * wired. A field of any other resource is reported neither displayable nor sortable however orderable its path is,
+     * because a catalogue reporting {@code true} there would advertise a column that listing cannot project and an
+     * ordering it discards: the client asks, receives the default columns in the default order, and is told nothing.
      *
      * <p>
      * Explicit rather than derived: the wiring lives in each listing service and nothing on a {@link FilterField} knows
-     * whether its listing was wired. A listing that gains ordering adds itself here, and
+     * whether its listing was wired. A listing that gains the pipeline adds itself here, and
      * {@code RequestValidatorHelper.revalidateSearchRequestDto} refuses a sort on every listing that has not.
      */
-    private static final Set<Resource> SORT_WIRED_RESOURCES = Set
+    private static final Set<Resource> CONFIGURABLE_COLUMN_RESOURCES = Set
             .of(Resource.CERTIFICATE, Resource.CRYPTOGRAPHIC_KEY, Resource.DISCOVERY, Resource.CONNECTOR,
                     Resource.SECRET, Resource.CBOM, Resource.SIGNING_RECORD);
 
@@ -208,7 +252,7 @@ public class SearchHelper {
      * Whether the listing of this resource applies the sort a request carries.
      */
     public static boolean listingAppliesSort(final Resource resource) {
-        return SORT_WIRED_RESOURCES.contains(resource);
+        return CONFIGURABLE_COLUMN_RESOURCES.contains(resource);
     }
 
     /**
@@ -225,11 +269,40 @@ public class SearchHelper {
     }
 
     /**
-     * What the catalogue advertises as sortable: a field whose path can be ordered by, on a listing that applies the
-     * ordering.
+     * What the catalogue advertises as sortable: a field the catalogue offers as a column at all, whose path can be
+     * ordered by. A sort is triggered by clicking a column header, so a field that cannot be shown cannot be ordered on
+     * however orderable its path is.
      */
-    private static boolean isSortable(final FilterField filterField) {
-        return SORT_WIRED_RESOURCES.contains(filterField.getRootResource()) && isOrderableField(filterField);
+    public static boolean isSortableField(final FilterField filterField) {
+        return CONFIGURABLE_COLUMN_RESOURCES.contains(filterField.getRootResource())
+                && isOrderableOnListing(filterField);
+    }
+
+    /**
+     * Whether a listing may be ordered by this field, which is what a requested sort is refused against.
+     *
+     * <p>
+     * Wider than the catalogue's {@code sortable} flag, and deliberately so. On a listing that publishes columns the
+     * two agree, because ordering there is triggered by clicking a column header and a field that listing cannot show
+     * has no header to click. Every other listing orders from its own code rather than from a header - the OID entries
+     * listing orders by {@code OID_ENTRY_CODE}, which no column picker ever offered - so only the path matters there.
+     */
+    public static boolean isOrderableOnListing(final FilterField filterField) {
+        return isOrderableField(filterField) && (isDisplayable(filterField)
+                || !CONFIGURABLE_COLUMN_RESOURCES.contains(filterField.getRootResource()));
+    }
+
+    /**
+     * Whether a property field may be requested as a column: its listing has to be wired to the column pipeline at all,
+     * and has to carry the value the column would show.
+     *
+     * <p>
+     * Answered here rather than by a pass over the assembled catalogue, so it is decided in the one place {@code
+     * sortable} is and no caller can assemble a catalogue that forgets to answer it.
+     */
+    public static boolean isDisplayable(final FilterField filterField) {
+        return CONFIGURABLE_COLUMN_RESOURCES.contains(filterField.getRootResource())
+                && !FilterFieldSets.ABSENT_FROM_LISTING.contains(filterField);
     }
 
     /**
@@ -255,7 +328,7 @@ public class SearchHelper {
     public static boolean isOrderableField(final FilterField filterField) {
         return filterField.getFieldAttribute() != null && !filterField.isNativeArrayField()
                 && filterField.getJsonPath() == null && filterField.getExpectedValue() == null
-                && !isBitMaskField(filterField) && !SharedAttributeFields.VALUES.contains(filterField);
+                && !isBitMaskField(filterField) && !FilterFieldSets.SHARING_AN_ATTRIBUTE.contains(filterField);
     }
 
     /** Whether the field's column is one integer holding a set of flags rather than the value the cell renders. */

--- a/src/main/java/com/otilm/core/util/SearchHelper.java
+++ b/src/main/java/com/otilm/core/util/SearchHelper.java
@@ -55,16 +55,11 @@ public class SearchHelper {
          * publishes a heading whose every cell is empty, whatever the request asks for.
          *
          * <p>
-         * Listed rather than derived. Neither of the two rules that look like they would decide this holds: every field
-         * of these listings has a non-null attribute, so having one excludes nothing, and reaching a value through a
-         * join predicts nothing either - {@code CERTIFICATE_PROTOCOL} is joined and absent from the listing while
-         * {@code RA_PROFILE_NAME} and {@code GROUP_NAME} are joined and present. What decides it is whether the query
-         * the listing runs selects the value, which only reading that query answers.
-         *
-         * <p>
-         * A field is listed here when the listing DTO has no property for it, or has one the list mapper leaves unset.
-         * A field the DTO does carry stays displayable even where no frontend renderer draws it yet: that is a column
-         * waiting for its cell, not a column that can never have one.
+         * A field belongs here when the listing DTO has no property for it, or has one the list mapper leaves unset -
+         * which only reading that mapper answers, so the set is listed rather than derived. Neither having an attribute
+         * nor reaching the value through a join predicts it: {@code CERTIFICATE_PROTOCOL} is joined and absent while
+         * {@code RA_PROFILE_NAME} and {@code GROUP_NAME} are joined and present. A field the DTO does carry stays
+         * displayable even where no frontend renderer draws it yet.
          */
         private static final Set<FilterField> ABSENT_FROM_LISTING = EnumSet
                 .of(
@@ -221,10 +216,9 @@ public class SearchHelper {
      * AttributeProjectable} DTO and passes the sort a request carries to the repository.
      *
      * <p>
-     * Both flags are published per field while the pipeline is wired per listing, and only the listings named here are
-     * wired. A field of any other resource is reported neither displayable nor sortable however orderable its path is,
-     * because a catalogue reporting {@code true} there would advertise a column that listing cannot project and an
-     * ordering it discards: the client asks, receives the default columns in the default order, and is told nothing.
+     * Both flags are published per field while the pipeline is wired per listing, so a field of any other resource is
+     * reported neither displayable nor sortable however orderable its path is - a {@code true} there would advertise a
+     * column that listing cannot project and an ordering it discards.
      *
      * <p>
      * Explicit rather than derived: the wiring lives in each listing service and nothing on a {@link FilterField} knows
@@ -258,10 +252,6 @@ public class SearchHelper {
     /**
      * What the catalogue advertises as sortable for an attribute field: a field the catalogue offers as a column at
      * all, whose value is what its cell shows, on a listing that applies the ordering.
-     *
-     * <p>
-     * Decided here rather than by a pass over the assembled catalogue, so it is answered wherever {@code displayable}
-     * is and no caller can assemble a catalogue that forgets to answer it.
      */
     private static boolean isSortable(final SearchFieldObject attributeSearchInfo, final Resource resource) {
         return isDisplayable(attributeSearchInfo, resource)
@@ -279,13 +269,15 @@ public class SearchHelper {
     }
 
     /**
-     * Whether a listing may be ordered by this field, which is what a requested sort is refused against.
+     * Whether a query may be ordered by this field, which is what a sort reaching {@code SortOrderBuilder} is refused
+     * against.
      *
      * <p>
      * Wider than the catalogue's {@code sortable} flag, and deliberately so. On a listing that publishes columns the
      * two agree, because ordering there is triggered by clicking a column header and a field that listing cannot show
-     * has no header to click. Every other listing orders from its own code rather than from a header - the OID entries
-     * listing orders by {@code OID_ENTRY_CODE}, which no column picker ever offered - so only the path matters there.
+     * has no header to click. Outside those listings the ordering is not a column's: a caller naming a
+     * {@code SortSpecification} against the repository directly - {@code OID_ENTRY_CODE} on the custom OID entries,
+     * which no column picker ever offered - has no header behind it, so only the path matters there.
      */
     public static boolean isOrderableOnListing(final FilterField filterField) {
         return isOrderableField(filterField) && (isDisplayable(filterField)
@@ -295,10 +287,6 @@ public class SearchHelper {
     /**
      * Whether a property field may be requested as a column: its listing has to be wired to the column pipeline at all,
      * and has to carry the value the column would show.
-     *
-     * <p>
-     * Answered here rather than by a pass over the assembled catalogue, so it is decided in the one place {@code
-     * sortable} is and no caller can assemble a catalogue that forgets to answer it.
      */
     public static boolean isDisplayable(final FilterField filterField) {
         return CONFIGURABLE_COLUMN_RESOURCES.contains(filterField.getRootResource())
@@ -341,16 +329,14 @@ public class SearchHelper {
      * all, and the content it holds has to be content a cell may show.
      *
      * <p>
-     * The listing gate is the same one the property path applies. A listing outside the pipeline never invokes {@code
-     * AttributeColumnProjector}, so the values of even an ordinary custom attribute of such a resource have nothing to
-     * fill them in.
+     * The listing gate is the one the property path applies: a listing outside the pipeline never invokes {@code
+     * AttributeColumnProjector}, so even an ordinary custom attribute of such a resource has nothing to fill its cells.
      *
      * <p>
      * Four kinds of content are then withheld on a wired listing. A secret is never rendered anywhere. Encrypted
-     * content is stored as ciphertext that only its own decryption path can read, and a listing does not take that
-     * path. A code block is multi-line by construction - the frontend renders it as a block element - so a single-line
-     * table cell cannot hold one without breaking the row. And an attribute whose definition is marked not visible is
-     * one the contract says to hide from the user, which rules out putting its values in a column of their own.
+     * content is ciphertext only its own decryption path can read, which a listing does not take. A code block is
+     * multi-line by construction, so a single-line table cell cannot hold one without breaking the row. And an
+     * attribute marked not visible is one the contract says to hide from the user.
      */
     private static boolean isDisplayable(final SearchFieldObject attributeSearchInfo, final Resource resource) {
         return CONFIGURABLE_COLUMN_RESOURCES.contains(resource)

--- a/src/main/java/com/otilm/core/util/SearchHelper.java
+++ b/src/main/java/com/otilm/core/util/SearchHelper.java
@@ -211,7 +211,7 @@ public class SearchHelper {
         fieldDataDto.setType(searchFieldTypeEnum.getFieldType());
         fieldDataDto.setValue(attributeSearchInfo.getContentItems());
         fieldDataDto.setAttributeContentType(attributeSearchInfo.getAttributeContentType());
-        fieldDataDto.setDisplayable(isDisplayable(attributeSearchInfo));
+        fieldDataDto.setDisplayable(isDisplayable(attributeSearchInfo, resource));
         fieldDataDto.setSortable(isSortable(attributeSearchInfo, resource));
         return fieldDataDto;
     }
@@ -264,7 +264,7 @@ public class SearchHelper {
      * is and no caller can assemble a catalogue that forgets to answer it.
      */
     private static boolean isSortable(final SearchFieldObject attributeSearchInfo, final Resource resource) {
-        return listingAppliesSort(resource) && isDisplayable(attributeSearchInfo)
+        return isDisplayable(attributeSearchInfo, resource)
                 && !COMPOSITE_CELL_CONTENT_TYPES.contains(attributeSearchInfo.getAttributeContentType());
     }
 
@@ -337,17 +337,25 @@ public class SearchHelper {
     }
 
     /**
-     * Whether an attribute field may be requested as a column.
+     * Whether an attribute field may be requested as a column: its listing has to be wired to the column pipeline at
+     * all, and the content it holds has to be content a cell may show.
      *
      * <p>
-     * Four kinds of field are withheld. A secret is never rendered anywhere. Encrypted content is stored as ciphertext
-     * that only its own decryption path can read, and a listing does not take that path. A code block is multi-line by
-     * construction - the frontend renders it as a block element - so a single-line table cell cannot hold one without
-     * breaking the row. And an attribute whose definition is marked not visible is one the contract says to hide from
-     * the user, which rules out putting its values in a column of their own.
+     * The listing gate is the same one the property path applies. A listing outside the pipeline never invokes {@code
+     * AttributeColumnProjector}, so the values of even an ordinary custom attribute of such a resource have nothing to
+     * fill them in.
+     *
+     * <p>
+     * Four kinds of content are then withheld on a wired listing. A secret is never rendered anywhere. Encrypted
+     * content is stored as ciphertext that only its own decryption path can read, and a listing does not take that
+     * path. A code block is multi-line by construction - the frontend renders it as a block element - so a single-line
+     * table cell cannot hold one without breaking the row. And an attribute whose definition is marked not visible is
+     * one the contract says to hide from the user, which rules out putting its values in a column of their own.
      */
-    private static boolean isDisplayable(final SearchFieldObject attributeSearchInfo) {
-        return !AttributeColumnProjector.WITHHELD_CONTENT_TYPES.contains(attributeSearchInfo.getAttributeContentType())
+    private static boolean isDisplayable(final SearchFieldObject attributeSearchInfo, final Resource resource) {
+        return CONFIGURABLE_COLUMN_RESOURCES.contains(resource)
+                && !AttributeColumnProjector.WITHHELD_CONTENT_TYPES
+                        .contains(attributeSearchInfo.getAttributeContentType())
                 && attributeSearchInfo.getProtectionLevel() != ProtectionLevel.ENCRYPTED
                 && attributeSearchInfo.isVisible();
     }

--- a/src/main/java/com/otilm/core/util/SortOrderBuilder.java
+++ b/src/main/java/com/otilm/core/util/SortOrderBuilder.java
@@ -201,10 +201,11 @@ public final class SortOrderBuilder {
             throw new ValidationException(
                     ValidationError.create("Unknown sort field identifier %s.".formatted(sort.fieldIdentifier())));
         }
-        // Refused against the same predicate the catalogue publishes as `sortable`, so a request the frontend was told
-        // to withhold is answered with an error rather than with a silently unordered page. Checked before the path is
-        // resolved, because several of these fields do resolve to a path - it is just not the value the column shows.
-        if (!SearchHelper.isOrderableField(field)) {
+        // Refused against the predicate the catalogue publishes as `sortable`, widened to the listings that publish
+        // no columns at all and order from their own code instead. So a request the frontend was told to withhold is
+        // answered with an error rather than with a silently unordered page. Checked before the path is resolved,
+        // because several of these fields do resolve to a path - it is just not the value the column shows.
+        if (!SearchHelper.isOrderableOnListing(field)) {
             throw new ValidationException(
                     ValidationError.create("Field %s cannot be used to order this listing.".formatted(field.name())));
         }

--- a/src/test/java/com/otilm/core/integration/search/ColumnCatalogueFlagsITest.java
+++ b/src/test/java/com/otilm/core/integration/search/ColumnCatalogueFlagsITest.java
@@ -19,6 +19,7 @@ import com.otilm.core.service.CbomExternalService;
 import com.otilm.core.service.DiscoveryExternalService;
 import com.otilm.core.service.SigningRecordExternalService;
 import com.otilm.core.service.TimeQualityConfigurationExternalService;
+import com.otilm.core.service.v2.ConnectorExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.SearchHelper;
 import java.util.List;
@@ -50,6 +51,9 @@ class ColumnCatalogueFlagsITest extends BaseSpringBootTest {
 
     @Autowired
     private TimeQualityConfigurationExternalService timeQualityConfigurationService;
+
+    @Autowired
+    private ConnectorExternalService connectorService;
 
     @Autowired
     private AttributeEngine attributeEngine;
@@ -100,11 +104,12 @@ class ColumnCatalogueFlagsITest extends BaseSpringBootTest {
 
     @Test
     void aNativeArrayPropertyFieldIsDisplayable() {
-        // A multi-valued field has no single scalar key to order a row by, but it does have values to render.
-        SearchFieldDataDto ntpServers = field(timeQualityConfigurationService.getSearchableFieldInformation(),
-                FilterField.TIME_QUALITY_CONFIGURATION_NTP_SERVERS.name()).orElseThrow();
+        // A multi-valued field has no single scalar key to order a row by, but it does have values to render. Taken
+        // from the connector catalogue because a listing outside the column pipeline offers no columns at all.
+        SearchFieldDataDto features = field(connectorService.getSearchableFieldInformationByGroup(),
+                FilterField.CONNECTOR_FEATURES.name()).orElseThrow();
 
-        Assertions.assertEquals(true, ntpServers.getDisplayable());
+        Assertions.assertEquals(true, features.getDisplayable());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/search/PropertyColumnDisplayabilityITest.java
+++ b/src/test/java/com/otilm/core/integration/search/PropertyColumnDisplayabilityITest.java
@@ -1,0 +1,134 @@
+package com.otilm.core.integration.search;
+
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.search.SearchFieldDataDto;
+import com.otilm.core.enums.FilterField;
+import com.otilm.core.util.BaseSpringBootTest;
+import com.otilm.core.util.SearchHelper;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * The property columns each configurable-column listing offers.
+ *
+ * <p>
+ * A property field is displayable when its listing carries the value the column would show - a judgement made per field
+ * against that listing's mapper, for the reasons the absent-from-listing set in {@link SearchHelper} records. So the
+ * decision is written out here as a literal, and the assertion is that the catalogue matches it exactly.
+ *
+ * <p>
+ * That exactness is the point. A field added to one of these listings is displayable by default, so it lands outside
+ * this map and turns the test red until someone has read the mapper and either added the field here or added it to the
+ * absent-from-listing set in {@link SearchHelper}. Neither a new blank column nor a quietly withdrawn one reaches the
+ * picker without that.
+ *
+ * <p>
+ * Property fields resolve their flags against the JPA metamodel, so this runs with a persistence context rather than as
+ * a plain unit test.
+ */
+class PropertyColumnDisplayabilityITest extends BaseSpringBootTest {
+
+    private static final Map<Resource, Set<FilterField>> OFFERED_COLUMNS = new EnumMap<>(Resource.class);
+
+    static {
+        OFFERED_COLUMNS
+                .put(Resource.CERTIFICATE,
+                        EnumSet
+                                .of(FilterField.COMMON_NAME, FilterField.SERIAL_NUMBER, FilterField.RA_PROFILE_NAME,
+                                        FilterField.CERTIFICATE_TYPE, FilterField.CERTIFICATE_STATE,
+                                        FilterField.CERTIFICATE_VALIDATION_STATUS, FilterField.COMPLIANCE_STATUS,
+                                        FilterField.GROUP_NAME, FilterField.OWNER, FilterField.ISSUER_COMMON_NAME,
+                                        FilterField.SIGNATURE_ALGORITHM, FilterField.ALT_SIGNATURE_ALGORITHM,
+                                        FilterField.FINGERPRINT, FilterField.NOT_AFTER, FilterField.NOT_BEFORE,
+                                        FilterField.PUBLIC_KEY_ALGORITHM, FilterField.ALT_PUBLIC_KEY_ALGORITHM,
+                                        FilterField.KEY_SIZE, FilterField.ALT_KEY_SIZE, FilterField.SUBJECTDN,
+                                        FilterField.ISSUERDN, FilterField.ISSUER_SERIAL_NUMBER, FilterField.PRIVATE_KEY,
+                                        FilterField.TRUSTED_CA, FilterField.HYBRID_CERTIFICATE, FilterField.ARCHIVED));
+
+        OFFERED_COLUMNS
+                .put(Resource.CRYPTOGRAPHIC_KEY, EnumSet
+                        .of(FilterField.CKI_NAME, FilterField.CKI_TYPE, FilterField.CKI_FORMAT, FilterField.CKI_STATE,
+                                FilterField.CKI_CRYPTOGRAPHIC_ALGORITHM, FilterField.CKI_USAGE, FilterField.CKI_LENGTH,
+                                FilterField.CKI_ENABLED, FilterField.CKI_CREATED, FilterField.CK_TOKEN_PROFILE,
+                                FilterField.CK_TOKEN_INSTANCE, FilterField.CK_GROUP, FilterField.CK_OWNER));
+
+        OFFERED_COLUMNS
+                .put(Resource.DISCOVERY,
+                        EnumSet
+                                .of(FilterField.DISCOVERY_NAME, FilterField.DISCOVERY_START_TIME,
+                                        FilterField.DISCOVERY_END_TIME, FilterField.DISCOVERY_STATUS,
+                                        FilterField.DISCOVERY_TOTAL_CERT_DISCOVERED,
+                                        FilterField.DISCOVERY_CONNECTOR_NAME, FilterField.DISCOVERY_KIND));
+
+        OFFERED_COLUMNS
+                .put(Resource.CONNECTOR, EnumSet
+                        .of(FilterField.CONNECTOR_NAME, FilterField.CONNECTOR_VERSION, FilterField.CONNECTOR_URL,
+                                FilterField.CONNECTOR_STATUS, FilterField.CONNECTOR_INTERFACE,
+                                FilterField.CONNECTOR_FEATURES, FilterField.CONNECTOR_FUNCTION_GROUP));
+
+        OFFERED_COLUMNS
+                .put(Resource.SECRET, EnumSet
+                        .of(FilterField.SECRET_NAME, FilterField.SECRET_TYPE, FilterField.SECRET_STATE,
+                                FilterField.SECRET_ENABLED, FilterField.SECRET_GROUP_NAME, FilterField.SECRET_OWNER,
+                                FilterField.SECRET_COMPLIANCE_STATUS, FilterField.SECRET_SOURCE_VAULT_PROFILE));
+
+        OFFERED_COLUMNS
+                .put(Resource.CBOM, EnumSet
+                        .of(FilterField.CBOM_SERIAL_NUMBER, FilterField.CBOM_VERSION, FilterField.CBOM_TIMESTAMP,
+                                FilterField.CBOM_SOURCE, FilterField.CBOM_ALGORITHMS_COUNT,
+                                FilterField.CBOM_CERTIFICATES_COUNT, FilterField.CBOM_PROTOCOLS_COUNT,
+                                FilterField.CBOM_CRYPTO_MATERIAL_COUNT, FilterField.CBOM_TOTAL_ASSETS_COUNT,
+                                FilterField.CBOM_ASSET_SYNC_STATE, FilterField.CBOM_ASSETS_SYNCED_AT));
+
+        OFFERED_COLUMNS
+                .put(Resource.SIGNING_RECORD, EnumSet
+                        .of(FilterField.SIGNING_RECORD_NAME, FilterField.SIGNING_RECORD_SIGNING_PROFILE,
+                                FilterField.SIGNING_RECORD_PROTOCOL, FilterField.SIGNING_RECORD_SIGNING_PROFILE_VERSION,
+                                FilterField.SIGNING_RECORD_SIGNING_TIME, FilterField.SIGNING_RECORD_CREATED));
+    }
+
+    /**
+     * A listing outside the map offers no columns at all: it returns a DTO the projector cannot fill, so every field of
+     * it reports false, and a resource missing from the map yields the empty set that says so.
+     */
+    @ParameterizedTest
+    @EnumSource(FilterField.class)
+    void thePublishedColumnsAreExactlyTheDecidedOnes(FilterField filterField) {
+        Set<FilterField> offered = OFFERED_COLUMNS.getOrDefault(filterField.getRootResource(), Set.of());
+
+        Assertions
+                .assertEquals(offered.contains(filterField), SearchHelper.isDisplayable(filterField),
+                        filterField.name());
+    }
+
+    /**
+     * On a listing that publishes columns a sort is triggered by clicking a column header, so a field that cannot be a
+     * column cannot be ordered on either, however orderable its path is. {@code CERTIFICATE_PROTOCOL} is the case that
+     * would otherwise disagree with itself: it resolves to one scalar the repository can order by, and shows nothing.
+     */
+    @Test
+    void aFieldThatCannotBeAColumnIsNotSortable() {
+        SearchFieldDataDto field = SearchHelper.prepareSearch(FilterField.CERTIFICATE_PROTOCOL);
+
+        Assertions.assertTrue(SearchHelper.isOrderableField(FilterField.CERTIFICATE_PROTOCOL));
+        Assertions.assertEquals(false, field.getDisplayable());
+        Assertions.assertEquals(false, field.getSortable());
+        Assertions.assertFalse(SearchHelper.isOrderableOnListing(FilterField.CERTIFICATE_PROTOCOL));
+    }
+
+    /**
+     * A listing outside the pipeline orders from its own code rather than from a column header, so withholding the
+     * column must not withhold the ordering: the OID entries listing orders by a field no picker ever offered.
+     */
+    @Test
+    void aListingWithoutColumnsStillOrdersByItsOwnFields() {
+        Assertions.assertFalse(SearchHelper.isDisplayable(FilterField.OID_ENTRY_CODE));
+        Assertions.assertTrue(SearchHelper.isOrderableOnListing(FilterField.OID_ENTRY_CODE));
+    }
+}

--- a/src/test/java/com/otilm/core/integration/search/PropertyColumnDisplayabilityITest.java
+++ b/src/test/java/com/otilm/core/integration/search/PropertyColumnDisplayabilityITest.java
@@ -15,18 +15,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 /**
- * The property columns each configurable-column listing offers.
+ * The property columns each configurable-column listing offers, written out as a literal and asserted to match the
+ * catalogue exactly.
  *
  * <p>
- * A property field is displayable when its listing carries the value the column would show - a judgement made per field
- * against that listing's mapper, for the reasons the absent-from-listing set in {@link SearchHelper} records. So the
- * decision is written out here as a literal, and the assertion is that the catalogue matches it exactly.
- *
- * <p>
- * That exactness is the point. A field added to one of these listings is displayable by default, so it lands outside
- * this map and turns the test red until someone has read the mapper and either added the field here or added it to the
- * absent-from-listing set in {@link SearchHelper}. Neither a new blank column nor a quietly withdrawn one reaches the
- * picker without that.
+ * The exactness is the point. A field added to one of these listings is displayable by default, so it lands outside
+ * this map and turns the test red until someone has read that listing's mapper and either added the field here or added
+ * it to the absent-from-listing set in {@link SearchHelper}. Neither a new blank column nor a quietly withdrawn one
+ * reaches the picker without that.
  *
  * <p>
  * Property fields resolve their flags against the JPA metamodel, so this runs with a persistence context rather than as
@@ -123,11 +119,11 @@ class PropertyColumnDisplayabilityITest extends BaseSpringBootTest {
     }
 
     /**
-     * A listing outside the pipeline orders from its own code rather than from a column header, so withholding the
-     * column must not withhold the ordering: the OID entries listing orders by a field no picker ever offered.
+     * Outside the pipeline an ordering is not a column's, so withholding the column must not withhold the ordering: a
+     * repository query can be ordered by {@code OID_ENTRY_CODE}, which no picker ever offered.
      */
     @Test
-    void aListingWithoutColumnsStillOrdersByItsOwnFields() {
+    void aFieldNoPickerOffersCanStillOrderARepositoryQuery() {
         Assertions.assertFalse(SearchHelper.isDisplayable(FilterField.OID_ENTRY_CODE));
         Assertions.assertTrue(SearchHelper.isOrderableOnListing(FilterField.OID_ENTRY_CODE));
     }

--- a/src/test/java/com/otilm/core/integration/service/ListViewServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ListViewServiceITest.java
@@ -334,16 +334,34 @@ class ListViewServiceITest extends BaseSpringBootTest {
 
     /**
      * A field can stop being a column after a view has stored it, which is what happens to every view saved before the
-     * listing's own columns were read against its mapper. Such a column is dropped on read rather than handed back for
-     * the picker to render as a heading with nothing under it.
+     * listing's own columns were read against its mapper. The column is still returned: the client reads the same
+     * catalogue and can name it as unavailable and offer to take it out, which withholding it silently prevents.
      */
     @Test
-    void aColumnTheListingNoLongerShowsIsSkippedOnRead() {
+    void aColumnTheListingNoLongerShowsIsKeptOnRead() {
         store("Withdrawn", List.of(column("COMMON_NAME"), column("CERTIFICATE_PROTOCOL")), null);
 
         ListViewDto read = listViewService.listViews(Resource.CERTIFICATE).getFirst();
 
-        Assertions.assertEquals(List.of("COMMON_NAME"), identifiersOf(read));
+        Assertions.assertEquals(List.of("COMMON_NAME", "CERTIFICATE_PROTOCOL"), identifiersOf(read));
+    }
+
+    /**
+     * A view whose every column was withdrawn at once. Filtering them out would answer an empty column list, which no
+     * update request may carry, so the next rename of such a view would be refused for a reason the caller cannot act
+     * on.
+     */
+    @Test
+    void aViewWhoseEveryColumnWasWithdrawnStillReadsBackASaveableShape()
+            throws NotFoundException, AlreadyExistException {
+        store("All withdrawn", List.of(column("CERTIFICATE_PROTOCOL"), column("KEY_USAGE")), null);
+
+        ListViewDto read = listViewService.listViews(Resource.CERTIFICATE).getFirst();
+
+        Assertions.assertEquals(List.of("CERTIFICATE_PROTOCOL", "KEY_USAGE"), identifiersOf(read));
+        ListViewDto renamed = listViewService
+                .editView(read.getUuid(), update("Renamed", column("CERTIFICATE_PROTOCOL"), column("KEY_USAGE")));
+        Assertions.assertEquals("Renamed", renamed.getName());
     }
 
     /**
@@ -415,6 +433,40 @@ class ListViewServiceITest extends BaseSpringBootTest {
 
         ValidationException e = Assertions
                 .assertThrows(ValidationException.class, () -> listViewService.createView(request));
+        Assertions.assertTrue(e.getMessage().contains("CERTIFICATE_PROTOCOL"));
+    }
+
+    /**
+     * The column gate applies to what a request introduces, not to what the view already holds. A view stored before
+     * the field was withdrawn is read back carrying it, so refusing it on write would leave the view unrenamable over a
+     * column the caller never touched.
+     */
+    @Test
+    void aWithdrawnColumnTheViewAlreadyCarriesSurvivesARename() throws NotFoundException, AlreadyExistException {
+        store("Legacy", List.of(column("COMMON_NAME"), column("CERTIFICATE_PROTOCOL")), null);
+        ListViewDto read = listViewService.listViews(Resource.CERTIFICATE).getFirst();
+
+        ListViewDto renamed = listViewService
+                .editView(read.getUuid(),
+                        update("Legacy renamed", column("COMMON_NAME"), column("CERTIFICATE_PROTOCOL")));
+
+        Assertions.assertEquals("Legacy renamed", renamed.getName());
+        Assertions.assertEquals(List.of("COMMON_NAME", "CERTIFICATE_PROTOCOL"), identifiersOf(renamed));
+    }
+
+    /**
+     * The exemption is for the columns the view carries and nothing wider: a withdrawn column can be kept or taken out,
+     * never introduced, so an edit cannot do what a creation is refused.
+     */
+    @Test
+    void aWithdrawnColumnCannotBeAddedToAnExistingView() throws AlreadyExistException {
+        ListViewDto created = listViewService.createView(request("Clean", column("COMMON_NAME")));
+
+        ValidationException e = Assertions
+                .assertThrows(ValidationException.class,
+                        () -> listViewService
+                                .editView(created.getUuid(),
+                                        update("Clean", column("COMMON_NAME"), column("CERTIFICATE_PROTOCOL"))));
         Assertions.assertTrue(e.getMessage().contains("CERTIFICATE_PROTOCOL"));
     }
 

--- a/src/test/java/com/otilm/core/integration/service/ListViewServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ListViewServiceITest.java
@@ -321,19 +321,54 @@ class ListViewServiceITest extends BaseSpringBootTest {
      */
     @Test
     void aColumnWhoseFieldNoLongerExistsIsSkippedOnRead() {
-        ListView stored = new ListView();
-        stored.setUserUuid(user);
-        stored.setResource(Resource.CERTIFICATE);
-        stored.setName("Stale");
-        stored
-                .setColumns(List
+        store("Stale",
+                List
                         .of(column("COMMON_NAME"), column("RETIRED_FIELD"),
-                                new ListViewColumnDto(FilterFieldSource.CUSTOM, "deleted|STRING", null)));
-        listViewRepository.save(stored);
+                                new ListViewColumnDto(FilterFieldSource.CUSTOM, "deleted|STRING", null)),
+                null);
 
         ListViewDto read = listViewService.listViews(Resource.CERTIFICATE).getFirst();
 
         Assertions.assertEquals(List.of("COMMON_NAME"), identifiersOf(read));
+    }
+
+    /**
+     * A field can stop being a column after a view has stored it, which is what happens to every view saved before the
+     * listing's own columns were read against its mapper. Such a column is dropped on read rather than handed back for
+     * the picker to render as a heading with nothing under it.
+     */
+    @Test
+    void aColumnTheListingNoLongerShowsIsSkippedOnRead() {
+        store("Withdrawn", List.of(column("COMMON_NAME"), column("CERTIFICATE_PROTOCOL")), null);
+
+        ListViewDto read = listViewService.listViews(Resource.CERTIFICATE).getFirst();
+
+        Assertions.assertEquals(List.of("COMMON_NAME"), identifiersOf(read));
+    }
+
+    /**
+     * The same for a stored ordering, which the listing now refuses: returning it would make the view unusable rather
+     * than merely unordered.
+     */
+    @Test
+    void anOrderingTheListingNoLongerAppliesIsDroppedOnRead() {
+        store("Stale ordering", List.of(column("COMMON_NAME")),
+                new SearchSortRequestDto(FilterFieldSource.PROPERTY, "CERTIFICATE_PROTOCOL", SortDirection.ASC));
+
+        ListViewDto read = listViewService.listViews(Resource.CERTIFICATE).getFirst();
+
+        Assertions.assertNull(read.getSort());
+        Assertions.assertEquals(List.of("COMMON_NAME"), identifiersOf(read));
+    }
+
+    private void store(String name, List<ListViewColumnDto> columns, SearchSortRequestDto sort) {
+        ListView stored = new ListView();
+        stored.setUserUuid(user);
+        stored.setResource(Resource.CERTIFICATE);
+        stored.setName(name);
+        stored.setColumns(columns);
+        stored.setSort(sort);
+        listViewRepository.save(stored);
     }
 
     @Test
@@ -368,6 +403,52 @@ class ListViewServiceITest extends BaseSpringBootTest {
         ValidationException e = Assertions
                 .assertThrows(ValidationException.class, () -> listViewService.createView(request));
         Assertions.assertTrue(e.getMessage().contains("CKI_NAME"));
+    }
+
+    /**
+     * The certificate listing carries no protocol value, so the field is one to filter on and never one to show.
+     * Accepting it as a column would store a view whose column is empty in every row of every page.
+     */
+    @Test
+    void aColumnTheListingCannotShowIsRejectedOnWrite() {
+        ListViewRequestDto request = request("Blank", column("COMMON_NAME"), column("CERTIFICATE_PROTOCOL"));
+
+        ValidationException e = Assertions
+                .assertThrows(ValidationException.class, () -> listViewService.createView(request));
+        Assertions.assertTrue(e.getMessage().contains("CERTIFICATE_PROTOCOL"));
+    }
+
+    /**
+     * A stored ordering is applied by re-issuing the listing request, and the listing refuses a field its catalogue
+     * does not publish as sortable - so a view accepting one would answer an error on every application.
+     */
+    @Test
+    void anOrderingTheListingWouldRefuseIsRejectedOnWrite() {
+        ListViewRequestDto request = request("Unorderable", column("COMMON_NAME"));
+        request
+                .setSort(new SearchSortRequestDto(FilterFieldSource.PROPERTY, "CERTIFICATE_PROTOCOL",
+                        SortDirection.ASC));
+
+        ValidationException e = Assertions
+                .assertThrows(ValidationException.class, () -> listViewService.createView(request));
+        Assertions.assertTrue(e.getMessage().contains("CERTIFICATE_PROTOCOL"));
+    }
+
+    /**
+     * Filtering and showing are separate capabilities: the same field the listing cannot show is one it can be filtered
+     * on, and tightening the columns must not withdraw the filter with them.
+     */
+    @Test
+    void aFilterOnAFieldTheListingCannotShowIsAccepted() throws AlreadyExistException {
+        ListViewRequestDto request = request("Filtered", column("COMMON_NAME"));
+        request
+                .setFilters(List
+                        .of(new SearchFilterRequestDto(FilterFieldSource.PROPERTY, "CERTIFICATE_PROTOCOL",
+                                FilterConditionOperator.EQUALS, "acme")));
+
+        ListViewDto created = listViewService.createView(request);
+
+        Assertions.assertEquals("CERTIFICATE_PROTOCOL", created.getFilters().getFirst().getFieldIdentifier());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/util/SearchHelperColumnFlagsTest.java
+++ b/src/test/java/com/otilm/core/util/SearchHelperColumnFlagsTest.java
@@ -59,6 +59,20 @@ class SearchHelperColumnFlagsTest {
         Assertions.assertEquals(false, prepare(AttributeContentType.CODEBLOCK, ProtectionLevel.NONE).getDisplayable());
     }
 
+    /**
+     * A listing outside the column pipeline never invokes the projector, so even an ordinary custom attribute of that
+     * resource has nothing to fill the cells of a column asking for it.
+     */
+    @Test
+    void noAttributeOfAnUnwiredListingIsOfferedAsAColumn() {
+        Assertions
+                .assertEquals(false,
+                        SearchHelper
+                                .prepareSearchForJSON(attributeField(AttributeContentType.TEXT, ProtectionLevel.NONE),
+                                        false, Resource.LOCATION)
+                                .getDisplayable());
+    }
+
     @Test
     void anOrdinaryAttributeOfAWiredListingIsSortable() {
         Assertions.assertEquals(true, prepare(AttributeContentType.TEXT, ProtectionLevel.NONE).getSortable());


### PR DESCRIPTION
`SearchHelper.prepareSearch` set `displayable` unconditionally, so every property field of every catalogue was advertised as a column a user may pick. For the fields the listing DTO carries no value for, picking one produced a heading whose every cell was empty.

The flag is now decided per field: a field is offered when its listing is wired to the configurable-column pipeline at all, and that listing carries the value the column would show.

Closes #2180.

## The decision

There is no rule to derive this from, and the issue's two candidates were both re-checked and both fail. Every `FilterField` of these seven listings has a non-null `fieldAttribute`, so "no attribute behind it" excludes none of them. Structure predicts nothing either: `CERTIFICATE_PROTOCOL` is reached through a join and is absent from the listing, while `RA_PROFILE_NAME` and `GROUP_NAME` are reached through joins and are present.

So it was decided by reading what each of the seven listings actually selects. Six go through a mapper; the certificate listing does not, building each `CertificateDto` from a JPQL constructor projection with `CertificateDetailDtoMapper.toListDto` serving only the protocol-specific listings. The result is an explicit `ABSENT_FROM_LISTING` set in `SearchHelper`, naming the query each group was read against.

Seventeen fields stop being offered:

| Inventory | Fields | Why |
|---|---|---|
| Certificate | `CERT_LOCATION_NAME`, `KEY_USAGE`, `SUBJECT_TYPE`, `SUBJECT_ALTERNATIVE_NAMES`, `OCSP_VALIDATION`, `CRL_VALIDATION`, `SIGNATURE_VALIDATION`, `CERTIFICATE_PROTOCOL`, `ACME_PROFILE`, `SCEP_PROFILE`, `CMP_PROFILE`, `ACME_ACCOUNT`, `SUCCEEDING_CERTIFICATES`, `PRECEDING_CERTIFICATES` | absent from the listing's constructor projection (`findCertificateDtosByUuidsIn`) and from `CertificateDto` itself |
| Connector | `CONNECTOR_AUTH_TYPE` | the v2 `ConnectorDto` the listing returns carries no authentication type; only the v1 detail DTO does |
| Secret | `SECRET_SYNC_VAULT_PROFILE` | `Secret.setCommonFields` sets the source vault profile and not the sync ones |
| Signing record | `SIGNING_RECORD_SIGNED_DOCUMENT_RETRIEVED_AT` | `SigningRecordMapper.toListDto` sets the retrieval timestamp on the detail DTO only |

Cryptographic keys, discoveries and CBOMs lose nothing — every field of those three is carried.

`SIGNING_RECORD_SIGNING_PROFILE_VERSION` stays offered although it is nested: `toListDto` pins it onto the `signingProfile` member from the record's own captured version. Whether a renderer reaches it is `fe-administrator#2067`'s question, not the catalogue's.

## The projection route, costed

The issue flagged a cheaper-looking route: relax the `fieldSource.getAttributeType() == null` check in `AttributeColumnProjector.parseRequestedColumns`, so a property column survives parsing and arrives as `attributeValues.property.KEY_USAGE`, which `getProjectedContent` on the frontend already reads without caring about the source.

It does not work, and the reason is one level below that check. The projector's only value source is `attributeContent2ObjectRepository.getProjectedAttributesContent(...)`, which matches stored rows by attribute type and attribute name against the attribute-content tables. A property field has no row there at all — `KEY_USAGE` is a column on `certificate`. Letting the column past the parse gate therefore returns nothing and renders the same empty cell, having spent a query to do it.

Making it work needs a second value source that reads the entity, which is the listing mappers again. That is strictly more than adding a DTO field and a renderer for the handful of fields anyone actually wants, so the route is not taken and the fields are withdrawn instead.

## Sortable follows displayable, on the listings that publish columns

Ordering there is triggered by clicking a column header, so a field that cannot be shown has no header to click, however orderable its path is. The attribute path already coupled the two flags this way; the property path now does too. `CERTIFICATE_PROTOCOL` is the case that disagreed with itself: it resolves to one scalar the repository can order by, and shows nothing.

The refusal in `SortOrderBuilder.resolveField` moves onto that same predicate, so the comment claiming it matches the published flag is true rather than nearly true. It is widened by one clause for the fields of listings that publish no columns at all, where an ordering is not a column's: a caller naming a `SortSpecification` against the repository directly can order by `OID_ENTRY_CODE`, which no picker ever offered. `SubclassFilterFieldSearchITest` covers that side, and the new test covers both.

Nothing a client can request reaches the widened branch — `RequestValidatorHelper` already refuses a requested sort on any listing outside the pipeline — so for client requests the gate and the catalogue agree exactly.

## Fields of unwired listings

A listing outside the pipeline returns a DTO the projector cannot fill, so its fields now report `false` for both flags rather than advertising a column that listing cannot project. `SORT_WIRED_RESOURCES` is renamed `CONFIGURABLE_COLUMN_RESOURCES` to say that it now gates both.

The attribute path takes the same gate. `prepareSearchForJSON` derived `displayable` from content visibility alone, so an ordinary custom, data or metadata attribute of an unwired resource stayed advertised as a column although that listing never invokes `AttributeColumnProjector` - `LOCATION` is the plainest case. Its `sortable` was already gated per resource; `displayable` now is too, and `sortable` reads it rather than repeating the check.

## Saved views are held to the same flags

`ListViewServiceImpl` validated a view's columns and ordering by catalogue *membership*, which is the filter capability. So the flags published here would not have stopped a view from storing `CERTIFICATE_PROTOCOL`: as a column it comes back blank in every row, and as an ordering it is refused by `SortOrderBuilder` when the view is applied, failing the whole listing request rather than merely ordering it differently.

The catalogue now carries the three capabilities separately - the conditions a field accepts, whether it may be a column, whether it may be an ordering - read off the published catalogue rather than from a second copy of its rules. Columns and orderings are validated against the latter two. Filters stay on membership, because a listing filters on values it does not select: a certificate is still found by its protocol.

Views stored before this lands need no migration, and keep their columns.

A read returns every column whose field the catalogue still offers, including one the listing can no longer show, and drops only a field that has left the catalogue outright - the omission `ListViewDto.columns` already documents. Two things depend on that. `fe-administrator` resolves availability against the same catalogue and renders a withdrawn column as unavailable, named in a notice and removable from the picker, which withholding it silently prevents. And a view whose columns were all withdrawn would otherwise read back as an empty column list, which `ListViewUpdateRequestDto` refuses with a 422, so the next rename or pin of it would fail over a column the caller never touched. The shape a read returns has to be a shape a write accepts.

The column gate therefore applies to what a request introduces rather than to what the view holds: a creation is held to the current catalogue in full, while an edit may keep or remove a column the stored view already carries. A withdrawn column cannot be introduced, and cannot strand the view holding it.

An ordering keeps both the strict gate and the drop on read, because the two costs are not alike: an undisplayable column costs one blank heading, while an ordering `SortOrderBuilder` refuses costs every application of the view. Such a view opens in the listing's own order instead of erroring, and `sort: null` is always a legal write shape.

## The pin

`PropertyColumnDisplayabilityITest` asserts the published set of columns per listing equals a written-out literal, field by field over the whole enum. A field added to a wired listing is displayable by default, so it lands outside that map and turns the test red until someone has read the mapper and classified it. Neither a new blank column nor a quietly withdrawn one reaches the picker without that.

`ColumnCatalogueFlagsITest.aNativeArrayPropertyFieldIsDisplayable` moves from the time-quality-configuration catalogue to the connector one, since the first is not a column pipeline listing and now offers no columns at all.

## Still open

The decision is one engineer's reading of the mappers. It wants confirming with the inventory owners before it ships, particularly the certificate list: fourteen columns is the largest withdrawal, and a column someone uses today is worse to lose than a blank one is to keep.


