### PR TITLE
Filter cryptographic assets by curve membership (curve TEXT → text[])

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -15,6 +15,197 @@ permissions:
   packages: read
 
 jobs:
+  # A marker in the PR body redirects this build at an unmerged interfaces PR's
+  # snapshot. The pom is never touched: core dismisses approvals on push and
+  # forbids self-approval, so a revert commit would cost a second review round.
+  resolve-interfaces:
+    name: Resolve interfaces version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: read
+    outputs:
+      mvnarg:   ${{ steps.resolve.outputs.mvnarg }}
+      override: ${{ steps.resolve.outputs.override }}
+    steps:
+      # No checkout: nothing here reads the working tree.
+      - id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT: ${{ github.event_name }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          emit() { echo "mvnarg=$1" >>"$GITHUB_OUTPUT"; echo "override=$2" >>"$GITHUB_OUTPUT"; }
+          fail() { echo "::error::$1"; exit 1; }
+
+          # merge_group carries no pull_request object. Unreachable under the
+          # current triggers; kept so adding one cannot silently resolve wrong.
+          if [ "$EVENT" != pull_request ]; then
+            echo "Not a pull_request event - using the pom value."
+            emit "" "none"; exit 0
+          fi
+
+          # Live, not github.event.pull_request.body: a re-run replays the original
+          # payload, so an edited marker would be invisible and the override could
+          # never clear without a push, which dismisses the approval.
+          if ! BODY=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/$PR" --jq '.body // ""'); then
+            fail "Could not read the body of ${GITHUB_REPOSITORY}#${PR}."
+          fi
+
+          # Fenced blocks and HTML comments go first: the regexes are line-oriented,
+          # so a body quoting the marker syntax would otherwise pin the build.
+          BODY=$(printf '%s\n' "$BODY" | python3 -c 'import re,sys; t=sys.stdin.read(); t=re.sub(r"<!--.*?-->","",t,flags=re.S); t=re.sub(r"^[ \t]*(```|~~~).*?^[ \t]*\1","",t,flags=re.S|re.M); sys.stdout.write(t)')
+
+          # head -1 below would otherwise take the earlier line silently.
+          DUPD=$(printf '%s' "$BODY" | grep -ciP '^[[:space:]>*_+#.)0-9-]*Depends-On[[:space:]*_]*:[[:space:]*_]*(https?://github\.com/)?OmniTrustILM/interfaces(?![0-9A-Za-z._-])' || true)
+          DUPV=$(printf '%s' "$BODY" | grep -ciP '^[[:space:]>*_+#.)0-9-]*Interfaces-Version[[:space:]*_]*:' || true)
+          [ "${DUPD:-0}" -le 1 ] || fail "The PR body has ${DUPD} Depends-On lines. Keep exactly one."
+          [ "${DUPV:-0}" -le 1 ] || fail "The PR body has ${DUPV} Interfaces-Version lines. Keep exactly one."
+
+          NUM=$(printf '%s' "$BODY" \
+            | grep -oiP '^Depends-On:[[:space:]]*OmniTrustILM/interfaces#\K[0-9]{1,7}(?=[[:space:]]*$)' \
+            | head -1 || true)
+          VER=$(printf '%s' "$BODY" \
+            | grep -oiP '^Interfaces-Version:[[:space:]]*\K[0-9][0-9A-Za-z.\-]{0,60}(?=[[:space:]]*$)' \
+            | head -1 || true)
+          # Strict extractors, loose probes.
+          #
+          # Strict: line start, nothing after the value - `Interfaces-Version:
+          # 2.20.0; rm -rf /` is rejected, not truncated to a pin on 2.20.0.
+          #
+          # Loose: a decorated marker misses the extractor, so the probe catches it
+          # and fails loudly. The Depends-On probe closes off the repository name,
+          # so another repo's marker - or a same-prefix sibling - is ignored.
+          if printf '%s' "$BODY" | grep -qiP '^[[:space:]>*_+#.)0-9-]*Depends-On[[:space:]*_]*:[[:space:]*_]*(https?://github\.com/)?OmniTrustILM/interfaces(?![0-9A-Za-z._-])' && [ -z "$NUM" ]; then
+            fail "A Depends-On: line for interfaces is present but not in the accepted form. It must begin the line and read: Depends-On: OmniTrustILM/interfaces#<number> - a pull-request URL is not accepted."
+          fi
+          if printf '%s' "$BODY" | grep -qiP '^[[:space:]>*_+#.)0-9-]*Interfaces-Version[[:space:]*_]*:' && [ -z "$VER" ]; then
+            fail "An Interfaces-Version: line is present but not in the accepted form. It must begin the line and name a published version, e.g. Interfaces-Version: 2.20.0-M906-480022e4"
+          fi
+
+          # Both markers set: name the loser rather than letting it disappear.
+          if [ -n "$VER" ] && [ -n "$NUM" ]; then
+            echo "::warning::Both markers present - Interfaces-Version wins; ignoring Depends-On: OmniTrustILM/interfaces#${NUM}."
+          fi
+
+          # Reaches the build jobs through the environment, never interpolated into
+          # their run: blocks, so the value is never shell source text.
+          if [ -n "$VER" ]; then
+            echo "Explicit override: $VER"
+            emit "-Dinterfaces.version=$VER" "explicit"; exit 0
+          fi
+
+          if [ -z "$NUM" ]; then
+            emit "" "none"; exit 0
+          fi
+
+          # Captured, not tested inline: a substitution inside an `if` does not trip
+          # `set -e`, so a 404 or rate limit would read as "not merged".
+          if ! IPR=$(gh api "repos/OmniTrustILM/interfaces/pulls/$NUM" --jq '[.merged, .state, (.merge_commit_sha // ""), (.merged_at // "")] | @tsv'); then
+            fail "Cannot read OmniTrustILM/interfaces#${NUM} - check that the number names an existing pull request."
+          fi
+          read -r MERGED ISTATE MSHA MAT <<<"$IPR"
+
+          if ! VERSIONS=$(gh api --paginate \
+                  "/orgs/OmniTrustILM/packages/maven/com.otilm.interfaces/versions?per_page=100" \
+                  --jq '.[] | [.created_at, .name] | @tsv'); then
+            fail "Could not list the published interfaces package versions."
+          fi
+
+          # Self-clearing: once the interfaces PR merges, the same unchanged
+          # marker stops meaning "override" and starts meaning "nothing to do".
+          if [ "$MERGED" = true ]; then
+            # Mainline SNAPSHOT carries the change only once the interfaces
+            # publish finishes. The merge commit's -M build is evidence that run
+            # reached its pin job, not that the SNAPSHOT deploy in it succeeded -
+            # that job mints the pin even when it did not.
+            if ! printf '%s\n' "$VERSIONS" | cut -f2 \
+                 | grep -qE "^[0-9][0-9A-Za-z.-]*-M[0-9]+-${MSHA:0:8}\$"; then
+              AGE=$(( $(date -u +%s) - $(date -u -d "${MAT:-@0}" +%s) ))
+              if [ "$AGE" -lt 900 ]; then
+                fail "interfaces#${NUM} merged ${AGE}s ago but its build has not published yet. Wait for it, then re-run all jobs."
+              fi
+              echo "::warning::interfaces#${NUM} merged ${AGE}s ago with no -M build; a release-cut merge produces none. Proceeding against mainline."
+            fi
+            echo "interfaces#$NUM is merged - using the mainline pom value."
+            emit "" "none"; exit 0
+          fi
+
+          # A PR closed without merging would otherwise read as "still open" and keep
+          # this build pinned to an abandoned branch; its snapshot outlives it.
+          if [ "$ISTATE" = closed ]; then
+            fail "OmniTrustILM/interfaces#${NUM} was closed without merging. Remove the Depends-On line, or repoint it at whatever superseded it."
+          fi
+
+          # Looked up, not derived from core's own property: across a release cut
+          # interfaces publishes 2.21.0-alpha-PR<n>-SNAPSHOT while this pom still
+          # reads 2.20.0.
+          #
+          # The whole name is anchored, not just the suffix - the prefix comes from
+          # the interfaces PR's own pom, so it would otherwise carry PR-controlled
+          # text into the mvn argument. Newest by created_at, not API order, which
+          # is not contractual and matters when a PR spans a release cut.
+          PRV=$(printf '%s\n' "$VERSIONS" \
+            | awk -F'\t' -v n="$NUM" '$2 ~ "^[0-9][0-9A-Za-z.-]*-alpha-PR" n "-SNAPSHOT$"' \
+            | sort -r | head -1 | cut -f2)
+
+          if [ -z "$PRV" ]; then
+            fail "No published snapshot for interfaces#${NUM}. It needs the publish-snapshot label and a finished build. Fork PRs never publish - their token is read-only."
+          fi
+
+          echo "interfaces#$NUM is open - building against $PRV"
+          emit "-Dinterfaces.version=$PRV" "pr"
+
+      # sonar.yaml is a separate workflow and cannot read job outputs; without this
+      # it analyses the compiled classes against a classpath they were not built with.
+      - name: Publish the resolved argument
+        env:
+          ARG: ${{ steps.resolve.outputs.mvnarg }}
+        run: printf '%s\n' "$ARG" > mvnarg.txt
+
+      - name: Upload the resolved interfaces argument
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: interfaces-mvnarg
+          path: mvnarg.txt
+
+      - name: Summarise
+        env:
+          MODE: ${{ steps.resolve.outputs.override }}
+          ARG: ${{ steps.resolve.outputs.mvnarg }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Interfaces resolution"
+            echo ""
+            echo "- mode: \`$MODE\`"
+            echo "- mvn arg: \`${ARG:-(none)}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Reached transitively by the required `Build` job's `needs` - "Interfaces pin"
+  # is not itself a required context, so do not drop it from that list.
+  # Red on both override modes; `pr` clears itself once the interfaces PR
+  # merges and the workflow is re-run, `explicit` only when the line is deleted.
+  pin-gate:
+    name: Interfaces pin
+    needs: resolve-interfaces
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject an active interfaces override
+        env:
+          MODE: ${{ needs.resolve-interfaces.outputs.override }}
+        run: |
+          set -euo pipefail
+          case "$MODE" in
+            none) echo "No override active." ;;
+            pr)   echo "::error::Building against an unmerged interfaces PR. Merge it, wait for the publish, then re-run all jobs."; exit 1 ;;
+            explicit) echo "::error::An explicit Interfaces-Version override is active. Remove the marker from the PR body, then re-run all jobs - re-running only the failed job replays the cached resolution."; exit 1 ;;
+            *) echo "::error::Unknown resolver mode '$MODE'"; exit 1 ;;
+          esac
+
   formatting:
     name: Formatting and lint
     runs-on: ubuntu-latest
