### PR TITLE
Add a netty override for CVE-2026-75595

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,11 @@
              The announced fix version 10.1.58 was never published; 10.1.59 is its released successor.
              Remove when the parent BOM manages at least this version. -->
         <tomcat.version>10.1.59</tomcat.version>
+        <!-- CVE-2026-75595 in netty-handler, which reaches the image transitively through
+             spring-boot-starter-reactor-netty and azure-core-http-netty rather than any direct dependency.
+             4.1.137.Final is the fix within the managed 4.1.x line; 4.2.17.Final also carries it but is a minor move.
+             Remove when the parent BOM manages at least this version. -->
+        <netty.version>4.1.137.Final</netty.version>
         <log-schema.version>1.1</log-schema.version>
         <hsqldb.version>2.7.3</hsqldb.version>
         <nimbus-jose-jwt.version>10.8</nimbus-jose-jwt.version>


### PR DESCRIPTION
## TLDR

Trivy fails the container gate on one critical finding, CVE-2026-75595 in netty-handler 4.1.136.Final.
The vulnerable code path is **not reachable here** — it is a server-side TLS handler and requests are
served by Tomcat, not netty — so this is scanner hygiene on a shipped-but-unused component rather than a
live exposure. Worth taking because the gate stays red on every pull request until it is. The 2.19 line
gets the same override in #2242.

## What fails

| Library | CVE | Severity | Installed | Fixed |
| --- | --- | --- | --- | --- |
| `io.netty:netty-handler (app.jar)` | CVE-2026-75595 | CRITICAL | 4.1.136.Final | 4.2.17.Final, 4.1.137.Final |

Netty is not a direct dependency. It reaches the image through `spring-boot-starter-reactor-netty` — the
WebClient used by the connector, auth-service and OPA clients — and through `azure-core-http-netty`, with
the version managed by the parent BOM. So the override is the only place to raise it.

`4.1.137.Final` is the fix inside the 4.1.x line the BOM already manages. `4.2.17.Final` carries it too
but is a minor move. The `netty.version` property raises every netty artifact together;
`netty-tcnative` has its own property and is not the vulnerable one.

The finding is new rather than newly introduced: it entered Trivy's database overnight on 2026-09-09.
The most recent container scan on a pull request here ran 2026-09-08T12:25Z, which is the only reason
this looks green today.

## Why it is not reachable

CVE-2026-75595 is an SNI routing bypass. A fragmented TLS ClientHello whose handshake header spans
records makes `io.netty.handler.ssl.SslClientHelloHandler#decode` read the wrong offset, throw, and fall
back to the default `SslContext`. It escalates to an unauthenticated mTLS bypass only where per-SNI
`SslContext` selection is the sole mTLS gate, the fallback context is permissive, and nothing at the
application layer re-checks the peer certificate.

`SslClientHelloHandler` is server-side: it inspects an *inbound* ClientHello. This service does not serve
TLS through netty. `spring-boot-starter-web` puts the servlet stack and embedded Tomcat on the classpath
and that is what serves requests; `spring-boot-starter-webflux` is present for `WebClient`, so netty is
only the *outbound* transport. Nothing in `src/main` references `SslClientHelloHandler`, `SniHandler`,
`reactor.netty.http.server` or `HttpServer.create` — no netty server is started, and there is no SNI-based
context selection to bypass.

So the vulnerable class ships but is never instantiated. It still shows up in any scan a customer runs
against the released image, which is the reason to raise it.

## Verified

Every netty artifact resolves to 4.1.137.Final. Netty only reaches runtime through WebClient, so the
verification is the paths that drive real HTTP over it — 53 tests, all passing:
`CbomRepositoryClientTest`, `OAuth2LoginControllerITest` (real servlet container plus OAuth2 token and
JWKS fetches), `JwtDecoderITest`, `ProxyProvisioningServiceITest`, `SecurityConfigITest` and
`AcmeProtocolFlowITest`. `spotless:check` passes.

Full CI is the authority on the rest of the suite and on the gate itself.
