### PR TITLE
Add a netty override to 4.1.137.Final for CVE-2026-75595

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,11 @@
           The announced fix version 10.1.58 was never published; 10.1.59 is its released successor.
           Remove when the parent BOM manages at least this version. -->
         <tomcat.version>10.1.59</tomcat.version>
+        <!-- CVE-2026-75595 in netty-handler, which reaches the image transitively through
+          spring-boot-starter-reactor-netty and azure-core-http-netty rather than any direct dependency.
+          4.1.137.Final is the fix within the managed 4.1.x line; 4.2.17.Final also carries it but is a minor move.
+          Remove when the parent BOM manages at least this version. -->
+        <netty.version>4.1.137.Final</netty.version>
 
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>ilm</sonar.organization>


### PR DESCRIPTION
## TLDR

Trivy fails the container gate on one critical finding, CVE-2026-75595 in netty-handler 4.1.136.Final.
It is the only finding in the image. The vulnerable code path is **not reachable in Core** — it is a
server-side TLS handler and Core serves HTTP with Tomcat, not netty — so this is scanner hygiene on a
shipped-but-unused component rather than a live exposure. Worth taking anyway: it is a one-line
patch-level move, and the gate stays red on every future pull request to this branch until it is.

## What fails

`Total: 1 (HIGH: 0, CRITICAL: 1)`:

| Library | CVE | Severity | Installed | Fixed |
| --- | --- | --- | --- | --- |
| `io.netty:netty-handler (app.jar)` | CVE-2026-75595 | CRITICAL | 4.1.136.Final | 4.2.17.Final, 4.1.137.Final |

Nothing else is reported. The Tomcat findings that failed this gate yesterday are gone, cleared by
#2238; this is a separate disclosure that reached Trivy's database overnight.

Netty is not a direct dependency. It reaches the image through `spring-boot-starter-reactor-netty` —
the WebClient used by the connector, auth-service and OPA clients — and through
`azure-core-http-netty`, with the version managed by the parent BOM. So the override is the only place
to raise it.

`4.1.137.Final` is the fix inside the 4.1.x line the BOM already manages. `4.2.17.Final` carries it too
but is a minor move, which does not belong in a hotfix. The `netty.version` property raises every netty
artifact together; `netty-tcnative` has its own property and is not the vulnerable one.

## How exploitable is this here

CVE-2026-75595 is an SNI routing bypass: a fragmented TLS ClientHello whose handshake header spans
records makes `io.netty.handler.ssl.SslClientHelloHandler#decode` read the wrong offset, throw, and fall
back to the default `SslContext`. It escalates to an unauthenticated mTLS bypass only where per-SNI
`SslContext` selection is the sole mTLS gate, the fallback context is permissive, and nothing at the
application layer re-checks the peer certificate.

`SslClientHelloHandler` is server-side: it inspects an *inbound* ClientHello to choose a context. Core
does not serve TLS through netty. `spring-boot-starter-web` puts the servlet stack and embedded Tomcat
on the classpath and that is what serves requests; `spring-boot-starter-webflux` is present for
`WebClient`, and netty is therefore only the *outbound* HTTP transport for the connector, auth-service
and OPA clients, plus `azure-core-http-netty`. Nothing in `src/main` references
`SslClientHelloHandler`, `SniHandler`, `reactor.netty.http.server` or `HttpServer.create`, so no netty
server is ever started and no SNI-based context selection exists to bypass.

So the finding is real in the sense that the vulnerable jar ships, and it will show up in any scan a
customer runs against the released image. It is not reachable in this product as configured.

## This is not specific to the 2.19 line

Neither this line nor `main` carries a netty override, and both resolve 4.1.136.Final from the same
Spring Boot 3.5.16 BOM. The most recent container scan on a main-targeting pull request ran
2026-09-08T12:25Z, before this CVE entered the database, which is the only reason main still looks
green. It will fail the same gate as soon as any main pull request is scanned, with the same
non-reachable finding. Main wants the same override, on the same scanner-hygiene grounds rather than as
an urgent fix.

## Verified

Every netty artifact resolves to 4.1.137.Final. Netty only reaches runtime through WebClient, so the
verification is the paths that drive real HTTP over it — 53 tests, all passing:

| Test | Covers |
| --- | --- |
| `CbomRepositoryClientTest` | WebClient against a stubbed HTTP server |
| `OAuth2LoginControllerITest` | real servlet container plus OAuth2 token and JWKS fetches |
| `JwtDecoderITest` | JWKS retrieval over HTTP |
| `ProxyProvisioningServiceITest` | outbound provisioning calls |
| `SecurityConfigITest` | the authentication chain end to end |
| `AcmeProtocolFlowITest` | the ACME protocol flow |

Full CI is the authority on the rest of the suite and on the gate itself.