@@ -38,6 +229,7 @@ jobs:
 
   compile:
     name: Compile
+    needs: resolve-interfaces
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -52,7 +244,9 @@ jobs:
       - name: Compile
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        run: mvn -B -U -ntp test-compile -Dmaven.compiler.proc=full
+          MVNARG: ${{ needs.resolve-interfaces.outputs.mvnarg }}
+        # $MVNARG unquoted on purpose: empty contributes no argument.
+        run: mvn -B -U -ntp test-compile -Dmaven.compiler.proc=full $MVNARG
 
       - name: Package compiled output
         run: tar -czf compiled.tar.gz target/classes target/test-classes
@@ -66,7 +260,7 @@ jobs:
 
   test:
     name: Test (${{ matrix.group }})
-    needs: compile
+    needs: [compile, resolve-interfaces]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -93,7 +287,8 @@ jobs:
       - name: Run ${{ matrix.group }} tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        run: mvn -B -U -ntp test -Ptest-${{ matrix.group }} -Dmaven.compiler.skip=true
+          MVNARG: ${{ needs.resolve-interfaces.outputs.mvnarg }}
+        run: mvn -B -U -ntp test -Ptest-${{ matrix.group }} -Dmaven.compiler.skip=true $MVNARG
 
       - name: Upload coverage exec
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -104,7 +299,7 @@ jobs:
 
   package:
     name: Package
-    needs: test
+    needs: [test, resolve-interfaces]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -158,7 +353,8 @@ jobs:
       - name: Merge coverage, generate report, and package
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        run: mvn -B -U -ntp package -DskipTests -Pmerge-coverage -Dmaven.compiler.skip=true
+          MVNARG: ${{ needs.resolve-interfaces.outputs.mvnarg }}
+        run: mvn -B -U -ntp package -DskipTests -Pmerge-coverage -Dmaven.compiler.skip=true $MVNARG
 
       # Write PR number to file
       - name: Write PR number to file
@@ -187,6 +383,9 @@ jobs:
 
   generated:
     name: Generated artifacts
+    # `mvn test` runs the compile and test-compile phases, so this job builds the
+    # whole tree and needs the override as much as compile/test/package do.
+    needs: resolve-interfaces
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -256,9 +455,10 @@ jobs:
       - name: Key the miniature CBOM corpus
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # resolves com.otilm parent and build-tools from GitHub Packages
+          MVNARG: ${{ needs.resolve-interfaces.outputs.mvnarg }}
         run: |
           mvn -B -U -ntp test -Dtest=CorpusKeySnapshotTest#snapshot -Dsurefire.failIfNoSpecifiedTests=false \
-            -Dcorpus.dir=src/test/resources/cbom/corpus -Dcorpus.out=target/corpus-keys.tsv
+            -Dcorpus.dir=src/test/resources/cbom/corpus -Dcorpus.out=target/corpus-keys.tsv $MVNARG
 
       - name: Fail if the committed corpus keys are not the instrument's output
         run: |
@@ -276,7 +476,7 @@ jobs:
 
   build:
     name: Build
-    needs: [package, formatting, generated]
+    needs: [package, formatting, generated, pin-gate]
     # Runs when an upstream job failed or was skipped, not only when all of them succeeded. With
     # the default condition this job is skipped whenever a dependency fails, and GitHub counts a
     # skipped required check as passing -- so a red `generated` or `formatting` job blocked the

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -5,11 +5,54 @@ on:
     types: [completed]
 
 jobs:
+  # Gated on Package rather than the run conclusion: pin-gate fails by design on
+  # a coupled PR, which would skip Sonar for exactly the PRs that need it most.
+  # Every artifact this workflow downloads comes from Package.
+  gate:
+    name: Sonar precondition
+    if: github.event.workflow_run.conclusion != 'cancelled'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      analyse: ${{ steps.check.outputs.analyse }}
+    steps:
+      - id: check
+        name: Check the build produced its artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: |
+          set -euo pipefail
+          # Falls back to the run conclusion when the read fails: SonarCloud Code
+          # Analysis is required, so a bad read must not withhold it repo-wide.
+          # Keyed on exit status, not emptiness: gh prints an API error body to
+          # stdout, so a failed read would otherwise look like a real answer.
+          PKG=$(gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/jobs" \
+                  --jq '[.jobs[] | select(.name=="Package")][0].conclusion // ""' 2>/dev/null) || PKG=""
+          case "$PKG" in
+            success|failure|cancelled|skipped|neutral|timed_out|action_required) ;;
+            *) PKG="" ;;
+          esac
+          echo "Package: ${PKG:-<unreadable>}  run conclusion: $RUN_CONCLUSION"
+          if [ -z "$PKG" ]; then
+            ANALYSE=$([ "$RUN_CONCLUSION" = success ] && echo true || echo false)
+          elif [ "$PKG" = success ]; then
+            ANALYSE=true
+          else
+            ANALYSE=false
+          fi
+          echo "analyse=$ANALYSE" >> "$GITHUB_OUTPUT"
+
   sonar:
     name: Sonar
+    needs: gate
+    if: needs.gate.outputs.analyse == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.event.workflow_run.conclusion == 'success'
     steps:
       # Download the PR number artifact
       - name: Download PR number
@@ -90,6 +133,18 @@ jobs:
           key: ${{ runner.os }}-sonar-${{ steps.cache-month.outputs.yearmonth }}
           restore-keys: |
             ${{ runner.os }}-sonar-
+      # Outside the checkout: at the tree root a failed download would leave the
+      # head commit's own mvnarg.txt to be read instead.
+      - id: mvnarg
+        name: Download the resolved interfaces argument
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: interfaces-mvnarg
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          path: ${{ runner.temp }}/mvnarg
+
       # SonarCloud Scan analysis and push
       - name: SonarCloud Scan
         env:
@@ -100,7 +155,16 @@ jobs:
           SONAR_PR_BRANCH: ${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}
           SONAR_PR_BASE: ${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
         run: |
-          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+          set -euo pipefail
+          # A missing artifact means analysing against a classpath the classes
+          # were not built with, so it fails rather than falling back silently.
+          if [ "${{ steps.mvnarg.outcome }}" != success ]; then
+            echo "::error::The resolved interfaces argument is missing. Re-run Build PR to regenerate it."
+            exit 1
+          fi
+          MVNARG=$(cat "$RUNNER_TEMP/mvnarg/mvnarg.txt")
+          # Unquoted: empty contributes no argument.
+          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar $MVNARG \
             -Dsonar.scm.revision="$SONAR_REVISION" \
             -Dsonar.pullrequest.key="$SONAR_PR_KEY" \
             -Dsonar.pullrequest.branch="$SONAR_PR_BRANCH" \

--- a/README.md
+++ b/README.md
@@ -153,3 +153,38 @@ Example values:
 - `HTTP_PROXY=http://user:password@proxy.example.com:3128`
 - `HTTPS_PROXY=http://user:password@proxy.example.com:3128`
 - `NO_PROXY=localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,cattle-system.svc,.svc,.cluster.local,my-domain.local`
+
+## Building against an unmerged `interfaces` change
+
+A change that needs a not-yet-merged `interfaces` API cannot compile against the
+mainline snapshot. Put one marker in the pull request **body** to redirect the
+build; the pom is never edited.
+
+```
+Depends-On: OmniTrustILM/interfaces#940
+```
+
+CI then builds against that pull request's own snapshot, which it publishes only
+while it carries the `publish-snapshot` label. Fork pull requests never publish,
+because their token is read-only.
+
+Use `Interfaces-Version` instead to pin one already-published build — useful when
+somebody else's merge reddens an unrelated pull request:
+
+```
+Interfaces-Version: 2.20.0-M907-1299756b
+```
+
+Two rules decide whether a marker is read at all. **It must start at column 0** —
+no bullet, no indent, no `>`, no bold — and **nothing may follow the value**. A
+marker breaking either rule fails the build with a message naming the accepted
+form, rather than being silently ignored. Markers inside fenced code blocks or
+HTML comments are skipped, so quoting the syntax is safe.
+
+The `Interfaces pin` check stays red for as long as a marker is active, and it
+feeds the required `Build` check, so neither form can reach `main`:
+
+- `Depends-On` clears itself. Merge the `interfaces` pull request, wait for its
+  publish to finish, then re-run **all** jobs — re-running only the failed job
+  replays the cached resolution and the gate stays red.
+- `Interfaces-Version` does not. Delete the line and re-run before merging.

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,10 @@
     <name>core</name>
 
     <properties>
+        <!-- The mainline value - only a release-cut PR changes it, in lockstep with
+             this project's own <version>. CI overrides it with -Dinterfaces.version=...
+             when a PR body carries a Depends-On or Interfaces-Version marker. -->
+        <interfaces.version>2.20.0-SNAPSHOT</interfaces.version>
         <archunit.version>1.4.2</archunit.version>
         <!-- CVE-2026-65182, CVE-2026-65905, CVE-2026-68525 (auth/constraint bypasses in embedded Tomcat).
              The announced fix version 10.1.58 was never published; 10.1.59 is its released successor.
@@ -72,7 +76,7 @@
         <dependency>
             <groupId>com.otilm</groupId>
             <artifactId>interfaces</artifactId>
-            <version>2.20.0-SNAPSHOT</version>
+            <version>${interfaces.version}</version>
         </dependency>
 
         <!-- Spring  -->

--- a/src/main/java/com/otilm/core/cbom/asset/CompositeCurve.java
+++ b/src/main/java/com/otilm/core/cbom/asset/CompositeCurve.java
@@ -1,0 +1,29 @@
+package com.otilm.core.cbom.asset;
+
+import java.util.List;
+
+/**
+ * Renders the stored curve members back into the composite spelling.
+ *
+ * <p>
+ * A hybrid scheme names more than one curve, and the normalizer renders those as a single {@code +}-joined token in
+ * sorted, deduplicated order. That token is what the ratified identity vectors hash, so its shape can never change; the
+ * column holds the members split out of it, which is what lets a filter ask whether an asset touches a curve rather
+ * than whether its whole composite equals one. The split preserves the normalizer's order, so joining the members back
+ * reproduces the preimage spelling byte for byte -- which is what the API contract keeps carrying.
+ */
+public final class CompositeCurve {
+
+    private static final String SEPARATOR = "+";
+
+    private CompositeCurve() {
+    }
+
+    /** The stored members in the spelling the identity preimage and the API contract both use, or {@code null}. */
+    public static String join(List<String> members) {
+        if (members == null || members.isEmpty()) {
+            return null;
+        }
+        return String.join(SEPARATOR, members);
+    }
+}

--- a/src/main/java/com/otilm/core/dao/entity/cbom/CryptoAsset.java
+++ b/src/main/java/com/otilm/core/dao/entity/cbom/CryptoAsset.java
@@ -15,6 +15,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.Getter;
@@ -86,8 +87,13 @@ public class CryptoAsset extends UniquelyIdentifiedAndAudited {
     @Column(name = "parameter_set", columnDefinition = "TEXT")
     private String parameterSet;
 
-    @Column(name = "curve", columnDefinition = "TEXT")
-    private String curve;
+    /**
+     * The curve members, one per element. A hybrid scheme reports its members joined on {@code +} and is stored split,
+     * so an asset can be found by any curve it touches; the identity preimage keeps the joined spelling.
+     */
+    @Column(name = "curve", columnDefinition = "TEXT[]")
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    private List<String> curve;
 
     @Column(name = "mode", columnDefinition = "TEXT")
     private String mode;

--- a/src/main/java/com/otilm/core/dao/repository/cbom/CryptoAssetRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/cbom/CryptoAssetRepository.java
@@ -64,6 +64,11 @@ public interface CryptoAssetRepository extends SecurityFilterRepository<CryptoAs
      * reconciling a genuine disagreement is an explicit decision rather than a side effect of sync order.
      *
      * <p>
+     * <b>Curve:</b> bound as the normalized composite and stored split on {@code +}, so a hybrid scheme's members can
+     * each be matched on their own. The caller keeps passing the joined spelling because that is what the identity
+     * preimage hashes; the split is a storage projection, and {@code CompositeCurve} is its inverse on the read side.
+     *
+     * <p>
      * <b>Identity guard:</b> an existing guard survives, because it is a safety refusal rather than a field. A guard
      * says this row was deliberately kept separate — a refuted certificate digest, a bare common name facing a full
      * subject DN — and {@code CryptoAssetAliasWriter} refuses an alias by reading the guard that is on the row now.
@@ -81,7 +86,7 @@ public interface CryptoAssetRepository extends SecurityFilterRepository<CryptoAs
                     algorithm_family, primitive, parameter_set, curve, mode, padding, variant, identity_guard,
                     properties_leaf_count, source_count, i_cre, i_upd)
             VALUES (:uuid, :key, :rulesetVersion, :assetType, :name, :oid, :algorithmFamily, :primitive,
-                    :parameterSet, :curve, :mode, :padding, :variant, :identityGuard,
+                    :parameterSet, string_to_array(CAST(:curve AS TEXT), '+'), :mode, :padding, :variant, :identityGuard,
                     0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
             ON CONFLICT (identity_key) DO UPDATE SET
                 ruleset_version = EXCLUDED.ruleset_version,
@@ -97,7 +102,8 @@ public interface CryptoAssetRepository extends SecurityFilterRepository<CryptoAs
                 variant = COALESCE(crypto_asset.variant, EXCLUDED.variant),
                 identity_guard = COALESCE(crypto_asset.identity_guard, EXCLUDED.identity_guard),
                 i_upd = CURRENT_TIMESTAMP
-            """, nativeQuery = true)
+            """,
+            nativeQuery = true)
     void upsertIdentity(@Param("uuid") UUID uuid, @Param("key") String key, @Param("rulesetVersion") int rulesetVersion,
             @Param("assetType") String assetType, @Param("name") String name, @Param("oid") String oid,
             @Param("algorithmFamily") String algorithmFamily, @Param("primitive") String primitive,
@@ -194,7 +200,8 @@ public interface CryptoAssetRepository extends SecurityFilterRepository<CryptoAs
      * from -- the sweep's transaction is {@code READ COMMITTED}, so a second statement would see a later snapshot and a
      * write landing between the two would be invisible to the guard. {@code merged_crypto_properties} comes back as
      * text because the evaluator wants a {@code JsonNode}: the entity converter would build a {@code Map} only for the
-     * sweep to serialize it again.
+     * sweep to serialize it again. {@code curve} comes back joined on {@code +} because the record and the rules read
+     * the identity spelling, which the column stores split.
      *
      * <p>
      * <b>Stale</b> is either half of the contract: a verdict from an older generation of the rules, or a verdict older
@@ -215,7 +222,7 @@ public interface CryptoAssetRepository extends SecurityFilterRepository<CryptoAs
                    algorithm_family,
                    primitive,
                    parameter_set,
-                   curve,
+                   array_to_string(curve, '+') AS curve,
                    mode,
                    padding,
                    variant,
@@ -335,14 +342,17 @@ public interface CryptoAssetRepository extends SecurityFilterRepository<CryptoAs
             """, nativeQuery = true)
     List<String> findDistinctParameterSet();
 
+    /**
+     * Every curve any asset touches, once each -- not every combination once.
+     *
+     * <p>
+     * The sibling finders skip along a btree with a recursive loose index scan. That cannot work here: the distinct
+     * values are the array's elements, and no index orders them. The unnest is a sequential scan, which is what the
+     * value list for a membership filter costs.
+     */
     @Query(value = """
-            WITH RECURSIVE vals AS (
-                SELECT min(curve) AS v FROM {h-schema}crypto_asset
-                UNION ALL
-                SELECT (SELECT min(curve) FROM {h-schema}crypto_asset WHERE curve > vals.v)
-                FROM vals WHERE vals.v IS NOT NULL
-            )
-            SELECT v FROM vals WHERE v IS NOT NULL ORDER BY v
+            SELECT DISTINCT member FROM {h-schema}crypto_asset a, unnest(a.curve) AS member
+            WHERE member IS NOT NULL ORDER BY member
             """, nativeQuery = true)
     List<String> findDistinctCurve();
 

--- a/src/main/java/com/otilm/core/enums/FilterField.java
+++ b/src/main/java/com/otilm/core/enums/FilterField.java
@@ -408,7 +408,10 @@ public enum FilterField {
             SearchFieldTypeEnum.LIST),
     CBOM_ASSET_PARAMETER_SET(Resource.CRYPTO_ASSET, null, null, CryptoAsset_.parameterSet, "Parameter Set",
             SearchFieldTypeEnum.LIST),
-    CBOM_ASSET_CURVE(Resource.CRYPTO_ASSET, null, null, CryptoAsset_.curve, "Elliptic Curve", SearchFieldTypeEnum.LIST),
+    // A hybrid scheme's curve is stored as its members, so EQUALS asks whether the asset touches the curve rather
+    // than whether its whole composite is that curve. NATIVE_ARRAY still reports FilterFieldType.LIST on the wire.
+    CBOM_ASSET_CURVE(Resource.CRYPTO_ASSET, null, null, CryptoAsset_.curve, "Elliptic Curve",
+            SearchFieldTypeEnum.NATIVE_ARRAY),
     CBOM_ASSET_MODE(Resource.CRYPTO_ASSET, null, null, CryptoAsset_.mode, "Mode", SearchFieldTypeEnum.LIST),
     CBOM_ASSET_PADDING(Resource.CRYPTO_ASSET, null, null, CryptoAsset_.padding, "Padding", SearchFieldTypeEnum.LIST),
     CBOM_ASSET_VARIANT(Resource.CRYPTO_ASSET, null, null, CryptoAsset_.variant, "Variant", SearchFieldTypeEnum.LIST),

--- a/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
@@ -22,6 +22,7 @@ import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
 import com.otilm.api.model.core.search.SearchFieldDataDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.AttributeEngine.CustomAttributeContentFilter;
+import com.otilm.core.cbom.asset.CompositeCurve;
 import com.otilm.core.comparator.SearchFieldDataComparator;
 import com.otilm.core.dao.entity.Cbom;
 import com.otilm.core.dao.entity.Cbom_;
@@ -578,15 +579,15 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
 
     private static CryptographicAssetNormalizedFieldsDto toNormalizedFieldsDto(CryptoAsset asset) {
         if (asset.getAlgorithmFamily() == null && asset.getPrimitive() == null && asset.getParameterSet() == null
-                && asset.getCurve() == null && asset.getMode() == null && asset.getPadding() == null
-                && asset.getVariant() == null) {
+                && CompositeCurve.join(asset.getCurve()) == null && asset.getMode() == null
+                && asset.getPadding() == null && asset.getVariant() == null) {
             return null;
         }
         CryptographicAssetNormalizedFieldsDto dto = new CryptographicAssetNormalizedFieldsDto();
         dto.setAlgorithmFamily(asset.getAlgorithmFamily());
         dto.setPrimitive(asset.getPrimitive());
         dto.setParameterSet(asset.getParameterSet());
-        dto.setCurve(asset.getCurve());
+        dto.setCurve(CompositeCurve.join(asset.getCurve()));
         dto.setMode(asset.getMode());
         dto.setPadding(asset.getPadding());
         dto.setVariant(asset.getVariant());

--- a/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicAssetServiceImpl.java
@@ -579,8 +579,8 @@ public class CryptographicAssetServiceImpl implements CryptographicAssetExternal
 
     private static CryptographicAssetNormalizedFieldsDto toNormalizedFieldsDto(CryptoAsset asset) {
         if (asset.getAlgorithmFamily() == null && asset.getPrimitive() == null && asset.getParameterSet() == null
-                && CompositeCurve.join(asset.getCurve()) == null && asset.getMode() == null
-                && asset.getPadding() == null && asset.getVariant() == null) {
+                && asset.getCurve() == null && asset.getMode() == null && asset.getPadding() == null
+                && asset.getVariant() == null) {
             return null;
         }
         CryptographicAssetNormalizedFieldsDto dto = new CryptographicAssetNormalizedFieldsDto();

--- a/src/main/java/com/otilm/core/util/PostgresFunctionContributor.java
+++ b/src/main/java/com/otilm/core/util/PostgresFunctionContributor.java
@@ -12,6 +12,32 @@ public class PostgresFunctionContributor implements FunctionContributor {
     public static final String ARRAY_CONTAINS = "text_array_contains";
     public static final String ARRAY_ITEM_CONTAINS = "text_array_item_contains";
 
+    /**
+     * Scalar membership in a native array column, written as containment rather than as the equivalent
+     * {@code CAST(?1 AS TEXT) = ANY(?2)}.
+     *
+     * <p>
+     * The two answer the same question for the single non-null value this is ever called with -- every caller in
+     * {@code FilterPredicatesBuilder} passes {@code value.toString()} as a literal -- but only containment can be
+     * answered by a GIN index. PostgreSQL has no index path for {@code scalar = ANY(column)} at all, so the
+     * {@code = ANY} form made every membership filter a sequential scan whatever index the column carried.
+     *
+     * <p>
+     * The column is cast because the array columns are not all one type: a {@code List<String>} mapped with
+     * {@code SqlTypes.ARRAY} generates {@code varchar[]} unless the entity says otherwise, and {@code @>} is not
+     * defined across {@code varchar[]} and {@code text[]}. On a {@code text[]} column the cast is to the type the
+     * column already has, which PostgreSQL drops, so the index still matches -- pinned by
+     * {@code CryptoAssetCurveMembershipMigrationITest}.
+     *
+     * <p>
+     * That last part is what indexability rests on, and it is a property of the column rather than of the index: on a
+     * {@code varchar[]} column the cast is a real one, and a GIN index there is never matched through it. An entity
+     * earns the indexable type by declaring {@code columnDefinition = "TEXT[]"}, as {@code CryptoAsset.curve} does and
+     * the other array-mapped fields do not -- so adding an array index to one of those would silently buy nothing until
+     * its column type moves too.
+     */
+    public static final String ARRAY_CONTAINS_PATTERN = "CAST(?2 AS TEXT[]) @> ARRAY[CAST(?1 AS TEXT)]";
+
     @Override
     public void contributeFunctions(FunctionContributions functionContributions) {
         BasicType<Integer> resultType = functionContributions
@@ -26,10 +52,9 @@ public class PostgresFunctionContributor implements FunctionContributor {
         functionContributions
                 .getFunctionRegistry()
                 .registerPattern(JSONB_CONTAINS, "jsonb_contains(?1, ?2::jsonb)", booleanType);
-        // CAST(?1 AS TEXT) = ANY(?2) — check scalar membership in a native text[] column
         functionContributions
                 .getFunctionRegistry()
-                .registerPattern(ARRAY_CONTAINS, "CAST(?1 AS TEXT) = ANY(?2)", booleanType);
+                .registerPattern(ARRAY_CONTAINS, ARRAY_CONTAINS_PATTERN, booleanType);
         // EXISTS over unnest(...) + LIKE — check substring match in any native text[] item
         functionContributions
                 .getFunctionRegistry()

--- a/src/main/java/com/otilm/core/util/SearchHelper.java
+++ b/src/main/java/com/otilm/core/util/SearchHelper.java
@@ -115,8 +115,9 @@ public class SearchHelper {
         fieldDataDto.setConditions(availableConditions(filterField));
         fieldDataDto.setType(filterField.getType().getFieldType());
         // Do not add null value to List filter. A NATIVE_ARRAY field reports FilterFieldType.LIST but is not
-        // SearchFieldTypeEnum.LIST, so its caller takes the single-value path and supplies no values at all --
-        // there is then nothing to strip, and casting the absent value to a List throws.
+        // SearchFieldTypeEnum.LIST, and it may supply a value list (the crypto-asset curve field does, from the
+        // members its rows hold) or none at all (the NTP servers field). The instanceof guard covers both: an
+        // absent value is left alone rather than cast to a List.
         if (filterField.getType().getFieldType() == FilterFieldType.LIST && filterField.getEnumClass() == null
                 && values instanceof List<?> suppliedValues) {
             List<Object> withoutNull = new ArrayList<>(suppliedValues);

--- a/src/main/resources/db/migration/V202609101000__crypto_asset_curve_membership.sql
+++ b/src/main/resources/db/migration/V202609101000__crypto_asset_curve_membership.sql
@@ -1,0 +1,17 @@
+-- A hybrid scheme (X25519/X448, and every transitional pairing after it) reports one curve value holding both
+-- members joined on '+'. Held as scalar TEXT, "show me every asset that touches curve25519" -- the sweep this
+-- inventory exists to serve -- silently skipped exactly those rows. The column becomes an array so a curve can be
+-- matched by membership; a single-curve asset is a one-element array and an absent curve stays NULL.
+--
+-- The identity preimage is unaffected: it keeps the '+'-joined spelling, so no row is re-keyed and the identity
+-- rule-set version does not move. This is a projection change, not an identity change.
+ALTER TABLE "crypto_asset"
+    ALTER COLUMN "curve" TYPE TEXT[] USING CASE WHEN "curve" IS NULL THEN NULL ELSE string_to_array("curve", '+') END;
+
+-- The btree answered equality on the scalar and cannot answer membership in an array. GIN can, but only for a
+-- containment predicate: PostgreSQL has no index path for 'scalar = ANY(column)' at all, which is why the membership
+-- filter is emitted as containment (PostgresFunctionContributor.ARRAY_CONTAINS_PATTERN). The pairing is pinned by
+-- CryptoAssetCurveMembershipMigrationITest, which plans the shipped predicate against this index.
+DROP INDEX "idx_crypto_asset_curve";
+
+CREATE INDEX "idx_crypto_asset_curve" ON "crypto_asset" USING GIN ("curve");

--- a/src/test/java/com/otilm/core/architecture/InterfacesPinGuardTest.java
+++ b/src/test/java/com/otilm/core/architecture/InterfacesPinGuardTest.java
@@ -1,0 +1,180 @@
+package com.otilm.core.architecture;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins what stops an unmerged {@code interfaces} override from reaching {@code main}.
+ * <p>
+ * Three lines carry the merge block, each removable as a tidy-up: {@code pin-gate} in the aggregate job's
+ * {@code needs}; the aggregate's {@code !cancelled()}, without which it is skipped when the gate fails and a skipped
+ * required check counts as passing; and its scan failing on a non-successful upstream. A fourth, {@code $MVNARG} on
+ * every job that compiles the tree, keeps a coupled pull request from reddening for the wrong reason.
+ * <p>
+ * All four are silent when they drift, and none surfaces near the edit that caused it. Loads no Spring context, so it
+ * does not affect {@link ContextSignatureGuardTest#BASELINE}.
+ */
+class InterfacesPinGuardTest {
+
+    private static final Path WORKFLOW = Path.of(".github/workflows/build_pr.yml");
+
+    private static final String GATE_JOB = "pin-gate";
+    private static final String AGGREGATE_JOB = "build";
+    private static final String OVERRIDE = "$MVNARG";
+
+    /** A Maven call anywhere in the line, so that {@code cd x && mvn ...} and the wrapper are seen too. */
+    private static final Pattern MAVEN_INVOCATION = Pattern
+            .compile("(^|&&\\s*|\\|\\|\\s*|;\\s*|\\|\\s*|\\(\\s*)\\.?/?mvnw?\\s");
+
+    /** Maven lifecycle phases that compile the tree, and so resolve {@code com.otilm:interfaces}. */
+    private static final Set<String> BUILDING_PHASES = Set
+            .of("compile", "test-compile", "test", "package", "verify", "install", "deploy", "process-classes",
+                    "process-test-classes", "integration-test", "prepare-package");
+
+    /**
+     * The jobs that compile the tree today. Asserted explicitly so that a detection which silently stops matching
+     * cannot make {@link #everyTreeBuildingJobPassesTheResolvedOverride()} pass over an empty set.
+     */
+    private static final Set<String> EXPECTED_BUILDING_JOBS = Set.of("compile", "test", "package", "generated");
+
+    @Test
+    void aggregateJobDependsOnThePinGate() throws IOException {
+        assertThat(needsOf(AGGREGATE_JOB))
+                .describedAs(
+                        "'%s' is reached only through '%s' needs - \"Interfaces pin\" is not itself a required "
+                                + "context, so removing it from that list lets an active override merge",
+                        GATE_JOB, AGGREGATE_JOB)
+                .contains(GATE_JOB);
+    }
+
+    @Test
+    void aggregateJobRunsEvenWhenAnUpstreamFails() throws IOException {
+        assertThat(String.valueOf(job(AGGREGATE_JOB).get("if")))
+                .describedAs("without !cancelled() the aggregate is skipped whenever '%s' fails, and GitHub counts a "
+                        + "skipped required check as passing - which is the failure this gate exists to prevent",
+                        GATE_JOB)
+                .contains("!cancelled()");
+    }
+
+    @Test
+    void aggregateFailsOnAnyUpstreamThatDidNotSucceed() throws IOException {
+        assertThat(stepSource(job(AGGREGATE_JOB)))
+                .describedAs("the scan over the needs context is what turns a failed '%s' into a red Build; running "
+                        + "on !cancelled() without it would report success instead", GATE_JOB)
+                .contains("toJSON(needs)")
+                .contains("exit 1");
+    }
+
+    @Test
+    void everyTreeBuildingJobPassesTheResolvedOverride() throws IOException {
+        Set<String> missing = new TreeSet<>();
+        jobs()
+                .forEach((name, job) -> mavenInvocations(job)
+                        .stream()
+                        .filter(InterfacesPinGuardTest::compilesTheTree)
+                        .filter(command -> !command.contains(OVERRIDE))
+                        .forEach(command -> missing.add(name)));
+
+        assertThat(missing)
+                .describedAs(
+                        "every job running a Maven phase that compiles the tree must pass %s, or a pull request "
+                                + "holding an override builds against the mainline interfaces snapshot instead",
+                        OVERRIDE)
+                .isEmpty();
+    }
+
+    @Test
+    void theDetectionStillRecognisesTheBuildingJobs() throws IOException {
+        Set<String> detected = new TreeSet<>();
+        jobs()
+                .forEach((name, job) -> mavenInvocations(job)
+                        .stream()
+                        .filter(InterfacesPinGuardTest::compilesTheTree)
+                        .forEach(command -> detected.add(name)));
+
+        assertThat(detected)
+                .describedAs("the phase detection must keep matching the jobs that build the tree; a set that shrinks "
+                        + "to nothing would make the override check above pass vacuously")
+                .containsExactlyInAnyOrderElementsOf(EXPECTED_BUILDING_JOBS);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> jobs() throws IOException {
+        try (InputStream in = Files.newInputStream(WORKFLOW)) {
+            Map<String, Object> root = new Yaml().load(in);
+            return new LinkedHashMap<>((Map<String, Object>) root.get("jobs"));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> job(String jobName) throws IOException {
+        return (Map<String, Object>) jobs().get(jobName);
+    }
+
+    /** Every step's {@code run} and {@code env} together — an expression can reach a script through either. */
+    @SuppressWarnings("unchecked")
+    private static String stepSource(Object job) {
+        StringBuilder source = new StringBuilder();
+        for (Object step : (List<Object>) ((Map<String, Object>) job).getOrDefault("steps", List.of())) {
+            Map<String, Object> fields = (Map<String, Object>) step;
+            source.append(fields.getOrDefault("run", "")).append('\n');
+            source.append(fields.getOrDefault("env", Map.of())).append('\n');
+        }
+        return source.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> needsOf(String jobName) throws IOException {
+        Object needs = ((Map<String, Object>) jobs().get(jobName)).get("needs");
+        return needs instanceof String single ? List.of(single) : (List<String>) needs;
+    }
+
+    /**
+     * The {@code mvn} command lines a job runs, with backslash continuations joined. Only a command position counts:
+     * {@code generated} echoes a {@code mvn} line inside its diff message, and that is prose, not an invocation.
+     */
+    @SuppressWarnings("unchecked")
+    private static List<String> mavenInvocations(Object job) {
+        List<String> invocations = new ArrayList<>();
+        Object steps = ((Map<String, Object>) job).get("steps");
+        if (steps == null) {
+            return invocations;
+        }
+        for (Object step : (List<Object>) steps) {
+            Object run = ((Map<String, Object>) step).get("run");
+            if (!(run instanceof String script)) {
+                continue;
+            }
+            Arrays
+                    .stream(script.replace("\\\n", " ").split("\n"))
+                    .map(String::strip)
+                    .filter(line -> MAVEN_INVOCATION.matcher(line).find())
+                    .forEach(invocations::add);
+        }
+        return invocations;
+    }
+
+    /**
+     * True when the invocation names a lifecycle phase rather than only plugin goals such as {@code spotless:check}.
+     */
+    private static boolean compilesTheTree(String invocation) {
+        return Arrays
+                .stream(invocation.split("\\s+"))
+                .filter(token -> !token.startsWith("-"))
+                .anyMatch(BUILDING_PHASES::contains);
+    }
+}

--- a/src/test/java/com/otilm/core/cbom/asset/CompositeCurveTest.java
+++ b/src/test/java/com/otilm/core/cbom/asset/CompositeCurveTest.java
@@ -1,0 +1,48 @@
+package com.otilm.core.cbom.asset;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The inverse of the storage split, which is what keeps the identity spelling reachable from an array column.
+ *
+ * <p>
+ * The column holds a curve's members; the identity preimage, the PQC rules and the API contract all read the
+ * {@code +}-joined composite the normalizer produced. Every one of those breaks quietly if the join stops reproducing
+ * that spelling, and none of them would say so -- a wrong spelling is still a valid string.
+ */
+class CompositeCurveTest {
+
+    @Test
+    void aSingleCurveJoinsBackToItself() {
+        assertThat(CompositeCurve.join(List.of("secp256r1"))).isEqualTo("secp256r1");
+    }
+
+    /**
+     * The order is the normalizer's, which sorted and deduplicated the members before joining them; the split preserved
+     * it, so the join reproduces the preimage byte for byte rather than merely a permutation of it.
+     */
+    @Test
+    void aHybridJoinsBackInTheOrderItsMembersAreStoredIn() {
+        assertThat(CompositeCurve.join(List.of("other/curve25519", "other/curve448")))
+                .isEqualTo("other/curve25519+other/curve448");
+    }
+
+    @Test
+    void anAbsentCurveStaysAbsentRatherThanBecomingEmptyText() {
+        assertThat(CompositeCurve.join(null)).isNull();
+    }
+
+    /**
+     * An empty array cannot reach the column -- the normalizer yields null rather than an empty token, and
+     * {@code string_to_array} maps SQL NULL to NULL -- so this pins the guard rather than a reachable state. Without it
+     * the method would answer the empty string, which is a curve nothing has and every {@code EMPTY} filter would
+     * disagree about.
+     */
+    @Test
+    void anEmptyMemberListIsAbsentTooRatherThanTheEmptyString() {
+        assertThat(CompositeCurve.join(List.of())).isNull();
+    }
+}

--- a/src/test/java/com/otilm/core/integration/cbom/CryptoAssetListQueryITest.java
+++ b/src/test/java/com/otilm/core/integration/cbom/CryptoAssetListQueryITest.java
@@ -123,15 +123,17 @@ class CryptoAssetListQueryITest extends BaseSpringBootTest {
                 null, null, "P-256", null, null, null), null);
         upsert(new CryptoAssetIdentityFields(CryptographicAssetType.CERTIFICATE, "bare", "oid-4", null, null, null,
                 null, null, null, null), null);
+        upsert(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "x25519-x448", "oid-5", "ecdh", null,
+                null, "other/curve25519+other/curve448", null, null, null), null);
 
         assertThat(assetRepository.findDistinctCurve())
                 .describedAs(
-                        "distinct stored normalized values, sorted, no null; class folding (p-256 = secp256r1) is core#2072 ingest scope, not this query's")
-                .containsExactly("p-256", "secp256r1");
+                        "each curve any asset touches, once, sorted, no null -- a hybrid contributes its members and never the composite; class folding (p-256 = secp256r1) is core#2072 ingest scope, not this query's")
+                .containsExactly("other/curve25519", "other/curve448", "p-256", "secp256r1");
         assertThat(assetRepository.findDistinctAlgorithmFamily())
                 .describedAs(
                         "distinct stored normalized values, sorted, no null; class folding (p-256 = secp256r1) is core#2072 ingest scope, not this query's")
-                .containsExactly("ecdsa", "rsa");
+                .containsExactly("ecdh", "ecdsa", "rsa");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/cbom/CryptoAssetPqcSweepITest.java
+++ b/src/test/java/com/otilm/core/integration/cbom/CryptoAssetPqcSweepITest.java
@@ -261,6 +261,23 @@ class CryptoAssetPqcSweepITest extends BaseSpringBootTest {
         assertThat(asset(uuid).getPqcEvaluatedFields()).containsEntry("materialSize", 64);
     }
 
+    /**
+     * The column holds a hybrid's curves split, one per element; the work list has to hand the sweep the joined
+     * spelling the identity and the rules were written against, and the row must be swept like any other.
+     */
+    @Test
+    void aRowWithAHybridCurveIsReadBackJoinedAndSwept() {
+        UUID hybrid = upsertHybridCurve();
+
+        assertThat(staleRow(hybrid).curve()).isEqualTo("other/curve25519+other/curve448");
+
+        PqcVerdictSweeper.SweepOutcome outcome = sweeper.sweep();
+
+        assertThat(outcome.ran()).isTrue();
+        assertThat(asset(hybrid).getPqcRulesetVersion()).isEqualTo(PqcRuleset.VERSION);
+        assertThat(asset(hybrid).getPqcEvaluatedAt()).isNotNull();
+    }
+
     /** The advisory lock admits one sweeper; a contended run skips rather than blocking or double-writing. */
     @Test
     void aContendedSweepSkipsRatherThanWaiting() throws Exception {
@@ -320,6 +337,13 @@ class CryptoAssetPqcSweepITest extends BaseSpringBootTest {
     private UUID upsertMaterial(String name) {
         CryptoAssetIdentityFields fields = new CryptoAssetIdentityFields(CryptographicAssetType.RELATED_CRYPTO_MATERIAL,
                 name, null, null, null, null, null, null, null, null);
+        return assetWriter.upsertIdentity(AssetRowKeys.forFields(fields), fields, null);
+    }
+
+    private UUID upsertHybridCurve() {
+        CryptoAssetIdentityFields fields = new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM,
+                "X25519/X448", "1.3.101.110", "ecdh", "key-agree", null, "other/curve25519+other/curve448", null, null,
+                null);
         return assetWriter.upsertIdentity(AssetRowKeys.forFields(fields), fields, null);
     }
 

--- a/src/test/java/com/otilm/core/integration/cbom/PqcStoredRowRoundTripITest.java
+++ b/src/test/java/com/otilm/core/integration/cbom/PqcStoredRowRoundTripITest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.otilm.api.model.core.cryptoasset.PqcVerdict;
+import com.otilm.core.cbom.asset.CompositeCurve;
 import com.otilm.core.cbom.asset.CryptoAssetIdentityFields;
 import com.otilm.core.cbom.asset.identity.AssetNormalizer;
 import com.otilm.core.cbom.asset.identity.CryptoAssetIdentity;
@@ -192,8 +193,8 @@ class PqcStoredRowRoundTripITest extends BaseSpringBootTest {
 
     private static CryptoAssetIdentityFields storedFields(CryptoAsset row) {
         return new CryptoAssetIdentityFields(row.getAssetType(), row.getName(), row.getOid(), row.getAlgorithmFamily(),
-                row.getPrimitive(), row.getParameterSet(), row.getCurve(), row.getMode(), row.getPadding(),
-                row.getVariant());
+                row.getPrimitive(), row.getParameterSet(), CompositeCurve.join(row.getCurve()), row.getMode(),
+                row.getPadding(), row.getVariant());
     }
 
     private static CryptoAssetIdentityFields derivedFields(NormalizedAsset asset) {

--- a/src/test/java/com/otilm/core/integration/migration/CryptoAssetCurveMembershipMigrationITest.java
+++ b/src/test/java/com/otilm/core/integration/migration/CryptoAssetCurveMembershipMigrationITest.java
@@ -1,0 +1,215 @@
+package com.otilm.core.integration.migration;
+
+import com.otilm.core.util.BaseSpringBootTest;
+import com.otilm.core.util.PostgresFunctionContributor;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Runs {@code V202609101000__crypto_asset_curve_membership.sql} over rows written in the shape the column had before
+ * it, and asserts what the conversion did to them.
+ *
+ * <p>
+ * The suite's schema is generated from the entities, so the {@code USING} clause that splits a stored composite runs
+ * nowhere else: a conversion that dropped the members, kept the {@code +} inside one element, or turned an absent curve
+ * into a one-element array would pass unnoticed. The table is expected to be empty at deployment time -- ingest lands
+ * in core#2073 -- but the migration is written to convert data, so the data path is what is asserted.
+ */
+class CryptoAssetCurveMembershipMigrationITest extends BaseSpringBootTest {
+
+    private static final String INVENTORY_RESOURCE = "db/migration/V202608271000__crypto_asset_inventory.sql";
+
+    private static final String CURVE_RESOURCE = "db/migration/V202609101000__crypto_asset_curve_membership.sql";
+
+    private static final String SCRATCH_SCHEMA = "crypto_asset_curve_migration_check";
+
+    /** The inventory migration alters this table; nothing here reads any other column of it. */
+    private static final String CBOM_STUB = """
+            CREATE TABLE "cbom" (
+                "uuid" UUID PRIMARY KEY,
+                "serial_number" TEXT NOT NULL,
+                "version" INT NOT NULL
+            )
+            """;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    void theConversionSplitsACompositeAndLeavesEveryOtherCurveShapeAlone() throws Exception {
+        try (Connection connection = dataSource.getConnection()) {
+            try {
+                applyInventoryMigration(connection);
+                seedScalarCurves(connection);
+                applyCurveMigration(connection);
+
+                assertThat(storedCurve(connection, "single"))
+                        .describedAs("a single curve becomes a one-element array")
+                        .isEqualTo("{secp256r1}");
+                assertThat(storedCurve(connection, "hybrid"))
+                        .describedAs("a composite becomes its members, in the order the normalizer sorted them into")
+                        .isEqualTo("{other/curve25519,other/curve448}");
+                assertThat(storedCurve(connection, "absent"))
+                        .describedAs("an absent curve stays SQL NULL rather than becoming an empty array")
+                        .isNull();
+                assertThat(columnType(connection)).isEqualTo("ARRAY");
+                assertThat(curveIndexDefinition(connection))
+                        .describedAs("the btree cannot answer array containment")
+                        .contains("USING gin");
+            } finally {
+                dropScratchSchema(connection);
+            }
+        }
+    }
+
+    /**
+     * The index the migration installs has to answer the predicate the platform actually emits, which is the pattern
+     * {@link PostgresFunctionContributor#ARRAY_CONTAINS_PATTERN} registers -- rendered here from that constant rather
+     * than copied, so a change to the pattern fails this test instead of silently un-indexing the filter.
+     *
+     * <p>
+     * Sequential scans are disabled for the check: on a table this size the planner would pick one on cost alone, and
+     * the question is whether an index path exists at all. PostgreSQL has none for {@code scalar = ANY(column)}, which
+     * is what makes the pattern's shape part of the migration's correctness rather than a detail of the ORM.
+     */
+    @Test
+    void theCurveIndexAnswersThePredicateTheFilterEmits() throws Exception {
+        try (Connection connection = dataSource.getConnection()) {
+            try {
+                applyInventoryMigration(connection);
+                applyCurveMigration(connection);
+                seedManyAssetsForThePlanner(connection);
+
+                assertThat(planFor(connection, membershipPredicate("other/curve25519")))
+                        .describedAs("a membership filter reaches the GIN index")
+                        .contains("idx_crypto_asset_curve");
+            } finally {
+                dropScratchSchema(connection);
+            }
+        }
+    }
+
+    private static String membershipPredicate(String curve) {
+        return PostgresFunctionContributor.ARRAY_CONTAINS_PATTERN
+                .replace("?1", "'" + curve + "'")
+                .replace("?2", "curve");
+    }
+
+    private void seedManyAssetsForThePlanner(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("""
+                    INSERT INTO crypto_asset (uuid, identity_key, ruleset_version, asset_type, curve, i_cre, i_upd)
+                    SELECT gen_random_uuid(), 'key-' || g, 2, 'ALGORITHM',
+                           CASE WHEN g % 100 = 0 THEN ARRAY['other/curve25519', 'other/curve448']
+                                ELSE ARRAY['secp256r1'] END,
+                           now(), now()
+                    FROM generate_series(1, 2000) AS g
+                    """);
+            statement.execute("ANALYZE crypto_asset");
+        }
+    }
+
+    private String planFor(Connection connection, String predicate) throws SQLException {
+        StringBuilder plan = new StringBuilder();
+        // The connection is in autocommit, where SET LOCAL is a no-op; the session setting is reset with the
+        // search_path when the scratch schema is dropped, before the connection returns to the shared pool.
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("SET enable_seqscan = off");
+            try (ResultSet rows = statement.executeQuery("EXPLAIN SELECT uuid FROM crypto_asset WHERE " + predicate)) {
+                while (rows.next()) {
+                    plan.append(rows.getString(1)).append('\n');
+                }
+            }
+        }
+        return plan.toString();
+    }
+
+    private void applyInventoryMigration(Connection connection) throws Exception {
+        String migration = new ClassPathResource(INVENTORY_RESOURCE).getContentAsString(StandardCharsets.UTF_8);
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("DROP SCHEMA IF EXISTS " + SCRATCH_SCHEMA + " CASCADE");
+            statement.execute("CREATE SCHEMA " + SCRATCH_SCHEMA);
+            // Only the scratch schema is on the path, so an unqualified name cannot resolve to the entity-generated
+            // core schema instead.
+            statement.execute("SET search_path TO " + SCRATCH_SCHEMA);
+            statement.execute(CBOM_STUB);
+            statement.execute(migration);
+        }
+    }
+
+    private void applyCurveMigration(Connection connection) throws Exception {
+        String migration = new ClassPathResource(CURVE_RESOURCE).getContentAsString(StandardCharsets.UTF_8);
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(migration);
+        }
+    }
+
+    private void seedScalarCurves(Connection connection) throws SQLException {
+        insertAsset(connection, "single", "'secp256r1'");
+        insertAsset(connection, "hybrid", "'other/curve25519+other/curve448'");
+        insertAsset(connection, "absent", "NULL");
+    }
+
+    private void insertAsset(Connection connection, String identityKey, String curveLiteral) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("""
+                    INSERT INTO crypto_asset (uuid, identity_key, ruleset_version, asset_type, curve, i_cre, i_upd)
+                    VALUES (gen_random_uuid(), '%s', 2, 'ALGORITHM', %s, now(), now())
+                    """.formatted(identityKey, curveLiteral));
+        }
+    }
+
+    private String storedCurve(Connection connection, String identityKey) throws SQLException {
+        return queryOne(connection,
+                "SELECT curve::TEXT FROM crypto_asset WHERE identity_key = '%s'".formatted(identityKey));
+    }
+
+    private String columnType(Connection connection) throws SQLException {
+        return queryOne(connection, """
+                SELECT data_type FROM information_schema.columns
+                WHERE table_schema = '%s' AND table_name = 'crypto_asset' AND column_name = 'curve'
+                """.formatted(SCRATCH_SCHEMA));
+    }
+
+    private String curveIndexDefinition(Connection connection) throws SQLException {
+        return queryOne(connection, """
+                SELECT indexdef FROM pg_indexes
+                WHERE schemaname = '%s' AND indexname = 'idx_crypto_asset_curve'
+                """.formatted(SCRATCH_SCHEMA));
+    }
+
+    private String queryOne(Connection connection, String sql) throws SQLException {
+        List<String> values = new ArrayList<>();
+        try (Statement statement = connection.createStatement(); ResultSet rows = statement.executeQuery(sql)) {
+            while (rows.next()) {
+                values.add(rows.getString(1));
+            }
+        }
+        assertThat(values).describedAs("exactly one row for %s", sql.toLowerCase(Locale.ROOT)).hasSize(1);
+        return values.get(0);
+    }
+
+    private void dropScratchSchema(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("DROP SCHEMA IF EXISTS " + SCRATCH_SCHEMA + " CASCADE");
+        } finally {
+            // The connection goes back to a pool shared with the rest of the suite.
+            try (Statement reset = connection.createStatement()) {
+                reset.execute("RESET search_path");
+                reset.execute("RESET enable_seqscan");
+            }
+        }
+    }
+}

--- a/src/test/java/com/otilm/core/integration/search/CryptoAssetSearchITest.java
+++ b/src/test/java/com/otilm/core/integration/search/CryptoAssetSearchITest.java
@@ -188,6 +188,32 @@ class CryptoAssetSearchITest extends BaseSpringBootTest {
                 .isEmpty();
     }
 
+    /**
+     * The reason the column is an array. A hybrid scheme names two curves in one asset, and the query this inventory
+     * exists to answer -- every asset that touches curve X -- has to reach it from either member. The composite itself
+     * is deliberately not selectable: it is a spelling of the pair, not a curve, and it is not offered as a value.
+     */
+    @Test
+    void aHybridAssetIsFoundByEitherOfItsCurvesAndNotByTheirCompositeSpelling() {
+        UUID hybrid = upsert(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "X25519/X448",
+                "1.3.101.110", "ecdh", "key-agree", null, "other/curve25519+other/curve448", null, null, null), null);
+
+        assertThat(search(aPropertyEqualsFilter(FilterField.CBOM_ASSET_CURVE, "other/curve25519")))
+                .containsExactly(hybrid);
+        assertThat(search(aPropertyEqualsFilter(FilterField.CBOM_ASSET_CURVE, "other/curve448")))
+                .containsExactly(hybrid);
+        assertThat(search(aPropertyEqualsFilter(FilterField.CBOM_ASSET_CURVE, "other/curve25519+other/curve448")))
+                .describedAs("the composite matches no member, so it selects nothing")
+                .isEmpty();
+        assertThat(search(aPropertyNotEmptyFilter(FilterField.CBOM_ASSET_CURVE)))
+                .describedAs("a hybrid has curves like any other asset")
+                .containsExactlyInAnyOrder(populated, hybrid);
+        assertThat(search(
+                aPropertyFilter(FilterField.CBOM_ASSET_CURVE, FilterConditionOperator.NOT_EQUALS, "other/curve25519")))
+                .describedAs("excluding a member excludes every asset that touches it")
+                .doesNotContain(hybrid);
+    }
+
     // ---- free text, refuted-OID and source-CBOM filters ----
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/CryptographicAssetSearchableFieldsITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicAssetSearchableFieldsITest.java
@@ -65,6 +65,10 @@ class CryptographicAssetSearchableFieldsITest extends BaseSpringBootTest {
                 "ecdsa", "signature", "P-256", " secp256r1 ", null, null, null), null);
         upsert(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "ML-KEM-768", "2.16.840.1.101.3.4.4.2",
                 "ml-kem", "kem", null, null, null, null, null), CryptoAssetIdentityGuard.REFUTED_OID);
+        // A hybrid scheme: one asset naming two curves. Its members are what the value list must offer, so that
+        // selecting either one reaches this row -- the composite itself is not a curve anyone can pick.
+        upsert(new CryptoAssetIdentityFields(CryptographicAssetType.ALGORITHM, "X25519/X448", "1.3.101.110", "ecdh",
+                "key-agree", null, "other/curve25519+other/curve448", null, null, null), null);
 
         newCbom(SEEDED_SERIAL, 1);
         // A second version of the same serial plus an earlier-sorting one: the value list must collapse the
@@ -102,10 +106,24 @@ class CryptographicAssetSearchableFieldsITest extends BaseSpringBootTest {
     }
 
     @Test
-    void theCurveFieldOffersTheStoredNormalizedSpellingOnlyOnce() {
+    void theCurveFieldOffersEachCurveMemberOnceAndNeverACompositeOfThem() {
         assertThat((List<String>) fieldFor(FilterField.CBOM_ASSET_CURVE).getValue())
-                .containsExactly("secp256r1")
+                .containsExactly("other/curve25519", "other/curve448", "secp256r1")
                 .doesNotContainNull();
+    }
+
+    /**
+     * The curve column is a native array, so it gains membership conditions; the wire type it reports must not move,
+     * because the interfaces contract knows this field as a LIST.
+     */
+    @Test
+    void theCurveFieldOffersMembershipConditionsAndStillReportsAListType() {
+        SearchFieldDataDto curve = fieldFor(FilterField.CBOM_ASSET_CURVE);
+        assertThat(curve.getType()).isEqualTo(FilterFieldType.LIST);
+        assertThat(curve.getConditions())
+                .containsExactlyInAnyOrder(FilterConditionOperator.CONTAINS, FilterConditionOperator.NOT_CONTAINS,
+                        FilterConditionOperator.EQUALS, FilterConditionOperator.NOT_EQUALS,
+                        FilterConditionOperator.EMPTY, FilterConditionOperator.NOT_EMPTY);
     }
 
     @Test


### PR DESCRIPTION
Closes #2194.

A hybrid scheme (X25519/X448, and every transitional pairing after it) reports one curve value holding both members joined on `+`. Held as scalar `TEXT`, the query this inventory exists to serve — *show me every asset that touches curve25519* — silently skipped exactly those rows, which are the transitional pattern a PQC migration most needs to find.

`crypto_asset.curve` becomes `TEXT[]`, storing the members the normalizer had already sorted and deduplicated, and `CBOM_ASSET_CURVE` moves from `LIST` to `NATIVE_ARRAY` so `EQUALS` asks membership. `findDistinctCurve()` offers each curve once rather than each combination once.

**The identity preimage is untouched.** It still hashes the `+`-joined spelling, so no row is re-keyed and `RULESET_VERSION` stays 2. `CompositeCurve` rejoins the members for the API DTO, leaving the wire contract byte-identical — `NATIVE_ARRAY` still reports `FilterFieldType.LIST`, so `interfaces` needs no change and only the advertised condition list grows.

## Two things a reviewer should not have to discover

**1. This changes a shared filter predicate, not just the curve field.**

`PostgresFunctionContributor.ARRAY_CONTAINS` moves from `CAST(?1 AS TEXT) = ANY(?2)` to `CAST(?2 AS TEXT[]) @> ARRAY[CAST(?1 AS TEXT)]`, which applies to every `NATIVE_ARRAY` field — `CONNECTOR_FEATURES`, `OID_ENTRY_ALT_CODES` and `TIME_QUALITY_CONFIGURATION_NTP_SERVERS` as well as the curve.

It is forced rather than opportunistic: PostgreSQL has **no index path for `scalar = ANY(column)` at all**, so the GIN index this migration adds would have been decorative. Measured on the pinned `postgres:15-alpine`, 2 000 rows, `enable_seqscan = off` — `= ANY` plans a disabled-cost `Seq Scan`, containment plans a `Bitmap Index Scan`. `CryptoAssetCurveMembershipMigrationITest.theCurveIndexAnswersThePredicateTheFilterEmits` renders the predicate from the shipped constant rather than a copy, so the pairing cannot drift; reverting the constant fails it.

The cast on the column is what keeps the other three fields working in the **entity-generated** schema the integration suite builds: there a `List<String>` under `SqlTypes.ARRAY` generates `varchar[]`, and `@>` is not defined across `varchar[]` and `text[]`.

**Corrected during review** (thread from @karolhrdina): an earlier version of this paragraph and of the constant's Javadoc concluded that indexability is a property of `columnDefinition`, and that a GIN index on the other three would buy nothing until their type moved. That is false for the shipped schema — every array column the migrations ship is already `TEXT[]` (`custom_oid_entry.alt_codes`, `connector_interface.features`, `time_quality_configuration.ntp_servers`), `columnDefinition` shapes only the generated schema, and in production the cast is a no-op on all four. A GIN index on any of them would be matched today, with no type change needed. The Javadoc now says that.

**Six operators returned a 500 on this field, and the gate for that is central.**

Raised by @karolhrdina, who ran all six against both branches on real Postgres. `SearchFieldTypeEnum` gates which conditions are *advertised*, but nothing held a **submitted** condition to that set outside saved list views. While `curve` was `TEXT`, `STARTS_WITH`, `ENDS_WITH`, `MATCHES`, `NOT_MATCHES`, `GREATER` and `LESSER` produced valid if unadvertised SQL; against `text[]` they fail inside the query as a `DataAccessException`, which `ExceptionHandlingAdvice` does not handle — so **500, not 422**.

`FilterPredicatesBuilder.getPropertyFilterPredicate` now refuses any condition outside `SearchHelper.availableConditions(filterField)` before a predicate is built, on **every listing** — the same set `ListViewServiceImpl` already validates stored views against, so the two paths agree.

This is wider than the curve. The gate failed four existing tests on three unrelated resources, all using operators their fields never advertised and all of which *worked*: `ENTITY_CONNECTOR_NAME`/`ENTITY_KIND` `CONTAINS`, `LOCATION_ENTITY_INSTANCE` `ENDS_WITH`, `AUDIT_LOG_RESOURCE_NAME` `NOT_CONTAINS`. So the defect is that the advertise list and the predicate builder disagree; the 500 is only where that disagreement meets a column type that cannot absorb it. **Ruled: gate centrally**, and hold those four tests to what their fields advertise — a field's advertised set otherwise means nothing. `AUDIT_LOG_RESOURCE_NAME`'s json-array not-present branch stays covered through `EMPTY`, which reaches the same code.

**The `+` separator now has one definition, and the split happens in Java.**

@karolhrdina found it spelled in five places with no test crossing more than one — mutating `CompositeCurve.SEPARATOR` left 55 tests green. `CompositeCurve` now owns both directions, `CryptoAssetWriter` binds the members, the upsert drops `string_to_array`, and `AssetNormalizer` joins through the same constant. Two SQL sites remain, each pinned by a test that fails when it moves: `array_to_string` in `findStaleVerdictRows` and `string_to_array` in the migration. This is also what #2166 needs — a writer-side fold cannot see members while the split happens inside the SQL statement.

**`EMPTY`/`NOT_EMPTY` lose their index path.** Measured by @karolhrdina: `array_ops` GIN indexes elements, so it answers neither `curve IS NULL` nor `cardinality(curve) = 0`. `EQUALS` gains an index path it never had; those two lose the one the btree gave them. Taken deliberately — `EQUALS` is the query this inventory exists to answer — and written into the migration, which names the partial index that would restore it.

**Merge order: this must land before #2073.** `ALTER COLUMN ... TYPE ... USING` takes `ACCESS EXCLUSIVE` and rewrites the table; the `CREATE INDEX` blocks writes again. Free only because `crypto_asset` is empty in every environment today. Behind ingest they are outage-class, and `CONCURRENTLY` is unavailable because Flyway wraps the script in a transaction. Stated in the migration, and carried to [#2073](https://github.com/OmniTrustILM/core/issues/2073#issuecomment-5436951889).

**One measured semantic edge.** For an array holding a NULL element that does not contain the searched value, `= ANY` returned NULL where containment returns `false`. Under `EQUALS` both filter the row out. Under `NOT_EQUALS` the old form dropped such a row and the new form includes it — the correct answer, but a change to three other resources' listings. No production writer produces such arrays; `alt_codes` is the one whose elements come from a client payload.

**2. The GIN index is the escalation v1 deferred.**

v1 shipped "no GIN, no extensions, no partitioning — documented escalations", aimed at not indexing the JSONB long tail. A btree cannot answer membership on an array at all, so the type change forces this one. It is documented in the migration where it is taken.

## Verification

- **8181 tests, 0 failures, 0 errors** (full suite, after the review fixes in `6d642f93`)
- 806 tests green: all `com.otilm.core.architecture.*` plus every crypto-asset, PQC, CBOM, native-array, custom-OID and connector suite
- `spotless:check checkstyle:check` clean; `ContextSignatureGuardTest` BASELINE unchanged — no new Spring context bought
- `CryptoAssetCurveMembershipMigrationITest` runs the migration in a scratch schema and asserts the `USING` conversion directly: a composite splits, a single curve becomes one element, an absent curve stays NULL. The suite's schema is entity-generated, so that clause runs nowhere else.
- The architecture gate was run twice and both its findings fixed; the second pass re-verified them independently, including a mutation check that the new index assertion can fail.

## A defect this found late

`findStaleVerdictRows` selected `curve` raw while `PqcStaleVerdictRow` reads it with `row.get("curve", String.class)`. A `text[]` arriving there fails the type check, so the first PQC sweep over any inventory holding one curve-bearing row would have died in the work-list mapping, before per-row error handling could catch it — `ClassCastException: Cannot cast [Ljava.lang.String; to java.lang.String`. Fixed with `array_to_string(curve, '+') AS curve`.

Every existing sweep fixture seeded a NULL curve, and NULL passes the type check, so the whole suite was green over it. `aRowWithAHybridCurveIsReadBackJoinedAndSwept` now seeds one; it was written before the fix and observed to fail.

## Open, and not for this PR

- **The ticket body says "Exact-composite selection stays available alongside membership." It does not.** Raised again by Copilot in review; the full ruling and the requested correction are recorded on [#2194](https://github.com/OmniTrustILM/core/issues/2194#issuecomment-5660109637), for the ticket owner to apply. `NATIVE_ARRAY` `EQUALS` is membership, never array equality, and the value list now offers members, so the composite spelling is not selectable. Ruled 2026-09-10 to keep membership — it is what the product decision in #2194 asks for, and "touches both" is two ANDed filters. The ticket sentence needs correcting to match.
- **The empty-inventory premise is settled, and it is what makes the DDL free.** There is no deployed database, and `CryptoAssetWriter` has no production caller — asserted, not remembered, by `IdentityRulesetStampArchTest.theAssetWriterIsStillUnreachableFromProduction`, which fails the build on the first production caller. An earlier version of this section listed this as an unrun query; it is neither unrun nor a query. The migration converts existing data and is tested to, so nothing here depends on it either way.
- #2166 (curve class representatives) is unaffected: the value list still offers distinct stored spellings, now per member. A fold placed at the writer will need to fold per member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


