### PR TITLE
Probe whether code review reads CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,3 +224,9 @@ Do not restate the version anywhere else — not here, not in a README, not in a
 goes stale the moment the pin moves, and then the floor can only be inferred again: the oldest server the
 migrations happen to parse on, the newest feature the native queries happen to use, and the image the
 tests happen to run give three different answers. The pin is the answer.
+
+## Fixture naming in integration tests (temporary canary — do not merge)
+
+In this repository, fixture variables declared inside a test method must carry an
+`fx` prefix — `fxCertificate`, not `certificate`. Flag any fixture variable in a
+test method that does not carry the prefix.

--- a/src/test/java/com/otilm/core/CanaryProbeTest.java
+++ b/src/test/java/com/otilm/core/CanaryProbeTest.java
@@ -1,0 +1,14 @@
+package com.otilm.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CanaryProbeTest {
+
+    @Test
+    void fixtureIsConstructed() {
+        String certificateSubject = "CN=canary";
+        assertThat(certificateSubject).isNotEmpty();
+    }
+}


### PR DESCRIPTION
**TLDR** — throwaway experiment, do not merge, closing as soon as the review posts. Checking whether Copilot code review actually reads `CLAUDE.md` from the head branch.

## Why

We are deciding whether to tune the native reviewer through instruction files. `CLAUDE.md` support is claimed in GitHub's 2026-07-17 changelog but absent from the custom-instructions reference matrix, so it is unverified. Retrospective evidence was suggestive but inconclusive: Copilot's declined finding on #2129 paired a claim that is code-derivable (`CryptoAssetPqcSweepTask` already documents that SaaS operators cannot touch yml) with one that only `CLAUDE.md` states (env-var overrides need Helm wiring).

Building a rollout on an unconfirmed premise is worse than spending one review to settle it.

## What this does

Adds a fixture-naming rule to `CLAUDE.md` that no model would produce unprompted, plus a test whose local variable breaks it.

## How to read the result

- Review flags `certificateSubject` for the missing `fx` prefix → `CLAUDE.md` is read and honoured.
- Review posts but ignores the rule → it is not read, or not honoured. Instruction files become the only channel.
- No review → configuration problem, diagnose before concluding anything.

The test is a plain unit test with no Spring annotations, so it does not add a context signature and `ContextSignatureGuardTest.BASELINE` is unaffected.