### PR TITLE
Consume the paged cbom-repository feed with bounded retry of skipped entries

### DIFF
--- a/src/main/java/com/otilm/core/cbom/client/BomSearchPage.java
+++ b/src/main/java/com/otilm/core/cbom/client/BomSearchPage.java
@@ -1,0 +1,24 @@
+package com.otilm.core.cbom.client;
+
+import com.otilm.core.model.cbom.BomEntryDto;
+import java.net.URI;
+import java.util.List;
+
+/**
+ * One page of the cbom-repository search feed.
+ *
+ * @param entries the page body, never null (an empty last page is legal)
+ * @param nextPage Core's own {@code /api/v1/bom} URL carrying the continuation query the repository's
+ * {@code Link rel="next"} header named, or null when the response carried no such header -- which, not the page size,
+ * is what says the run is complete. Opaque to callers: hand it back to {@code CbomRepositoryClient#nextPage}.
+ */
+public record BomSearchPage(List<BomEntryDto> entries, URI nextPage) {
+
+    public BomSearchPage {
+        entries = entries == null ? List.of() : List.copyOf(entries);
+    }
+
+    public boolean hasNext() {
+        return nextPage != null;
+    }
+}

--- a/src/main/java/com/otilm/core/cbom/client/CbomRepositoryClient.java
+++ b/src/main/java/com/otilm/core/cbom/client/CbomRepositoryClient.java
@@ -4,14 +4,20 @@ import com.otilm.api.exception.CbomRepositoryException;
 import com.otilm.api.model.core.cbom.CbomUploadRequestDto;
 import com.otilm.api.model.core.settings.PlatformSettingsDto;
 import com.otilm.api.model.core.settings.SettingsSection;
+import com.otilm.core.config.CbomSyncProperties;
 import com.otilm.core.model.cbom.BomCreateResponseDto;
 import com.otilm.core.model.cbom.BomEntryDto;
 import com.otilm.core.model.cbom.BomResponseDto;
 import com.otilm.core.model.cbom.BomSearchRequestDto;
 import com.otilm.core.model.cbom.BomVersionDto;
 import com.otilm.core.settings.SettingsCache;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -23,6 +29,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
@@ -66,21 +73,150 @@ public class CbomRepositoryClient {
                 .getBody(), request);
     }
 
