### PR TITLE
Offer only commentable resources as a comment condition's host

### DIFF
--- a/src/main/java/com/otilm/core/enums/FilterField.java
+++ b/src/main/java/com/otilm/core/enums/FilterField.java
@@ -84,7 +84,9 @@ import com.otilm.core.model.cbom.CryptoAssetIdentityGuard;
 import jakarta.persistence.metamodel.Attribute;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import lombok.Getter;
 
 @Getter
@@ -283,10 +285,11 @@ public enum FilterField {
     AUDIT_LOG_ACTOR_NAME(Resource.AUDIT_LOG, null, null, AuditLog_.actorName, "Actor name", SearchFieldTypeEnum.STRING),
     AUDIT_LOG_ACTOR_AUTH_METHOD(Resource.AUDIT_LOG, null, null, AuditLog_.actorAuthMethod, "Actor Auth method",
             SearchFieldTypeEnum.LIST, AuthMethod.class),
+    // NONE is a recorded resource for module-level operations; an absent affiliated resource is stored as no value
     AUDIT_LOG_RESOURCE(Resource.AUDIT_LOG, null, null, AuditLog_.resource, "Resource", SearchFieldTypeEnum.LIST,
-            Resource.class),
+            Resource.class, resourcesExcept(Resource.ANY)),
     AUDIT_LOG_AFFILIATED_RESOURCE(Resource.AUDIT_LOG, null, null, AuditLog_.affiliatedResource, "Affiliated resource",
-            SearchFieldTypeEnum.LIST, Resource.class),
+            SearchFieldTypeEnum.LIST, Resource.class, resourcesExcept(Resource.NONE, Resource.ANY)),
     AUDIT_LOG_OPERATION(Resource.AUDIT_LOG, null, null, AuditLog_.operation, "Operation", SearchFieldTypeEnum.LIST,
             Operation.class),
     AUDIT_LOG_OPERATION_RESULT(Resource.AUDIT_LOG, null, null, AuditLog_.operationResult, "Operation result",
@@ -317,7 +320,7 @@ public enum FilterField {
 
     // Approval
     APPROVAL_RESOURCE(Resource.APPROVAL, null, null, Approval_.resource, "Resource", SearchFieldTypeEnum.LIST,
-            Resource.class),
+            Resource.class, resourcesExcept(Resource.NONE, Resource.ANY)),
     APPROVAL_ACTION(Resource.APPROVAL, null, null, Approval_.action, "Action", SearchFieldTypeEnum.LIST,
             ResourceAction.class),
     APPROVAL_STATUS(Resource.APPROVAL, null, null, Approval_.status, Constants.STATUS, SearchFieldTypeEnum.LIST,
@@ -556,6 +559,11 @@ public enum FilterField {
     /** The values a list field backed by an enum offers: the subset it declares, or every constant otherwise. */
     public IPlatformEnum[] getEnumValues() {
         return enumValues != null ? enumValues : enumClass.getEnumConstants();
+    }
+
+    /** Every resource but the given wildcards, which scope a grant and are never the resource of a stored record. */
+    private static Set<Resource> resourcesExcept(Resource first, Resource... rest) {
+        return EnumSet.complementOf(EnumSet.of(first, rest));
     }
 
     public boolean isNativeArrayField() {

--- a/src/main/java/com/otilm/core/enums/FilterField.java
+++ b/src/main/java/com/otilm/core/enums/FilterField.java
@@ -83,6 +83,7 @@ import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.model.cbom.CryptoAssetIdentityGuard;
 import jakarta.persistence.metamodel.Attribute;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import lombok.Getter;
 
@@ -328,7 +329,7 @@ public enum FilterField {
 
     // Comment
     COMMENT_HOST_RESOURCE(Resource.COMMENT, null, null, ResourceObjectAssociation_.resource, "Host Resource",
-            SearchFieldTypeEnum.LIST, Resource.class),
+            SearchFieldTypeEnum.LIST, Resource.class, Resource.getCommentableResources()),
     COMMENT_PARENT(Resource.COMMENT, null, null, Comment_.parentUuid, "Parent Comment", SearchFieldTypeEnum.PRESENCE),
     COMMENT_AUTHOR(Resource.COMMENT, Resource.USER, null, Comment_.authorUsername, "Author", SearchFieldTypeEnum.LIST),
     COMMENT_BODY(Resource.COMMENT, null, null, Comment_.body, "Body", SearchFieldTypeEnum.STRING),
@@ -496,6 +497,7 @@ public enum FilterField {
     private final String label;
     private final String[] jsonPath;
     private final Class<? extends IPlatformEnum> enumClass;
+    private final IPlatformEnum[] enumValues;
     private final boolean settable;
     private final Object expectedValue;
 
@@ -515,10 +517,29 @@ public enum FilterField {
         this(rootResource, fieldResource, joinAttributes, fieldAttribute, label, type, enumClass, null, false, null);
     }
 
+    /**
+     * A list field that offers only some constants of its enum: the rest could never match anything, and a condition
+     * built on one of them would save and then silently never fire.
+     */
+    FilterField(final Resource rootResource, final Resource fieldResource, final List<Attribute> joinAttributes,
+            final Attribute fieldAttribute, final String label, final SearchFieldTypeEnum type,
+            final Class<? extends IPlatformEnum> enumClass, final Collection<? extends IPlatformEnum> enumValues) {
+        this(rootResource, fieldResource, joinAttributes, fieldAttribute, label, type, enumClass, null, false, null,
+                enumValues.toArray(IPlatformEnum[]::new));
+    }
+
     FilterField(final Resource rootResource, final Resource fieldResource, final List<Attribute> joinAttributes,
             final Attribute fieldAttribute, final String label, final SearchFieldTypeEnum type,
             final Class<? extends IPlatformEnum> enumClass, final Object expectedValue, final boolean settable,
             final String[] jsonPath) {
+        this(rootResource, fieldResource, joinAttributes, fieldAttribute, label, type, enumClass, expectedValue,
+                settable, jsonPath, null);
+    }
+
+    FilterField(final Resource rootResource, final Resource fieldResource, final List<Attribute> joinAttributes,
+            final Attribute fieldAttribute, final String label, final SearchFieldTypeEnum type,
+            final Class<? extends IPlatformEnum> enumClass, final Object expectedValue, final boolean settable,
+            final String[] jsonPath, final IPlatformEnum[] enumValues) {
         this.rootResource = rootResource;
         this.fieldResource = fieldResource;
         this.joinAttributes = joinAttributes == null ? List.of() : joinAttributes;
@@ -527,8 +548,14 @@ public enum FilterField {
         this.type = type;
         this.jsonPath = jsonPath;
         this.enumClass = enumClass;
+        this.enumValues = enumValues;
         this.settable = settable;
         this.expectedValue = expectedValue;
+    }
+
+    /** The values a list field backed by an enum offers: the subset it declares, or every constant otherwise. */
+    public IPlatformEnum[] getEnumValues() {
+        return enumValues != null ? enumValues : enumClass.getEnumConstants();
     }
 
     public boolean isNativeArrayField() {

--- a/src/main/java/com/otilm/core/service/impl/ResourceServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/ResourceServiceImpl.java
@@ -218,9 +218,7 @@ public class ResourceServiceImpl implements ResourceExternalService, ResourceInt
             } else {
                 // Filter field has values of an Enum
                 if (filterField.getEnumClass() != null) {
-                    fieldDataDtos
-                            .add(SearchHelper
-                                    .prepareSearch(filterField, filterField.getEnumClass().getEnumConstants()));
+                    fieldDataDtos.add(SearchHelper.prepareSearch(filterField, filterField.getEnumValues()));
                     // Filter field has values of all objects of another entity
                 } else if (filterField.getFieldResource() != null) {
                     fieldDataDtos

--- a/src/main/java/com/otilm/core/util/SearchHelper.java
+++ b/src/main/java/com/otilm/core/util/SearchHelper.java
@@ -132,7 +132,7 @@ public class SearchHelper {
             if (values == null) {
                 fieldDataDto
                         .setValue(Arrays
-                                .stream(fieldDataDto.getPlatformEnum().getEnumClass().getEnumConstants())
+                                .stream(filterField.getEnumValues())
                                 .map(IPlatformEnum::getCode)
                                 .sorted()
                                 .toList());

--- a/src/test/java/com/otilm/core/integration/service/AuditLogServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/AuditLogServiceITest.java
@@ -17,6 +17,7 @@ import com.otilm.api.model.core.logging.records.ResourceObjectIdentity;
 import com.otilm.api.model.core.logging.records.ResourceRecord;
 import com.otilm.api.model.core.search.FilterConditionOperator;
 import com.otilm.api.model.core.search.FilterFieldSource;
+import com.otilm.api.model.core.search.SearchFieldDataDto;
 import com.otilm.api.model.core.settings.logging.AuditLoggingSettingsDto;
 import com.otilm.api.model.core.settings.logging.LoggingSettingsDto;
 import com.otilm.api.model.core.settings.logging.ResourceLoggingSettingsDto;
@@ -41,6 +42,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 class AuditLogServiceITest extends BaseSpringBootTest {
@@ -88,6 +91,33 @@ class AuditLogServiceITest extends BaseSpringBootTest {
         loggingSettingsDto.setEventLogs(eventLoggingSettingsDto);
 
         settingService.updateLoggingSettings(loggingSettingsDto);
+    }
+
+    @Test
+    void searchableResourceFieldsOfferNoWildcardsARecordCannotCarry() {
+        List<SearchFieldDataDto> fields = auditLogService
+                .getSearchableFieldInformationByGroup()
+                .stream()
+                .flatMap(group -> group.getSearchFieldData().stream())
+                .toList();
+
+        // Module-level operations are audited with resource NONE, so that one stays; ANY scopes grants only
+        assertThat(codesOffered(fields, FilterField.AUDIT_LOG_RESOURCE))
+                .contains("NONE", "certificates")
+                .doesNotContain("ANY");
+        assertThat(codesOffered(fields, FilterField.AUDIT_LOG_AFFILIATED_RESOURCE))
+                .contains("certificates")
+                .doesNotContain("NONE", "ANY");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> codesOffered(List<SearchFieldDataDto> fields, FilterField field) {
+        return (List<String>) fields
+                .stream()
+                .filter(candidate -> field.name().equals(candidate.getFieldIdentifier()))
+                .findFirst()
+                .orElseThrow()
+                .getValue();
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/ResourceServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ResourceServiceITest.java
@@ -367,17 +367,35 @@ class ResourceServiceITest extends BaseSpringBootTest {
      */
     @Test
     void commentHostResourceOffersOnlyTheCommentableResources() throws NotFoundException {
-        SearchFieldDataDto hostResource = resourceService
-                .listResourceRuleFilterFields(Resource.COMMENT, false)
-                .stream()
-                .flatMap(group -> group.getSearchFieldData().stream())
-                .filter(field -> FilterField.COMMENT_HOST_RESOURCE.name().equals(field.getFieldIdentifier()))
-                .findFirst()
-                .orElseThrow();
+        Object[] offered = offeredValues(Resource.COMMENT, FilterField.COMMENT_HOST_RESOURCE);
 
-        Object[] offered = (Object[]) hostResource.getValue();
         assertThat(offered).containsExactlyInAnyOrder(Resource.getCommentableResources().toArray());
         assertThat(offered).doesNotContain(Resource.NONE, Resource.ANY, Resource.COMMENT, Resource.CERTIFICATE_REQUEST);
+    }
+
+    @Test
+    void resourceFieldsOfferNoWildcardsARecordCannotCarry() throws NotFoundException {
+        // Module-level operations are audited with resource NONE, so that one stays; ANY scopes grants only
+        assertThat(offeredValues(Resource.AUDIT_LOG, FilterField.AUDIT_LOG_RESOURCE))
+                .contains(Resource.NONE, Resource.CERTIFICATE)
+                .doesNotContain(Resource.ANY);
+        assertThat(offeredValues(Resource.AUDIT_LOG, FilterField.AUDIT_LOG_AFFILIATED_RESOURCE))
+                .contains(Resource.CERTIFICATE)
+                .doesNotContain(Resource.NONE, Resource.ANY);
+        assertThat(offeredValues(Resource.APPROVAL, FilterField.APPROVAL_RESOURCE))
+                .contains(Resource.CERTIFICATE)
+                .doesNotContain(Resource.NONE, Resource.ANY);
+    }
+
+    private Object[] offeredValues(Resource resource, FilterField field) throws NotFoundException {
+        SearchFieldDataDto data = resourceService
+                .listResourceRuleFilterFields(resource, false)
+                .stream()
+                .flatMap(group -> group.getSearchFieldData().stream())
+                .filter(candidate -> field.name().equals(candidate.getFieldIdentifier()))
+                .findFirst()
+                .orElseThrow();
+        return (Object[]) data.getValue();
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/ResourceServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ResourceServiceITest.java
@@ -35,6 +35,7 @@ import com.otilm.api.model.core.other.ResourceDto;
 import com.otilm.api.model.core.other.ResourceEvent;
 import com.otilm.api.model.core.other.ResourceEventDto;
 import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
+import com.otilm.api.model.core.search.SearchFieldDataDto;
 import com.otilm.core.dao.entity.AttributeContent2Object;
 import com.otilm.core.dao.entity.AttributeContentItem;
 import com.otilm.core.dao.entity.AttributeDefinition;
@@ -79,6 +80,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
@@ -363,6 +365,21 @@ class ResourceServiceITest extends BaseSpringBootTest {
      * this mismatch, a missing {@code ResourceToClass} constant, or the next one -- into a build failure, which is why
      * this asserts nothing about the cause.
      */
+    @Test
+    void commentHostResourceOffersOnlyTheCommentableResources() throws NotFoundException {
+        SearchFieldDataDto hostResource = resourceService
+                .listResourceRuleFilterFields(Resource.COMMENT, false)
+                .stream()
+                .flatMap(group -> group.getSearchFieldData().stream())
+                .filter(field -> FilterField.COMMENT_HOST_RESOURCE.name().equals(field.getFieldIdentifier()))
+                .findFirst()
+                .orElseThrow();
+
+        Object[] offered = (Object[]) hostResource.getValue();
+        assertThat(offered).containsExactlyInAnyOrder(Resource.getCommentableResources().toArray());
+        assertThat(offered).doesNotContain(Resource.NONE, Resource.ANY, Resource.COMMENT, Resource.CERTIFICATE_REQUEST);
+    }
+
     @Test
     void everyResourceWithFilterFieldsCanBeListed() {
         List<Resource> declared = Arrays


### PR DESCRIPTION
Closes #2229

The Host Resource field of a comment condition offered every constant of the `Resource` enum, 67 values, though only 22 resources can host a comment (Epic: OmniTrustILM/ilm#246). A rule built on one of the other 45 saved without a warning and never fired.

## What's here

- `FilterField` — a list field backed by an enum can declare the subset of its constants it offers, through one more constructor and `getEnumValues()`, which falls back to every constant. The field listing in `ResourceServiceImpl` asks the field for its values instead of reading the enum class; predicate building and trigger evaluation still go through the enum class and are untouched.
- `COMMENT_HOST_RESOURCE` declares `Resource.getCommentableResources()`, the same set request validation and the startup action registration use.
- While at it, the same bug class on the other `Resource`-backed fields: `AUDIT_LOG_AFFILIATED_RESOURCE` and `APPROVAL_RESOURCE` no longer offer `NONE` or `ANY`, and `AUDIT_LOG_RESOURCE` no longer offers `ANY`. `NONE` stays on the audit resource field because module-level operations are audited with it. The set is the complement of the two wildcards, computed rather than listed, so it cannot drift.
- Tests — the resource service ITest pins the host resource values to exactly the commentable set, and the three resource fields to the presence and absence of the wildcards.

## Notes for reviewers

- Not done here, on purpose: the per-check certificate validation fields offer all eight `CertificateValidationStatus` values while the validator can only produce four for OCSP and CRL and three for the signature check, and `APPROVAL_ACTION` offers every action while approvals arise for a handful. Both subsets live in code that is not `FilterField`, so declaring them here would duplicate knowledge; they want a single source of truth first and are a separate change.