-    public List<BomEntryDto> search(final BomSearchRequestDto query) throws CbomRepositoryException {
-        String baseUrl = getCbomRepositoryBaseUrl();
+    /** The last path segment of {@link #CBOM_SEARCH}; a Link target may name it or leave the path empty. */
+    private static final String SEARCH_SEGMENT = "bom";
+
+    /** How much of an unusable Link target is quoted in the Core log. */
+    private static final int LINK_TARGET_ECHO_LIMIT = 200;
+
+    /**
+     * Opens a search run: documents created strictly after {@code query.after} (null reads as 0), the first page when
+     * {@code query.limit} is set, the whole unpaged legacy listing when it is not. Follow pages with
+     * {@link #nextPage(BomSearchPage)} until {@link BomSearchPage#hasNext()} is false; the absence of the repository's
+     * {@code Link rel="next"} header -- not the page size -- says the run is complete.
+     */
+    public BomSearchPage search(final BomSearchRequestDto query) throws CbomRepositoryException {
+        final Integer limit = query.getLimit();
+        if (limit != null && (limit < CbomSyncProperties.MIN_PAGE_SIZE || limit > CbomSyncProperties.MAX_PAGE_SIZE)) {
+            throw new IllegalArgumentException("CBOM Repository search limit must be within %d..%d, was %d"
+                    .formatted(CbomSyncProperties.MIN_PAGE_SIZE, CbomSyncProperties.MAX_PAGE_SIZE, limit));
+        }
+        final String baseUrl = getCbomRepositoryBaseUrl();
+        final UriComponentsBuilder builder = UriComponentsBuilder
+                .fromUriString(baseUrl)
+                .path(CBOM_SEARCH)
+                .queryParam("after", query.getAfter() == null ? 0L : query.getAfter());
+        if (limit != null) {
+            builder.queryParam("limit", limit);
+        }
+        return fetchPage(builder.build().toUri());
+    }
+
+    /** Fetches the page a previous page's {@code Link rel="next"} header pointed at. */
+    public BomSearchPage nextPage(final BomSearchPage page) throws CbomRepositoryException {
+        if (!page.hasNext()) {
+            throw new IllegalArgumentException("The page carries no next link; the run is complete");
+        }
+        return fetchPage(page.nextPage());
+    }
+
+    private BomSearchPage fetchPage(final URI pageUri) throws CbomRepositoryException {
         final WebClient.RequestBodyUriSpec request = client.method(HttpMethod.GET);
-        return processRequest(r -> r
-                .uri(uriBuilder -> UriComponentsBuilder
-                        .fromUriString(baseUrl)
-                        .path(CBOM_SEARCH)
-                        .queryParam("after", query.getAfter())
-                        .build()
-                        .toUri())
-                .retrieve()
-                .toEntity(new ParameterizedTypeReference<List<BomEntryDto>>() {
-                })
-                .block()
-                .getBody(), request);
+        final ResponseEntity<List<BomEntryDto>> response;
+        try {
+            response = processRequest(
+                    r -> r.uri(pageUri).retrieve().toEntity(new ParameterizedTypeReference<List<BomEntryDto>>() {
+                    }).block(), request);
+        } catch (CbomRepositoryException e) {
+            throw pageRequestFailed(e);
+        }
+        final Optional<String> target = LinkHeader.nextTarget(response.getHeaders().get(HttpHeaders.LINK));
+        final URI next = target.isPresent() ? resolveNextPage(pageUri, target.get()) : null;
+        return new BomSearchPage(response.getBody(), next);
+    }
+
+    /**
+     * A failed page request keeps its status -- the sync run classifies a 503 by it, and any other status fails the run
+     * -- but not the repository's own {@code detail}: a failed page fails the whole run, whose message an operator
+     * reads in the scheduler's job result, and that sentence is chosen by the other side. It is logged for the Core log
+     * and replaced here with Core's own.
+     */
+    private static CbomRepositoryException pageRequestFailed(final CbomRepositoryException failure) {
+        final ProblemDetail reported = failure.getProblemDetail();
+        if (reported == null) {
+            return failure;
+        }
+        logger
+                .warn("CBOM Repository failed a page request with HTTP {}: {}", reported.getStatus(),
+                        reported.getDetail());
+        final ProblemDetail shaped = ProblemDetail.forStatus(reported.getStatus());
+        shaped.setDetail("CBOM Repository failed a page request (HTTP " + reported.getStatus() + ")");
+        return new CbomRepositoryException(shaped);
+    }
+
+    /**
+     * The repository sends the next page as a relative-path reference, {@code bom?cursor=..&limit=..}. Only its query
+     * is used: it is appended to the URL that was just requested, so the host, the mount prefix and any path an ingress
+     * rewrites stay Core's own -- the README names this as the way for a client that builds URLs from a configured
+     * base. An absolute or path-absolute target, a path other than the search segment, a target without a query, or a
+     * query that names {@code after} (the contract forbids combining a cursor with it) means the contract changed under
+     * Core; the run fails rather than following it.
+     */
+    static URI resolveNextPage(final URI requested, final String target) throws CbomRepositoryException {
+        final URI reference;
+        try {
+            reference = new URI(target);
+        } catch (URISyntaxException e) {
+            throw unusableLink(target);
+        }
+        final boolean relativeToSearch = reference.getScheme() == null && reference.getRawAuthority() == null
+                && !reference.getRawSchemeSpecificPart().startsWith("//")
+                && (reference.getRawPath().isEmpty() || SEARCH_SEGMENT.equals(reference.getRawPath()));
+        if (!relativeToSearch || StringUtils.isBlank(reference.getRawQuery())
+                || namesAfterParameter(reference.getRawQuery())) {
+            throw unusableLink(target);
+        }
+        // The cursor is opaque and may itself carry characters such as the '=' of base64 padding. Decomposing the
+        // query into name/value pairs -- as UriComponentsBuilder#replaceQuery followed by build(true) does, to
+        // validate each value against Type.QUERY_PARAM -- rejects such a legal value with an unchecked
+        // IllegalArgumentException instead of the 502 below. Appending the raw query verbatim to the request URL's
+        // own base (its query stripped) keeps the token exactly as the repository sent it.
+        final String base = UriComponentsBuilder.fromUri(requested).replaceQuery(null).build(true).toUriString();
+        final URI next;
+        try {
+            next = URI.create(base + "?" + reference.getRawQuery());
+        } catch (IllegalArgumentException e) {
+            throw unusableLink(target);
+        }
+        if (next.equals(requested)) {
+            throw new CbomRepositoryException(ProblemDetail
+                    .forStatusAndDetail(HttpStatus.BAD_GATEWAY, "CBOM Repository repeated the page cursor"));
+        }
+        return next;
+    }
+
+    /**
+     * The contract forbids combining a cursor with {@code after}; a Link that does anyway is not safe to follow. The
+     * name is compared decoded, because the server decodes it before it reads it: {@code %61fter} is {@code after}, and
+     * comparing the raw text would let a target carry the parameter past this guard. The escapes are already known to
+     * be well formed -- the target parsed as a URI, which rejects the rest.
+     */
+    private static boolean namesAfterParameter(final String rawQuery) {
+        for (final String pair : rawQuery.split("&")) {
+            final int equals = pair.indexOf('=');
+            final String rawName = equals >= 0 ? pair.substring(0, equals) : pair;
+            if ("after".equals(URLDecoder.decode(rawName, StandardCharsets.UTF_8))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The target goes to the Core log, not into the detail: it is server-supplied text of unbounded length, an absolute
+     * one names the repository's own host and mount path, and the detail reaches more than the scheduler's job result
+     * -- the sync endpoint's REST caller gets it through the error advice too. Only its first
+     * {@value #LINK_TARGET_ECHO_LIMIT} characters are logged.
+     */
+    private static CbomRepositoryException unusableLink(final String target) {
+        if (logger.isWarnEnabled()) {
+            logger
+                    .warn("CBOM Repository returned an unusable Link header for the next page: {}",
+                            StringUtils.abbreviate(target, LINK_TARGET_ECHO_LIMIT));
+        }
+        return new CbomRepositoryException(ProblemDetail
+                .forStatusAndDetail(HttpStatus.BAD_GATEWAY,
+                        "CBOM Repository returned an unusable Link header for the next page"));
     }
 
     public BomResponseDto read(final String urn, final Integer version) throws CbomRepositoryException {
@@ -155,21 +291,20 @@ public class CbomRepositoryClient {
 
     public static Mono<ClientResponse> handleHttpExceptions(final ClientResponse clientResponse) {
         if (clientResponse.statusCode().isError()) {
-            return clientResponse
-                    .bodyToMono(ProblemDetail.class)
-                    .flatMap(problemDetail -> Mono.<ClientResponse>error(new CbomRepositoryException(problemDetail)))
-                    .switchIfEmpty(Mono.defer(() -> {
-                        ProblemDetail pd = ProblemDetail.forStatus(clientResponse.statusCode());
-                        return Mono.error(new CbomRepositoryException(pd));
-                    }))
-                    .onErrorResume(e -> {
-                        if (e instanceof CbomRepositoryException) {
-                            return Mono.error(e);
-                        }
-                        return Mono
-                                .error(new CbomRepositoryException(
-                                        ProblemDetail.forStatus(clientResponse.statusCode())));
-                    });
+            return clientResponse.bodyToMono(ProblemDetail.class).flatMap(problemDetail -> {
+                // The response's status is the one the callers classify by, not whatever the body says: a body
+                // that is JSON but no problem detail decodes with status 0, and a body may name another status.
+                problemDetail.setStatus(clientResponse.statusCode().value());
+                return Mono.<ClientResponse>error(new CbomRepositoryException(problemDetail));
+            }).switchIfEmpty(Mono.defer(() -> {
+                ProblemDetail pd = ProblemDetail.forStatus(clientResponse.statusCode());
+                return Mono.error(new CbomRepositoryException(pd));
+            })).onErrorResume(e -> {
+                if (e instanceof CbomRepositoryException) {
+                    return Mono.error(e);
+                }
+                return Mono.error(new CbomRepositoryException(ProblemDetail.forStatus(clientResponse.statusCode())));
+            });
         }
         return Mono.just(clientResponse);
     }

--- a/src/main/java/com/otilm/core/cbom/client/LinkHeader.java
+++ b/src/main/java/com/otilm/core/cbom/client/LinkHeader.java
@@ -1,0 +1,217 @@
+package com.otilm.core.cbom.client;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Reads the {@code rel="next"} target out of RFC 8288 {@code Link} headers.
+ *
+ * <p>
+ * Only what the cbom-repository feed needs: the target of the first link related as {@code next}. The header is walked
+ * once by hand rather than matched by a regular expression -- both the quoted-string and the parameter-list grammar
+ * repeat an alternation, and a backtracking engine implements group repetition by recursing once per repetition, so a
+ * long header can exhaust the stack. A quoted value stays intact, so a {@code title="a, b"} on the same link does not
+ * split it. Anything that is not a well-formed link is ignored rather than rejected; the caller decides what a missing
+ * {@code next} means.
+ */
+final class LinkHeader {
+
+    private LinkHeader() {
+    }
+
+    static Optional<String> nextTarget(List<String> headerValues) {
+        if (headerValues == null) {
+            return Optional.empty();
+        }
+        for (String headerValue : headerValues) {
+            if (headerValue == null) {
+                continue;
+            }
+            final Optional<String> target = nextTargetIn(headerValue);
+            if (target.isPresent()) {
+                return target;
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<String> nextTargetIn(String headerValue) {
+        final LinkScanner scanner = new LinkScanner(headerValue);
+        while (scanner.advanceToLink()) {
+            final String target = scanner.readTarget();
+            if (target == null) {
+                // An unterminated '<': nothing well-formed can follow it.
+                return Optional.empty();
+            }
+            if (scanner.parametersRelateAsNext()) {
+                return Optional.of(target.trim());
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * A position in one header line. Every method reads forward from it, so a header line is walked exactly once
+     * however many links and parameters it carries, and no input can nest the reader.
+     */
+    private static final class LinkScanner {
+
+        private static final String NEXT = "next";
+
+        /** The token characters of RFC 7230, less the alphanumerics. */
+        private static final String TOKEN_SYMBOLS = "!#$%&'*+.^_`|~-";
+
+        private final String header;
+        private int at;
+
+        private LinkScanner(String header) {
+            this.header = header;
+        }
+
+        /** Moves onto the next {@code '<'}, or reports that the rest of the header holds no link. */
+        private boolean advanceToLink() {
+            final int start = header.indexOf('<', at);
+            if (start < 0) {
+                at = header.length();
+                return false;
+            }
+            at = start;
+            return true;
+        }
+
+        /** The target of the link the scanner stands on, or null when its {@code '>'} is missing. */
+        private String readTarget() {
+            final int end = header.indexOf('>', at + 1);
+            if (end < 0) {
+                at = header.length();
+                return null;
+            }
+            final String target = header.substring(at + 1, end);
+            at = end + 1;
+            return target;
+        }
+
+        /**
+         * Reads this link's parameters and reports whether its first {@code rel} names {@code next}. The parameters are
+         * read to the end of the link even once the answer is known: a quoted value may hold a {@code '<'} that would
+         * otherwise be read as the start of a link.
+         */
+        private boolean parametersRelateAsNext() {
+            boolean relSeen = false;
+            boolean next = false;
+            while (advanceToParameter()) {
+                final String name = readName();
+                final String value = readValue();
+                if (!relSeen && "rel".equalsIgnoreCase(name)) {
+                    relSeen = true;
+                    next = namesNext(value);
+                }
+            }
+            return next;
+        }
+
+        /**
+         * Moves onto the name of the next parameter of the current link, or reports that the link ended: at the end of
+         * the header, at the comma that opens the next link, or at text that is not a parameter list at all. The comma
+         * is left where it is -- {@link #advanceToLink()} reads over it looking for the next target.
+         */
+        private boolean advanceToParameter() {
+            skipWhitespace();
+            if (at >= header.length() || header.charAt(at) != ';') {
+                return false;
+            }
+            at++;
+            skipWhitespace();
+            return true;
+        }
+
+        /** A parameter name, empty when the position holds no token character. */
+        private String readName() {
+            final int start = at;
+            while (at < header.length() && isTokenCharacter(header.charAt(at))) {
+                at++;
+            }
+            return header.substring(start, at);
+        }
+
+        /** The value of the parameter just named, unquoted, or null when the parameter carries none. */
+        private String readValue() {
+            skipWhitespace();
+            if (at >= header.length() || header.charAt(at) != '=') {
+                return null;
+            }
+            at++;
+            skipWhitespace();
+            if (at < header.length() && header.charAt(at) == '"') {
+                return readQuotedValue();
+            }
+            return readTokenValue();
+        }
+
+        /** A quoted value with its escapes resolved; an unterminated quote runs to the end of the header. */
+        private String readQuotedValue() {
+            at++;
+            final StringBuilder value = new StringBuilder();
+            while (at < header.length()) {
+                final char character = header.charAt(at++);
+                if (character == '"') {
+                    break;
+                }
+                if (character == '\\' && at < header.length()) {
+                    value.append(header.charAt(at++));
+                } else {
+                    value.append(character);
+                }
+            }
+            return value.toString();
+        }
+
+        /** An unquoted value: everything up to the next parameter, link or space. */
+        private String readTokenValue() {
+            final int start = at;
+            while (at < header.length() && !isValueBoundary(header.charAt(at))) {
+                at++;
+            }
+            return header.substring(start, at);
+        }
+
+        private void skipWhitespace() {
+            while (at < header.length() && Character.isWhitespace(header.charAt(at))) {
+                at++;
+            }
+        }
+
+        /**
+         * Whether a {@code rel} value names {@code next}. The value is a space-separated list of relation types,
+         * compared token by token so a {@code nextish} never matches.
+         */
+        private static boolean namesNext(String relValue) {
+            if (relValue == null) {
+                return false;
+            }
+            int at = 0;
+            while (at < relValue.length()) {
+                while (at < relValue.length() && Character.isWhitespace(relValue.charAt(at))) {
+                    at++;
+                }
+                final int start = at;
+                while (at < relValue.length() && !Character.isWhitespace(relValue.charAt(at))) {
+                    at++;
+                }
+                if (at - start == NEXT.length() && relValue.regionMatches(true, start, NEXT, 0, NEXT.length())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static boolean isTokenCharacter(char character) {
+            return character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z'
+                    || character >= '0' && character <= '9' || TOKEN_SYMBOLS.indexOf(character) >= 0;
+        }
+
+        private static boolean isValueBoundary(char character) {
+            return character == ';' || character == ',' || Character.isWhitespace(character);
+        }
+    }
+}

--- a/src/main/java/com/otilm/core/config/ApplicationConfig.java
+++ b/src/main/java/com/otilm/core/config/ApplicationConfig.java
@@ -45,7 +45,10 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 @EnableJpaAuditing(auditorAwareRef = "auditorAware")
-@EnableConfigurationProperties({DiscoveryProperties.class, ConnectorApiClientProperties.class})
+@EnableConfigurationProperties({
+        DiscoveryProperties.class,
+        ConnectorApiClientProperties.class,
+        CbomSyncProperties.class})
 @ComponentScan(basePackages = "com.otilm.core",
         excludeFilters = @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class))
 public class ApplicationConfig {

--- a/src/main/java/com/otilm/core/config/CbomSyncProperties.java
+++ b/src/main/java/com/otilm/core/config/CbomSyncProperties.java
@@ -1,0 +1,50 @@
+package com.otilm.core.config;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.boot.convert.DurationUnit;
+
+/**
+ * Tuning for the CBOM header sync against cbom-repository, bound from {@code cbom.sync.*} and validated at startup.
+ *
+ * <p>
+ * These are deployment-time protocol parameters, not operator settings: the page size is bounded by the repository's
+ * contract, and the overlap has to cover clock skew between Core and the object store plus the longest upload the
+ * deployment expects (S3 stamps a multipart upload with its initiation time). The repository documents 60 s.
+ *
+ * @param pageSize the {@code limit} sent with {@code GET /api/v1/bom}; 1..1000 per the contract, 1000 by default
+ * @param overlap how far behind the last successful run's start the next run lists from; 60 s by default. A bare number
+ * binds as seconds: without {@code @DurationUnit} Spring reads it as milliseconds, so {@code 60} would silently mean 60
+ * ms and the overlap would vanish
+ * @param skippedRetryRuns how many later runs retry an entry that could not be stored before it is recorded as
+ * permanently skipped; 3 by default, 0 writes an entry off at its first failure
+ */
+@ConfigurationProperties(prefix = "cbom.sync")
+public record CbomSyncProperties(@DefaultValue("1000") int pageSize,
+        @DefaultValue("60s") @DurationUnit(ChronoUnit.SECONDS) Duration overlap,
+        @DefaultValue("3") int skippedRetryRuns) {
+
+    public static final int MIN_PAGE_SIZE = 1;
+    public static final int MAX_PAGE_SIZE = 1000;
+
+    public CbomSyncProperties {
+        if (pageSize < MIN_PAGE_SIZE || pageSize > MAX_PAGE_SIZE) {
+            throw new IllegalArgumentException("cbom.sync.page-size must be within %d..%d, was %d"
+                    .formatted(MIN_PAGE_SIZE, MAX_PAGE_SIZE, pageSize));
+        }
+        if (overlap == null || overlap.isNegative()) {
+            throw new IllegalArgumentException("cbom.sync.overlap must be a non-negative duration, was " + overlap);
+        }
+        if (skippedRetryRuns < 0) {
+            throw new IllegalArgumentException(
+                    "cbom.sync.skipped-retry-runs must be zero or positive, was " + skippedRetryRuns);
+        }
+    }
+
+    /** The first failed attempt plus the configured retries: the attempt count at which an entry is written off. */
+    public int maxAttempts() {
+        return 1 + skippedRetryRuns;
+    }
+}

--- a/src/main/java/com/otilm/core/dao/entity/Cbom.java
+++ b/src/main/java/com/otilm/core/dao/entity/Cbom.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 import lombok.Getter;
@@ -23,9 +24,12 @@ import org.hibernate.proxy.HibernateProxy;
 @ToString
 @RequiredArgsConstructor
 @Entity
-@Table(name = "cbom")
-// Stated here as well as in the migration so the entity-generated schema the tests run against carries the same
-// invariant and the same constraint name as production.
+// The unique constraint and the check below are stated here as well as in the migration so the entity-generated
+// schema the tests run against carries the same invariants under the same names as production: the header sync tells
+// a duplicate from any other refusal by reading `cbom_serial_version_unique` off the violation.
+@Table(name = "cbom",
+        uniqueConstraints = @UniqueConstraint(name = "cbom_serial_version_unique",
+                columnNames = {"serial_number", "version"}))
 @Check(name = "ck_cbom_asset_sync_state",
         constraints = "asset_sync_state IN ('PENDING', 'IN_PROGRESS', 'SYNCED', 'FAILED')")
 public class Cbom extends UniquelyIdentified implements DtoMapper<CbomDto> {

--- a/src/main/java/com/otilm/core/dao/entity/cbom/CbomSyncSkip.java
+++ b/src/main/java/com/otilm/core/dao/entity/cbom/CbomSyncSkip.java
@@ -1,0 +1,97 @@
+package com.otilm.core.dao.entity.cbom;
+
+import com.otilm.core.dao.entity.UniquelyIdentified;
+import com.otilm.core.model.cbom.CbomHeaderCounts;
+import com.otilm.core.model.cbom.CbomSyncSkipState;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.OffsetDateTime;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.Check;
+
+/**
+ * A repository feed entry that a sync run could not store, remembered so it is not lost when the watermark moves past
+ * it.
+ *
+ * <p>
+ * The feed offers a document once: the next run lists from the start of the last successful run minus the overlap, so
+ * an entry that failed -- its document unreadable for a moment, a Core validation refusing it -- would otherwise never
+ * be offered again while the run still counted as successful. The row keeps the identity the repository serves
+ * documents by, the counts the feed reported (so a recovered entry gets the same header a first-try entry gets), and
+ * the attempt bookkeeping of the bounded retry. It is deleted the moment the document is stored, whichever state it is
+ * in. A row whose budget is spent stays {@code PERMANENTLY_SKIPPED}: no run loads it again, nothing in the API reads it
+ * yet, and it is found in the database and in the Core log's warning for the write-off. Its retention and an operator's
+ * view of it are follow-up work.
+ *
+ * <p>
+ * {@code reason} is operator-visible, so it is always text Core shaped -- never a driver or framework message.
+ */
+@Getter
+@Setter
+@Entity
+@Table(name = "cbom_sync_skip",
+        uniqueConstraints = @UniqueConstraint(name = "uq_cbom_sync_skip_serial_version",
+                columnNames = {"serial_number", "version"}))
+@Check(name = "ck_cbom_sync_skip_state", constraints = "state IN ('RETRYING', 'PERMANENTLY_SKIPPED')")
+public class CbomSyncSkip extends UniquelyIdentified {
+
+    @Column(name = "serial_number", nullable = false, columnDefinition = "TEXT")
+    private String serialNumber;
+
+    @Column(name = "version", nullable = false)
+    private int version;
+
+    @Column(name = "reason", nullable = false, columnDefinition = "TEXT")
+    private String reason;
+
+    /** Sync runs that tried this entry, the one that first failed included. */
+    @Column(name = "attempts", nullable = false)
+    private int attempts;
+
+    @Column(name = "first_skipped_at", nullable = false)
+    private OffsetDateTime firstSkippedAt;
+
+    @Column(name = "last_attempt_at", nullable = false)
+    private OffsetDateTime lastAttemptAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "state", nullable = false, columnDefinition = "TEXT")
+    private CbomSyncSkipState state;
+
+    @Column(name = "algorithms_count", nullable = false)
+    private int algorithmsCount;
+
+    @Column(name = "certificates_count", nullable = false)
+    private int certificatesCount;
+
+    @Column(name = "protocols_count", nullable = false)
+    private int protocolsCount;
+
+    @Column(name = "crypto_material_count", nullable = false)
+    private int cryptoMaterialCount;
+
+    @Column(name = "total_assets_count", nullable = false)
+    private int totalAssetsCount;
+
+    public CbomHeaderCounts counts() {
+        return new CbomHeaderCounts(algorithmsCount, certificatesCount, protocolsCount, cryptoMaterialCount,
+                totalAssetsCount);
+    }
+
+    // No-op overrides required by S2160: identity and hashing stay UUID-based, and the added columns never affect
+    // equality.
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+}

--- a/src/main/java/com/otilm/core/dao/repository/cbom/CbomSyncSkipRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/cbom/CbomSyncSkipRepository.java
@@ -1,0 +1,72 @@
+package com.otilm.core.dao.repository.cbom;
+
+import com.otilm.core.dao.entity.cbom.CbomSyncSkip;
+import com.otilm.core.model.cbom.CbomHeaderCounts;
+import com.otilm.core.model.cbom.CbomSyncSkipState;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Feed entries the header sync could not store, kept for a bounded retry.
+ *
+ * <p>
+ * A plain {@link JpaRepository}: platform bookkeeping, never a listed resource. Writes go through
+ * {@code CbomSyncSkipWriter}.
+ */
+@Repository
+public interface CbomSyncSkipRepository extends JpaRepository<CbomSyncSkip, UUID> {
+
+    /**
+     * The rows in one state, oldest failure first, {@code uuid} as the tie-break so the order is total. The sync loads
+     * the {@code RETRYING} rows only: a written-off row never leaves the table on its own, so loading every row would
+     * grow with every document ever written off rather than with the live retry set.
+     */
+    List<CbomSyncSkip> findAllByStateOrderByFirstSkippedAtAscUuidAsc(CbomSyncSkipState state);
+
+    Optional<CbomSyncSkip> findBySerialNumberAndVersion(String serialNumber, int version);
+
+    /**
+     * Counts one more failed attempt for an identity, creating the row on the first failure.
+     *
+     * <p>
+     * <b>Concurrency:</b> two runs failing on the same entry at once both count -- the unique constraint is the
+     * arbiter, so neither insert fails. The attempt budget is spent a run early in that case, which is the safe
+     * direction. A row already written off stays written off: {@code state} only ever moves to
+     * {@code PERMANENTLY_SKIPPED}, when the new attempt count reaches {@code maxAttempts}.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+            INSERT INTO {h-schema}cbom_sync_skip (uuid, serial_number, version, reason, attempts, first_skipped_at,
+                last_attempt_at, state, algorithms_count, certificates_count, protocols_count, crypto_material_count,
+                total_assets_count)
+            VALUES (:uuid, :serialNumber, :version, :reason, 1, :now, :now,
+                CASE WHEN 1 >= :maxAttempts THEN 'PERMANENTLY_SKIPPED' ELSE 'RETRYING' END,
+                :#{#counts.algorithms()}, :#{#counts.certificates()}, :#{#counts.protocols()},
+                :#{#counts.cryptoMaterial()}, :#{#counts.totalAssets()})
+            ON CONFLICT (serial_number, version) DO UPDATE SET
+                reason = EXCLUDED.reason,
+                attempts = cbom_sync_skip.attempts + 1,
+                last_attempt_at = EXCLUDED.last_attempt_at,
+                state = CASE WHEN cbom_sync_skip.attempts + 1 >= :maxAttempts THEN 'PERMANENTLY_SKIPPED'
+                             ELSE cbom_sync_skip.state END,
+                algorithms_count = EXCLUDED.algorithms_count,
+                certificates_count = EXCLUDED.certificates_count,
+                protocols_count = EXCLUDED.protocols_count,
+                crypto_material_count = EXCLUDED.crypto_material_count,
+                total_assets_count = EXCLUDED.total_assets_count
+            """, nativeQuery = true)
+    void upsertAttempt(@Param("uuid") UUID uuid, @Param("serialNumber") String serialNumber,
+            @Param("version") int version, @Param("reason") String reason, @Param("now") OffsetDateTime now,
+            @Param("maxAttempts") int maxAttempts, @Param("counts") CbomHeaderCounts counts);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM CbomSyncSkip s WHERE s.serialNumber = :serialNumber AND s.version = :version")
+    int deleteBySerialNumberAndVersion(@Param("serialNumber") String serialNumber, @Param("version") int version);
+}

--- a/src/main/java/com/otilm/core/model/cbom/BomEntryDto.java
+++ b/src/main/java/com/otilm/core/model/cbom/BomEntryDto.java
@@ -1,13 +1,26 @@
 package com.otilm.core.model.cbom;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+/**
+ * One entry of the cbom-repository search feed ({@code GET /api/v1/bom}), contract 0.3.0.
+ *
+ * <p>
+ * The wire name of the creation time is {@code created_at} (snake case, unlike every other field). In paged mode
+ * ({@code limit} sent) an object whose stored statistics are missing or unreadable is still listed, with
+ * {@code cryptoStats} null and the reason in {@code warnings}; the unpaged call never emits either. The warning codes
+ * are {@code crypto-stats-missing} and {@code crypto-stats-invalid} (no counts, {@code cryptoStats} null),
+ * {@code crypto-stats-shallow} (top-level components only) and {@code crypto-stats-truncated} (cut off at the
+ * repository's depth bound); the sync logs them as sent and does not branch on them.
+ */
 @Setter
 @Getter
 @Schema(description = "BOM entry")
@@ -23,20 +36,29 @@ public class BomEntryDto {
             requiredMode = Schema.RequiredMode.REQUIRED)
     private String version;
 
-    @NotNull
-    @Schema(description = "RFC 3339 timestamp when this CBOM was created", example = "2026-01-25T21:35:05Z",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-    private OffsetDateTime timestamp;
+    @JsonProperty("created_at")
+    @Schema(description = "RFC 3339 timestamp (UTC, second precision) when this document version was stored",
+            example = "2026-01-25T21:35:05Z", requiredMode = Schema.RequiredMode.REQUIRED)
+    private OffsetDateTime createdAt;
 
-    @NotNull
-    @Schema(description = "Crypto statistics", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "Crypto statistics; null in paged mode when the stored statistics could not be read, see warnings",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private CryptoStatsDto cryptoStats;
+
+    @Schema(description = "Paged mode only: crypto-stats-missing, crypto-stats-invalid, crypto-stats-shallow, crypto-stats-truncated",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private List<String> warnings;
+
+    public boolean hasWarnings() {
+        return warnings != null && !warnings.isEmpty();
+    }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
                 .append("serialNumber", serialNumber)
                 .append("version", version)
+                .append("warnings", warnings)
                 .toString();
     }
 }

--- a/src/main/java/com/otilm/core/model/cbom/BomSearchRequestDto.java
+++ b/src/main/java/com/otilm/core/model/cbom/BomSearchRequestDto.java
@@ -11,11 +11,19 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @Schema(description = "Search BOMs created after a timestamp")
 public class BomSearchRequestDto {
 
-    @Schema(description = "Unix timestamp", example = "1769156084", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Schema(description = "Unix timestamp (seconds); documents created strictly after it are listed. Null means 0.",
+            example = "1769156084", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private Long after;
+
+    @Schema(description = "Page size 1..1000 sent as `limit`. Null selects the unpaged legacy call, which never pages.",
+            example = "1000", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Integer limit;
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("after", after).toString();
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("after", after)
+                .append("limit", limit)
+                .toString();
     }
 }

--- a/src/main/java/com/otilm/core/model/cbom/CbomHeaderCounts.java
+++ b/src/main/java/com/otilm/core/model/cbom/CbomHeaderCounts.java
@@ -1,0 +1,38 @@
+package com.otilm.core.model.cbom;
+
+import com.otilm.core.dao.entity.Cbom;
+
+/**
+ * The five per-CBOM asset counts the {@code cbom} row carries, as the repository feed reports them.
+ *
+ * <p>
+ * Every count is advisory: legacy objects hold a shallow count and, in paged mode, an object whose statistics could not
+ * be read arrives with {@code cryptoStats: null}. Such an entry is still stored -- with zero counts, left for the asset
+ * ingest recount -- so the whole shape is null-tolerant and never throws.
+ */
+public record CbomHeaderCounts(int algorithms, int certificates, int protocols, int cryptoMaterial, int totalAssets) {
+
+    public static final CbomHeaderCounts ZERO = new CbomHeaderCounts(0, 0, 0, 0, 0);
+
+    public static CbomHeaderCounts from(CryptoStatsDto stats) {
+        if (stats == null || stats.getCryptoAssets() == null) {
+            return ZERO;
+        }
+        CryptoAssetsDto assets = stats.getCryptoAssets();
+        return new CbomHeaderCounts(total(assets.getAlgorithms()), total(assets.getCertificates()),
+                total(assets.getProtocols()), total(assets.getRelatedCryptoMaterials()),
+                assets.getTotal() == null ? 0 : assets.getTotal());
+    }
+
+    public void applyTo(Cbom cbom) {
+        cbom.setAlgorithmsCount(algorithms);
+        cbom.setCertificatesCount(certificates);
+        cbom.setProtocolsCount(protocols);
+        cbom.setCryptoMaterialCount(cryptoMaterial);
+        cbom.setTotalAssetsCount(totalAssets);
+    }
+
+    private static int total(CryptoAssetCountDto count) {
+        return count == null || count.getTotal() == null ? 0 : count.getTotal();
+    }
+}

--- a/src/main/java/com/otilm/core/model/cbom/CbomSyncSkipState.java
+++ b/src/main/java/com/otilm/core/model/cbom/CbomSyncSkipState.java
@@ -1,0 +1,9 @@
+package com.otilm.core.model.cbom;
+
+/** Where a feed entry that Core could not store stands in its bounded retry. */
+public enum CbomSyncSkipState {
+    /** Retried at the end of each sync run until the attempt budget is spent. */
+    RETRYING,
+    /** The budget is spent; the entry is kept as a record and never retried by the sync. */
+    PERMANENTLY_SKIPPED
+}

--- a/src/main/java/com/otilm/core/service/impl/CbomServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CbomServiceImpl.java
@@ -28,14 +28,18 @@ import com.otilm.core.attribute.engine.AttributeColumnProjector;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.AttributeEngine.CustomAttributeContentFilter;
 import com.otilm.core.attribute.engine.ListingSortResolver;
+import com.otilm.core.cbom.client.BomSearchPage;
 import com.otilm.core.cbom.client.CbomRepositoryClient;
 import com.otilm.core.comparator.SearchFieldDataComparator;
+import com.otilm.core.config.CbomSyncProperties;
 import com.otilm.core.dao.CryptoAssetConstraintTranslator;
 import com.otilm.core.dao.entity.Cbom;
 import com.otilm.core.dao.entity.Cbom_;
 import com.otilm.core.dao.entity.ScheduledJobHistory;
+import com.otilm.core.dao.entity.cbom.CbomSyncSkip;
 import com.otilm.core.dao.repository.CbomRepository;
 import com.otilm.core.dao.repository.ScheduledJobHistoryRepository;
+import com.otilm.core.dao.repository.cbom.CbomSyncSkipRepository;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.events.transaction.TransactionHandler;
 import com.otilm.core.logging.LoggerWrapper;
@@ -45,12 +49,15 @@ import com.otilm.core.model.cbom.BomEntryDto;
 import com.otilm.core.model.cbom.BomResponseDto;
 import com.otilm.core.model.cbom.BomSearchRequestDto;
 import com.otilm.core.model.cbom.BomVersionDto;
+import com.otilm.core.model.cbom.CbomHeaderCounts;
+import com.otilm.core.model.cbom.CbomSyncSkipState;
 import com.otilm.core.model.cbom.CryptoStatsDto;
 import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.CbomExternalService;
 import com.otilm.core.service.CbomInternalService;
+import com.otilm.core.service.writer.cbom.CbomSyncSkipWriter;
 import com.otilm.core.tasks.CbomSyncTask;
 import com.otilm.core.util.CbomUtil;
 import com.otilm.core.util.FilterPredicatesBuilder;
@@ -60,8 +67,13 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import java.net.URI;
+import java.time.Duration;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -87,6 +99,22 @@ public class CbomServiceImpl implements CbomExternalService, CbomInternalService
 
     private static final LoggerWrapper logger = new LoggerWrapper(CbomServiceImpl.class, Module.CORE, Resource.CBOM);
 
+    /** Feed entries with this version are the original upload, never a re-synced revision; the sync ignores them. */
+    private static final String ORIGINAL_VERSION = "original";
+
+    /**
+     * Safety net against a repository that never stops handing out cursors -- ten million entries at the default page
+     * size, not a capacity figure any real deployment is expected to approach.
+     */
+    private static final int MAX_PAGES_PER_RUN = 10_000;
+
+    /**
+     * The unique constraint the dedup key is guarded by, declared under this name in both the migration and
+     * {@link Cbom}. Only this violation means "another writer got there first"; any other refusal by the database is
+     * this entry's problem and is recorded as such rather than counted as a duplicate.
+     */
+    private static final String DEDUP_CONSTRAINT = "cbom_serial_version_unique";
+
     private CbomRepository cbomRepository;
 
     private CbomRepositoryClient cbomRepositoryClient;
@@ -100,6 +128,12 @@ public class CbomServiceImpl implements CbomExternalService, CbomInternalService
     private AttributeColumnProjector attributeColumnProjector;
 
     private ListingSortResolver listingSortResolver;
+
+    private CbomSyncProperties syncProperties;
+
+    private CbomSyncSkipWriter syncSkipWriter;
+
+    private CbomSyncSkipRepository syncSkipRepository;
 
     @Autowired
     public void setCbomRepository(CbomRepository cbomRepository) {
@@ -134,6 +168,21 @@ public class CbomServiceImpl implements CbomExternalService, CbomInternalService
     @Autowired
     public void setTransactionHandler(TransactionHandler transactionHandler) {
         this.transactionHandler = transactionHandler;
+    }
+
+    @Autowired
+    public void setSyncProperties(CbomSyncProperties syncProperties) {
+        this.syncProperties = syncProperties;
+    }
+
+    @Autowired
+    public void setSyncSkipWriter(CbomSyncSkipWriter syncSkipWriter) {
+        this.syncSkipWriter = syncSkipWriter;
+    }
+
+    @Autowired
+    public void setSyncSkipRepository(CbomSyncSkipRepository syncSkipRepository) {
+        this.syncSkipRepository = syncSkipRepository;
     }
 
     @Override
@@ -281,7 +330,13 @@ public class CbomServiceImpl implements CbomExternalService, CbomInternalService
         cbom.setSpecVersion(specVersion);
         cbom.setTimestamp(CbomUtil.getMetadataTimestamp(content).orElse(null));
         cbom.setSource(CbomUtil.getMetadataComponentName(content).orElse(null));
-        setCryptoStats(cbom, serialNumber, version, cryptoStats);
+        if (cryptoStats == null) {
+            logger
+                    .getLogger()
+                    .debug("CBOM document retrieved from repository for serialNumber {} and version {} does not contain crypto stats",
+                            serialNumber, version);
+        }
+        CbomHeaderCounts.from(cryptoStats).applyTo(cbom);
 
         // save into the database only in case it does not exists
         if (cbomRepository.existsBySerialNumberAndVersion(serialNumber, version)) {
@@ -426,150 +481,490 @@ public class CbomServiceImpl implements CbomExternalService, CbomInternalService
         return cbomRepository.findByUuid(uuid).orElseThrow(() -> new NotFoundException(Cbom.class, uuid));
     }
 
-    private void setCryptoStats(Cbom cbom, String serialNumber, int version, CryptoStatsDto cryptoStats) {
-        // Defensive handling of potentially null nested response objects
-        int algorithmsCount = 0;
-        int certificatesCount = 0;
-        int protocolsCount = 0;
-        int cryptoMaterialCount = 0;
-        int totalAssetsCount = 0;
-        if (cryptoStats != null && cryptoStats.getCryptoAssets() != null) {
-            if (cryptoStats.getCryptoAssets().getAlgorithms() != null
-                    && cryptoStats.getCryptoAssets().getAlgorithms().getTotal() != null) {
-                algorithmsCount = cryptoStats.getCryptoAssets().getAlgorithms().getTotal();
-            }
-            if (cryptoStats.getCryptoAssets().getCertificates() != null
-                    && cryptoStats.getCryptoAssets().getCertificates().getTotal() != null) {
-                certificatesCount = cryptoStats.getCryptoAssets().getCertificates().getTotal();
-            }
-            if (cryptoStats.getCryptoAssets().getProtocols() != null
-                    && cryptoStats.getCryptoAssets().getProtocols().getTotal() != null) {
-                protocolsCount = cryptoStats.getCryptoAssets().getProtocols().getTotal();
-            }
-            if (cryptoStats.getCryptoAssets().getRelatedCryptoMaterials() != null
-                    && cryptoStats.getCryptoAssets().getRelatedCryptoMaterials().getTotal() != null) {
-                cryptoMaterialCount = cryptoStats.getCryptoAssets().getRelatedCryptoMaterials().getTotal();
-            }
-            if (cryptoStats.getCryptoAssets().getTotal() != null) {
-                totalAssetsCount = cryptoStats.getCryptoAssets().getTotal();
-            }
-        } else {
-            logger
-                    .getLogger()
-                    .debug("CBOM document retrieved from repository for serialNumber {} and version {} does not contain crypto stats",
-                            serialNumber, version);
-        }
-
-        cbom.setAlgorithmsCount(algorithmsCount);
-        cbom.setCertificatesCount(certificatesCount);
-        cbom.setProtocolsCount(protocolsCount);
-        cbom.setCryptoMaterialCount(cryptoMaterialCount);
-        cbom.setTotalAssetsCount(totalAssetsCount);
-    }
-
+    @Override
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     @ExternalAuthorization(resource = Resource.CBOM, action = ResourceAction.CREATE)
     public void syncAuthorized() throws CbomRepositoryException {
         if (!cbomRepositoryClient.isConfigured()) {
             logger.getLogger().debug("CBOM sync: CBOM Repository not configured: skipped;");
             return;
         }
-        sync();
+        runSync();
     }
 
+    /**
+     * One sync run against the repository's paged search.
+     *
+     * <p>
+     * The run opens with {@code after = start of the last successful run - overlap} and follows the repository's
+     * {@code Link rel="next"} header until a page carries none; the absence of the header, not the page size, ends the
+     * run. Every entry is deduplicated on {@code (serialNumber, version)} and stored in its own transaction; an entry
+     * with {@code cryptoStats: null} is stored with zero counts, left for the asset ingest recount. An entry that could
+     * not be stored is recorded in {@code cbom_sync_skip} and retried at the end of the next
+     * {@code cbom.sync.skipped-retry-runs} runs, then kept as permanently skipped -- so one failing document can never
+     * hold the watermark back, and no entry is lost silently. Any non-2xx answer to a page request fails the run
+     * instead: the watermark does not advance and the whole run is repeated. A document read that reaches the sync as
+     * HTTP 503 -- the repository declaring itself unavailable, or the client's own refused connection or response
+     * timeout -- is charged to that document like any other failure, one hanging document among no other new documents
+     * included. Only a run that shows a repository-wide outage -- no read succeeded at all and at least two of the feed
+     * pass's documents failed that way -- fails without charging those failures to the retry budget. A retry's failure
+     * never counts towards that verdict: the page requests of the same run just succeeded, so the repository is up, and
+     * a retry that is exempt from being charged would never spend its budget.
+     *
+     * <p>
+     * Runs without an ambient transaction, and so does the scheduler task calling it: the run pages an external service
+     * and reads one document per entry, which must not happen inside the platform's 120 s default transaction. The
+     * writes it needs are the entry transactions ({@code REQUIRES_NEW}) and the {@code CbomSyncSkipWriter} methods
+     * ({@code REQUIRED}, so each commits on its own).
+     */
+    @Override
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public String sync() throws CbomRepositoryException {
-        long timestamp = getLastSyncTimestamp();
-        BomSearchRequestDto query = new BomSearchRequestDto();
-        query.setAfter(timestamp);
-        List<BomEntryDto> cboms = cbomRepositoryClient.search(query);
-        logger
-                .getLogger()
-                .debug("CBOM sync: {} CBOM entries retrieved from repository for after: {}", cboms.size(),
-                        query.getAfter());
+        return runSync();
+    }
 
-        int skipped = 0;
-        int duplicates = 0;
-        int stored = 0;
+    /**
+     * The run itself, held apart from the two public entry points so that neither reaches it through {@code this}:
+     * Spring applies the transaction advice of {@code @Transactional} only to a call arriving from outside the bean, so
+     * a self-invocation would run the boundary of whichever caller it came from.
+     */
+    private String runSync() throws CbomRepositoryException {
+        final SyncRun run = new SyncRun(OffsetDateTime.now(), syncProperties.maxAttempts());
+        final Map<SyncIdentity, CbomSyncSkip> skips = loadSkipRecords();
 
-        for (BomEntryDto entry : cboms) {
-            int version;
-            try {
-                version = validateSyncedCbomEntry(entry);
-            } catch (AlreadyExistException e) {
-                logger.getLogger().debug("CBOM Sync: {}", e.getMessage());
-                duplicates++;
-                continue;
-            } catch (ValidationException e) {
-                logger.getLogger().debug("CBOM Sync: {}", e.getMessage());
-                skipped++;
-                continue;
-            }
+        readFeed(run, skips);
+        retrySkipped(run, skips);
+        settleUnavailable(run);
 
-            // specVersion, source and metadata.timestamp arguments missing from BomEntryDto
-            // - load them from CBOM itself
-            BomResponseDto response;
-            try {
-                response = read(entry.getSerialNumber(), version);
-            } catch (NotFoundException e) {
-                logger
-                        .getLogger()
-                        .warn("CBOM Sync: CBOM serialNumber {} and version {}: not exists. Skipping the sync",
-                                entry.getSerialNumber(), version);
-                skipped++;
-                continue;
-            } catch (Exception ex) {
-                logger
-                        .getLogger()
-                        .warn("CBOM Sync: CBOM serialNumber {} and version {}: error while reading the CBOM document from repository. Skipping the sync. Error: {}",
-                                entry.getSerialNumber(), version, ex.getMessage());
-                skipped++;
-                continue;
-            }
+        final String syncResultMessage = run.summary();
+        logger.getLogger().info("CBOM Sync: finished. {}", syncResultMessage);
+        return syncResultMessage;
+    }
 
-            AtomicBoolean isDuplicate = new AtomicBoolean(false);
-            try {
-                transactionHandler.runInNewTransaction(() -> {
-                    try {
-                        createCbomEntry(entry, version, response);
-                    } catch (AlreadyExistException e) {
-                        // Pre-check duplicate: no DB operation occurred, transaction is healthy.
-                        // AlreadyExistException is checked so it cannot cross the Runnable boundary;
-                        // handle it here and signal the result via isDuplicate.
-                        isDuplicate.set(true);
-                    }
-                });
-            } catch (DataIntegrityViolationException e) {
-                // Race condition: unique constraint hit at DB level. The REQUIRES_NEW transaction
-                // is already rolled back; count as duplicate rather than an error.
-                logger
-                        .getLogger()
-                        .debug("CBOM Sync: CBOM serialNumber {} and version {}: already exists (unique constraint). Skipping the sync",
-                                entry.getSerialNumber(), version);
-                duplicates++;
-                continue;
-            } catch (Exception e) {
-                logger
-                        .getLogger()
-                        .debug("CBOM Sync: CBOM serialNumber {} and version {} syncing error {}.",
-                                entry.getSerialNumber(), version, e.getMessage());
-                skipped++;
-                continue;
+    /**
+     * The live retry set: the {@code RETRYING} rows, oldest failure first. Written-off rows stay in the table but are
+     * not loaded -- their number only ever grows -- so a row this map does not hold is looked up by identity when an
+     * entry fails or is stored ({@link #previousSkip}, {@link #resolveSkipIfRecorded}).
+     */
+    private Map<SyncIdentity, CbomSyncSkip> loadSkipRecords() {
+        final Map<SyncIdentity, CbomSyncSkip> skips = new LinkedHashMap<>();
+        for (CbomSyncSkip skip : syncSkipRepository
+                .findAllByStateOrderByFirstSkippedAtAscUuidAsc(CbomSyncSkipState.RETRYING)) {
+            skips.put(new SyncIdentity(skip.getSerialNumber(), skip.getVersion()), skip);
+        }
+        return skips;
+    }
+
+    /** The entry's skip row as it stood at the start of the run, or null if the entry has never failed before. */
+    private CbomSyncSkip previousSkip(SyncIdentity identity, Map<SyncIdentity, CbomSyncSkip> skips) {
+        final CbomSyncSkip retrying = skips.get(identity);
+        if (retrying != null) {
+            return retrying;
+        }
+        return syncSkipRepository
+                .findBySerialNumberAndVersion(identity.serialNumber(), identity.version())
+                .orElse(null);
+    }
+
+    private void readFeed(SyncRun run, Map<SyncIdentity, CbomSyncSkip> skips) throws CbomRepositoryException {
+        final BomSearchRequestDto query = new BomSearchRequestDto();
+        query.setAfter(getLastSyncTimestamp());
+        query.setLimit(syncProperties.pageSize());
+        logger.getLogger().debug("CBOM sync: listing entries created after {}", query.getAfter());
+
+        final Set<URI> requestedPages = new HashSet<>();
+        BomSearchPage page = cbomRepositoryClient.search(query);
+        while (true) {
+            run.pages++;
+            if (run.pages > MAX_PAGES_PER_RUN) {
+                throw new CbomRepositoryException(ProblemDetail
+                        .forStatusAndDetail(HttpStatus.BAD_GATEWAY,
+                                "CBOM Repository handed out more than " + MAX_PAGES_PER_RUN + " pages in one run"));
             }
-            if (isDuplicate.get()) {
-                logger
-                        .getLogger()
-                        .debug("CBOM Sync: CBOM serialNumber {} and version {}: already exists. Skipping the sync",
-                                entry.getSerialNumber(), version);
-                duplicates++;
-                continue;
+            if (page.hasNext() && page.entries().isEmpty()) {
+                // The repository fills a page to the limit while candidates remain and sends a Link only when it
+                // stopped before the end of the listing, so an empty page can only ever be the last one. An empty
+                // page that still claims a next page is a broken feed; following it would spin until the page
+                // ceiling above.
+                throw new CbomRepositoryException(ProblemDetail
+                        .forStatusAndDetail(HttpStatus.BAD_GATEWAY,
+                                "CBOM Repository sent an empty page that still claims a next page"));
             }
-            stored++;
+            run.read += page.entries().size();
+            logger.getLogger().debug("CBOM sync: page {} holds {} CBOM entries", run.pages, page.entries().size());
+            for (BomEntryDto entry : page.entries()) {
+                processFeedEntry(entry, run, skips);
+            }
+            if (!page.hasNext()) {
+                warnIfTheOpeningPageLooksUnpaged(run, page);
+                return;
+            }
+            if (!requestedPages.add(page.nextPage())) {
+                throw new CbomRepositoryException(ProblemDetail
+                        .forStatusAndDetail(HttpStatus.BAD_GATEWAY,
+                                "CBOM Repository sent a page cursor it had already sent in this run"));
+            }
+            page = cbomRepositoryClient.nextPage(page);
+        }
+    }
+
+    /**
+     * A repository older than 0.3.0 has no {@code Link} header and no cursor: it answers the search with as much of the
+     * listing as {@code limit} allows and says nothing about the rest. From here that is indistinguishable from a
+     * complete single page -- so a full opening page without a Link is called out, because Core would otherwise report
+     * a clean run over what may be only the first {@code page-size} entries of the listing.
+     */
+    private void warnIfTheOpeningPageLooksUnpaged(SyncRun run, BomSearchPage page) {
+        if (run.pages == 1 && page.entries().size() >= syncProperties.pageSize()) {
+            logger
+                    .getLogger()
+                    .warn("CBOM Sync: the opening page holds {} entries (the requested limit) but carries no Link header; a cbom-repository older than 0.3.0 does not page, so this run may have been truncated. Upgrade every repository replica to 0.3.0 or newer",
+                            page.entries().size());
+        }
+    }
+
+    private void processFeedEntry(BomEntryDto entry, SyncRun run, Map<SyncIdentity, CbomSyncSkip> skips) {
+        if (ORIGINAL_VERSION.equals(entry.getVersion())) {
+            logger
+                    .getLogger()
+                    .debug("CBOM Sync: ignoring the original upload of serialNumber {}", entry.getSerialNumber());
+            run.originals++;
+            return;
+        }
+        final SyncIdentity identity;
+        try {
+            identity = identityOf(entry);
+        } catch (ValidationException e) {
+            logger.getLogger().warn("CBOM Sync: {}", e.getMessage());
+            run.invalid++;
+            return;
+        }
+        if (!run.attempted.add(identity)) {
+            // The feed offered this identity twice in the same run (e.g. a page overlapping a retried cursor); the
+            // first occurrence already carries whatever this run will do for it, so treat the repeat as a duplicate
+            // rather than attempting it -- and recording a skip -- a second time.
+            logger
+                    .getLogger()
+                    .debug("CBOM Sync: CBOM serialNumber {} and version {} was already offered earlier in this run; skipping the repeat",
+                            identity.serialNumber(), identity.version());
+            run.duplicates++;
+            return;
+        }
+        if (cbomRepository.existsBySerialNumberAndVersion(identity.serialNumber(), identity.version())) {
+            logger
+                    .getLogger()
+                    .debug("CBOM Sync: CBOM serialNumber {} and version {}: already exists. Skipping the sync",
+                            identity.serialNumber(), identity.version());
+            run.duplicates++;
+            resolveSkipIfRecorded(identity, skips, run);
+            return;
         }
 
-        String syncResultMessage = "Read %d entries, skipped due to an error %d, skipped duplicates %d, stored %d new entries"
-                .formatted(cboms.size(), skipped, duplicates, stored);
-        logger.getLogger().info("CBOM Sync: finished. {}", syncResultMessage);
+        final CbomHeaderCounts counts = CbomHeaderCounts.from(entry.getCryptoStats());
+        final StoreOutcome outcome = store(identity, counts, run);
+        switch (outcome.kind()) {
+            case STORED -> {
+                run.stored++;
+                if (entry.hasWarnings()) {
+                    logger
+                            .getLogger()
+                            .warn("CBOM Sync: repository flagged CBOM serialNumber {} version {} with {}; header counts {}",
+                                    identity.serialNumber(), identity.version(), entry.getWarnings(),
+                                    entry.getCryptoStats() == null
+                                            ? "are left at zero until the asset ingest recounts them"
+                                            : "were taken from the feed as reported");
+                }
+                resolveSkipIfRecorded(identity, skips, run);
+            }
+            case DUPLICATE -> {
+                run.duplicates++;
+                resolveSkipIfRecorded(identity, skips, run);
+            }
+            case FAILED -> recordFailure(identity, outcome.reason(), counts, run, previousSkip(identity, skips));
+            case UNAVAILABLE -> {
+                run.feedDeferred++;
+                run.deferred.add(new DeferredSkip(identity, counts, outcome.reason(), previousSkip(identity, skips)));
+            }
+            default -> throw new IllegalStateException("Unhandled store outcome " + outcome.kind());
+        }
+    }
 
-        return syncResultMessage;
+    private void retrySkipped(SyncRun run, Map<SyncIdentity, CbomSyncSkip> skips) {
+        for (CbomSyncSkip skip : List.copyOf(skips.values())) {
+            retrySkippedEntry(skip, run, skips);
+        }
+    }
+
+    /**
+     * One recorded skip's retry. An entry this run's feed pass already attempted is left alone -- that attempt carries
+     * whatever the run does for it.
+     */
+    private void retrySkippedEntry(CbomSyncSkip skip, SyncRun run, Map<SyncIdentity, CbomSyncSkip> skips) {
+        final SyncIdentity identity = new SyncIdentity(skip.getSerialNumber(), skip.getVersion());
+        if (run.attempted.contains(identity)) {
+            return;
+        }
+        run.retried++;
+        if (cbomRepository.existsBySerialNumberAndVersion(identity.serialNumber(), identity.version())) {
+            resolveSkipIfRecorded(identity, skips, run);
+            return;
+        }
+        final StoreOutcome outcome = store(identity, skip.counts(), run);
+        switch (outcome.kind()) {
+            case FAILED -> recordFailure(identity, outcome.reason(), skip.counts(), run, skip);
+            case UNAVAILABLE -> run.deferred.add(new DeferredSkip(identity, skip.counts(), outcome.reason(), skip));
+            default -> resolveSkipIfRecorded(identity, skips, run);
+        }
+    }
+
+    /**
+     * Reads the document and stores the header row in its own transaction. Never throws for one entry's failure -- the
+     * outcome is the caller's signal. A read Core could not get an answer to at all yields {@code UNAVAILABLE} rather
+     * than a skip: whether that was this document or the whole repository is only known once every read of the run is
+     * done, so the verdict is left to {@link #settleUnavailable(SyncRun)}.
+     */
+    private StoreOutcome store(SyncIdentity identity, CbomHeaderCounts counts, SyncRun run) {
+        final BomResponseDto document;
+        try {
+            document = read(identity.serialNumber(), identity.version());
+            run.successfulReads++;
+        } catch (NotFoundException e) {
+            return StoreOutcome.failed("document not found in the repository (HTTP 404)");
+        } catch (CbomRepositoryException e) {
+            final ProblemDetail problemDetail = e.getProblemDetail();
+            if (problemDetail == null) {
+                return StoreOutcome.unavailable("repository failed the document read (status unknown)");
+            }
+            final String reason = "repository failed the document read (HTTP " + problemDetail.getStatus() + ")";
+            // A 503 is not a verdict on this document: the repository answers it when it is unavailable as a whole, and
+            // the client synthesizes it when it never got an answer -- a refused connection, or the response timeout.
+            // Any other status the repository chose, 5xx included, is about this document and is charged to it.
+            return problemDetail.getStatus() == HttpStatus.SERVICE_UNAVAILABLE.value()
+                    ? StoreOutcome.unavailable(reason)
+                    : StoreOutcome.failed(reason);
+        } catch (RuntimeException e) {
+            logger
+                    .getLogger()
+                    .warn("CBOM Sync: CBOM serialNumber {} and version {}: reading the document failed",
+                            identity.serialNumber(), identity.version(), e);
+            return StoreOutcome.failed("reading the document failed unexpectedly (see the Core log)");
+        }
+
+        final AtomicBoolean isDuplicate = new AtomicBoolean(false);
+        try {
+            transactionHandler.runInNewTransaction(() -> {
+                try {
+                    createCbomEntry(identity, counts, document);
+                } catch (AlreadyExistException e) {
+                    // Pre-check duplicate: no DB operation occurred, transaction is healthy.
+                    // AlreadyExistException is checked so it cannot cross the Runnable boundary;
+                    // handle it here and signal the result via isDuplicate.
+                    isDuplicate.set(true);
+                }
+            });
+        } catch (DataIntegrityViolationException e) {
+            if (CryptoAssetConstraintTranslator
+                    .constraintNameOf(e)
+                    .filter(DEDUP_CONSTRAINT::equalsIgnoreCase)
+                    .isEmpty()) {
+                // Some other invariant of the `cbom` row was violated -- a column the feed left null, a check
+                // constraint. Counting that as a duplicate would drop the entry silently, so it is recorded for retry.
+                logger
+                        .getLogger()
+                        .warn("CBOM Sync: CBOM serialNumber {} and version {}: the database refused the CBOM row",
+                                identity.serialNumber(), identity.version(), e);
+                return StoreOutcome.failed("storing the CBOM row failed: the database refused it (see the Core log)");
+            }
+            // Race condition: the dedup key's unique constraint was hit at DB level. The REQUIRES_NEW transaction
+            // is already rolled back; count as duplicate rather than an error.
+            logger
+                    .getLogger()
+                    .debug("CBOM Sync: CBOM serialNumber {} and version {}: already exists (unique constraint). Skipping the sync",
+                            identity.serialNumber(), identity.version());
+            return StoreOutcome.DUPLICATE;
+        } catch (ValidationException e) {
+            return StoreOutcome.failed("the stored document was refused: " + e.getMessage());
+        } catch (RuntimeException e) {
+            logger
+                    .getLogger()
+                    .warn("CBOM Sync: CBOM serialNumber {} and version {}: storing the CBOM row failed",
+                            identity.serialNumber(), identity.version(), e);
+            return StoreOutcome.failed("storing the CBOM row failed unexpectedly (see the Core log)");
+        }
+        return isDuplicate.get() ? StoreOutcome.DUPLICATE : StoreOutcome.STORED;
+    }
+
+    /**
+     * Decides what the reads Core never got an answer to (see {@link #store}) were: this document's failure, or the
+     * repository's. Nothing about one such read tells the two apart -- the client answers a refused connection and a
+     * response that timed out with the same 503 -- but the run as a whole does. When it looks like an outage
+     * ({@link #looksLikeOutage(SyncRun)}) the repository is what failed: the run fails without charging anyone's retry
+     * budget, and because the task maps a 503 to a skipped run, the watermark holds and the same entries are offered
+     * again. Otherwise each deferred document, a retried one included, is charged for its own failure, exactly as any
+     * other failed entry is.
+     */
+    private void settleUnavailable(SyncRun run) throws CbomRepositoryException {
+        if (run.deferred.isEmpty()) {
+            return;
+        }
+        if (looksLikeOutage(run)) {
+            throw new CbomRepositoryException(ProblemDetail
+                    .forStatusAndDetail(HttpStatus.SERVICE_UNAVAILABLE,
+                            "CBOM Repository failed every document read of this run (" + run.deferred.size()
+                                    + " documents); no server-side read failure was charged to the retry budget"
+                                    + " and the run is not counted as successful"));
+        }
+        for (DeferredSkip deferred : run.deferred) {
+            recordFailure(deferred.identity(), deferred.reason(), deferred.counts(), run, deferred.previous());
+        }
+    }
+
+    /**
+     * A run shows an outage only when nothing proves the repository serves documents at all: no read succeeded and at
+     * least two documents of the feed pass failed server-side. One new document failing on its own is not that
+     * evidence, so it is charged like any other failure -- one hanging document must never hold the watermark.
+     *
+     * <p>
+     * The retry phase's failures do not count towards the verdict, however many there are. The page requests of this
+     * very run succeeded, so the repository is serving; and a retry the verdict exempted from being charged would keep
+     * being exempted in every quiet run to come -- the run skipped every hour, the watermark never recorded again, the
+     * budget never spent -- which is the unbounded retry the table exists to prevent. The price is one attempt charged
+     * to a retry when an outage begins between the page requests and the retries of the same run.
+     */
+    private static boolean looksLikeOutage(SyncRun run) {
+        return run.successfulReads == 0 && run.feedDeferred >= 2;
+    }
+
+    /**
+     * Records one entry's failure and charges it to exactly one counter of the report: recorded for retry, written off
+     * on this run, or failed again after having been written off earlier -- so an entry is never reported as both
+     * queued for retry and given up on.
+     */
+    private void recordFailure(SyncIdentity identity, String reason, CbomHeaderCounts counts, SyncRun run,
+            CbomSyncSkip previous) {
+        switch (recordSkip(identity, reason, counts, run, previous)) {
+            case RETRYING -> run.recordedForRetry++;
+            case WRITTEN_OFF -> run.permanentlySkipped++;
+            case ALREADY_WRITTEN_OFF -> run.alreadyPermanent++;
+        }
+    }
+
+    /**
+     * Records one more failed attempt and reports it. A row already permanently skipped before this attempt was
+     * reported when that happened, so a further failure of a written-off entry logs at INFO only.
+     *
+     * @param previous the row's state at the start of this run, or null if this is its first failure ever
+     */
+    private SkipOutcome recordSkip(SyncIdentity identity, String reason, CbomHeaderCounts counts, SyncRun run,
+            CbomSyncSkip previous) {
+        final CbomSyncSkip attempted = syncSkipWriter
+                .recordAttempt(identity.serialNumber(), identity.version(), reason, counts, run.startedAt,
+                        run.maxAttempts);
+        if (attempted.getState() != CbomSyncSkipState.PERMANENTLY_SKIPPED) {
+            logger
+                    .getLogger()
+                    .warn("CBOM Sync: CBOM serialNumber {} version {} could not be stored (attempt {} of {}): {}. It is retried on the next run",
+                            identity.serialNumber(), identity.version(), attempted.getAttempts(), run.maxAttempts,
+                            reason);
+            return SkipOutcome.RETRYING;
+        }
+        if (previous != null && previous.getState() == CbomSyncSkipState.PERMANENTLY_SKIPPED) {
+            logger
+                    .getLogger()
+                    .info("CBOM Sync: CBOM serialNumber {} version {} already permanently skipped; failed again: {}",
+                            identity.serialNumber(), identity.version(), reason);
+            return SkipOutcome.ALREADY_WRITTEN_OFF;
+        }
+        logger
+                .getLogger()
+                .warn("CBOM Sync: CBOM serialNumber {} version {} is permanently skipped after {} attempts: {}",
+                        identity.serialNumber(), identity.version(), attempted.getAttempts(), reason);
+        return SkipOutcome.WRITTEN_OFF;
+    }
+
+    /**
+     * Deletes the entry's skip row, if it has one, now that the document is stored. The live retry set answers for
+     * {@code RETRYING} rows; a written-off row is looked up, so it too is resolved when its document finally arrives.
+     */
+    private void resolveSkipIfRecorded(SyncIdentity identity, Map<SyncIdentity, CbomSyncSkip> skips, SyncRun run) {
+        if (skips.remove(identity) == null && syncSkipRepository
+                .findBySerialNumberAndVersion(identity.serialNumber(), identity.version())
+                .isEmpty()) {
+            return;
+        }
+        syncSkipWriter.resolve(identity.serialNumber(), identity.version());
+        run.resolved++;
+        logger
+                .getLogger()
+                .info("CBOM Sync: CBOM serialNumber {} version {} is stored; its skip record is resolved",
+                        identity.serialNumber(), identity.version());
+    }
+
+    private SyncIdentity identityOf(BomEntryDto entry) throws ValidationException {
+        if (entry.getSerialNumber() == null) {
+            throw new ValidationException(
+                    "CBOM entry with missing serial number and version %s".formatted(entry.getVersion()));
+        }
+        try {
+            return new SyncIdentity(entry.getSerialNumber(), Integer.parseInt(entry.getVersion()));
+        } catch (NumberFormatException e) {
+            throw new ValidationException("CBOM document with serialNumber %s has invalid version %s"
+                    .formatted(entry.getSerialNumber(), entry.getVersion()));
+        }
+    }
+
+    private long getLastSyncTimestamp() {
+        Optional<ScheduledJobHistory> lastSync = scheduledJobHistoryRepository
+                .findFirstByScheduledJobJobNameAndSchedulerExecutionStatusOrderByJobExecutionDesc(CbomSyncTask.NAME,
+                        SchedulerJobExecutionStatus.SUCCESS);
+
+        if (lastSync.isEmpty()) {
+            logger.getLogger().debug("CBOM sync: no previous run found, performing initial sync.");
+            return 0L;
+        }
+
+        ScheduledJobHistory lastSyncJob = lastSync.get();
+        Date jobExecution = lastSyncJob.getJobExecution();
+        if (jobExecution == null) {
+            logger.getLogger().debug("CBOM sync: last sync job has no execution start time, performing initial sync.");
+            return 0L;
+        }
+        return watermarkSeconds(jobExecution, syncProperties.overlap());
+    }
+
+    /**
+     * The {@code after} bound of a run, in whole seconds: where the last successful run started, less the overlap that
+     * covers clock skew and in-flight uploads, and never before the epoch. Package-private and static so the one piece
+     * of arithmetic the whole watermark rests on can be pinned without booting a context.
+     */
+    static long watermarkSeconds(Date lastSuccessfulRunStart, Duration overlap) {
+        return Math.max(0L, Math.floorDiv(lastSuccessfulRunStart.getTime(), 1000L) - overlap.toSeconds());
+    }
+
+    private void createCbomEntry(SyncIdentity identity, CbomHeaderCounts counts, BomResponseDto response)
+            throws AlreadyExistException {
+        if (cbomRepository.existsBySerialNumberAndVersion(identity.serialNumber(), identity.version())) {
+            throw new AlreadyExistException("CBOM with serialNumber %s and version %s already exists"
+                    .formatted(identity.serialNumber(), identity.version()));
+        }
+
+        Cbom cbom = new Cbom();
+        cbom.setSerialNumber(identity.serialNumber());
+        cbom.setVersion(identity.version());
+        Optional<String> specVersion = CbomUtil.getString(response, "specVersion");
+        if (specVersion.isEmpty()) {
+            throw new ValidationException("CBOM Repository returned empty specVersion");
+        } else {
+            cbom.setSpecVersion(specVersion.get());
+        }
+        cbom.setTimestamp(CbomUtil.getMetadataTimestamp(response).orElse(null));
+        cbom.setSource(CbomUtil.getMetadataComponentName(response).orElse(null));
+        counts.applyTo(cbom);
+        // Let DataIntegrityViolationException propagate unchecked so the REQUIRES_NEW
+        // transaction is not left rollback-only when caught inside the Runnable boundary.
+        // The sync loop catches it and counts it as a duplicate when the violated constraint is the
+        // (serialNumber, version) uniqueness; any other constraint is recorded for retry.
+        cbomRepository.save(cbom);
     }
 
     public boolean isCbomRepositoryClientConfigured() {
@@ -594,79 +989,84 @@ public class CbomServiceImpl implements CbomExternalService, CbomInternalService
         return response;
     }
 
-    private int validateSyncedCbomEntry(BomEntryDto entry) throws ValidationException, AlreadyExistException {
-        if (entry.getSerialNumber() == null) {
-            throw new ValidationException(
-                    "CBOM entry with missing serial number and version %s".formatted(entry.getVersion()));
-        }
-
-        int version;
-        try {
-            version = Integer.parseInt(entry.getVersion());
-        } catch (NumberFormatException e) {
-            throw new ValidationException("CBOM document with serialNumber %s has invalid version %s"
-                    .formatted(entry.getSerialNumber(), entry.getVersion()));
-        }
-
-        boolean cbomVersionExists = cbomRepository.existsBySerialNumberAndVersion(entry.getSerialNumber(), version);
-        if (cbomVersionExists) {
-            throw new AlreadyExistException(
-                    "CBOM document with serial number %s and version %s already exists. Skipping the sync"
-                            .formatted(entry.getSerialNumber(), version));
-        }
-
-        return version;
+    /** The pair the repository serves documents by and Core deduplicates on. */
+    private record SyncIdentity(String serialNumber, int version) {
     }
 
-    private long getLastSyncTimestamp() {
-        Optional<ScheduledJobHistory> lastSync = scheduledJobHistoryRepository
-                .findFirstByScheduledJobJobNameAndSchedulerExecutionStatusOrderByJobExecutionDesc(CbomSyncTask.NAME,
-                        SchedulerJobExecutionStatus.SUCCESS);
+    /**
+     * What happened to one entry; {@code reason} is operator-safe text, set for {@code FAILED} and {@code UNAVAILABLE}.
+     */
+    private record StoreOutcome(Kind kind, String reason) {
 
-        if (lastSync.isEmpty()) {
-            logger.getLogger().debug("CBOM sync: no previous run found, performing initial sync.");
-            return 0L;
+        enum Kind {
+            STORED,
+            DUPLICATE,
+            FAILED,
+            /** The document read got no answer; whose failure that was is decided for the run as a whole. */
+            UNAVAILABLE
         }
 
-        long timestamp = 0L;
-        ScheduledJobHistory lastSyncJob = lastSync.get();
-        Date jobExecution = lastSyncJob.getJobExecution();
-        if (jobExecution == null) {
-            logger.getLogger().debug("CBOM sync: last sync job has no execution start time, performing initial sync.");
-        } else {
-            long safetyOverlapSeconds = 60L;
-            long baseTimestamp = jobExecution.getTime() / 1000;
-            timestamp = Math.max(0L, baseTimestamp - safetyOverlapSeconds);
+        static final StoreOutcome STORED = new StoreOutcome(Kind.STORED, null);
+        static final StoreOutcome DUPLICATE = new StoreOutcome(Kind.DUPLICATE, null);
+
+        static StoreOutcome failed(String reason) {
+            return new StoreOutcome(Kind.FAILED, reason);
         }
-        return timestamp;
+
+        static StoreOutcome unavailable(String reason) {
+            return new StoreOutcome(Kind.UNAVAILABLE, reason);
+        }
     }
 
-    private void createCbomEntry(BomEntryDto entry, int version, BomResponseDto response) throws AlreadyExistException {
-        String serialNumber = entry.getSerialNumber();
-        if (cbomRepository.existsBySerialNumberAndVersion(serialNumber, version)) {
-            throw new AlreadyExistException(
-                    "CBOM with serialNumber %s and version %s already exists".formatted(serialNumber, version));
+    /** What recording a failed attempt did to the entry's skip row. */
+    private enum SkipOutcome {
+        RETRYING,
+        WRITTEN_OFF,
+        ALREADY_WRITTEN_OFF
+    }
+
+    /**
+     * One entry whose document read got no answer, held until the end of the run.
+     *
+     * @param previous the skip row's state at the start of the run, or null if the entry has never failed before
+     */
+    private record DeferredSkip(SyncIdentity identity, CbomHeaderCounts counts, String reason, CbomSyncSkip previous) {
+    }
+
+    /** Counters of one run and the identities it has already tried, so the retry phase does not try them twice. */
+    private static final class SyncRun {
+        final OffsetDateTime startedAt;
+        final int maxAttempts;
+        final Set<SyncIdentity> attempted = new HashSet<>();
+        /** Entries whose document read got no answer, awaiting the run's verdict. */
+        final List<DeferredSkip> deferred = new ArrayList<>();
+        int pages;
+        int read;
+        /** Of {@link #deferred}, the entries the feed pass offered; only these weigh in the outage verdict. */
+        int feedDeferred;
+        int stored;
+        int duplicates;
+        int originals;
+        int invalid;
+        int recordedForRetry;
+        int retried;
+        int resolved;
+        int permanentlySkipped;
+        int alreadyPermanent;
+        int successfulReads;
+
+        SyncRun(OffsetDateTime startedAt, int maxAttempts) {
+            this.startedAt = startedAt;
+            this.maxAttempts = maxAttempts;
         }
 
-        Cbom cbom = new Cbom();
-        cbom.setSerialNumber(entry.getSerialNumber());
-        cbom.setVersion(version);
-        Optional<String> specVersion = CbomUtil.getString(response, "specVersion");
-        if (specVersion.isEmpty()) {
-            throw new ValidationException("CBOM Repository returned empty specVersion");
-        } else {
-            cbom.setSpecVersion(specVersion.get());
+        String summary() {
+            return ("Read %d entries in %d pages: stored %d new entries, skipped duplicates %d, ignored %d original documents, "
+                    + "%d invalid entries; %d entries could not be stored and were recorded for retry; "
+                    + "retried %d previously skipped entries, %d skip records resolved; %d entries are now permanently skipped; "
+                    + "%d offers of permanently skipped entries failed again")
+                    .formatted(read, pages, stored, duplicates, originals, invalid, recordedForRetry, retried, resolved,
+                            permanentlySkipped, alreadyPermanent);
         }
-        cbom.setTimestamp(CbomUtil.getMetadataTimestamp(response).orElse(null));
-        cbom.setSource(CbomUtil.getMetadataComponentName(response).orElse(null));
-        cbom.setAlgorithmsCount(entry.getCryptoStats().getCryptoAssets().getAlgorithms().getTotal());
-        cbom.setCertificatesCount(entry.getCryptoStats().getCryptoAssets().getCertificates().getTotal());
-        cbom.setProtocolsCount(entry.getCryptoStats().getCryptoAssets().getProtocols().getTotal());
-        cbom.setCryptoMaterialCount(entry.getCryptoStats().getCryptoAssets().getRelatedCryptoMaterials().getTotal());
-        cbom.setTotalAssetsCount(entry.getCryptoStats().getCryptoAssets().getTotal());
-        // Let DataIntegrityViolationException propagate unchecked so the REQUIRES_NEW
-        // transaction is not left rollback-only when caught inside the Runnable boundary.
-        // The sync loop catches it specifically and counts it as a duplicate.
-        cbomRepository.save(cbom);
     }
 }

--- a/src/main/java/com/otilm/core/service/writer/cbom/CbomSyncSkipWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/cbom/CbomSyncSkipWriter.java
@@ -1,0 +1,52 @@
+package com.otilm.core.service.writer.cbom;
+
+import com.otilm.core.dao.entity.cbom.CbomSyncSkip;
+import com.otilm.core.dao.repository.cbom.CbomSyncSkipRepository;
+import com.otilm.core.model.cbom.CbomHeaderCounts;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Short transactional writes to the bounded-retry record of the CBOM header sync.
+ *
+ * <p>
+ * Every method is {@code REQUIRED}, so it commits in its own transaction when the sync loop -- which runs without one,
+ * because it pages an external service -- calls it after the entry's own transaction has already rolled back. Called
+ * from inside that failing transaction it would be rolled back with it, and the failure would be lost; owning that
+ * boundary is the sync loop's job.
+ */
+@Service
+public class CbomSyncSkipWriter {
+
+    private final CbomSyncSkipRepository repository;
+
+    public CbomSyncSkipWriter(CbomSyncSkipRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * Counts a failed attempt and returns the row as it now stands, so the caller can tell whether the budget is spent.
+     *
+     * @param operatorSafeReason text the caller shaped itself; stored verbatim and shown to an operator, so never a
+     * driver or framework message
+     */
+    @Transactional
+    public CbomSyncSkip recordAttempt(String serialNumber, int version, String operatorSafeReason,
+            CbomHeaderCounts counts, OffsetDateTime now, int maxAttempts) {
+        repository
+                .upsertAttempt(UUID.randomUUID(), serialNumber, version, operatorSafeReason, now, maxAttempts, counts);
+        return repository
+                .findBySerialNumberAndVersion(serialNumber, version)
+                .orElseThrow(() -> new IllegalStateException(
+                        "cbom_sync_skip row vanished between its upsert and its read for " + serialNumber + " version "
+                                + version));
+    }
+
+    /** Forgets the record: the document is stored. Returns 0 when there was none. */
+    @Transactional
+    public int resolve(String serialNumber, int version) {
+        return repository.deleteBySerialNumberAndVersion(serialNumber, version);
+    }
+}

--- a/src/main/java/com/otilm/core/tasks/CbomSyncTask.java
+++ b/src/main/java/com/otilm/core/tasks/CbomSyncTask.java
@@ -1,6 +1,7 @@
 package com.otilm.core.tasks;
 
 import com.otilm.api.exception.CbomRepositoryException;
+import com.otilm.api.exception.PlatformException;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.scheduler.SchedulerJobExecutionStatus;
 import com.otilm.core.api.ScheduledJobSkippedException;
@@ -50,8 +51,13 @@ public class CbomSyncTask implements ScheduledJobTask {
         return true;
     }
 
+    /**
+     * Runs without a transaction of its own: the run pages an external service and reads one document per entry, and
+     * the service method it calls is {@code NOT_SUPPORTED} for that reason. Opening a transaction here only to have it
+     * suspended for the whole run would keep it open, unused, for as long as the run takes.
+     */
     @Override
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public ScheduledTaskResult performJob(final ScheduledJobInfo scheduledJobInfo, final Object taskData) {
         if (!cbomService.isCbomRepositoryClientConfigured()) {
             throw new ScheduledJobSkippedException();
@@ -66,9 +72,13 @@ public class CbomSyncTask implements ScheduledJobTask {
                 throw new ScheduledJobSkippedException();
             }
 
+            // Only a shaped domain exception's own message is operator-safe; anything else (JPA, the WebClient
+            // stack, a bare RuntimeException) could quote driver or framework internals, so it is replaced with the
+            // fallback below. The stack trace itself is still logged, for the Core log.
+            final String safeReason = PlatformException.safeMessage(e, "unexpected error, see the Core log");
             final String errorMessage = String
                     .format("Unable to sync CBOMs for job %s. Error: %s",
-                            scheduledJobInfo == null ? "" : scheduledJobInfo.jobName(), e.getMessage());
+                            scheduledJobInfo == null ? "" : scheduledJobInfo.jobName(), safeReason);
             logger.error(errorMessage, e);
             return new ScheduledTaskResult(SchedulerJobExecutionStatus.FAILED, errorMessage, Resource.CBOM, null);
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -410,6 +410,16 @@ connector:
 cbom:
   client:
     max-buffer-size: ${CBOM_CLIENT_MAX_BUFFER_SIZE:20971520}
+  sync:
+    # Page size sent as `limit` to the repository search (1..1000); pages are followed through `Link rel="next"`.
+    page-size: ${CBOM_SYNC_PAGE_SIZE:1000}
+    # Each run lists documents created after (start of the last successful run - overlap). The overlap must cover
+    # clock skew between Core and the object store plus the longest upload duration (S3 stamps a multipart upload with
+    # its initiation time); the repository documents 60 s. Re-read entries are deduplicated on (serialNumber, version).
+    # A bare number is read as seconds; a unit suffix (60s, 2m) is also accepted.
+    overlap: ${CBOM_SYNC_OVERLAP:60s}
+    # An entry that could not be stored is retried on this many later runs, then recorded as permanently skipped.
+    skipped-retry-runs: ${CBOM_SYNC_SKIPPED_RETRY_RUNS:3}
 
 signing-record:
   outbox:

--- a/src/main/resources/db/migration/V202609081800__cbom_sync_skip.sql
+++ b/src/main/resources/db/migration/V202609081800__cbom_sync_skip.sql
@@ -1,0 +1,29 @@
+-- Feed entries the CBOM header sync could not store, kept for a bounded retry. The repository search offers a
+-- document once: the next run lists from (start of the last successful run - overlap), so an entry whose document
+-- could not be read or whose row could not be written would otherwise be lost silently while the run still counted
+-- as successful. A row is deleted the moment the document is stored; a row whose attempt budget is spent stays
+-- PERMANENTLY_SKIPPED and is not loaded by a run again -- retention and an operator's view of it are follow-up work.
+CREATE TABLE "cbom_sync_skip"
+(
+    "uuid"                  UUID        NOT NULL,
+    -- The identity the repository serves documents by; no FK to cbom, which by definition has no row for it.
+    "serial_number"         TEXT        NOT NULL,
+    "version"               INT         NOT NULL,
+    -- Shaped by Core, never a driver message: this string is operator-visible.
+    "reason"                TEXT        NOT NULL,
+    -- Sync runs that tried the entry, the first failure included.
+    "attempts"              INT         NOT NULL,
+    "first_skipped_at"      TIMESTAMPTZ NOT NULL,
+    "last_attempt_at"       TIMESTAMPTZ NOT NULL,
+    "state"                 TEXT        NOT NULL,
+    -- The counts the feed reported, so a recovered entry gets the same header a first-try entry gets.
+    "algorithms_count"      INT         NOT NULL,
+    "certificates_count"    INT         NOT NULL,
+    "protocols_count"       INT         NOT NULL,
+    "crypto_material_count" INT         NOT NULL,
+    "total_assets_count"    INT         NOT NULL,
+    PRIMARY KEY ("uuid"),
+    -- Target of the ON CONFLICT that counts another attempt.
+    CONSTRAINT "uq_cbom_sync_skip_serial_version" UNIQUE ("serial_number", "version"),
+    CONSTRAINT "ck_cbom_sync_skip_state" CHECK ("state" IN ('RETRYING', 'PERMANENTLY_SKIPPED'))
+);

--- a/src/test/java/com/otilm/core/cbom/client/CbomRepositoryClientTest.java
+++ b/src/test/java/com/otilm/core/cbom/client/CbomRepositoryClientTest.java
@@ -14,6 +14,7 @@ import com.otilm.core.model.cbom.BomResponseDto;
 import com.otilm.core.model.cbom.BomSearchRequestDto;
 import com.otilm.core.model.cbom.BomVersionDto;
 import com.otilm.core.settings.SettingsCache;
+import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -24,6 +25,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
@@ -33,8 +35,11 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -122,66 +127,243 @@ class CbomRepositoryClientTest {
         assertThrows(CbomRepositoryException.class, () -> client.create(request));
     }
 
-    @Test
-    void testSearch_Success() throws Exception {
-        // Arrange
-        BomSearchRequestDto searchRequest = new BomSearchRequestDto();
-        Long after = OffsetDateTime.parse("2026-01-19T21:35:05Z").toEpochSecond();
-        searchRequest.setAfter(after);
+    private static final String ENTRY_1 = """
+            {"serialNumber":"urn:uuid:test-1","version":"1","created_at":"2026-01-19T21:35:05Z",
+             "cryptoStats":{"cryptoAssets":{"total":4,"algorithms":{"total":1},"certificates":{"total":1},
+             "protocols":{"total":1},"relatedCryptoMaterials":{"total":1}}}}""";
+    private static final String ENTRY_2 = """
+            {"serialNumber":"urn:uuid:test-2","version":"original","created_at":"2026-01-19T21:35:06Z",
+             "cryptoStats":null,"warnings":["crypto-stats-missing"]}""";
+    private static final String ENTRY_3 = """
+            {"serialNumber":"urn:uuid:test-3","version":"2","created_at":"2026-01-19T21:35:07Z",
+             "cryptoStats":{"cryptoAssets":{"total":0,"algorithms":{"total":0},"certificates":{"total":0},
+             "protocols":{"total":0},"relatedCryptoMaterials":{"total":0}}},
+             "warnings":["crypto-stats-shallow","crypto-stats-truncated"],"unknownFutureField":true}""";
 
-        BomEntryDto entry1 = new BomEntryDto();
-        entry1.setSerialNumber("urn:uuid:test-1");
-        entry1.setVersion("1");
+    private static BomSearchRequestDto pagedQuery(long after, int limit) {
+        BomSearchRequestDto query = new BomSearchRequestDto();
+        query.setAfter(after);
+        query.setLimit(limit);
+        return query;
+    }
 
-        BomEntryDto entry2 = new BomEntryDto();
-        entry2.setSerialNumber("urn:uuid:test-2");
-        entry2.setVersion("1");
-
-        List<BomEntryDto> responseList = List.of(entry1, entry2);
-
+    private void stubPage(String queryParam, String value, String body, String linkHeader) {
+        var response = aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody(body);
+        if (linkHeader != null) {
+            response = response.withHeader("Link", linkHeader);
+        }
         wireMock
                 .stubFor(get(urlPathEqualTo("/api/v1/bom"))
-                        .withQueryParam("after", equalTo(String.valueOf(after)))
-                        .willReturn(aResponse()
-                                .withStatus(200)
-                                .withHeader("Content-Type", "application/json")
-                                .withBody(objectMapper.writeValueAsString(responseList))));
-
-        // Act
-        List<BomEntryDto> result = client.search(searchRequest);
-
-        // Assert
-        assertNotNull(result);
-        assertEquals(2, result.size());
-        assertEquals("urn:uuid:test-1", result.get(0).getSerialNumber());
-        assertEquals("urn:uuid:test-2", result.get(1).getSerialNumber());
-
-        wireMock
-                .verify(getRequestedFor(urlPathEqualTo("/api/v1/bom"))
-                        .withQueryParam("after", equalTo(String.valueOf(after))));
+                        .withQueryParam(queryParam, equalTo(value))
+                        .willReturn(response));
     }
 
     @Test
-    void testSearch_WithNullAfter() throws Exception {
-        // Arrange
-        BomSearchRequestDto searchRequest = new BomSearchRequestDto();
-        searchRequest.setAfter(null);
+    void search_opensARunWithAfterAndLimitAndMapsTheContract() throws Exception {
+        stubPage("after", "1768858505", "[" + ENTRY_1 + "," + ENTRY_2 + "," + ENTRY_3 + "]", null);
 
-        List<BomEntryDto> responseList = List.of();
+        BomSearchPage page = client.search(pagedQuery(1768858505L, 1000));
+
+        assertEquals(3, page.entries().size());
+        assertFalse(page.hasNext());
+        BomEntryDto first = page.entries().get(0);
+        assertEquals("urn:uuid:test-1", first.getSerialNumber());
+        assertEquals(OffsetDateTime.parse("2026-01-19T21:35:05Z"), first.getCreatedAt());
+        assertEquals(4, first.getCryptoStats().getCryptoAssets().getTotal());
+        assertFalse(first.hasWarnings());
+        BomEntryDto second = page.entries().get(1);
+        assertEquals("original", second.getVersion());
+        assertNull(second.getCryptoStats());
+        assertEquals(List.of("crypto-stats-missing"), second.getWarnings());
+        BomEntryDto third = page.entries().get(2);
+        assertEquals(List.of("crypto-stats-shallow", "crypto-stats-truncated"), third.getWarnings());
+        wireMock
+                .verify(getRequestedFor(urlPathEqualTo("/api/v1/bom"))
+                        .withQueryParam("after", equalTo("1768858505"))
+                        .withQueryParam("limit", equalTo("1000"))
+                        .withQueryParam("cursor", absent()));
+    }
+
+    @Test
+    void search_followsLinkNextByAppendingItsQueryToTheOwnSearchUrl() throws Exception {
+        stubPage("after", "0", "[" + ENTRY_1 + "]", "<bom?cursor=c1&limit=1>; rel=\"next\"");
+        stubPage("cursor", "c1", "[" + ENTRY_2 + "]",
+                "<bom?cursor=c2&limit=1>; rel=\"next\", <bom?after=0&limit=1>; rel=\"first\"");
+        stubPage("cursor", "c2", "[]", null);
+
+        BomSearchPage first = client.search(pagedQuery(0, 1));
+        assertTrue(first.hasNext());
+        assertEquals(URI.create(baseUrl + "/api/v1/bom?cursor=c1&limit=1"), first.nextPage());
+
+        BomSearchPage second = client.nextPage(first);
+        assertEquals("urn:uuid:test-2", second.entries().get(0).getSerialNumber());
+        assertTrue(second.hasNext());
+
+        BomSearchPage third = client.nextPage(second);
+        assertTrue(third.entries().isEmpty());
+        assertFalse(third.hasNext());
 
         wireMock
-                .stubFor(get(urlPathEqualTo("/api/v1/bom"))
+                .verify(getRequestedFor(urlPathEqualTo("/api/v1/bom"))
+                        .withQueryParam("cursor", equalTo("c1"))
+                        .withQueryParam("limit", equalTo("1"))
+                        .withQueryParam("after", absent()));
+    }
+
+    @Test
+    void search_followsALinkCursorThatContainsBase64PaddingVerbatim() {
+        String rawQuery = "cursor=djF8MTc4ODQ1MTIwMDAwMHx1cm46dXVpZA%3D%3D==&limit=1";
+        stubPage("after", "0", "[" + ENTRY_1 + "]", "<bom?" + rawQuery + ">; rel=\"next\"");
+        wireMock
+                .stubFor(get(urlEqualTo("/api/v1/bom?" + rawQuery))
                         .willReturn(aResponse()
                                 .withStatus(200)
                                 .withHeader("Content-Type", "application/json")
-                                .withBody(objectMapper.writeValueAsString(responseList))));
+                                .withBody("[]")));
 
-        // Act
-        List<BomEntryDto> result = client.search(searchRequest);
+        BomSearchPage first = assertDoesNotThrow(() -> client.search(pagedQuery(0, 1)));
+        assertTrue(first.hasNext());
+        assertEquals(rawQuery, first.nextPage().getRawQuery());
 
-        // Assert
-        assertNotNull(result);
-        assertTrue(result.isEmpty());
+        BomSearchPage second = assertDoesNotThrow(() -> client.nextPage(first));
+        assertTrue(second.entries().isEmpty());
+    }
+
+    @Test
+    void search_withoutLimitIsTheUnpagedLegacyCall() throws Exception {
+        stubPage("after", "0", "[" + ENTRY_1 + "]", null);
+        BomSearchRequestDto query = new BomSearchRequestDto();
+        query.setAfter(null);
+
+        BomSearchPage page = client.search(query);
+
+        assertEquals(1, page.entries().size());
+        assertFalse(page.hasNext());
+        wireMock
+                .verify(getRequestedFor(urlPathEqualTo("/api/v1/bom"))
+                        .withQueryParam("after", equalTo("0"))
+                        .withQueryParam("limit", absent()));
+    }
+
+    @Test
+    void search_rejectsALimitOutsideTheContractBeforeCalling() {
+        BomSearchRequestDto belowTheContract = pagedQuery(0, 0);
+        BomSearchRequestDto aboveTheContract = pagedQuery(0, 1001);
+        assertThrows(IllegalArgumentException.class, () -> client.search(belowTheContract));
+        assertThrows(IllegalArgumentException.class, () -> client.search(aboveTheContract));
+        wireMock.verify(0, getRequestedFor(urlPathEqualTo("/api/v1/bom")));
+    }
+
+    @Test
+    void search_refusesAnAbsoluteOrPathAbsoluteOrForeignLinkTarget() {
+        for (String target : List
+                .of("https://evil.example/api/v1/bom?cursor=c1&limit=1", "/api/v1/bom?cursor=c1&limit=1",
+                        "boms?cursor=c1&limit=1", "bom", "bom?", "bom?cursor=c1&after=0&limit=1",
+                        // The server decodes the name before it reads it, so an encoded 'after' is 'after' and must
+                        // not pass a guard that compares the raw text.
+                        "bom?cursor=c1&%61fter=0&limit=1", "bom?cursor=c1&%61%66%74%65%72=0&limit=1",
+                        // A network-path reference with an empty authority is not a relative-path reference either.
+                        "//?cursor=c1&limit=1")) {
+            wireMock.resetAll();
+            stubPage("after", "0", "[]", "<" + target + ">; rel=\"next\"");
+            CbomRepositoryException ex = assertThrows(CbomRepositoryException.class,
+                    () -> client.search(pagedQuery(0, 1)), target);
+            assertEquals(502, ex.getProblemDetail().getStatus(), target);
+            // The target itself is not echoed: an absolute one names the repository's host, and the detail reaches
+            // the sync endpoint's REST caller as well as the scheduler result. It goes to the log instead.
+            assertEquals("CBOM Repository returned an unusable Link header for the next page",
+                    ex.getProblemDetail().getDetail(), target);
+        }
+    }
+
+    @Test
+    void read_classifiesAFailedDocumentReadByTheResponseStatusNotByTheBody() {
+        // An ingress or a repository build that answers with plain JSON rather than a problem detail: the body decodes
+        // to a ProblemDetail with status 0, and the sync's 503-or-charge decision must not read that.
+        wireMock
+                .stubFor(get(urlPathEqualTo("/api/v1/bom/urn:uuid:down"))
+                        .willReturn(aResponse()
+                                .withStatus(503)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\"error\":\"service unavailable\"}")));
+
+        CbomRepositoryException ex = assertThrows(CbomRepositoryException.class, () -> client.read("urn:uuid:down", 1));
+
+        assertNotNull(ex.getProblemDetail());
+        assertEquals(503, ex.getProblemDetail().getStatus());
+    }
+
+    @Test
+    void search_classifiesAFailedPageByTheResponseStatusNotByTheBody() {
+        wireMock
+                .stubFor(get(urlPathEqualTo("/api/v1/bom"))
+                        .willReturn(aResponse()
+                                .withStatus(500)
+                                .withHeader("Content-Type", "application/problem+json")
+                                .withBody("{\"type\":\"about:blank\",\"title\":\"stub\",\"status\":503,"
+                                        + "\"detail\":\"a body that claims another status\"}")));
+
+        BomSearchRequestDto query = pagedQuery(0, 1);
+        CbomRepositoryException ex = assertThrows(CbomRepositoryException.class, () -> client.search(query));
+
+        assertEquals(500, ex.getProblemDetail().getStatus());
+        assertEquals("CBOM Repository failed a page request (HTTP 500)", ex.getProblemDetail().getDetail());
+    }
+
+    @Test
+    void nextPage_refusesACursorThatRepeatsTheRequestedPage() throws Exception {
+        stubPage("after", "0", "[]", "<bom?cursor=c1&limit=1>; rel=\"next\"");
+        stubPage("cursor", "c1", "[]", "<bom?cursor=c1&limit=1>; rel=\"next\"");
+
+        BomSearchPage first = client.search(pagedQuery(0, 1));
+        CbomRepositoryException ex = assertThrows(CbomRepositoryException.class, () -> client.nextPage(first));
+        assertEquals(502, ex.getProblemDetail().getStatus());
+        assertEquals("CBOM Repository repeated the page cursor", ex.getProblemDetail().getDetail());
+    }
+
+    @Test
+    void nextPage_requiresAPageWithANextLink() throws Exception {
+        stubPage("after", "0", "[]", null);
+        BomSearchPage last = client.search(pagedQuery(0, 1));
+        assertThrows(IllegalArgumentException.class, () -> client.nextPage(last));
+    }
+
+    @Test
+    void search_keepsTheStatusOfAFailedPageButNotTheRepositoryDetail() {
+        wireMock
+                .stubFor(get(urlPathEqualTo("/api/v1/bom"))
+                        .willReturn(aResponse()
+                                .withStatus(500)
+                                .withHeader("Content-Type", "application/problem+json")
+                                .withBody(
+                                        "{\"type\":\"about:blank\",\"title\":\"Internal Server Error\",\"status\":500,"
+                                                + "\"detail\":\"ERROR: relation \\\"bom\\\" does not exist\"}")));
+
+        BomSearchRequestDto query = pagedQuery(0, 1);
+        CbomRepositoryException ex = assertThrows(CbomRepositoryException.class, () -> client.search(query));
+
+        // The status is what the sync classifies by, so it is kept. The sentence is not: a failed page fails the run,
+        // and the run's message reaches an operator through the scheduler result.
+        assertEquals(500, ex.getProblemDetail().getStatus());
+        assertEquals("CBOM Repository failed a page request (HTTP 500)", ex.getProblemDetail().getDetail());
+    }
+
+    @Test
+    void nextPage_propagatesA400FromAReplicaThatDoesNotKnowTheCursor() throws Exception {
+        stubPage("after", "0", "[]", "<bom?cursor=c1&limit=1>; rel=\"next\"");
+        wireMock
+                .stubFor(get(urlPathEqualTo("/api/v1/bom"))
+                        .withQueryParam("cursor", equalTo("c1"))
+                        .willReturn(aResponse()
+                                .withStatus(400)
+                                .withHeader("Content-Type", "application/problem+json")
+                                .withBody(
+                                        "{\"type\":\"about:blank\",\"title\":\"Bad Request\",\"status\":400,\"detail\":\"unknown parameter cursor\"}")));
+
+        BomSearchPage first = client.search(pagedQuery(0, 1));
+        CbomRepositoryException ex = assertThrows(CbomRepositoryException.class, () -> client.nextPage(first));
+        assertEquals(400, ex.getProblemDetail().getStatus());
+        assertEquals("CBOM Repository failed a page request (HTTP 400)", ex.getProblemDetail().getDetail());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/cbom/client/LinkHeaderTest.java
+++ b/src/test/java/com/otilm/core/cbom/client/LinkHeaderTest.java
@@ -1,0 +1,154 @@
+package com.otilm.core.cbom.client;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LinkHeaderTest {
+
+    private static final String NEXT = "<bom?cursor=djF8MTc4ODQ1MTIwMDAwMHx1cm4&limit=1000>; rel=\"next\"";
+
+    @Test
+    void returnsTheTargetOfTheNextLink() {
+        assertThat(LinkHeader.nextTarget(List.of(NEXT))).contains("bom?cursor=djF8MTc4ODQ1MTIwMDAwMHx1cm4&limit=1000");
+    }
+
+    @Test
+    void acceptsABareRelValueAndIgnoresCase() {
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>;rel=Next"))).contains("bom?cursor=a&limit=5");
+    }
+
+    @Test
+    void findsNextAmongSeveralLinksInOneHeaderLine() {
+        String header = "<bom?cursor=first&limit=5>; rel=\"prev\", <bom?cursor=second&limit=5>; rel=\"next\"";
+        assertThat(LinkHeader.nextTarget(List.of(header))).contains("bom?cursor=second&limit=5");
+    }
+
+    @Test
+    void findsNextAmongSeveralHeaderLines() {
+        assertThat(LinkHeader.nextTarget(List.of("<x>; rel=\"self\"", NEXT)))
+                .contains("bom?cursor=djF8MTc4ODQ1MTIwMDAwMHx1cm4&limit=1000");
+    }
+
+    @Test
+    void matchesNextInsideASpaceSeparatedRelList() {
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>; rel=\"alternate next\"")))
+                .contains("bom?cursor=a&limit=5");
+    }
+
+    @Test
+    void aCommaInsideAQuotedParameterDoesNotSplitTheLink() {
+        String header = "<bom?cursor=a&limit=5>; title=\"a, b; c\"; rel=\"next\"";
+        assertThat(LinkHeader.nextTarget(List.of(header))).contains("bom?cursor=a&limit=5");
+    }
+
+    @Test
+    void ignoresLinksWithOtherRelations() {
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>; rel=\"prev\""))).isEmpty();
+    }
+
+    @Test
+    void relNextIsNotMatchedAsASubstring() {
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>; rel=\"nextish\""))).isEmpty();
+    }
+
+    @Test
+    void emptyOrMissingHeadersYieldNothing() {
+        assertThat(LinkHeader.nextTarget(null)).isEmpty();
+        assertThat(LinkHeader.nextTarget(List.of())).isEmpty();
+        assertThat(LinkHeader.nextTarget(List.of(""))).isEmpty();
+        assertThat(LinkHeader.nextTarget(List.of("garbage without brackets; rel=\"next\""))).isEmpty();
+    }
+
+    @Test
+    void aLongHeaderIsWalkedWithoutRecursion() {
+        // The grammar this parses needs repetition over an alternation, which a backtracking regex engine recurses
+        // on -- one frame per repetition, so a header this size overflows the stack. The scanner must not.
+        String title = "x".repeat(200_000);
+        String parameters = "; anchor=\"#a\"".repeat(50_000);
+        String header = "<bom?cursor=a&limit=5>; title=\"" + title + "\"" + parameters + "; rel=\"prev\", "
+                + "<bom?cursor=b&limit=5>; rel=\"next\"";
+        assertThat(LinkHeader.nextTarget(List.of(header))).contains("bom?cursor=b&limit=5");
+    }
+
+    @Test
+    void anEscapedQuoteDoesNotEndAQuotedValue() {
+        String header = "<bom?cursor=a&limit=5>; title=\"a \\\" ; b\"; rel=\"next\"";
+        assertThat(LinkHeader.nextTarget(List.of(header))).contains("bom?cursor=a&limit=5");
+    }
+
+    @Test
+    void aTargetInsideAQuotedValueIsNotReadAsALink() {
+        String header = "<bom?cursor=a&limit=5>; title=\"<bom?cursor=trap&limit=5>; rel=next\"; rel=\"prev\", "
+                + "<bom?cursor=b&limit=5>; rel=\"next\"";
+        assertThat(LinkHeader.nextTarget(List.of(header))).contains("bom?cursor=b&limit=5");
+    }
+
+    @Test
+    void theFirstRelOfALinkDecidesIt() {
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>; rel=\"prev\"; rel=\"next\""))).isEmpty();
+    }
+
+    @Test
+    void aRelWithoutAValueRelatesToNothing() {
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>; rel; rel=\"next\""))).isEmpty();
+    }
+
+    @Test
+    void aParameterWithoutAValueDoesNotHideTheRel() {
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>; anchor; rel=\"next\"")))
+                .contains("bom?cursor=a&limit=5");
+    }
+
+    @Test
+    void textThatIsNotAParameterListEndsTheLink() {
+        String header = "<bom?cursor=a&limit=5>; rel=\"prev\" &&, <bom?cursor=b&limit=5>; rel=\"next\"";
+        assertThat(LinkHeader.nextTarget(List.of(header))).contains("bom?cursor=b&limit=5");
+    }
+
+    @Test
+    void anUnterminatedTargetOrQuotedValueYieldsNothing() {
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5; rel=\"next\""))).isEmpty();
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>; title=\"oops"))).isEmpty();
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>; title=\"oops\\"))).isEmpty();
+    }
+
+    @Test
+    void aNullHeaderValueDoesNotStopTheSearch() {
+        assertThat(LinkHeader.nextTarget(Arrays.asList(null, NEXT)))
+                .contains("bom?cursor=djF8MTc4ODQ1MTIwMDAwMHx1cm4&limit=1000");
+    }
+
+    @Test
+    void anUnquotedValueEndsAtTheNextParameterLinkOrSpace() {
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>; rel=next; title=x")))
+                .contains("bom?cursor=a&limit=5");
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>; rel=prev, <bom?cursor=b&limit=5>; rel=next")))
+                .contains("bom?cursor=b&limit=5");
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>; rel=next junk")))
+                .contains("bom?cursor=a&limit=5");
+    }
+
+    @Test
+    void aParameterNameMayHoldAnyTokenCharacter() {
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>; X-Meta9!=\"v\"; rel=\"next\"")))
+                .contains("bom?cursor=a&limit=5");
+    }
+
+    @Test
+    void aHeaderThatEndsMidParameterYieldsNothing() {
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>"))).isEmpty();
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>;"))).isEmpty();
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>; rel"))).isEmpty();
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>; rel="))).isEmpty();
+    }
+
+    @Test
+    void aRelListMayBePaddedWithSpaces() {
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>; rel=\" next \"")))
+                .contains("bom?cursor=a&limit=5");
+        assertThat(LinkHeader.nextTarget(List.of("<bom?cursor=a&limit=5>; rel=\"prev \""))).isEmpty();
+    }
+}

--- a/src/test/java/com/otilm/core/config/CbomSyncPropertiesTest.java
+++ b/src/test/java/com/otilm/core/config/CbomSyncPropertiesTest.java
@@ -1,0 +1,74 @@
+package com.otilm.core.config;
+
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CbomSyncPropertiesTest {
+
+    @Test
+    void theDocumentedDefaultsAreAccepted() {
+        CbomSyncProperties p = new CbomSyncProperties(1000, Duration.ofSeconds(60), 3);
+        assertThat(p.maxAttempts()).isEqualTo(4);
+    }
+
+    @Test
+    void theDefaultValuesBindWhenNoPropertyIsSet() {
+        Binder binder = new Binder(new MapConfigurationPropertySource(Map.of()));
+        CbomSyncProperties bound = binder.bindOrCreate("cbom.sync", Bindable.of(CbomSyncProperties.class));
+        assertThat(bound).isEqualTo(new CbomSyncProperties(1000, Duration.ofSeconds(60), 3));
+    }
+
+    @Test
+    void aBareOverlapNumberBindsAsSeconds() {
+        // Without @DurationUnit Spring reads a unitless duration as milliseconds, so CBOM_SYNC_OVERLAP=60 would bind
+        // as 60 ms and toSeconds() would round it away to no overlap at all.
+        Binder binder = new Binder(new MapConfigurationPropertySource(Map.of("cbom.sync.overlap", "60")));
+        CbomSyncProperties bound = binder.bindOrCreate("cbom.sync", Bindable.of(CbomSyncProperties.class));
+        assertThat(bound.overlap()).isEqualTo(Duration.ofSeconds(60));
+    }
+
+    @Test
+    void anOverlapWithAUnitSuffixStillBindsByThatUnit() {
+        Binder binder = new Binder(new MapConfigurationPropertySource(Map.of("cbom.sync.overlap", "2m")));
+        CbomSyncProperties bound = binder.bindOrCreate("cbom.sync", Bindable.of(CbomSyncProperties.class));
+        assertThat(bound.overlap()).isEqualTo(Duration.ofSeconds(120));
+    }
+
+    @Test
+    void zeroRetryRunsMeansAFailedEntryIsWrittenOffAtOnce() {
+        assertThat(new CbomSyncProperties(1, Duration.ZERO, 0).maxAttempts()).isEqualTo(1);
+    }
+
+    @Test
+    void aPageSizeOutsideTheRepositoryContractIsRefused() {
+        Duration overlap = Duration.ofSeconds(60);
+        assertThatThrownBy(() -> new CbomSyncProperties(0, overlap, 3))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cbom.sync.page-size");
+        assertThatThrownBy(() -> new CbomSyncProperties(1001, overlap, 3))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cbom.sync.page-size");
+    }
+
+    @Test
+    void aNegativeOverlapOrRetryBudgetIsRefused() {
+        Duration negative = Duration.ofSeconds(-1);
+        Duration overlap = Duration.ofSeconds(60);
+        assertThatThrownBy(() -> new CbomSyncProperties(1000, negative, 3))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cbom.sync.overlap");
+        assertThatThrownBy(() -> new CbomSyncProperties(1000, null, 3))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cbom.sync.overlap");
+        assertThatThrownBy(() -> new CbomSyncProperties(1000, overlap, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cbom.sync.skipped-retry-runs");
+    }
+}

--- a/src/test/java/com/otilm/core/integration/service/CbomServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CbomServiceITest.java
@@ -31,6 +31,7 @@ import com.otilm.core.dao.entity.ScheduledJobHistory;
 import com.otilm.core.dao.repository.CbomRepository;
 import com.otilm.core.dao.repository.ScheduledJobHistoryRepository;
 import com.otilm.core.dao.repository.ScheduledJobsRepository;
+import com.otilm.core.dao.repository.cbom.CbomSyncSkipRepository;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.model.cbom.BomEntryDto;
 import com.otilm.core.model.cbom.BomVersionDto;
@@ -45,6 +46,7 @@ import com.otilm.core.service.writer.cbom.CbomAssetSyncStateWriter;
 import com.otilm.core.settings.SettingsCache;
 import com.otilm.core.tasks.CbomSyncTask;
 import com.otilm.core.util.BaseSpringBootTest;
+import java.sql.SQLException;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -54,11 +56,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
@@ -111,6 +115,9 @@ class CbomServiceITest extends BaseSpringBootTest {
 
     @Autowired
     private CbomRepository cbomRepository;
+
+    @Autowired
+    private CbomSyncSkipRepository skipRepository;
 
     @Autowired
     private CbomAssetSyncStateWriter syncStateWriter;
@@ -1321,13 +1328,16 @@ class CbomServiceITest extends BaseSpringBootTest {
         mockSearchResponse(response);
 
         // When
-        cbomInternalService.sync();
+        String result = cbomInternalService.sync();
 
         // Then no boms were stored
         List<Cbom> savedCboms = cbomRepository.findAll();
         assertEquals(0, savedCboms.size());
         // ... and no get detail REST API has been called
         mockServer.verify(0, WireMock.getRequestedFor(WireMock.urlPathEqualTo("/api/v1/bom/serial-1")));
+        // an entry without a usable identity cannot be retried, so nothing is recorded for it
+        assertEquals(0, skipRepository.count());
+        assertTrue(result.contains("1 invalid entries"));
     }
 
     @Test
@@ -1366,6 +1376,11 @@ class CbomServiceITest extends BaseSpringBootTest {
         List<String> serialNumbers = savedCboms.stream().map(Cbom::getSerialNumber).sorted().toList();
 
         assertTrue(serialNumbers.containsAll(List.of("serial-1")));
+        // the 404 entry is not lost: it is recorded for the bounded retry
+        assertEquals(1, skipRepository.count());
+        assertEquals("serial-2", skipRepository.findAll().getFirst().getSerialNumber());
+        assertEquals("document not found in the repository (HTTP 404)",
+                skipRepository.findAll().getFirst().getReason());
     }
 
     @Test
@@ -1525,9 +1540,7 @@ class CbomServiceITest extends BaseSpringBootTest {
         mockEntrySpecVersionSource(entry, "1.6", "source");
 
         doReturn(false).when(cbomRepositorySpy).existsBySerialNumberAndVersion(serialNumber, version);
-        doThrow(new org.springframework.dao.DataIntegrityViolationException("duplicate key"))
-                .when(cbomRepositorySpy)
-                .save(any(Cbom.class));
+        doThrow(constraintViolation("cbom_serial_version_unique")).when(cbomRepositorySpy).save(any(Cbom.class));
 
         // When
         String result = cbomInternalService.sync();
@@ -1535,6 +1548,36 @@ class CbomServiceITest extends BaseSpringBootTest {
         // Then: DataIntegrityViolationException propagates out of the transaction and is counted as duplicate
         assertTrue(result.contains("skipped duplicates 1"));
         assertTrue(result.contains("stored 0 new entries"));
+    }
+
+    @Test
+    void sync_shouldRecordASkipWhenTheDatabaseRefusesTheRowForAnotherConstraint() throws Exception {
+        // Only the dedup key's unique constraint means "someone else stored it first". Any other invariant of the
+        // `cbom` row -- a check constraint, a column the feed left null -- is this entry's own problem, and counting
+        // it as a duplicate would drop the entry without a trace.
+        String serialNumber = "serial-other-constraint";
+        int version = 1;
+
+        BomEntryDto entry = entry(serialNumber, String.valueOf(version), OffsetDateTime.now());
+        mockSearchResponse(List.of(entry));
+        mockEntrySpecVersionSource(entry, "1.6", "source");
+
+        doReturn(false).when(cbomRepositorySpy).existsBySerialNumberAndVersion(serialNumber, version);
+        doThrow(constraintViolation("ck_cbom_asset_sync_state")).when(cbomRepositorySpy).save(any(Cbom.class));
+
+        String result = cbomInternalService.sync();
+
+        assertTrue(result.contains("1 entries could not be stored and were recorded for retry"), result);
+        assertTrue(result.contains("stored 0 new entries"), result);
+        assertEquals(1, skipRepository.count());
+        assertEquals("storing the CBOM row failed: the database refused it (see the Core log)",
+                skipRepository.findAll().getFirst().getReason());
+    }
+
+    /** A refusal shaped the way the JPA stack delivers one: the constraint name lives in the Hibernate cause. */
+    private static DataIntegrityViolationException constraintViolation(String constraintName) {
+        return new DataIntegrityViolationException("duplicate key", new ConstraintViolationException("duplicate key",
+                new SQLException("duplicate key value", "23505"), constraintName));
     }
 
     private String bomEntryJson() {
@@ -1558,7 +1601,7 @@ class CbomServiceITest extends BaseSpringBootTest {
         BomEntryDto entry = new BomEntryDto();
         entry.setSerialNumber(serialNumber);
         entry.setVersion(version);
-        entry.setTimestamp(timestamp);
+        entry.setCreatedAt(timestamp);
         entry.setCryptoStats(cryptoStats);
 
         return entry;

--- a/src/test/java/com/otilm/core/integration/service/CbomSyncITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CbomSyncITest.java
@@ -1,0 +1,746 @@
+package com.otilm.core.integration.service;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.otilm.api.exception.CbomRepositoryException;
+import com.otilm.api.model.core.settings.PlatformSettingsDto;
+import com.otilm.api.model.core.settings.SettingsSection;
+import com.otilm.api.model.core.settings.UtilsSettingsDto;
+import com.otilm.core.config.CbomSyncProperties;
+import com.otilm.core.dao.entity.Cbom;
+import com.otilm.core.dao.entity.cbom.CbomSyncSkip;
+import com.otilm.core.dao.repository.CbomRepository;
+import com.otilm.core.dao.repository.cbom.CbomSyncSkipRepository;
+import com.otilm.core.model.cbom.CbomHeaderCounts;
+import com.otilm.core.model.cbom.CbomSyncSkipState;
+import com.otilm.core.service.CbomInternalService;
+import com.otilm.core.service.impl.CbomServiceImpl;
+import com.otilm.core.service.writer.cbom.CbomSyncSkipWriter;
+import com.otilm.core.settings.SettingsCache;
+import com.otilm.core.util.BaseSpringBootTest;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ProblemDetail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The header sync against a stubbed cbom-repository speaking the 0.3.0 feed contract: {@code limit} paging followed
+ * through {@code Link rel="next"}, {@code created_at}, {@code cryptoStats: null} with its warning codes, the
+ * {@code original} version, and the bounded retry of entries that could not be stored. The older sync tests in
+ * {@link CbomServiceITest} keep covering the watermark and the duplicate races.
+ */
+class CbomSyncITest extends BaseSpringBootTest {
+
+    private static final String SEARCH = "/api/v1/bom";
+    private static final String STATS = """
+            {"cryptoAssets":{"total":4,"algorithms":{"total":1},"certificates":{"total":1},
+             "protocols":{"total":1},"relatedCryptoMaterials":{"total":1}}}""";
+
+    @Autowired
+    private CbomInternalService cbomInternalService;
+
+    @Autowired
+    private CbomRepository cbomRepository;
+
+    @Autowired
+    private CbomSyncSkipRepository skipRepository;
+
+    @Autowired
+    private SettingsCache settingsCache;
+
+    @Autowired
+    private CbomSyncProperties syncProperties;
+
+    @Autowired
+    private CbomSyncSkipWriter skipWriter;
+
+    private WireMockServer repository;
+    private PlatformSettingsDto originalSettings;
+    private ListAppender<ILoggingEvent> logged;
+
+    @BeforeEach
+    void startRepository() {
+        originalSettings = SettingsCache.getSettings(SettingsSection.PLATFORM);
+        repository = new WireMockServer(0);
+        repository.start();
+        PlatformSettingsDto settings = new PlatformSettingsDto();
+        settings.setUtils(new UtilsSettingsDto());
+        settings.getUtils().setCbomRepositoryUrl("http://localhost:" + repository.port());
+        settingsCache.cacheSettings(SettingsSection.PLATFORM, settings);
+
+        logged = new ListAppender<>();
+        logged.start();
+        syncLogger().addAppender(logged);
+    }
+
+    @AfterEach
+    void stopRepository() {
+        try {
+            repository.stop();
+        } finally {
+            settingsCache.cacheSettings(SettingsSection.PLATFORM, originalSettings);
+            syncLogger().detachAppender(logged);
+            logged.stop();
+        }
+    }
+
+    // ---- bound properties ----
+
+    @Test
+    void theSyncPropertiesBindTheDocumentedDefaults() {
+        assertThat(syncProperties.pageSize()).isEqualTo(1000);
+        assertThat(syncProperties.overlap()).isEqualTo(Duration.ofSeconds(60));
+        assertThat(syncProperties.skippedRetryRuns()).isEqualTo(3);
+        assertThat(syncProperties.maxAttempts()).isEqualTo(4);
+    }
+
+    // ---- paging ----
+
+    @Test
+    void aRunOpensWithAfterAndLimitAndFollowsLinkNextUntilAPageCarriesNone() throws Exception {
+        stubPage("after", "0", "[" + entry("urn:uuid:a", "1", STATS, null) + "]", next("c1"));
+        stubPage("cursor", "c1", "[" + entry("urn:uuid:b", "1", STATS, null) + "]", next("c2"));
+        // one entry and no Link: the absence of the header, not the page size, ends the run
+        stubPage("cursor", "c2", "[" + entry("urn:uuid:c", "1", STATS, null) + "]", null);
+        stubDocument("urn:uuid:a", 1);
+        stubDocument("urn:uuid:b", 1);
+        stubDocument("urn:uuid:c", 1);
+
+        String result = cbomInternalService.sync();
+
+        assertThat(cbomRepository.findAll())
+                .extracting(Cbom::getSerialNumber)
+                .containsExactlyInAnyOrder("urn:uuid:a", "urn:uuid:b", "urn:uuid:c");
+        assertThat(result).startsWith("Read 3 entries in 3 pages: stored 3 new entries");
+        repository
+                .verify(WireMock
+                        .getRequestedFor(WireMock.urlPathEqualTo(SEARCH))
+                        .withQueryParam("after", WireMock.equalTo("0"))
+                        .withQueryParam("limit", WireMock.equalTo("1000")));
+        repository
+                .verify(WireMock
+                        .getRequestedFor(WireMock.urlPathEqualTo(SEARCH))
+                        .withQueryParam("cursor", WireMock.equalTo("c1"))
+                        .withQueryParam("limit", WireMock.equalTo("1000"))
+                        .withQueryParam("after", WireMock.absent()));
+        repository
+                .verify(0,
+                        WireMock
+                                .getRequestedFor(WireMock.urlPathEqualTo(SEARCH))
+                                .withQueryParam("cursor", WireMock.equalTo("c2"))
+                                .withQueryParam("after", WireMock.matching(".*")));
+    }
+
+    @Test
+    void anEmptyFirstPageIsAValidEmptyRun() throws Exception {
+        stubPage("after", "0", "[]", null);
+
+        String result = cbomInternalService.sync();
+
+        assertThat(result).startsWith("Read 0 entries in 1 pages: stored 0 new entries");
+        assertThat(cbomRepository.count()).isZero();
+    }
+
+    @Test
+    void aFailingCursorPageFailsTheRunAndKeepsWhatEarlierPagesStored() throws Exception {
+        stubPage("after", "0", "[" + entry("urn:uuid:a", "1", STATS, null) + "]", next("c1"));
+        repository
+                .stubFor(WireMock
+                        .get(WireMock.urlPathEqualTo(SEARCH))
+                        .withQueryParam("cursor", WireMock.equalTo("c1"))
+                        .willReturn(problem(400, "unknown parameter cursor")));
+        stubDocument("urn:uuid:a", 1);
+
+        assertThatThrownBy(() -> cbomInternalService.sync())
+                .isInstanceOf(CbomRepositoryException.class)
+                .satisfies(e -> {
+                    ProblemDetail problemDetail = ((CbomRepositoryException) e).getProblemDetail();
+                    assertThat(problemDetail.getStatus()).isEqualTo(400);
+                    // The run's message reaches an operator; the repository's own sentence does not travel with it.
+                    assertThat(problemDetail.getDetail())
+                            .isEqualTo("CBOM Repository failed a page request (HTTP 400)")
+                            .doesNotContain("unknown parameter cursor");
+                });
+
+        assertThat(cbomRepository.findAll()).extracting(Cbom::getSerialNumber).containsExactly("urn:uuid:a");
+        assertThat(skipRepository.count()).isZero();
+    }
+
+    @Test
+    void aRepeatedCursorFailsTheRunInsteadOfLooping() throws Exception {
+        stubPage("after", "0", "[" + entry("urn:uuid:p1", "1", STATS, null) + "]", next("c1"));
+        stubPage("cursor", "c1", "[" + entry("urn:uuid:p2", "1", STATS, null) + "]", next("c2"));
+        stubPage("cursor", "c2", "[" + entry("urn:uuid:p3", "1", STATS, null) + "]", next("c1"));
+        stubDocument("urn:uuid:p1", 1);
+        stubDocument("urn:uuid:p2", 1);
+        stubDocument("urn:uuid:p3", 1);
+
+        assertThatThrownBy(() -> cbomInternalService.sync())
+                .isInstanceOf(CbomRepositoryException.class)
+                .satisfies(e -> {
+                    assertThat(((CbomRepositoryException) e).getProblemDetail().getStatus()).isEqualTo(502);
+                    assertThat(((CbomRepositoryException) e).getProblemDetail().getDetail())
+                            .isEqualTo("CBOM Repository sent a page cursor it had already sent in this run");
+                });
+        assertThat(cbomRepository.findAll())
+                .extracting(Cbom::getSerialNumber)
+                .containsExactlyInAnyOrder("urn:uuid:p1", "urn:uuid:p2", "urn:uuid:p3");
+    }
+
+    @Test
+    void anEmptyPageThatStillClaimsANextPageFailsTheRun() throws Exception {
+        stubPage("after", "0", "[" + entry("urn:uuid:a", "1", STATS, null) + "]", next("c1"));
+        stubPage("cursor", "c1", "[]", next("c2"));
+        stubDocument("urn:uuid:a", 1);
+
+        assertThatThrownBy(() -> cbomInternalService.sync())
+                .isInstanceOf(CbomRepositoryException.class)
+                .satisfies(e -> assertThat(((CbomRepositoryException) e).getProblemDetail().getDetail())
+                        .isEqualTo("CBOM Repository sent an empty page that still claims a next page"));
+        assertThat(cbomRepository.findAll()).extracting(Cbom::getSerialNumber).containsExactly("urn:uuid:a");
+        repository
+                .verify(0,
+                        WireMock
+                                .getRequestedFor(WireMock.urlPathEqualTo(SEARCH))
+                                .withQueryParam("cursor", WireMock.equalTo("c2")));
+    }
+
+    @Test
+    void anIdentityOfferedTwiceInOneRunIsAttemptedOnceAndTheSecondOfferCountsAsADuplicate() throws Exception {
+        // the same entry on two pages of one run (an object overwritten mid-run is re-yielded under its new stamp)
+        stubPage("after", "0", "[" + entry("urn:uuid:twice", "1", STATS, null) + "]", next("c1"));
+        stubPage("cursor", "c1", "[" + entry("urn:uuid:twice", "1", STATS, null) + "]", null);
+        stubDocumentFailure("urn:uuid:twice", 1, 500);
+
+        String result = cbomInternalService.sync();
+
+        assertThat(result)
+                .contains("skipped duplicates 1")
+                .contains("1 entries could not be stored and were recorded for retry");
+        assertThat(onlySkip().getAttempts()).isEqualTo(1);
+    }
+
+    // ---- the corrected entry contract ----
+
+    @Test
+    void nullCryptoStatsWithMissingOrInvalidWarningsAreStoredWithZeroCountsAndLogged() throws Exception {
+        stubPage("after", "0", "[" + entry("urn:uuid:missing", "1", null, "crypto-stats-missing") + ","
+                + entry("urn:uuid:invalid", "2", null, "crypto-stats-invalid") + "]", null);
+        stubDocument("urn:uuid:missing", 1);
+        stubDocument("urn:uuid:invalid", 2);
+
+        String result = cbomInternalService.sync();
+
+        assertThat(result).startsWith("Read 2 entries in 1 pages: stored 2 new entries");
+        assertThat(cbomRepository.findAll()).allSatisfy(cbom -> {
+            assertThat(cbom.getTotalAssetsCount()).isZero();
+            assertThat(cbom.getAlgorithmsCount()).isZero();
+        });
+        assertThat(skipRepository.count()).isZero();
+        assertThat(warnings())
+                .anySatisfy(m -> assertThat(m).contains("urn:uuid:missing").contains("crypto-stats-missing"))
+                .anySatisfy(m -> assertThat(m).contains("urn:uuid:invalid").contains("crypto-stats-invalid"));
+    }
+
+    @Test
+    void shallowAndTruncatedWarningsKeepTheReportedCountsAndAreLogged() throws Exception {
+        stubPage("after", "0", "[" + entry("urn:uuid:shallow", "1", STATS, "crypto-stats-shallow") + ","
+                + entry("urn:uuid:truncated", "1", STATS, "crypto-stats-truncated") + "]", null);
+        stubDocument("urn:uuid:shallow", 1);
+        stubDocument("urn:uuid:truncated", 1);
+
+        cbomInternalService.sync();
+
+        assertThat(cbomRepository.findAll())
+                .hasSize(2)
+                .allSatisfy(cbom -> assertThat(cbom.getTotalAssetsCount()).isEqualTo(4));
+        assertThat(warnings())
+                .anySatisfy(m -> assertThat(m).contains("urn:uuid:shallow").contains("crypto-stats-shallow"))
+                .anySatisfy(m -> assertThat(m).contains("urn:uuid:truncated").contains("crypto-stats-truncated"));
+    }
+
+    @Test
+    void theOriginalUploadIsIgnoredWithoutAReadAndWithoutASkipRecord() throws Exception {
+        stubPage("after", "0", "[" + entry("urn:uuid:a", "original", null, "crypto-stats-missing") + ","
+                + entry("urn:uuid:a", "1", STATS, null) + "]", null);
+        stubDocument("urn:uuid:a", 1);
+
+        String result = cbomInternalService.sync();
+
+        assertThat(result).contains("stored 1 new entries").contains("ignored 1 original documents");
+        assertThat(skipRepository.count()).isZero();
+        repository
+                .verify(0,
+                        WireMock
+                                .getRequestedFor(WireMock.urlPathEqualTo("/api/v1/bom/urn:uuid:a"))
+                                .withQueryParam("version", WireMock.equalTo("original")));
+    }
+
+    // ---- bounded retry ----
+
+    @Test
+    void anEntryWhoseDocumentCannotBeReadIsRecordedRetriedOnThreeRunsThenPermanentlySkipped() throws Exception {
+        stubPage("after", "0", "[" + entry("urn:uuid:bad", "1", STATS, null) + "]", null);
+        stubDocumentFailure("urn:uuid:bad", 1, 500);
+
+        String firstRun = cbomInternalService.sync();
+        assertThat(firstRun).contains("1 entries could not be stored and were recorded for retry");
+        CbomSyncSkip afterFirst = onlySkip();
+        assertThat(afterFirst.getAttempts()).isEqualTo(1);
+        assertThat(afterFirst.getState()).isEqualTo(CbomSyncSkipState.RETRYING);
+        assertThat(afterFirst.getReason()).isEqualTo("repository failed the document read (HTTP 500)");
+        assertThat(afterFirst.getTotalAssetsCount()).isEqualTo(4);
+
+        // later runs: the feed no longer offers the entry (watermark moved on); the retry phase does
+        stubPage("after", "0", "[]", null);
+        for (int run = 2; run <= 3; run++) {
+            String result = cbomInternalService.sync();
+            assertThat(result)
+                    .contains(
+                            "retried 1 previously skipped entries, 0 skip records resolved; 0 entries are now permanently skipped");
+            assertThat(onlySkip().getAttempts()).isEqualTo(run);
+            assertThat(onlySkip().getState()).isEqualTo(CbomSyncSkipState.RETRYING);
+        }
+        String fourthRun = cbomInternalService.sync();
+        // Written off on this run: reported once as given up on, not also as recorded for retry.
+        assertThat(fourthRun)
+                .contains("0 entries could not be stored and were recorded for retry")
+                .contains(
+                        "retried 1 previously skipped entries, 0 skip records resolved; 1 entries are now permanently skipped");
+        assertThat(onlySkip().getAttempts()).isEqualTo(4);
+        assertThat(onlySkip().getState()).isEqualTo(CbomSyncSkipState.PERMANENTLY_SKIPPED);
+        assertThat(warnings()).anySatisfy(m -> assertThat(m).contains("urn:uuid:bad").contains("permanently skipped"));
+
+        int readsSoFar = repository
+                .countRequestsMatching(
+                        WireMock.getRequestedFor(WireMock.urlPathEqualTo("/api/v1/bom/urn:uuid:bad")).build())
+                .getCount();
+        String fifthRun = cbomInternalService.sync();
+        assertThat(fifthRun).contains("retried 0 previously skipped entries");
+        assertThat(repository
+                .countRequestsMatching(
+                        WireMock.getRequestedFor(WireMock.urlPathEqualTo("/api/v1/bom/urn:uuid:bad")).build())
+                .getCount()).isEqualTo(readsSoFar);
+        assertThat(cbomRepository.count()).isZero();
+    }
+
+    @Test
+    void aSkippedEntryThatBecomesReadableIsStoredWithTheCountsTheFeedReportedAndItsRecordResolved() throws Exception {
+        stubPage("after", "0", "[" + entry("urn:uuid:late", "3", STATS, null) + "]", null);
+        stubDocumentFailure("urn:uuid:late", 3, 404);
+        cbomInternalService.sync();
+        assertThat(onlySkip().getReason()).isEqualTo("document not found in the repository (HTTP 404)");
+
+        stubPage("after", "0", "[]", null);
+        stubDocument("urn:uuid:late", 3);
+        String result = cbomInternalService.sync();
+
+        assertThat(result).contains("retried 1 previously skipped entries, 1 skip records resolved");
+        assertThat(skipRepository.count()).isZero();
+        Cbom stored = cbomRepository.findAll().getFirst();
+        assertThat(stored.getSerialNumber()).isEqualTo("urn:uuid:late");
+        assertThat(stored.getVersion()).isEqualTo(3);
+        assertThat(stored.getTotalAssetsCount()).isEqualTo(4);
+    }
+
+    @Test
+    void aSkippedEntryOfferedAgainByTheFeedIsStoredOnceAndNotRetriedTwiceInTheSameRun() throws Exception {
+        stubPage("after", "0", "[" + entry("urn:uuid:again", "1", STATS, null) + "]", null);
+        stubDocumentFailure("urn:uuid:again", 1, 500);
+        cbomInternalService.sync();
+        assertThat(onlySkip().getAttempts()).isEqualTo(1);
+
+        // the overlap re-offers the entry and its document is readable now
+        stubDocument("urn:uuid:again", 1);
+        String result = cbomInternalService.sync();
+
+        assertThat(result)
+                .contains("stored 1 new entries")
+                .contains("retried 0 previously skipped entries, 1 skip records resolved");
+        assertThat(skipRepository.count()).isZero();
+        assertThat(cbomRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void aSkippedEntryOfferedAgainAndFailingAgainCountsOneAttemptForTheRun() throws Exception {
+        stubPage("after", "0", "[" + entry("urn:uuid:twice", "1", STATS, null) + "]", null);
+        stubDocumentFailure("urn:uuid:twice", 1, 500);
+
+        cbomInternalService.sync();
+        String result = cbomInternalService.sync();
+
+        assertThat(result).contains("retried 0 previously skipped entries");
+        assertThat(onlySkip().getAttempts()).isEqualTo(2);
+    }
+
+    @Test
+    void aSingleNewDocumentWhoseReadFailsServerSideIsChargedEvenWithoutOtherReads() throws Exception {
+        // One new document in the window and its read never answers: charging it is the only way the watermark can
+        // move at all. Failing the run instead would freeze the feed on this one document forever.
+        stubPage("after", "0", "[" + entry("urn:uuid:a", "1", STATS, null) + "]", null);
+        repository
+                .stubFor(WireMock
+                        .get(WireMock.urlPathEqualTo("/api/v1/bom/urn:uuid:a"))
+                        .willReturn(problem(503, "down")));
+
+        String result = cbomInternalService.sync();
+
+        assertThat(result).contains("1 entries could not be stored and were recorded for retry");
+        CbomSyncSkip skip = onlySkip();
+        assertThat(skip.getSerialNumber()).isEqualTo("urn:uuid:a");
+        assertThat(skip.getAttempts()).isEqualTo(1);
+        assertThat(skip.getReason()).isEqualTo("repository failed the document read (HTTP 503)");
+        assertThat(cbomRepository.count()).isZero();
+    }
+
+    @Test
+    void anOutageWhereEveryReadFailsServerSideFailsTheRunWithoutChargingTheBudget() throws Exception {
+        // Several documents and not one answer: that is the repository, not the documents. The run fails so the
+        // watermark holds and the same entries are offered again once it is back.
+        stubPage("after", "0",
+                "[" + entry("urn:uuid:a", "1", STATS, null) + "," + entry("urn:uuid:b", "1", STATS, null) + "]", null);
+        stubDocumentFailure("urn:uuid:a", 1, 503);
+        stubDocumentFailure("urn:uuid:b", 1, 503);
+
+        assertThatThrownBy(() -> cbomInternalService.sync())
+                .isInstanceOf(CbomRepositoryException.class)
+                .satisfies(e -> {
+                    assertThat(((CbomRepositoryException) e).getProblemDetail().getStatus()).isEqualTo(503);
+                    assertThat(((CbomRepositoryException) e).getProblemDetail().getDetail())
+                            .startsWith("CBOM Repository failed every document read of this run (2 documents)");
+                });
+
+        assertThat(skipRepository.count()).isZero();
+        assertThat(cbomRepository.count()).isZero();
+    }
+
+    @Test
+    void aServerSideReadFailureIsChargedToThatDocumentWhenOtherReadsSucceed() throws Exception {
+        // One document Core never got an answer for, while the repository served the other: that is the document's
+        // problem, not an outage, so the run completes and only this entry is charged an attempt.
+        stubPage("after", "0",
+                "[" + entry("urn:uuid:ok", "1", STATS, null) + "," + entry("urn:uuid:hang", "1", STATS, null) + "]",
+                null);
+        stubDocument("urn:uuid:ok", 1);
+        stubDocumentFailure("urn:uuid:hang", 1, 503);
+
+        String result = cbomInternalService.sync();
+
+        assertThat(result)
+                .contains("stored 1 new entries")
+                .contains("1 entries could not be stored and were recorded for retry");
+        assertThat(cbomRepository.findAll()).extracting(Cbom::getSerialNumber).containsExactly("urn:uuid:ok");
+        CbomSyncSkip skip = onlySkip();
+        assertThat(skip.getSerialNumber()).isEqualTo("urn:uuid:hang");
+        assertThat(skip.getAttempts()).isEqualTo(1);
+        assertThat(skip.getReason()).isEqualTo("repository failed the document read (HTTP 503)");
+    }
+
+    @Test
+    void aPermanentlyHangingDocumentIsWrittenOffAfterTheBudgetEvenWhenTheFeedStaysQuiet() throws Exception {
+        // One document that never answers -- a 503, or a read that exceeds the client's response timeout, which is
+        // mapped to 503 -- while the feed offers nothing new. If a retry's unanswered read counted as an outage, the
+        // run
+        // would be skipped every hour, the watermark never recorded again and the budget never spent: the retry the
+        // table is meant to bound would be unbounded for exactly the hanging document it was built for.
+        stubPage("after", "0", "[" + entry("urn:uuid:hang", "1", STATS, null) + "]", null);
+        stubDocumentFailure("urn:uuid:hang", 1, 503);
+        cbomInternalService.sync();
+        assertThat(onlySkip().getAttempts()).isEqualTo(1);
+
+        stubPage("after", "0", "[]", null);
+        for (int run = 2; run <= 3; run++) {
+            String result = cbomInternalService.sync();
+            assertThat(result).contains("retried 1 previously skipped entries");
+            assertThat(onlySkip().getAttempts()).isEqualTo(run);
+            assertThat(onlySkip().getState()).isEqualTo(CbomSyncSkipState.RETRYING);
+        }
+
+        // The overlap re-offering an entry that is already stored is no evidence either way.
+        Cbom alreadyStored = new Cbom();
+        alreadyStored.setSerialNumber("urn:uuid:dup");
+        alreadyStored.setVersion(1);
+        alreadyStored.setSpecVersion("1.6");
+        cbomRepository.save(alreadyStored);
+        stubPage("after", "0", "[" + entry("urn:uuid:dup", "1", STATS, null) + "]", null);
+        String fourthRun = cbomInternalService.sync();
+
+        assertThat(fourthRun).contains("skipped duplicates 1").contains("1 entries are now permanently skipped");
+        assertThat(onlySkip().getAttempts()).isEqualTo(4);
+        assertThat(onlySkip().getState()).isEqualTo(CbomSyncSkipState.PERMANENTLY_SKIPPED);
+        assertThat(onlySkip().getReason()).isEqualTo("repository failed the document read (HTTP 503)");
+    }
+
+    @Test
+    void aRetryPhaseFailureDoesNotCountTowardsAnOutage() throws Exception {
+        stubPage("after", "0", "[" + entry("urn:uuid:later", "1", STATS, null) + "]", null);
+        stubDocumentFailure("urn:uuid:later", 1, 500);
+        cbomInternalService.sync();
+        assertThat(onlySkip().getAttempts()).isEqualTo(1);
+
+        // Two unanswered reads in the run, but only one of them a feed document: the page requests succeeded, so the
+        // repository is serving, and a retry's failure is its own. Both are charged and the run completes.
+        stubPage("after", "0", "[" + entry("urn:uuid:fresh", "1", STATS, null) + "]", null);
+        stubDocumentFailure("urn:uuid:fresh", 1, 503);
+        stubDocumentFailure("urn:uuid:later", 1, 503);
+
+        String result = cbomInternalService.sync();
+
+        assertThat(result)
+                .contains("2 entries could not be stored and were recorded for retry")
+                .contains("retried 1 previously skipped entries");
+        List<CbomSyncSkip> skips = skipRepository.findAll();
+        assertThat(skips).hasSize(2);
+        assertThat(skips)
+                .filteredOn(skip -> skip.getSerialNumber().equals("urn:uuid:later"))
+                .singleElement()
+                .satisfies(skip -> assertThat(skip.getAttempts()).isEqualTo(2));
+        assertThat(skips)
+                .filteredOn(skip -> skip.getSerialNumber().equals("urn:uuid:fresh"))
+                .singleElement()
+                .satisfies(skip -> assertThat(skip.getAttempts()).isEqualTo(1));
+    }
+
+    @Test
+    void aWrittenOffEntryIsStillResolvedWhenItsDocumentFinallyStores() throws Exception {
+        // Written-off rows are not loaded by the run any more, so this goes through the per-identity lookup.
+        skipWriter
+                .recordAttempt("urn:uuid:revived", 1, "reason", CbomHeaderCounts.ZERO,
+                        OffsetDateTime.now().truncatedTo(ChronoUnit.MICROS), 1);
+        assertThat(onlySkip().getState()).isEqualTo(CbomSyncSkipState.PERMANENTLY_SKIPPED);
+        stubPage("after", "0", "[" + entry("urn:uuid:revived", "1", STATS, null) + "]", null);
+        stubDocument("urn:uuid:revived", 1);
+
+        String result = cbomInternalService.sync();
+
+        assertThat(result).contains("stored 1 new entries").contains("1 skip records resolved");
+        assertThat(skipRepository.count()).isZero();
+        assertThat(cbomRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void aServerSideFailureIsChargedInTheRetryPhaseWhenAnotherReadSucceeded() throws Exception {
+        stubPage("after", "0", "[" + entry("urn:uuid:later", "1", STATS, null) + "]", null);
+        stubDocumentFailure("urn:uuid:later", 1, 500);
+        cbomInternalService.sync();
+        assertThat(onlySkip().getAttempts()).isEqualTo(1);
+
+        // This run reads one document successfully, so the repository is up and the retry's failure is its own.
+        stubPage("after", "0", "[" + entry("urn:uuid:fresh", "1", STATS, null) + "]", null);
+        stubDocument("urn:uuid:fresh", 1);
+        stubDocumentFailure("urn:uuid:later", 1, 503);
+
+        String result = cbomInternalService.sync();
+
+        assertThat(result).contains("stored 1 new entries");
+        assertThat(cbomRepository.findAll()).extracting(Cbom::getSerialNumber).containsExactly("urn:uuid:fresh");
+        assertThat(onlySkip().getAttempts()).isEqualTo(2);
+        assertThat(onlySkip().getReason()).isEqualTo("repository failed the document read (HTTP 503)");
+    }
+
+    @Test
+    void anEntryAlreadyInTheDatabaseIsADuplicateWithoutADocumentRead() throws Exception {
+        Cbom stored = new Cbom();
+        stored.setSerialNumber("urn:uuid:dup");
+        stored.setVersion(1);
+        stored.setSpecVersion("1.6");
+        cbomRepository.save(stored);
+        stubPage("after", "0", "[" + entry("urn:uuid:dup", "1", STATS, null) + "]", null);
+
+        String result = cbomInternalService.sync();
+
+        assertThat(result).contains("skipped duplicates 1").contains("stored 0 new entries");
+        assertThat(skipRepository.count()).isZero();
+        assertThat(cbomRepository.count()).isEqualTo(1);
+        repository.verify(0, WireMock.getRequestedFor(WireMock.urlPathEqualTo("/api/v1/bom/urn:uuid:dup")));
+    }
+
+    @Test
+    void aDocumentWithoutSpecVersionIsRecordedWithCoreShapedReason() throws Exception {
+        stubPage("after", "0", "[" + entry("urn:uuid:nospec", "1", STATS, null) + "]", null);
+        repository
+                .stubFor(WireMock
+                        .get(WireMock.urlPathEqualTo("/api/v1/bom/urn:uuid:nospec"))
+                        .withQueryParam("version", WireMock.equalTo("1"))
+                        .willReturn(WireMock
+                                .aResponse()
+                                .withStatus(200)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\"metadata\":{\"component\":{\"name\":\"x\"}}}")));
+
+        cbomInternalService.sync();
+
+        assertThat(onlySkip().getReason())
+                .isEqualTo("the stored document was refused: CBOM Repository returned empty specVersion");
+        assertThat(cbomRepository.count()).isZero();
+    }
+
+    @Test
+    void anAlreadyPermanentlySkippedEntryOfferedAgainIsNotCountedAsNewlyPermanent() throws Exception {
+        OffsetDateTime now = OffsetDateTime.now().truncatedTo(ChronoUnit.MICROS);
+        // already written off
+        skipWriter.recordAttempt("urn:uuid:gone", 1, "earlier failure", CbomHeaderCounts.ZERO, now, 1);
+        stubPage("after", "0", "[" + entry("urn:uuid:gone", "1", STATS, null) + "]", null);
+        stubDocumentFailure("urn:uuid:gone", 1, 500);
+
+        String result = cbomInternalService.sync();
+
+        assertThat(result)
+                .contains("0 entries could not be stored and were recorded for retry")
+                .contains("0 entries are now permanently skipped")
+                .contains("1 offers of permanently skipped entries failed again");
+        assertThat(onlySkip().getAttempts()).isEqualTo(2);
+        assertThat(onlySkip().getState()).isEqualTo(CbomSyncSkipState.PERMANENTLY_SKIPPED);
+        assertThat(warnings())
+                .noneSatisfy(m -> assertThat(m).contains("urn:uuid:gone").contains("permanently skipped after"));
+    }
+
+    // ---- writer-level state machine ----
+    // Timestamps: PostgreSQL stores microseconds, so inputs are truncated with `.truncatedTo(ChronoUnit.MICROS)`
+    // and compared through `toInstant()`.
+
+    @Test
+    void recordAttemptWithABudgetOfOneWritesTheEntryOffAtOnce() {
+        OffsetDateTime now = OffsetDateTime.now().truncatedTo(ChronoUnit.MICROS);
+
+        CbomSyncSkip stored = skipWriter
+                .recordAttempt("urn:uuid:budget-one", 1, "reason one", CbomHeaderCounts.ZERO, now, 1);
+
+        assertThat(stored.getAttempts()).isEqualTo(1);
+        assertThat(stored.getState()).isEqualTo(CbomSyncSkipState.PERMANENTLY_SKIPPED);
+        assertThat(stored.getFirstSkippedAt().toInstant()).isEqualTo(now.toInstant());
+        assertThat(stored.getLastAttemptAt().toInstant()).isEqualTo(now.toInstant());
+    }
+
+    @Test
+    void aSecondAttemptCountsUpKeepsFirstSkippedAtAndTakesTheNewReasonAndCounts() {
+        OffsetDateTime first = OffsetDateTime.now().minusHours(1).truncatedTo(ChronoUnit.MICROS);
+        OffsetDateTime second = OffsetDateTime.now().truncatedTo(ChronoUnit.MICROS);
+        skipWriter.recordAttempt("urn:uuid:twice", 2, "first reason", new CbomHeaderCounts(1, 1, 1, 1, 4), first, 4);
+
+        CbomSyncSkip stored = skipWriter
+                .recordAttempt("urn:uuid:twice", 2, "second reason", new CbomHeaderCounts(2, 0, 0, 0, 2), second, 4);
+
+        assertThat(stored.getAttempts()).isEqualTo(2);
+        assertThat(stored.getState()).isEqualTo(CbomSyncSkipState.RETRYING);
+        assertThat(stored.getFirstSkippedAt().toInstant()).isEqualTo(first.toInstant());
+        assertThat(stored.getLastAttemptAt().toInstant()).isEqualTo(second.toInstant());
+        assertThat(stored.getReason()).isEqualTo("second reason");
+        assertThat(stored.counts()).isEqualTo(new CbomHeaderCounts(2, 0, 0, 0, 2));
+        assertThat(skipRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void aWrittenOffRowStaysWrittenOffWhenTheBudgetIsRaisedLater() {
+        OffsetDateTime now = OffsetDateTime.now().truncatedTo(ChronoUnit.MICROS);
+        skipWriter.recordAttempt("urn:uuid:written-off", 1, "reason", CbomHeaderCounts.ZERO, now, 1);
+
+        CbomSyncSkip stored = skipWriter
+                .recordAttempt("urn:uuid:written-off", 1, "reason", CbomHeaderCounts.ZERO, now, 10);
+
+        assertThat(stored.getAttempts()).isEqualTo(2);
+        assertThat(stored.getState()).isEqualTo(CbomSyncSkipState.PERMANENTLY_SKIPPED);
+    }
+
+    @Test
+    void resolveDeletesTheRecordAndReportsWhetherOneExisted() {
+        OffsetDateTime now = OffsetDateTime.now().truncatedTo(ChronoUnit.MICROS);
+        skipWriter.recordAttempt("urn:uuid:resolved", 1, "reason", CbomHeaderCounts.ZERO, now, 4);
+
+        assertThat(skipWriter.resolve("urn:uuid:resolved", 1)).isEqualTo(1);
+        assertThat(skipWriter.resolve("urn:uuid:resolved", 1)).isZero();
+        assertThat(skipRepository.count()).isZero();
+    }
+
+    // ---- helpers ----
+
+    private static String entry(String serialNumber, String version, String statsJson, String warning) {
+        return """
+                {"serialNumber":"%s","version":"%s","created_at":"2026-01-25T21:35:05Z","cryptoStats":%s%s}"""
+                .formatted(serialNumber, version, statsJson == null ? "null" : statsJson,
+                        warning == null ? "" : ",\"warnings\":[\"" + warning + "\"]");
+    }
+
+    private static String next(String cursor) {
+        return "<bom?cursor=" + cursor + "&limit=1000>; rel=\"next\"";
+    }
+
+    private void stubPage(String param, String value, String body, String linkHeader) {
+        ResponseDefinitionBuilder response = WireMock
+                .aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(body);
+        if (linkHeader != null) {
+            response = response.withHeader("Link", linkHeader);
+        }
+        MappingBuilder mapping = WireMock
+                .get(WireMock.urlPathEqualTo(SEARCH))
+                .withQueryParam(param, WireMock.equalTo(value));
+        repository.stubFor(mapping.willReturn(response));
+    }
+
+    private void stubDocument(String serialNumber, int version) {
+        repository
+                .stubFor(WireMock
+                        .get(WireMock.urlPathEqualTo("/api/v1/bom/" + serialNumber))
+                        .withQueryParam("version", WireMock.equalTo(String.valueOf(version)))
+                        .willReturn(WireMock
+                                .aResponse()
+                                .withStatus(200)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(
+                                        "{\"specVersion\":\"1.6\",\"metadata\":{\"timestamp\":\"2026-01-25T21:00:00Z\",\"component\":{\"name\":\"source-"
+                                                + serialNumber + "\"}}}")));
+    }
+
+    private void stubDocumentFailure(String serialNumber, int version, int status) {
+        repository
+                .stubFor(WireMock
+                        .get(WireMock.urlPathEqualTo("/api/v1/bom/" + serialNumber))
+                        .withQueryParam("version", WireMock.equalTo(String.valueOf(version)))
+                        .willReturn(problem(status, "stubbed failure")));
+    }
+
+    private static ResponseDefinitionBuilder problem(int status, String detail) {
+        return WireMock
+                .aResponse()
+                .withStatus(status)
+                .withHeader("Content-Type", "application/problem+json")
+                .withBody("{\"type\":\"about:blank\",\"title\":\"stub\",\"status\":" + status + ",\"detail\":\""
+                        + detail + "\"}");
+    }
+
+    private CbomSyncSkip onlySkip() {
+        List<CbomSyncSkip> skips = skipRepository.findAll();
+        assertThat(skips).hasSize(1);
+        return skips.getFirst();
+    }
+
+    private List<String> warnings() {
+        return logged.list
+                .stream()
+                .filter(e -> e.getLevel() == Level.WARN)
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+    }
+
+    private static Logger syncLogger() {
+        return (Logger) LoggerFactory.getLogger(CbomServiceImpl.class);
+    }
+}

--- a/src/test/java/com/otilm/core/integration/tasks/CbomSyncTaskITest.java
+++ b/src/test/java/com/otilm/core/integration/tasks/CbomSyncTaskITest.java
@@ -9,7 +9,6 @@ import com.otilm.core.tasks.CbomSyncTask;
 import com.otilm.core.tasks.ScheduledJobInfo;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -19,6 +18,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,40 +35,60 @@ class CbomSyncTaskITest extends BaseSpringBootTest {
     void testPerformJob_Success() throws Exception {
         ScheduledJobInfo scheduledJobInfo = new ScheduledJobInfo(CbomSyncTask.NAME);
         Object taskData = new Object();
-        Mockito.when(cbomService.isCbomRepositoryClientConfigured()).thenReturn(true);
+        when(cbomService.isCbomRepositoryClientConfigured()).thenReturn(true);
 
         ScheduledTaskResult result = cbomSyncTask.performJob(scheduledJobInfo, taskData);
 
         assertEquals(SchedulerJobExecutionStatus.SUCCESS, result.getStatus());
-        Mockito.verify(cbomService, Mockito.times(1)).isCbomRepositoryClientConfigured();
-        Mockito.verify(cbomService, Mockito.times(1)).sync();
+        verify(cbomService, times(1)).isCbomRepositoryClientConfigured();
+        verify(cbomService, times(1)).sync();
     }
 
     @Test
     void testPerformJob_Failure() throws Exception {
         ScheduledJobInfo scheduledJobInfo = new ScheduledJobInfo(CbomSyncTask.NAME);
-        Mockito.when(cbomService.isCbomRepositoryClientConfigured()).thenReturn(true);
-        Mockito.doThrow(new RuntimeException("Sync failed")).when(cbomService).sync();
+        when(cbomService.isCbomRepositoryClientConfigured()).thenReturn(true);
+        doThrow(new RuntimeException("Sync failed")).when(cbomService).sync();
 
         ScheduledTaskResult result = cbomSyncTask.performJob(scheduledJobInfo, new Object());
 
         assertEquals(SchedulerJobExecutionStatus.FAILED, result.getStatus());
-        assertTrue(result.getResultMessage().contains("Sync failed"));
-        Mockito.verify(cbomService, Mockito.times(1)).isCbomRepositoryClientConfigured();
-        Mockito.verify(cbomService, Mockito.times(1)).sync();
+        // A bare RuntimeException is not a PlatformException, so its raw message must not reach the operator-visible
+        // result -- only the fallback text may.
+        assertTrue(result.getResultMessage().contains("unexpected error, see the Core log"));
+        assertFalse(result.getResultMessage().contains("Sync failed"));
+        verify(cbomService, times(1)).isCbomRepositoryClientConfigured();
+        verify(cbomService, times(1)).sync();
+    }
+
+    @Test
+    void testPerformJob_Failure_PlatformExceptionMessageIsSurfaced() throws Exception {
+        ScheduledJobInfo scheduledJobInfo = new ScheduledJobInfo(CbomSyncTask.NAME);
+        when(cbomService.isCbomRepositoryClientConfigured()).thenReturn(true);
+        ProblemDetail problemDetail = ProblemDetail
+                .forStatusAndDetail(HttpStatus.BAD_GATEWAY, "CBOM Repository repeated the page cursor");
+        doThrow(new CbomRepositoryException(problemDetail)).when(cbomService).sync();
+
+        ScheduledTaskResult result = cbomSyncTask.performJob(scheduledJobInfo, new Object());
+
+        assertEquals(SchedulerJobExecutionStatus.FAILED, result.getStatus());
+        // CbomRepositoryException is a PlatformException with a Core-shaped message, so it is surfaced verbatim.
+        assertTrue(result.getResultMessage().contains("CBOM Repository repeated the page cursor"));
+        verify(cbomService, times(1)).isCbomRepositoryClientConfigured();
+        verify(cbomService, times(1)).sync();
     }
 
     @Test
     void testPerformJob_Skip() throws Exception {
         ScheduledJobInfo scheduledJobInfo = new ScheduledJobInfo(CbomSyncTask.NAME);
-        Mockito.when(cbomService.isCbomRepositoryClientConfigured()).thenReturn(false);
+        when(cbomService.isCbomRepositoryClientConfigured()).thenReturn(false);
 
         Object triggerObject = new Object();
         assertThrows(ScheduledJobSkippedException.class,
                 () -> cbomSyncTask.performJob(scheduledJobInfo, triggerObject));
 
-        Mockito.verify(cbomService, Mockito.times(1)).isCbomRepositoryClientConfigured();
-        Mockito.verify(cbomService, Mockito.times(0)).sync();
+        verify(cbomService, times(1)).isCbomRepositoryClientConfigured();
+        verify(cbomService, times(0)).sync();
     }
 
     @Test

--- a/src/test/java/com/otilm/core/model/cbom/CbomHeaderCountsTest.java
+++ b/src/test/java/com/otilm/core/model/cbom/CbomHeaderCountsTest.java
@@ -1,0 +1,41 @@
+package com.otilm.core.model.cbom;
+
+import com.otilm.core.dao.entity.Cbom;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CbomHeaderCountsTest {
+
+    @Test
+    void absentStatisticsCountAsZero() {
+        assertThat(CbomHeaderCounts.from(null)).isEqualTo(CbomHeaderCounts.ZERO);
+        assertThat(CbomHeaderCounts.from(new CryptoStatsDto())).isEqualTo(CbomHeaderCounts.ZERO);
+    }
+
+    @Test
+    void aPartiallyFilledStatisticsObjectCountsWhatItHas() {
+        CryptoAssetCountDto five = new CryptoAssetCountDto();
+        five.setTotal(5);
+        CryptoAssetsDto assets = new CryptoAssetsDto();
+        assets.setAlgorithms(five);
+        assets.setCertificates(new CryptoAssetCountDto()); // total null
+        assets.setTotal(5);
+        CryptoStatsDto stats = new CryptoStatsDto();
+        stats.setCryptoAssets(assets);
+
+        assertThat(CbomHeaderCounts.from(stats)).isEqualTo(new CbomHeaderCounts(5, 0, 0, 0, 5));
+    }
+
+    @Test
+    void appliesEveryCountToTheRow() {
+        Cbom cbom = new Cbom();
+        new CbomHeaderCounts(1, 2, 3, 4, 10).applyTo(cbom);
+
+        assertThat(cbom.getAlgorithmsCount()).isEqualTo(1);
+        assertThat(cbom.getCertificatesCount()).isEqualTo(2);
+        assertThat(cbom.getProtocolsCount()).isEqualTo(3);
+        assertThat(cbom.getCryptoMaterialCount()).isEqualTo(4);
+        assertThat(cbom.getTotalAssetsCount()).isEqualTo(10);
+    }
+}

--- a/src/test/java/com/otilm/core/service/impl/CbomSyncWatermarkTest.java
+++ b/src/test/java/com/otilm/core/service/impl/CbomSyncWatermarkTest.java
@@ -1,0 +1,44 @@
+package com.otilm.core.service.impl;
+
+import java.time.Duration;
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The one piece of arithmetic the whole feed rests on: the {@code after} bound a run opens with. It is the start of the
+ * last successful run, in whole seconds, less the overlap that covers clock skew between Core and the object store and
+ * uploads still in flight when that run started. Pinned here rather than in an integration test because nothing about
+ * it needs a database or a repository -- and because an overlap that silently came out as zero is exactly the defect
+ * this guards.
+ */
+class CbomSyncWatermarkTest {
+
+    /** An arbitrary run start with a sub-second remainder, so the truncation to whole seconds is exercised too. */
+    private static final Date RUN_START = new Date(1_700_000_000_999L);
+
+    private static final long RUN_START_SECOND = 1_700_000_000L;
+
+    @Test
+    void theDefaultOverlapMovesTheBoundASecondPerSecondBack() {
+        assertThat(CbomServiceImpl.watermarkSeconds(RUN_START, Duration.ofSeconds(60)))
+                .isEqualTo(RUN_START_SECOND - 60);
+    }
+
+    @Test
+    void withoutAnOverlapTheBoundIsTheRunStartSecond() {
+        assertThat(CbomServiceImpl.watermarkSeconds(RUN_START, Duration.ZERO)).isEqualTo(RUN_START_SECOND);
+    }
+
+    @Test
+    void aLongOverlapIsSubtractedInFull() {
+        assertThat(CbomServiceImpl.watermarkSeconds(RUN_START, Duration.ofMinutes(5)))
+                .isEqualTo(RUN_START_SECOND - 300);
+    }
+
+    @Test
+    void aRunStartEarlierThanTheOverlapClampsToTheEpoch() {
+        assertThat(CbomServiceImpl.watermarkSeconds(new Date(30_000L), Duration.ofSeconds(60))).isZero();
+    }
+}


### PR DESCRIPTION
Core consumes the cbom-repository 0.3.0 search feed the way the contract now describes it, and stops losing entries it could not store. Closes #2208. **25 files, one commit**, rebased onto `main` after #2236 and #2228. Follow-ups: #2249, #2250, #2251.

## What changes on the wire

`CbomServiceImpl.sync()` opens a run with `GET /api/v1/bom?after=<watermark>&limit=1000` and follows
`Link: <bom?cursor=…&limit=…>; rel="next"` until a page carries no `Link` — the absence of the header,
not the page size, ends the run. The target is a relative-path reference, so `CbomRepositoryClient`
appends only its query to Core's own `/api/v1/bom` URL (the README's recipe for a client that builds URLs
from a configured base): host, mount prefix and any ingress rewrite stay Core's, and the cursor token is
forwarded byte for byte (`search_followsALinkCursorThatContainsBase64PaddingVerbatim` pins padding and
percent-escapes). An absolute, path-absolute, network-path, foreign-path or query-less target, a target
that smuggles `after` next to `cursor` (compared decoded, so `%61fter` counts), and an immediately repeated
cursor are refused with a Core-shaped 502 whose detail names none of the target — an absolute one carries
the repository's own host, and the detail reaches a REST caller of the sync endpoint as well as the job
result; the target goes to the Core log. A failed page request likewise keeps its status but not the
repository's own sentence. The `Link` header itself is parsed by a small hand-walked RFC 8288 scanner
(`LinkHeader`), quoted parameters included, with no regex recursion to overflow on a long header.

`BomEntryDto` maps `created_at` (the dead `timestamp` is gone), `cryptoStats` is nullable and `warnings`
is read. The watermark rule is unchanged — start of the last successful run minus the overlap — but the
overlap is now `cbom.sync.overlap` (default 60 s, `@DurationUnit(SECONDS)` so `CBOM_SYNC_OVERLAP=60`
means seconds). Any non-2xx to a page request fails the run, so the watermark holds and the whole run is
repeated, exactly as the contract asks for a replica that does not know `cursor` yet.

## Nothing is skipped silently any more

An entry the sync cannot store — its document unreadable, the repository refusing it, a Core validation
refusing the stored document, the database refusing the row for anything but the `(serialNumber,
version)` uniqueness — is recorded in the new `cbom_sync_skip` table with an operator-safe reason and
the counts the feed reported, and retried at the end of each of the next `cbom.sync.skipped-retry-runs`
runs (default 3). After that it is kept as `PERMANENTLY_SKIPPED`, the watermark advances as today, and
the run still counts as successful — one corrupt document cannot hold the inventory back. A run loads
only the `RETRYING` rows (the live retry set; written-off rows are looked up by identity when an entry
fails or is stored, so the per-run load does not grow with every document ever written off). A skip
record is deleted the moment the document is stored, whether the retry phase stored it or the overlap
re-offered it, and whichever state it is in. `cryptoStats: null` entries are stored with zero counts, left for the ingest recount (#2209), with the
warning codes logged against the entry identity; `crypto-stats-shallow`/`-truncated` keep the reported
counts. `version: "original"` is ignored without a read and without a skip record.

Server-side read failures need one more rule, found by the adversarial review: Core maps its own refused
connections and the 35 s response timeout to HTTP 503, so "503 fails the run" would let a single hanging
document freeze the watermark. A 503 is therefore deferred: it is charged to its document like any other
failure unless the run shows a repository-wide outage — no read succeeded at all and at least two of the
**feed pass's** documents failed that way — in which case the run is skipped (503 →
`ScheduledJobSkippedException`) and nothing is charged. A retry's failure never counts towards that
verdict: the page requests of the same run just succeeded, and a retry exempt from being charged would be
exempt in every quiet run to come — skipped hourly, watermark never recorded, budget never spent — which
is the unbounded retry the table exists to prevent (review finding; `aPermanentlyHangingDocument…` pins
it). The status that drives the decision is the HTTP response's, never the one a problem-detail body
claims. Every other status, 5xx included, is that document's verdict and is charged at once.

## Transaction boundaries

`sync()` and `syncAuthorized()` run `@Transactional(NOT_SUPPORTED)`, and so does the scheduler's
`CbomSyncTask.performJob` (as `DiscoveryCertificateTask` already did): the run pages an external service
and reads one document per entry, which must not sit inside the platform's 120 s default transaction.
Entry stores keep their `REQUIRES_NEW` transaction; skip bookkeeping goes through the REQUIRED
`CbomSyncSkipWriter`, whose native upsert (`ON CONFLICT (serial_number, version)`) carries the attempt
arithmetic and uses the unique constraint as the concurrency arbiter. The `Cbom` entity now names
`cbom_serial_version_unique` (the migration already did), so the entity-generated test schema carries the
constraint the sync classifies duplicates by. Loop guards: a run-level cursor set, "an empty page never
carries a `Link`", and a 10 000-page ceiling — each fails the run with a Core-shaped 502.

`CbomSyncTask` no longer forwards `e.getMessage()` to the scheduler result for arbitrary exceptions;
only a `PlatformException`'s own sentence gets through, anything else becomes "unexpected error, see the
Core log".

## Configuration

`application.yml` gains `cbom.sync.page-size` (`CBOM_SYNC_PAGE_SIZE`, 1000), `cbom.sync.overlap`
(`CBOM_SYNC_OVERLAP`, 60 s) and `cbom.sync.skipped-retry-runs` (`CBOM_SYNC_SKIPPED_RETRY_RUNS`, 3),
bound and validated by `CbomSyncProperties`. Both reviews made the same point — a SaaS operator can reach
neither yml nor an environment variable, and `skipped-retry-runs` is operator policy — so **#2249** moves all
three into the Settings UI, which also retires the env-var placeholders and the Helm wiring they would need.
This PR keeps the yml placement until then.

## Prerequisites and follow-ups (handled outside this PR)

- Every cbom-repository replica must run **0.3.0 or newer**: Core always sends `limit` and ends the run on a
  missing `Link`, so a 0.2.0 replica would truncate a run silently. Core WARNs when the opening page is
  full and `Link`-less, which is that signature.
- `SchedulerListener`'s class-level `jakarta.transaction.Transactional` still keeps the job-history commit
  inside the 120 s transaction (pre-existing): a successful run longer than that leaves no SUCCESS row and
  the watermark waits for a run that fits. Filed as **#2251**.
- `cbom_sync_skip` has no retention and no operator view or reset yet: **#2250** adds a sweep of
  `PERMANENTLY_SKIPPED` rows after a retention period, a UI that names the document and its reason with a
  retry, everything configurable from the Settings UI. #2073 builds its per-CBOM unit of work on this loop;
  #2209 recounts the zero counts.

## Tests

Against a WireMock repository speaking the 0.3.0 contract, with raw JSON bodies: `LinkHeaderTest` 22,
`CbomRepositoryClientTest` 20, `CbomHeaderCountsTest` 3, `CbomSyncPropertiesTest` 7,
`CbomSyncWatermarkTest` 4, new `CbomSyncITest` 28 (three-page run, empty first page, 400 on a cursor page,
cursor loop, empty page with `Link`, null stats per warning code, `original`, the five-run retry budget,
recovery with the reported counts, duplicate re-offers, the outage rule and the hanging document that
must not become one, a written-off row resolved by a late store, writer-level upsert transitions),
`CbomServiceITest` 45, `CbomSyncTaskITest` 9, plus the ArchUnit and context-budget guards
(`ContextSignatureGuardTest` stays at 61). Spotless and Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



